### PR TITLE
Fixed G4 and event display configurations using single wire and photon visibility.

### DIFF
--- a/fcl/evd/overburden/CMakeLists.txt
+++ b/fcl/evd/overburden/CMakeLists.txt
@@ -1,10 +1,8 @@
-add_subdirectory("overburden")
-
 # Install fcl files in /job subdirectory.
 
 install_fhicl()
 
 # Also put a copy in the source tree.
+
 FILE(GLOB fcl_files *.fcl)
 install_source( EXTRAS ${fcl_files} )
-

--- a/fcl/evd/overburden/evd_nooverburden_icarus.fcl
+++ b/fcl/evd/overburden/evd_nooverburden_icarus.fcl
@@ -1,0 +1,12 @@
+#
+# File:    evd_nooverburden_icarus.fcl
+# Purpose: No-overburden single-wire version of `evd_icarus.fcl`.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    July 13, 2020
+#
+
+#include "evd_icarus.fcl"
+
+# turn to no-overburden geometry:
+#include "use_nooverburden_geometry_icarus.fcl"
+

--- a/fcl/evd/overburden/evd_overburden_icarus.fcl
+++ b/fcl/evd/overburden/evd_overburden_icarus.fcl
@@ -1,0 +1,12 @@
+#
+# File:    evd_overburden_icarus.fcl
+# Purpose: Overburden single-wire version of `evd_icarus.fcl`.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    July 13, 2020
+#
+
+#include "evd_icarus.fcl"
+
+# turn to overburden geometry:
+#include "use_overburden_geometry_icarus.fcl"
+

--- a/fcl/g4/overburden/cosmics_nooverburden_g4_icarus_volCryostat.fcl
+++ b/fcl/g4/overburden/cosmics_nooverburden_g4_icarus_volCryostat.fcl
@@ -12,3 +12,4 @@
 # turn to no-overburden geometry:
 #include "use_nooverburden_geometry_icarus.fcl"
 
+services.PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping

--- a/fcl/g4/overburden/cosmics_nooverburden_g4_icarus_volDetEnc.fcl
+++ b/fcl/g4/overburden/cosmics_nooverburden_g4_icarus_volDetEnc.fcl
@@ -12,3 +12,4 @@
 # turn to no-overburden geometry:
 #include "use_nooverburden_geometry_icarus.fcl"
 
+services.PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping

--- a/fcl/g4/overburden/cosmics_overburden_g4_icarus_volCryostat.fcl
+++ b/fcl/g4/overburden/cosmics_overburden_g4_icarus_volCryostat.fcl
@@ -12,3 +12,4 @@
 # turn to overburden geometry:
 #include "use_overburden_geometry_icarus.fcl"
 
+services.PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping

--- a/fcl/g4/overburden/cosmics_overburden_g4_icarus_volDetEnc.fcl
+++ b/fcl/g4/overburden/cosmics_overburden_g4_icarus_volDetEnc.fcl
@@ -12,3 +12,4 @@
 # turn to overburden geometry:
 #include "use_overburden_geometry_icarus.fcl"
 
+services.PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping

--- a/fcl/g4/overburden/nooverburden_g4_icarus.fcl
+++ b/fcl/g4/overburden/nooverburden_g4_icarus.fcl
@@ -12,3 +12,4 @@
 # turn to no-overburden geometry:
 #include "use_nooverburden_geometry_icarus.fcl"
 
+services.PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping

--- a/fcl/g4/overburden/overburden_g4_icarus.fcl
+++ b/fcl/g4/overburden/overburden_g4_icarus.fcl
@@ -12,3 +12,4 @@
 # turn to overburden geometry:
 #include "use_overburden_geometry_icarus.fcl"
 
+services.PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping

