### PR TITLE
for basic testing with geant4 10.6

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -34,7 +34,7 @@ table_fragment_end
 # Add the dependent product and version
 
 product             version
-larsoft                   v08_56_00
+larsoft                   v08_55_00_01
 icarusutil                v08_51_00
 icarus_signal_processing  v08_51_00
 icarus_data               v08_55_01

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -51,12 +51,10 @@ end_product_list
 # We now define allowed qualifiers and the corresponding qualifiers for the depdencies.
 # Make a table by adding columns before "notes".
 # e15  - with gcc 6.4.0 and -std=c++1y
-qualifier		larsoft			icarusutil   icarus_signal_processing   icarus_data  sbndaq_artdaq_core     genie_xsec              fftw  guideline_sl libwda notes
-e19:debug		e19:debug		e19:debug          e19:debug               -nq-        e19:debug	       G1810a0211a:k250:e1000   debug    -nq-           -nq-
-e19:opt			e19:opt			e19:opt     	   e19:opt                 -nq-        e19:opt	       G1810a0211a:k250:e1000   opt      -nq-           -nq-
-e19:prof    	e19:prof		e19:prof    	   e19:prof                -nq-        e19:prof	       G1810a0211a:k250:e1000   prof     -nq-           -nq-
+qualifier	larsoft		icarusutil   icarus_signal_processing   icarus_data  sbndaq_artdaq_core     genie_xsec              fftw  guideline_sl libwda notes
+e19:debug	e19:debug	e19:debug          e19:debug               -nq-        e19:debug       G1810a0211a:k250:e1000   debug    -nq-           -nq-
+e19:prof    	e19:prof	e19:prof    	   e19:prof                -nq-        e19:prof	       G1810a0211a:k250:e1000   prof     -nq-           -nq-
 c7:debug    	c7:debug    	c7:debug    	   c7:debug                -nq-        c7:debug	       G1810a0211a:k250:e1000   debug    -nq-           -nq-
-c7:opt      	c7:opt      	c7:opt      	   c7:opt                  -nq-        c7:opt	    	   G1810a0211a:k250:e1000   opt      -nq-           -nq-
 c7:prof     	c7:prof     	c7:prof     	   c7:prof                 -nq-        c7:prof	       G1810a0211a:k250:e1000   prof     -nq-           -nq-
 end_qualifier_list
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -3,7 +3,7 @@
 # The *parent* line must the first non-commented line and defines this product and version
 # The version must be of the form vxx_yy_zz (e.g. v01_02_03)
 parent icaruscode v08_56_00
-defaultqual e17
+defaultqual e19
 
 # These optional lines define where headers, libraries, and executables go and should
 # be used only if your product does not conform to the defaults.
@@ -51,7 +51,7 @@ end_product_list
 # We now define allowed qualifiers and the corresponding qualifiers for the depdencies.
 # Make a table by adding columns before "notes".
 # e15  - with gcc 6.4.0 and -std=c++1y
-qualifier	larsoft		icarusutil   icarus_signal_processing   icarus_data  sbndaq_artdaq_core     genie_xsec              fftw  guideline_sl libwda notes
+qualifier	larsoft		icarusutil   icarus_signal_processing	icarus_data  sbndaq_artdaq_core     genie_xsec              fftw  guideline_sl libwda notes
 e19:debug	e19:debug	e19:debug          e19:debug               -nq-        e19:debug       G1810a0211a:k250:e1000   debug    -nq-           -nq-
 e19:prof    	e19:prof	e19:prof    	   e19:prof                -nq-        e19:prof	       G1810a0211a:k250:e1000   prof     -nq-           -nq-
 c7:debug    	c7:debug    	c7:debug    	   c7:debug                -nq-        c7:debug	       G1810a0211a:k250:e1000   debug    -nq-           -nq-

--- a/ups/setup_for_development
+++ b/ups/setup_for_development
@@ -84,6 +84,8 @@ source $CETBUILDTOOLS_DIR/bin/set_dev_lib
 source $CETBUILDTOOLS_DIR/bin/set_dev_bin
 # set FHICL_FILE_PATH
 source $CETBUILDTOOLS_DIR/bin/set_dev_fhicl
+# set FW_SEARCH_PATH
+source $CETBUILDTOOLS_DIR/bin/set_dev_fwsearch
 
 # final sanity check and report
 source $CETBUILDTOOLS_DIR/bin/set_dev_check_report


### PR DESCRIPTION
This PR is provided so we can run the CI for geant4 10.6. Some changes were needed to fix old files in the ups directory. The only other change is using larsoft v08_55_00_01.

To trigger the build manually:
kx509
setup lar_ci
trigger --build-delay 0 --cert /tmp/x509up_u1147 --version develop --workflow icaruscodestandalone_wf --revisions "SBNSoftware/icaruscode#24"
( SBNSoftware / icaruscode # 24 )