### PR TITLE
update wirecell wire geometry with the fixed split layout

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
@@ -123,7 +123,7 @@ base {
     },
 
     files: {
-        wires: "icarus-wires-dualanode-v2.json.bz2",
+        wires: "icarus-wires-dualanode-v3.json.bz2",
 
         fields: ["garfield-icarus-fnal-commissioning.json.bz2"],
 


### PR DESCRIPTION
Hi @SFBayLaser, this PR is for loading the new wire geometry for wirecell. The new wire geometry is converted from your feature branch "usher_finalsplitwiregeometry". 

Please merge this PR after you merge the fixed split geometry from your feature branch.

Also, could you help update a data file in `icarus_data`?  Just simply replace `icarus_data/WirecellData/icarus-wires-dualanode-v2.json.bz2` with `/icarus/app/users/wgu/larsoft/j07/wire-cell-data/icarus-wires-dualanode-v3.json.bz2`.