--- a/fcl/services/photpropservices_icarus.fcl
+++ b/fcl/services/photpropservices_icarus.fcl
@@ -105,19 +105,22 @@ icarus_photonvisibilityservice_mapped: {
 ### Legacy configuration
 ###
 #
-# This is the configuration used by the "standard" ICARUS job configurations
-# until icaruscode v08_50_00.
-# It is part of `icarus_legacy_services` configuration, and it should not
-# be used by itself since it requires a specific geometry and channel mapping.
+# This configuration should be used with the "old" PMT channel mapping.
+# PMT channel mapping reflects the optical detector sorting.
+# This sorting was changed when moving to the split wire geometry, so that the
+# new geometry included a new TPC and PMT channel mapping.
+# For the single wire geometry, this does not apply and the old configuration
+# is needed.
 # Use as:
 #     
-#     services: @local::icarus_legacy_services
+#     services.PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping
 #     
-# This configuration is almost frozen (i.e. it would be frozen except that it
-# relies on `standard_library_vuv_prop_timing_photonvisibilityservice` which
-# we are not reproducing here).
+# This configuration is almost self-contained (i.e. it would be self-contained
+# except that it relies on
+# `standard_library_vuv_prop_timing_photonvisibilityservice` which we are not
+# reproducing here).
 #
-icarus_legacy_photonvisibilityservice_v08_50_00: {
+icarus_photonvisibilityservice_noPMTremapping: {
 
   @table::standard_library_vuv_prop_timing_photonvisibilityservice
 
@@ -140,8 +143,23 @@ icarus_legacy_photonvisibilityservice_v08_50_00: {
     tool_type: ICARUSPhotonMappingTransformations
   }
 
-} # icarus_legacy_photonvisibilityservice_v08_50_00
+} # icarus_photonvisibilityservice_noPMTremapping
 
+
+#
+# This is the configuration used by the "standard" ICARUS job configurations
+# until icaruscode v08_50_00.
+# It is part of `icarus_legacy_services` configuration, and it should not
+# be used by itself since it requires a specific geometry and channel mapping.
+# Use as:
+#     
+#     services: @local::icarus_legacy_services
+#     
+# This configuration is almost frozen (i.e. it would be frozen except that it
+# relies on `standard_library_vuv_prop_timing_photonvisibilityservice` which
+# we are not reproducing here).
+#
+icarus_legacy_photonvisibilityservice_v08_50_00: @local::icarus_photonvisibilityservice_noPMTremapping
 
 
 ###############################################################################

--- a/fcl/services/services_icarus_simulation.fcl
+++ b/fcl/services/services_icarus_simulation.fcl
@@ -134,6 +134,34 @@ icarus_simulation_services: {
 
 
 ################################################################################
+###  Single first induction wire service configuration
+###
+### Single first induction wire geometry uses a different mapping for both TPC
+### and PMT channels. Because the photon visibility lookup table has a specific
+### mapping encoded in it, its configuration needs to reflect the mapping
+### currently used by the software.
+### This set of services includes:
+### 
+###  * single first induction wire geometry, with overburden
+###  * old PMT mapping
+###  * old photon visibility library
+### 
+### It is going to replace `icarus_simulation_services`, i.e. it includes (all*)
+### services.
+###
+
+icarus_single_wire_services: {
+    
+    @table::icarus_simulation_services
+    
+    @table::icarus_single_induction_overburden_geometry_services
+    
+    PhotonVisibilityService: @local::icarus_photonvisibilityservice_noPMTremapping
+
+} # icarus_single_wire_services
+
+
+###
 ###  Legacy service configuration (v08_50_00)
 ###
 ### This set of services is required to run with data produced with icaruscode
@@ -148,15 +176,7 @@ icarus_simulation_services: {
 ### services.
 ###
 
-icarus_legacy_services_v08_50_00: {
-    
-    @table::icarus_simulation_services
-    
-    @table::icarus_single_induction_overburden_geometry_services
-    
-    PhotonVisibilityService: @local::icarus_legacy_photonvisibilityservice_v08_50_00
-
-} # icarus_legacy_services_v08_50_00
+icarus_legacy_services_v08_50_00: @local::icarus_single_wire_services
 
 
 ################################################################################


### PR DESCRIPTION
`icaruscode` contains some overburden/no overburden configurations, which are currently using single first induction wires and therefore require a special PMT mapping. Their `PhotonVisibilityService` configuration has been updated to reflect that.