### PR TITLE
Adding/updating fhicl files from Christian Farnese for Calorimetry Wo…

### DIFF
--- a/fcl/calorimetry/detsim_QLcorr_calorimetry_workshop2020.fcl
+++ b/fcl/calorimetry/detsim_QLcorr_calorimetry_workshop2020.fcl
@@ -1,0 +1,27 @@
+#include "multitpc_detsim_icarus.fcl"
+
+process_name: DetSim
+
+
+services:
+{
+@table::services
+@table::icarus_legacy_services_v08_50_00
+}
+
+
+services.Geometry: @local::icarus_single_induction_nooverburden_geometry
+services.ExpGeoHelperInterface: @local::icarus_single_induction_geometry_helper
+
+
+physics.producers.daq0.SuppressNoSignal: true
+physics.producers.daq0.TPCVec:              [[0,0]]
+physics.producers.daq1.SuppressNoSignal: true
+physics.producers.daq2.SuppressNoSignal: true
+physics.producers.daq3.SuppressNoSignal: true
+physics.producers.daq1.TPCVec:              [[0,1]]
+physics.producers.daq2.TPCVec:              [[1,0]]
+physics.producers.daq3.TPCVec:              [[1,1]]
+
+services.LArPropertiesService.ScintPreScale: 1.0
+physics.producers.opdaq.QE: 0.121

--- a/fcl/calorimetry/g4_QLcorr_calorimetry_workshop2020.fcl
+++ b/fcl/calorimetry/g4_QLcorr_calorimetry_workshop2020.fcl
@@ -25,4 +25,4 @@ services.SpaceChargeService.InputFilename: 'SCEoffsets/SCEoffsets_ICARUS_E500_vo
 
 services.LArG4Parameters.IonAndScintCalculator: "Correlated"
 services.LArPropertiesService.ScintByParticleType: true
-
+ervices.LArPropertiesService.ScintPreScale: 1.0


### PR DESCRIPTION
…rkshop 2020

Including the email thread describing these updates in more detail:

Thanks, Christian, I will prepare corresponding ones for SBND (similar modification is needed).

Looping in Maya so she can integrate the new files into production.  Tracy, do we need a new release for this?

--Mike


On 6/30/20 1:34 PM, Christian Farnese wrote:
> ... sorry the real new lines should be
>
> g4 stage
>
> services.LArG4Parameters.IonAndScintCalculator: "Correlated"
> services.LArPropertiesService.ScintByParticleType: true
> services.LArPropertiesService.ScintPreScale: 1.0
>
> detsim stage
>
> services.LArPropertiesService.ScintPreScale: 1.0
> physics.producers.opdaq.QE: 0.121
>
> I prepared for ICARUS the two fhicls for the workshop with these lines: you can find them here
>
> /icarus/data/users/cfarnese/productions_v085501/final_fhicl
>
> g4_QLcorr_calorimetry_workshop2020.fcl
> detsim_QLcorr_calorimetry_workshop2020.fcl
>
> Unfortunately I can not test these right now but please have a look at them!!
>
> Christian
>
>
>
> On Tue, 30 Jun 2020 21:24:58 +0200, Christian Farnese wrote
> > Dear Gianluca,
> >
> > can you provide some more explanations? It is not clear to me what I have to test for the ICARUS case...
> >
> > If I understand correctly you suggest to use for the new QLcorr method from Will in the g4 stage the following lines
> >
> > services.LArG4Parameters.IonAndScintCalculator: "Correlated"
> > services.LArPropertiesService.ScintByParticleType: true
> > services.LArPropertiesService.ScintPreScale: 1.0
> >
> > so changing in particular also the last value, ScintPreScale, that actually is 0.121
> >
> > Then we should edit the detsim fhicl adding this line
> >
> > physics.producers.opdaq.QE: 0.121
> >
> > is it correct? I am asking because at the moment in the multitpc_detsim_icarus.fcl this parameter is just defined in this way... so why I need to put it? Thanks for the explanations and for the help!!
> >
> > Christian
> >
> > On Tue, 30 Jun 2020 13:25:33 -0500, Will Foreman wrote
> > >
> >
> > >  
> > > On Jun 30, 2020, at 11:26 AM, Gianluca Petrillo
> > <petrillo@slac.stanford.edu> wrote:
> > > Try to decorate your job configuration with:   # all configurations (esp.
> > G4, DetSim)  services.LArPropertiesService.ScintPreScale: 1.0   # only DetSim:
> > physics.producers.opdaq.QE: 0.121
> >
> > >
> >
> > > I agree with this suggestion.
> > >
> >
> > > Is that just the default QE that ICARUS uses for the opdet digitizer? If
> > so, there should be no need to set it again in the production FCL (though it
> > couldn’t hurt!). The most important thing is to have ScintPreScale = 1 — since
> > because it is not used in the existing iteration of the Correlated alg, it is
> > effectively “1” in the LArG4 stage, and the digitizer should know about that...
>
