### PR TITLE
fix a configuration bug for wirecell signal processing

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/icarus/nf.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/nf.jsonnet
@@ -2,7 +2,6 @@
 
 local g = import 'pgraph.jsonnet';
 local wc = import 'wirecell.jsonnet';
-local gainmap = import 'pgrapher/experiment/pdsp/chndb-rel-gain.jsonnet';
 
 function(params, anode, chndbobj, n, name='')
   {
@@ -13,11 +12,6 @@ function(params, anode, chndbobj, n, name='')
       data: {
         noisedb: wc.tn(chndbobj),
         anode: wc.tn(anode),
-//        resmp: [
-//          {channels: std.range(2128, 2175), sample_from: 5996},
-//          {channels: std.range(1520, 1559), sample_from: 5996},
-//          {channels: std.range( 440,  479), sample_from: 5996},
-//        ],
       },
     },
     local grouped = {
@@ -29,36 +23,6 @@ function(params, anode, chndbobj, n, name='')
         rms_threshold: 0.0,
       },
     },
-    local sticky = {
-      type: 'pdStickyCodeMitig',
-      name: name,
-      data: {
-        extra_stky: [
-          {channels: std.range(n * 2560, (n + 1) * 2560 - 1), bits: [0,1,63]},
-          {channels: [4], bits: [6]  },
-          {channels: [159], bits: [6]  },
-          {channels: [164], bits: [36] },
-          {channels: [168], bits: [7]  },
-          {channels: [323], bits: [24] },
-          {channels: [451], bits: [25] },
-        ],
-        noisedb: wc.tn(chndbobj),
-        anode: wc.tn(anode),
-        stky_sig_like_val: 15.0,
-        stky_sig_like_rms: 2.0,
-        stky_max_len: 10,
-      },
-    },
-    local gaincalib = {
-      type: 'pdRelGainCalib',
-      name: name,
-      data: {
-        noisedb: wc.tn(chndbobj),
-        anode: wc.tn(anode),
-        rel_gain: gainmap.rel_gain,
-      },
-    },
-
 
     local obnf = g.pnode({
       type: 'OmnibusNoiseFilter',
@@ -72,9 +36,7 @@ function(params, anode, chndbobj, n, name='')
         // only when the channelmask is merged to `bad`
         // maskmap: {sticky: "bad", ledge: "bad", noisy: "bad"},
         channel_filters: [
-          // wc.tn(sticky),
           wc.tn(single),
-          // wc.tn(gaincalib),
         ],
         grouped_filters: [
           // wc.tn(grouped),
@@ -85,7 +47,7 @@ function(params, anode, chndbobj, n, name='')
         intraces: 'orig%d' % anode.data.ident,  // frame tag get all traces
         outtraces: 'raw%d' % anode.data.ident,
       },
-    }, uses=[chndbobj, anode, sticky, single, grouped, gaincalib], nin=1, nout=1),
+    }, uses=[chndbobj, anode, single, grouped], nin=1, nout=1),
 
 
     pipe: g.pipeline([obnf], name=name),

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
@@ -108,7 +108,7 @@ local wcls_output = {
       anode: wc.tn(mega_anode),
       digitize: false,  // true means save as RawDigit, else recob::Wire
       frame_tags: ['gauss', 'wiener'],
-      frame_scale: [0.04, 0.04],
+      frame_scale: [0.1, 0.1],
       // nticks: params.daq.nticks,
       chanmaskmaps: [],
       nticks: -1,


### PR DESCRIPTION
Here is the test command.
```
lar -n1 -c prodsingle_common_icarus.fcl -o gen.root
lar -n1 -c cosmics_g4_icarus_volCryostat.fcl gen.root -o g4.root
lar -n1 -c wcls-multitpc-sim-drift-simchannel.fcl g4.root -o wcsim.root
lar -n1 -c wcls-decode-to-sig.fcl wcsim.root -o decon.root
```
The output deconvolution result is in the unit of electrons but scaled by 0.1. One can change the scaling here: `icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet` 
```
frame_scale: [0.1, 0.1],
```