### PR TITLE
Feature/usher decoderandhitthresholds

### DIFF
--- a/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
@@ -75,17 +75,17 @@ gaus_hitfinder_icarus.LongPulseWidth:                                           
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0:                        @local::candhitfinder_morphological
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.Plane:                  0
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.MinDeltaTicks:          4
-gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.MinDeltaPeaks:          1.5
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.MinDeltaPeaks:          2.5
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.DilationThreshold:      8
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1:                        @local::candhitfinder_morphological
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.Plane:                  1
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.MinDeltaTicks:          4
-gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.MinDeltaPeaks:          1.5
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.MinDeltaPeaks:          2.5
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.DilationThreshold:      8
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2:                        @local::candhitfinder_morphological
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.Plane:                  2
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.MinDeltaTicks:          4
-gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.MinDeltaPeaks:          1.5
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.MinDeltaPeaks:          2.5
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.DilationThreshold:      8
 
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -45,6 +45,11 @@ icarus_decon1droi:
     Baseline:                   @local::icarus_baselinemostprobave
 }
 
+# Override the NumSigma here so we can adjust per plane
+icarus_decon1droi.ROIFinderToolVec.ROIFinderToolPlane0.NumSigma: 3.0
+icarus_decon1droi.ROIFinderToolVec.ROIFinderToolPlane1.NumSigma: 3.5
+icarus_decon1droi.ROIFinderToolVec.ROIFinderToolPlane2.NumSigma: 3.0
+
 icarus_recowireroiicarus:
 {
     module_type:                "RecoWireROIICARUS"


### PR DESCRIPTION
Updates to the decoder - REVERSE THE POLARITY OF THE SIGNALS to match what is "expected" in the offline world (and matching what was done for CERN tests). There is also an update which improves the calculation of the final pedestal offset. 
Updates to ROI/Hit finding - increasing the thresholds for both ROI and hit finding.