### PR TITLE
Changes to use LArSoft v9

### DIFF
--- a/icaruscode/Analysis/HitEfficiencyAna_module.cc
+++ b/icaruscode/Analysis/HitEfficiencyAna_module.cc
@@ -28,7 +28,6 @@
 //#include "cetlib/search_path.h"
 #include "cetlib/cpu_timer.h"
 #include "lardata/Utilities/AssociationUtil.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 
@@ -118,7 +117,6 @@ private:
 
     // Other variables that will be shared between different methods.
     const geo::GeometryCore*           fGeometry;       // pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;
     const lariov::DetPedestalProvider& fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 }; // class HitEfficiencyAna
 
@@ -136,7 +134,6 @@ HitEfficiencyAna::HitEfficiencyAna(fhicl::ParameterSet const& parameterSet)
 
 {
     fGeometry = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     // Read in the parameters from the .fcl file.
     this->reconfigure(parameterSet);

--- a/icaruscode/Analysis/RawDigitAna_module.cc
+++ b/icaruscode/Analysis/RawDigitAna_module.cc
@@ -18,9 +18,9 @@
 //#include "cetlib/search_path.h"
 #include "cetlib/cpu_timer.h"
 #include "lardata/Utilities/AssociationUtil.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 
 // Framework includes
 #include "art/Framework/Core/EDAnalyzer.h"
@@ -103,7 +103,6 @@ private:
 
     // Other variables that will be shared between different methods.
     const geo::GeometryCore*           fGeometry;       // pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;
     const lariov::DetPedestalProvider& fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 }; // class RawDigitAna
 
@@ -120,7 +119,6 @@ RawDigitAna::RawDigitAna(fhicl::ParameterSet const& parameterSet)
 
 {
     fGeometry = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     // Read in the parameters from the .fcl file.
     this->reconfigure(parameterSet);
@@ -145,7 +143,9 @@ void RawDigitAna::beginJob()
     // The arguments to 'make<whatever>' are the same as those passed
     // to the 'whatever' constructor, provided 'whatever' is a ROOT
     // class that TFileService recognizes.
-    for (auto& rawDigitHistTool : fRawDigitHistogramToolVec) rawDigitHistTool->initializeHists(tfs, "RawDigitAna");
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob(clockData);
+    for (auto& rawDigitHistTool : fRawDigitHistogramToolVec) rawDigitHistTool->initializeHists(clockData, detProp, tfs, "RawDigitAna");
 
     // zero out the event counter
     fNumEvents = 0;
@@ -188,6 +188,9 @@ void RawDigitAna::analyze(const art::Event& event)
 
     fNumEvents++;
     
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(event, clockData);
+
     // Loop over RawDigits
     for(const auto& rawDigitLabel : fRawDigitProducerLabelVec)
     {
@@ -214,7 +217,7 @@ void RawDigitAna::analyze(const art::Event& event)
             IRawDigitHistogramTool::RawDigitPtrVec allRawDigitVec;
             art::fill_ptr_vector(allRawDigitVec, rawDigitHandle);
             
-            for(auto& rawDigitHistTool : fRawDigitHistogramToolVec) rawDigitHistTool->fillHistograms(allRawDigitVec,channelMap);
+            for(auto& rawDigitHistTool : fRawDigitHistogramToolVec) rawDigitHistTool->fillHistograms(clockData, detProp, allRawDigitVec,channelMap);
         }
     }
 

--- a/icaruscode/Analysis/TrackHitAna_module.cc
+++ b/icaruscode/Analysis/TrackHitAna_module.cc
@@ -34,7 +34,6 @@
 //#include "cetlib/search_path.h"
 #include "cetlib/cpu_timer.h"
 #include "lardata/Utilities/AssociationUtil.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 
@@ -134,7 +133,6 @@ private:
 
     // Other variables that will be shared between different methods.
     const geo::GeometryCore*           fGeometry;       // pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;
     const lariov::DetPedestalProvider& fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 }; // class TrackHitAna
 
@@ -151,7 +149,6 @@ TrackHitAna::TrackHitAna(fhicl::ParameterSet const& parameterSet)
 
 {
     fGeometry = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     // Read in the parameters from the .fcl file.
     this->reconfigure(parameterSet);

--- a/icaruscode/Analysis/WireAna_module.cc
+++ b/icaruscode/Analysis/WireAna_module.cc
@@ -18,7 +18,6 @@
 //#include "cetlib/search_path.h"
 #include "cetlib/cpu_timer.h"
 #include "lardata/Utilities/AssociationUtil.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 
@@ -103,7 +102,6 @@ private:
 
     // Other variables that will be shared between different methods.
     const geo::GeometryCore*           fGeometry;       // pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;
     const lariov::DetPedestalProvider& fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 }; // class WireAna
 
@@ -120,7 +118,6 @@ WireAna::WireAna(fhicl::ParameterSet const& parameterSet)
 
 {
     fGeometry = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     // Read in the parameters from the .fcl file.
     this->reconfigure(parameterSet);

--- a/icaruscode/Analysis/tools/BasicHitAnalysis_tool.cc
+++ b/icaruscode/Analysis/tools/BasicHitAnalysis_tool.cc
@@ -1,4 +1,3 @@
-
 #include "icaruscode/Analysis/tools/IHitHistogramTool.h"
 
 #include "fhiclcpp/ParameterSet.h"
@@ -10,7 +9,6 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 
 #include "lardataobj/RecoBase/Hit.h"
 
@@ -130,7 +128,6 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore*           fGeometry;             ///< pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;   ///< Detector properties service
 };
     
 //----------------------------------------------------------------------------
@@ -143,7 +140,6 @@ private:
 BasicHitAnalysis::BasicHitAnalysis(fhicl::ParameterSet const & pset)
 {
     fGeometry           = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
     
     configure(pset);
     

--- a/icaruscode/Analysis/tools/BasicTrackAnalysis_tool.cc
+++ b/icaruscode/Analysis/tools/BasicTrackAnalysis_tool.cc
@@ -1,4 +1,3 @@
-
 #include "icaruscode/Analysis/tools/ITrackHistogramTool.h"
 
 #include "fhiclcpp/ParameterSet.h"
@@ -12,7 +11,6 @@
 #include "canvas/Persistency/Common/FindManyP.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 
 #include "lardataobj/RecoBase/Hit.h"
 
@@ -99,7 +97,6 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore*           fGeometry;             ///< pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;   ///< Detector properties service
 };
     
 //----------------------------------------------------------------------------
@@ -112,7 +109,6 @@ private:
 BasicTrackAnalysis::BasicTrackAnalysis(fhicl::ParameterSet const & pset)
 {
     fGeometry           = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
     
     configure(pset);
     

--- a/icaruscode/Analysis/tools/BasicWireAnalysis_tool.cc
+++ b/icaruscode/Analysis/tools/BasicWireAnalysis_tool.cc
@@ -1,4 +1,3 @@
-
 #include "icaruscode/Analysis/tools/IWireHistogramTool.h"
 
 #include "fhiclcpp/ParameterSet.h"
@@ -11,7 +10,6 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalService.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalProvider.h"
 #include "larreco/HitFinder/HitFinderTools/IWaveformTool.h"
@@ -153,7 +151,6 @@ private:
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore&                fGeometry;             ///< pointer to Geometry service
     icarusutil::SignalShapingICARUSService& fSignalServices;       ///< The signal shaping service
-    const detinfo::DetectorProperties*      fDetectorProperties;   ///< Detector properties service
     const lariov::DetPedestalProvider&      fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 };
     
@@ -169,8 +166,6 @@ BasicWireAnalysis::BasicWireAnalysis(fhicl::ParameterSet const & pset) :
     fSignalServices(*art::ServiceHandle<icarusutil::SignalShapingICARUSService>()),
     fPedestalRetrievalAlg(*lar::providerFrom<lariov::DetPedestalService>())
 {
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    
     configure(pset);
     
     // Report.

--- a/icaruscode/Analysis/tools/CMakeLists.txt
+++ b/icaruscode/Analysis/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ add_definitions(-DEIGEN_FFTW_DEFAULT)
 
 art_make( TOOL_LIBRARIES lardataobj_RecoBase
                          lardataobj_Simulation
+                         lardataalg_DetectorInfo
                          icaruscode_TPC_SignalProcessing_RawDigitFilter_Algorithms
                          larcorealg_Geometry
                          larcore_Geometry_Geometry_service

--- a/icaruscode/Analysis/tools/HitFinderAnalysis_tool.cc
+++ b/icaruscode/Analysis/tools/HitFinderAnalysis_tool.cc
@@ -1,4 +1,3 @@
-
 #include "icaruscode/Analysis/tools/IHitEfficiencyHistogramTool.h"
 
 #include "fhiclcpp/ParameterSet.h"
@@ -11,7 +10,6 @@
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 
@@ -186,8 +184,6 @@ private:
 
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore*           fGeometry;             ///< pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;   ///< Detector properties service
-    const detinfo::DetectorClocks*     fClockService;         ///< Detector clocks service
 };
     
 //----------------------------------------------------------------------------
@@ -200,8 +196,6 @@ private:
 HitFinderAnalysis::HitFinderAnalysis(fhicl::ParameterSet const & pset) : fTree(nullptr)
 {
     fGeometry           = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    fClockService       = lar::providerFrom<detinfo::DetectorClocksService>();
     
     configure(pset);
     
@@ -473,6 +467,7 @@ void HitFinderAnalysis::fillHistograms(const art::Event& event) const
         }
     }
     
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
     const lariov::ChannelStatusProvider& chanFilt = art::ServiceHandle<lariov::ChannelStatusService>()->GetProvider();
 
     std::vector<int> nSimChannelHitVec = {0,0,0};
@@ -604,9 +599,9 @@ void HitFinderAnalysis::fillHistograms(const art::Event& event) const
             unsigned short stopTDC  = tdcToIDEMap.rbegin()->first;
             
             // Convert to ticks to get in same units as hits
-            unsigned short startTick = fClockService->TPCTDC2Tick(startTDC)        + fOffsetVec[plane];
-            unsigned short stopTick  = fClockService->TPCTDC2Tick(stopTDC)         + fOffsetVec[plane];
-            unsigned short maxETick  = fClockService->TPCTDC2Tick(maxElectronsTDC) + fOffsetVec[plane];
+            unsigned short startTick = clockData.TPCTDC2Tick(startTDC)        + fOffsetVec[plane];
+            unsigned short stopTick  = clockData.TPCTDC2Tick(stopTDC)         + fOffsetVec[plane];
+            unsigned short maxETick  = clockData.TPCTDC2Tick(maxElectronsTDC) + fOffsetVec[plane];
 
             fSimNumTDCVec[plane]->Fill(stopTick - startTick, 1.);
     
@@ -718,7 +713,7 @@ void HitFinderAnalysis::fillHistograms(const art::Event& event) const
                             // Get the number of electrons
                             for(unsigned short tick = hitStartTickBest; tick <= hitStopTickBest; tick++)
                             {
-                                unsigned short hitTDC = fClockService->TPCTick2TDC(tick - fOffsetVec[plane]);
+                                unsigned short hitTDC = clockData.TPCTick2TDC(tick - fOffsetVec[plane]);
                         
                                 TDCToIDEMap::iterator ideIterator = tdcToIDEMap.find(hitTDC);
                         

--- a/icaruscode/Analysis/tools/IRawDigitHistogramTool.h
+++ b/icaruscode/Analysis/tools/IRawDigitHistogramTool.h
@@ -19,6 +19,10 @@
 #include "canvas/Persistency/Common/Ptr.h"
 #include "lardataobj/RawData/RawDigit.h"
 #include "lardataobj/Simulation/SimChannel.h"
+namespace detinfo {
+  class DetectorClocksData;
+  class DetectorPropertiesData;
+}
 
 class IRawDigitHistogramTool
 {
@@ -41,7 +45,9 @@ public:
      *  @param TFileService   handle to the TFile service
      *  @param string         subdirectory to store the hists in
      */
-    virtual void initializeHists(art::ServiceHandle<art::TFileService>&, const std::string&) = 0;
+    virtual void initializeHists(detinfo::DetectorClocksData const& clockData,
+                                 detinfo::DetectorPropertiesData const& detProp,
+                                 art::ServiceHandle<art::TFileService>&, const std::string&) = 0;
 
     /**
      *  @brief Interface for method to executve at the end of run processing
@@ -56,7 +62,9 @@ public:
     using RawDigitPtrVec = std::vector<art::Ptr<raw::RawDigit>>;
     using SimChannelMap  = std::map<raw::ChannelID_t, const sim::SimChannel*>;
     
-    virtual void fillHistograms(const RawDigitPtrVec&, const SimChannelMap&)  const = 0;
+    virtual void fillHistograms(const detinfo::DetectorClocksData&,
+                                const detinfo::DetectorPropertiesData&,
+                                const RawDigitPtrVec&, const SimChannelMap&)  const = 0;
 };
 
 #endif

--- a/icaruscode/Analysis/tools/MCTruth/AssociationsTruth_tool.cc
+++ b/icaruscode/Analysis/tools/MCTruth/AssociationsTruth_tool.cc
@@ -1,4 +1,3 @@
-
 #include "icaruscode/Analysis/tools/MCTruth/IMCTruthMatching.h"
 
 #include "icaruscode/gallery/MCTruthBase/MCTruthAssociations.h"
@@ -13,7 +12,6 @@
 #include "canvas/Persistency/Common/FindManyP.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/Utilities/AssociationUtil.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/AnalysisBase/BackTrackerMatchingData.h"
@@ -78,60 +76,71 @@ public:
     
     // Return a pointer to the simb::MCParticle object corresponding to
     // the given TrackID
-    const simb::MCParticle* TrackIDToParticle(int const& id)       const override {return fMCTruthAssociations.TrackIDToParticle(id);}
-    const simb::MCParticle* TrackIDToMotherParticle(int const& id) const override {return fMCTruthAssociations.TrackIDToMotherParticle(id);}
+    const simb::MCParticle* TrackIDToParticle(int const id)       const override {return fMCTruthAssociations.TrackIDToParticle(id);}
+    const simb::MCParticle* TrackIDToMotherParticle(int const id) const override {return fMCTruthAssociations.TrackIDToMotherParticle(id);}
     
     // Get art::Ptr<> to simb::MCTruth and related information
-    const art::Ptr<simb::MCTruth>&                TrackIDToMCTruth(int const& id)                        const override;
+    const art::Ptr<simb::MCTruth>&                TrackIDToMCTruth(int id)                               const override;
     const art::Ptr<simb::MCTruth>&                ParticleToMCTruth(const simb::MCParticle* p)           const override;
     std::vector<const simb::MCParticle*>          MCTruthToParticles(art::Ptr<simb::MCTruth> const& mct) const override;
     const std::vector< art::Ptr<simb::MCTruth> >& MCTruthVector()                                        const override;
     
     // this method will return the Geant4 track IDs of
     // the particles contributing ionization electrons to the identified hit
-    std::vector<sim::TrackIDE> HitToTrackID(recob::Hit const& hit)           const override;
-    std::vector<sim::TrackIDE> HitToTrackID(art::Ptr<recob::Hit> const& hit) const override;
+    std::vector<sim::TrackIDE> HitToTrackID(detinfo::DetectorClocksData const&,
+                                            recob::Hit const& hit)           const override;
+    std::vector<sim::TrackIDE> HitToTrackID(detinfo::DetectorClocksData const&,
+                                            art::Ptr<recob::Hit> const& hit) const override;
     
     // method to return a subset of allhits that are matched to a list of TrackIDs
-    const std::vector<std::vector<art::Ptr<recob::Hit>>> TrackIDsToHits(std::vector<art::Ptr<recob::Hit>> const& allhits,
+    std::vector<std::vector<art::Ptr<recob::Hit>>> TrackIDsToHits(detinfo::DetectorClocksData const& clockData,
+                                                                  std::vector<art::Ptr<recob::Hit>> const& allhits,
                                                                                 std::vector<int> const& tkIDs) const override;
     
     // method to return the EveIDs of particles contributing ionization
     // electrons to the identified hit
-    std::vector<sim::TrackIDE> HitToEveID(art::Ptr<recob::Hit> const& hit) const override;
-    
+    std::vector<sim::TrackIDE> HitToEveID(detinfo::DetectorClocksData const& clockData,
+                                          art::Ptr<recob::Hit> const& hit) const override;
+
     // method to return the XYZ position of the weighted average energy deposition for a given hit
-    std::vector<double>  HitToXYZ(art::Ptr<recob::Hit> const& hit) const override;
-    
+    std::vector<double> HitToXYZ(detinfo::DetectorClocksData const&,
+                                 art::Ptr<recob::Hit> const& hit) const override;
+
     // method to return the XYZ position of a space point (unweighted average XYZ of component hits).
-    std::vector<double> SpacePointToXYZ(art::Ptr<recob::SpacePoint> const& spt,
+    std::vector<double> SpacePointToXYZ(detinfo::DetectorClocksData const& clockData,
+                                        art::Ptr<recob::SpacePoint> const& spt,
                                         art::Event                  const& evt,
                                         std::string                 const& label) const override;
     
     // method to return the XYZ position of a space point (unweighted average XYZ of component hits).
-    std::vector<double> SpacePointHitsToXYZ(art::PtrVector<recob::Hit> const& hits) const override;
-    
+    std::vector<double> SpacePointHitsToXYZ(detinfo::DetectorClocksData const& clockData,
+                                            art::PtrVector<recob::Hit>  const& hits) const override;
+
     // method to return the fraction of hits in a collection that come from the specified Geant4 track ids
-    double HitCollectionPurity(std::set<int>                              trackIDs,
-                                       std::vector< art::Ptr<recob::Hit> > const& hits) const override;
-    
+    double HitCollectionPurity(detinfo::DetectorClocksData         const&,
+                               std::set<int>                       const& trackIDs,
+                               std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+
     // method to return the fraction of all hits in an event from a specific set of Geant4 track IDs that are
     // represented in a collection of hits
-    double HitCollectionEfficiency(std::set<int>                              trackIDs,
+    double HitCollectionEfficiency(detinfo::DetectorClocksData         const&,
+                                   std::set<int>                       const& trackIDs,
                                    std::vector< art::Ptr<recob::Hit> > const& hits,
                                    std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                   geo::View_t                         const& view) const override;
+                                   geo::View_t                         const  view) const override;
     
     // method to return the fraction of charge in a collection that come from the specified Geant4 track ids
-    double HitChargeCollectionPurity(std::set<int>                              trackIDs,
-                                             std::vector< art::Ptr<recob::Hit> > const& hits) const override;
-    
+  double HitChargeCollectionPurity(detinfo::DetectorClocksData         const&,
+                                   std::set<int>                       const& trackIDs,
+                                   std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+
     // method to return the fraction of all charge in an event from a specific set of Geant4 track IDs that are
     // represented in a collection of hits
-    double HitChargeCollectionEfficiency(std::set<int>                              trackIDs,
+    double HitChargeCollectionEfficiency(detinfo::DetectorClocksData         const&,
+                                         std::set<int>                       const& trackIDs,
                                          std::vector< art::Ptr<recob::Hit> > const& hits,
                                          std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                         geo::View_t                         const& view) const override;
+                                         geo::View_t                         const  view) const override;
     
     // method to return all EveIDs corresponding to the current sim::ParticleList
     std::set<int> GetSetOfEveIDs() const override;
@@ -140,10 +149,12 @@ public:
     std::set<int> GetSetOfTrackIDs() const override;
     
     // method to return all EveIDs corresponding to the given list of hits
-    std::set<int> GetSetOfEveIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const override;
-    
+    std::set<int> GetSetOfEveIDs(detinfo::DetectorClocksData const& clockData,
+                                 std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+
     // method to return all TrackIDs corresponding to the given list of hits
-    std::set<int> GetSetOfTrackIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+    std::set<int> GetSetOfTrackIDs(detinfo::DetectorClocksData const&,
+                                   std::vector< art::Ptr<recob::Hit> > const& hits) const override;
 
 private:
     
@@ -159,7 +170,6 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore*           fGeometry;             ///< pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;   ///< Detector properties service
 };
     
 //----------------------------------------------------------------------------
@@ -173,7 +183,6 @@ AssociationsTruth::AssociationsTruth(fhicl::ParameterSet const & pset) :
     fMCTruthAssociations(pset.get<fhicl::ParameterSet>("MCTruthAssociations"))
 {
     fGeometry           = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
     
     reconfigure(pset);
     
@@ -236,7 +245,7 @@ void AssociationsTruth::Rebuild(const art::Event& evt)
     MCTruthAssns mcTruthAssns(mcParticleHandle, evt, fG4ProducerLabel);
   
     // Pass this to the truth associations code
-    fMCTruthAssociations.setup(partHitAssnsVec, mcParticlePtrVec, mcTruthAssns, *fGeometry, *fDetectorProperties);
+    fMCTruthAssociations.setup(partHitAssnsVec, mcParticlePtrVec, mcTruthAssns, *fGeometry);
     
     // Ugliness to follow! Basically, we need to build the "particle list" and the current implementation of
     // that code requires a copy...
@@ -263,7 +272,7 @@ const sim::ParticleList& AssociationsTruth::ParticleList() const
 }
     
 //----------------------------------------------------------------------
-const art::Ptr<simb::MCTruth>& AssociationsTruth::TrackIDToMCTruth(int const& id) const
+const art::Ptr<simb::MCTruth>& AssociationsTruth::TrackIDToMCTruth(int const id) const
 {
     return fMCTruthAssociations.TrackIDToMCTruth(id);
 }
@@ -287,7 +296,8 @@ const std::vector< art::Ptr<simb::MCTruth> >&  AssociationsTruth::MCTruthVector(
 }
 
 //----------------------------------------------------------------------
-std::vector<sim::TrackIDE> AssociationsTruth::HitToTrackID(recob::Hit const& hit) const
+std::vector<sim::TrackIDE> AssociationsTruth::HitToTrackID(detinfo::DetectorClocksData const&,
+                                                           recob::Hit const& hit) const
 {
     std::vector<truth::TrackIDE> locTrackIDEVec = fMCTruthAssociations.HitToTrackID(&hit);
     std::vector<sim::TrackIDE>   outputVec;
@@ -300,14 +310,16 @@ std::vector<sim::TrackIDE> AssociationsTruth::HitToTrackID(recob::Hit const& hit
 }
 
 //----------------------------------------------------------------------
-std::vector<sim::TrackIDE> AssociationsTruth::HitToTrackID(art::Ptr<recob::Hit> const& hit) const
+std::vector<sim::TrackIDE> AssociationsTruth::HitToTrackID(detinfo::DetectorClocksData const& clockData,
+                                                           art::Ptr<recob::Hit> const& hit) const
 {
-    return HitToTrackID(*hit.get());
+    return HitToTrackID(clockData, *hit);
 }
 
 //----------------------------------------------------------------------
-const std::vector<std::vector<art::Ptr<recob::Hit>>> AssociationsTruth::TrackIDsToHits(std::vector<art::Ptr<recob::Hit>> const& allhits,
-                                                                                       std::vector<int> const& tkIDs) const
+std::vector<std::vector<art::Ptr<recob::Hit>>> AssociationsTruth::TrackIDsToHits(detinfo::DetectorClocksData const&,
+                                                                                 std::vector<art::Ptr<recob::Hit>> const& allhits,
+                                                                                 std::vector<int> const& tkIDs) const
 {
     return fMCTruthAssociations.TrackIDsToHits(allhits,tkIDs);
 }
@@ -316,7 +328,8 @@ const std::vector<std::vector<art::Ptr<recob::Hit>>> AssociationsTruth::TrackIDs
 // plist is assumed to have adopted the appropriate EveIdCalculator prior to
 // having been passed to this method. It is likely that the EmEveIdCalculator is
 // the one you always want to use
-std::vector<sim::TrackIDE> AssociationsTruth::HitToEveID(art::Ptr<recob::Hit> const& hit) const
+std::vector<sim::TrackIDE> AssociationsTruth::HitToEveID(detinfo::DetectorClocksData const&,
+                                                         art::Ptr<recob::Hit> const& hit) const
 {
     std::vector<truth::TrackIDE> locTrackIDEVec = fMCTruthAssociations.HitToEveID(hit);
     std::vector<sim::TrackIDE>   outputVec;
@@ -341,56 +354,66 @@ std::set<int> AssociationsTruth::GetSetOfTrackIDs() const
 }
     
 //----------------------------------------------------------------------
-std::set<int> AssociationsTruth::GetSetOfEveIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const
+std::set<int> AssociationsTruth::GetSetOfEveIDs(detinfo::DetectorClocksData const&,
+                                                std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     return fMCTruthAssociations.GetSetOfEveIDs(hits);
 }
     
 //----------------------------------------------------------------------
-std::set<int> AssociationsTruth::GetSetOfTrackIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const
+std::set<int> AssociationsTruth::GetSetOfTrackIDs(detinfo::DetectorClocksData const&,
+                                                  std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     return fMCTruthAssociations.GetSetOfTrackIDs(hits);
 }
     
 //----------------------------------------------------------------------
-double AssociationsTruth::HitCollectionPurity(std::set<int> trackIDs, std::vector< art::Ptr<recob::Hit> > const& hits) const
+double AssociationsTruth::HitCollectionPurity(detinfo::DetectorClocksData const&,
+                                              std::set<int> const& trackIDs,
+                                              std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     return fMCTruthAssociations.HitCollectionPurity(trackIDs, hits);
 }
     
 //----------------------------------------------------------------------
-double AssociationsTruth::HitChargeCollectionPurity(std::set<int> trackIDs, std::vector< art::Ptr<recob::Hit> > const& hits) const
+double AssociationsTruth::HitChargeCollectionPurity(detinfo::DetectorClocksData const&,
+                                                    std::set<int> const& trackIDs,
+                                                    std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     return fMCTruthAssociations.HitChargeCollectionPurity(trackIDs, hits);
 }
     
     
 //----------------------------------------------------------------------
-double AssociationsTruth::HitCollectionEfficiency(std::set<int>                              trackIDs,
+double AssociationsTruth::HitCollectionEfficiency(detinfo::DetectorClocksData         const&,
+                                                  std::set<int>                       const& trackIDs,
                                                   std::vector< art::Ptr<recob::Hit> > const& hits,
                                                   std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                                  geo::View_t const&                         view) const
+                                                  geo::View_t                         const  view) const
 {
     return fMCTruthAssociations.HitCollectionEfficiency(trackIDs, hits, allhits, view);
 }
     
 //----------------------------------------------------------------------
-double AssociationsTruth::HitChargeCollectionEfficiency(std::set<int>                              trackIDs,
+double AssociationsTruth::HitChargeCollectionEfficiency(detinfo::DetectorClocksData         const&,
+                                                        std::set<int>                       const& trackIDs,
                                                         std::vector< art::Ptr<recob::Hit> > const& hits,
                                                         std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                                        geo::View_t                         const& view) const
+                                                        geo::View_t                         const  view) const
 {
     return fMCTruthAssociations.HitChargeCollectionEfficiency(trackIDs, hits, allhits, view);
 }
     
 //----------------------------------------------------------------------
-std::vector<double> AssociationsTruth::HitToXYZ(art::Ptr<recob::Hit> const& hit) const
+std::vector<double> AssociationsTruth::HitToXYZ(detinfo::DetectorClocksData const&,
+                                                art::Ptr<recob::Hit> const& hit) const
 {
     return fMCTruthAssociations.HitToXYZ(hit);
 }
     
 //----------------------------------------------------------------------
-std::vector<double> AssociationsTruth::SpacePointToXYZ(art::Ptr<recob::SpacePoint> const& spt,
+std::vector<double> AssociationsTruth::SpacePointToXYZ(detinfo::DetectorClocksData const& clockData,
+                                                       art::Ptr<recob::SpacePoint> const& spt,
                                                        art::Event                  const& evt,
                                                        std::string                 const& label) const
 {
@@ -404,11 +427,12 @@ std::vector<double> AssociationsTruth::SpacePointToXYZ(art::Ptr<recob::SpacePoin
     art::PtrVector<recob::Hit> hits;
     for(size_t h = 0; h < hitv.size(); ++h) hits.push_back(hitv[h]);
     
-    return this->SpacePointHitsToXYZ(hits);
+    return this->SpacePointHitsToXYZ(clockData, hits);
 }
     
 //----------------------------------------------------------------------
-std::vector<double> AssociationsTruth::SpacePointHitsToXYZ(art::PtrVector<recob::Hit> const& hits) const
+std::vector<double> AssociationsTruth::SpacePointHitsToXYZ(detinfo::DetectorClocksData const&,
+                                                           art::PtrVector<recob::Hit>  const& hits) const
 {
     return fMCTruthAssociations.SpacePointHitsToXYZ(hits);
 }

--- a/icaruscode/Analysis/tools/MCTruth/BackTrackerTruth_tool.cc
+++ b/icaruscode/Analysis/tools/MCTruth/BackTrackerTruth_tool.cc
@@ -1,4 +1,3 @@
-
 #include "icaruscode/Analysis/tools/MCTruth/IMCTruthMatching.h"
 
 #include "fhiclcpp/ParameterSet.h"
@@ -12,7 +11,6 @@
 #include "canvas/Persistency/Common/FindManyP.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "larsim/MCCheater/BackTrackerService.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
@@ -73,60 +71,71 @@ public:
     
     // Return a pointer to the simb::MCParticle object corresponding to
     // the given TrackID
-    const simb::MCParticle* TrackIDToParticle(int const& id)       const override;
-    const simb::MCParticle* TrackIDToMotherParticle(int const& id) const override;
+    const simb::MCParticle* TrackIDToParticle(int const id)       const override;
+    const simb::MCParticle* TrackIDToMotherParticle(int const id) const override;
     
     // Get art::Ptr<> to simb::MCTruth and related information
-    const art::Ptr<simb::MCTruth>&                TrackIDToMCTruth(int const& id)                        const override;
+    const art::Ptr<simb::MCTruth>&                TrackIDToMCTruth(int const id)                        const override;
     const art::Ptr<simb::MCTruth>&                ParticleToMCTruth(const simb::MCParticle* p)           const override;
     std::vector<const simb::MCParticle*>          MCTruthToParticles(art::Ptr<simb::MCTruth> const& mct) const override;
     const std::vector< art::Ptr<simb::MCTruth> >& MCTruthVector()                                        const override;
     
     // this method will return the Geant4 track IDs of
     // the particles contributing ionization electrons to the identified hit
-    std::vector<sim::TrackIDE> HitToTrackID(recob::Hit const& hit)           const override;
-    std::vector<sim::TrackIDE> HitToTrackID(art::Ptr<recob::Hit> const& hit) const override;
+    std::vector<sim::TrackIDE> HitToTrackID(detinfo::DetectorClocksData const& clockData,
+                                            recob::Hit const& hit)           const override;
+    std::vector<sim::TrackIDE> HitToTrackID(detinfo::DetectorClocksData const& clockData,
+                                            art::Ptr<recob::Hit> const& hit) const override;
     
     // method to return a subset of allhits that are matched to a list of TrackIDs
-    const std::vector<std::vector<art::Ptr<recob::Hit>>> TrackIDsToHits(std::vector<art::Ptr<recob::Hit>> const& allhits,
-                                                                                std::vector<int> const& tkIDs) const override;
-    
+    std::vector<std::vector<art::Ptr<recob::Hit>>> TrackIDsToHits(detinfo::DetectorClocksData const& clockData,
+                                                                  std::vector<art::Ptr<recob::Hit>> const& allhits,
+                                                                  std::vector<int> const& tkIDs) const override;
+
     // method to return the EveIDs of particles contributing ionization
     // electrons to the identified hit
-    std::vector<sim::TrackIDE> HitToEveID(art::Ptr<recob::Hit> const& hit) const override;
-    
+    std::vector<sim::TrackIDE> HitToEveID(detinfo::DetectorClocksData const& clockData,
+                                          art::Ptr<recob::Hit>        const& hit) const override;
+
     // method to return the XYZ position of the weighted average energy deposition for a given hit
-    std::vector<double>  HitToXYZ(art::Ptr<recob::Hit> const& hit) const override;
-    
+    std::vector<double> HitToXYZ(detinfo::DetectorClocksData const& clockData,
+                                 art::Ptr<recob::Hit>        const& hit) const override;
+
     // method to return the XYZ position of a space point (unweighted average XYZ of component hits).
-    std::vector<double> SpacePointToXYZ(art::Ptr<recob::SpacePoint> const& spt,
-                                                art::Event                  const& evt,
-                                                std::string                 const& label) const override;
-    
+    std::vector<double> SpacePointToXYZ(detinfo::DetectorClocksData const&,
+                                        art::Ptr<recob::SpacePoint> const& spt,
+                                        art::Event                  const& evt,
+                                        std::string                 const& label) const override;
+
     // method to return the XYZ position of a space point (unweighted average XYZ of component hits).
-    std::vector<double> SpacePointHitsToXYZ(art::PtrVector<recob::Hit> const& hits) const override;
-    
+    std::vector<double> SpacePointHitsToXYZ(detinfo::DetectorClocksData const& clockData,
+                                            art::PtrVector<recob::Hit>  const& hits) const override;
+
     // method to return the fraction of hits in a collection that come from the specified Geant4 track ids
-    double HitCollectionPurity(std::set<int>                              trackIDs,
-                                       std::vector< art::Ptr<recob::Hit> > const& hits) const override;
-    
+    double HitCollectionPurity(detinfo::DetectorClocksData         const& clockData,
+                               std::set<int>                       const& trackIDs,
+                               std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+
     // method to return the fraction of all hits in an event from a specific set of Geant4 track IDs that are
     // represented in a collection of hits
-    double HitCollectionEfficiency(std::set<int>                              trackIDs,
-                                           std::vector< art::Ptr<recob::Hit> > const& hits,
-                                           std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                           geo::View_t                         const& view) const override;
+    double HitCollectionEfficiency(detinfo::DetectorClocksData         const& clockData,
+                                   std::set<int>                       const& trackIDs,
+                                   std::vector< art::Ptr<recob::Hit> > const& hits,
+                                   std::vector< art::Ptr<recob::Hit> > const& allhits,
+                                   geo::View_t                         const  view) const override;
     
     // method to return the fraction of charge in a collection that come from the specified Geant4 track ids
-    double HitChargeCollectionPurity(std::set<int>                              trackIDs,
-                                             std::vector< art::Ptr<recob::Hit> > const& hits) const override;
-    
+    double HitChargeCollectionPurity(detinfo::DetectorClocksData         const& clockData,
+                                     std::set<int>                       const& trackIDs,
+                                     std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+
     // method to return the fraction of all charge in an event from a specific set of Geant4 track IDs that are
     // represented in a collection of hits
-    double HitChargeCollectionEfficiency(std::set<int>                              trackIDs,
-                                                 std::vector< art::Ptr<recob::Hit> > const& hits,
-                                                 std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                                 geo::View_t                         const& view) const override;
+    double HitChargeCollectionEfficiency(detinfo::DetectorClocksData         const& clockData,
+                                         std::set<int>                       const& trackIDs,
+                                         std::vector< art::Ptr<recob::Hit> > const& hits,
+                                         std::vector< art::Ptr<recob::Hit> > const& allhits,
+                                         geo::View_t                         const  view) const override;
     
     // method to return all EveIDs corresponding to the current sim::ParticleList
     std::set<int> GetSetOfEveIDs() const override;
@@ -135,10 +144,12 @@ public:
     std::set<int> GetSetOfTrackIDs() const override;
     
     // method to return all EveIDs corresponding to the given list of hits
-    std::set<int> GetSetOfEveIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const override;
-    
+    std::set<int> GetSetOfEveIDs(detinfo::DetectorClocksData const& clockData,
+                                 std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+
     // method to return all TrackIDs corresponding to the given list of hits
-    std::set<int> GetSetOfTrackIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const override;
+    std::set<int> GetSetOfTrackIDs(detinfo::DetectorClocksData const& clockData,
+                                   std::vector< art::Ptr<recob::Hit> > const& hits) const override;
 
 private:
     
@@ -147,7 +158,6 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore*                      fGeometry;             ///< pointer to Geometry service
-    const detinfo::DetectorProperties*            fDetectorProperties;   ///< Detector properties service
 };
     
 //----------------------------------------------------------------------------
@@ -160,7 +170,6 @@ private:
 BackTrackerTruth::BackTrackerTruth(fhicl::ParameterSet const & pset)
 {
     fGeometry           = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
     
     reconfigure(pset);
     
@@ -194,21 +203,21 @@ const sim::ParticleList& BackTrackerTruth::ParticleList() const
 
     
 //----------------------------------------------------------------------
-const simb::MCParticle* BackTrackerTruth::TrackIDToParticle(int const& id) const
+const simb::MCParticle* BackTrackerTruth::TrackIDToParticle(int const id) const
 {
     art::ServiceHandle<cheat::ParticleInventoryService> partInventory;
     return partInventory->TrackIdToParticle_P(id);
 }
     
 //----------------------------------------------------------------------
-const simb::MCParticle* BackTrackerTruth::TrackIDToMotherParticle(int const& id) const
+const simb::MCParticle* BackTrackerTruth::TrackIDToMotherParticle(int const id) const
 {
     art::ServiceHandle<cheat::ParticleInventoryService> partInventory;
     return partInventory->TrackIdToMotherParticle_P(id);
 }
     
 //----------------------------------------------------------------------
-const art::Ptr<simb::MCTruth>& BackTrackerTruth::TrackIDToMCTruth(int const& id) const
+const art::Ptr<simb::MCTruth>& BackTrackerTruth::TrackIDToMCTruth(int const id) const
 {
     art::ServiceHandle<cheat::ParticleInventoryService> partInventory;
     return partInventory->TrackIdToMCTruth_P(id);
@@ -236,29 +245,31 @@ const std::vector< art::Ptr<simb::MCTruth> >&  BackTrackerTruth::MCTruthVector()
 }
 
 //----------------------------------------------------------------------
-std::vector<sim::TrackIDE> BackTrackerTruth::HitToTrackID(recob::Hit const& hit) const
+std::vector<sim::TrackIDE> BackTrackerTruth::HitToTrackID(detinfo::DetectorClocksData const& clockData,
+                                                          recob::Hit const& hit) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitToTrackIDEs(hit);
+    return backTracker->HitToTrackIDEs(clockData, hit);
 }
 
 //----------------------------------------------------------------------
-std::vector<sim::TrackIDE> BackTrackerTruth::HitToTrackID(art::Ptr<recob::Hit> const& hit) const
+std::vector<sim::TrackIDE> BackTrackerTruth::HitToTrackID(detinfo::DetectorClocksData const& clockData,
+                                                          art::Ptr<recob::Hit> const& hit) const
 {
-    art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitToTrackIDEs(*hit);
+    return HitToTrackID(clockData, *hit);
 }
 
 //----------------------------------------------------------------------
-const std::vector<std::vector<art::Ptr<recob::Hit>>> BackTrackerTruth::TrackIDsToHits(std::vector<art::Ptr<recob::Hit>> const& allhits,
-                                                                                 std::vector<int> const& tkIDs) const
+std::vector<std::vector<art::Ptr<recob::Hit>>> BackTrackerTruth::TrackIDsToHits(detinfo::DetectorClocksData const& clockData,
+                                                                                std::vector<art::Ptr<recob::Hit>> const& allhits,
+                                                                                std::vector<int> const& tkIDs) const
 {
     std::vector<std::vector<art::Ptr<recob::Hit>>> tkIDsToHitsVec;
     art::ServiceHandle<cheat::BackTrackerService>  backTracker;
 
     for(const auto& tkID : tkIDs)
     {
-        std::vector<art::Ptr<recob::Hit>> hitVec = backTracker->TrackIdToHits_Ps(tkID, allhits);
+        std::vector<art::Ptr<recob::Hit>> hitVec = backTracker->TrackIdToHits_Ps(clockData, tkID, allhits);
         tkIDsToHitsVec.push_back(hitVec);
     }
 
@@ -269,10 +280,11 @@ const std::vector<std::vector<art::Ptr<recob::Hit>>> BackTrackerTruth::TrackIDsT
 // plist is assumed to have adopted the appropriate EveIdCalculator prior to
 // having been passed to this method. It is likely that the EmEveIdCalculator is
 // the one you always want to use
-std::vector<sim::TrackIDE> BackTrackerTruth::HitToEveID(art::Ptr<recob::Hit> const& hit) const
+std::vector<sim::TrackIDE> BackTrackerTruth::HitToEveID(detinfo::DetectorClocksData const& clockData,
+                                                        art::Ptr<recob::Hit> const& hit) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitToEveTrackIDEs(hit);
+    return backTracker->HitToEveTrackIDEs(clockData, hit);
 }
     
 //----------------------------------------------------------------------
@@ -290,63 +302,73 @@ std::set<int> BackTrackerTruth::GetSetOfTrackIDs() const
 }
     
 //----------------------------------------------------------------------
-std::set<int> BackTrackerTruth::GetSetOfEveIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const
+std::set<int> BackTrackerTruth::GetSetOfEveIDs(detinfo::DetectorClocksData const& clockData,
+                                               std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->GetSetOfEveIds(hits);
+    return backTracker->GetSetOfEveIds(clockData, hits);
 }
     
 //----------------------------------------------------------------------
-std::set<int> BackTrackerTruth::GetSetOfTrackIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const
+std::set<int> BackTrackerTruth::GetSetOfTrackIDs(detinfo::DetectorClocksData const& clockData,
+                                                 std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->GetSetOfTrackIds(hits);
+    return backTracker->GetSetOfTrackIds(clockData, hits);
 }
     
 //----------------------------------------------------------------------
-double BackTrackerTruth::HitCollectionPurity(std::set<int> trackIDs, std::vector< art::Ptr<recob::Hit> > const& hits) const
+double BackTrackerTruth::HitCollectionPurity(detinfo::DetectorClocksData const& clockData,
+                                             std::set<int> const& trackIDs,
+                                             std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitCollectionPurity(trackIDs, hits);
+    return backTracker->HitCollectionPurity(clockData, trackIDs, hits);
 }
     
 //----------------------------------------------------------------------
-double BackTrackerTruth::HitChargeCollectionPurity(std::set<int> trackIDs, std::vector< art::Ptr<recob::Hit> > const& hits) const
+double BackTrackerTruth::HitChargeCollectionPurity(detinfo::DetectorClocksData const& clockData,
+                                                   std::set<int> const& trackIDs,
+                                                   std::vector< art::Ptr<recob::Hit> > const& hits) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitChargeCollectionPurity(trackIDs, hits);
+    return backTracker->HitChargeCollectionPurity(clockData, trackIDs, hits);
 }
     
     
 //----------------------------------------------------------------------
-double BackTrackerTruth::HitCollectionEfficiency(std::set<int> trackIDs,
-                                            std::vector< art::Ptr<recob::Hit> > const& hits,
-                                            std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                            geo::View_t const& view) const
+double BackTrackerTruth::HitCollectionEfficiency(detinfo::DetectorClocksData         const& clockData,
+                                                 std::set<int>                       const& trackIDs,
+                                                 std::vector< art::Ptr<recob::Hit> > const& hits,
+                                                 std::vector< art::Ptr<recob::Hit> > const& allhits,
+                                                 geo::View_t                         const  view) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitCollectionEfficiency(trackIDs, hits, allhits, view);
+    return backTracker->HitCollectionEfficiency(clockData, trackIDs, hits, allhits, view);
 }
     
 //----------------------------------------------------------------------
-double BackTrackerTruth::HitChargeCollectionEfficiency(std::set<int>                              trackIDs,
-                                                  std::vector< art::Ptr<recob::Hit> > const& hits,
-                                                  std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                                  geo::View_t                         const& view) const
+double BackTrackerTruth::HitChargeCollectionEfficiency(detinfo::DetectorClocksData         const& clockData,
+                                                       std::set<int>                       const& trackIDs,
+                                                       std::vector< art::Ptr<recob::Hit> > const& hits,
+                                                       std::vector< art::Ptr<recob::Hit> > const& allhits,
+                                                       geo::View_t                         const  view) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitChargeCollectionEfficiency(trackIDs, hits, allhits, view);
+    return backTracker->HitChargeCollectionEfficiency(clockData, trackIDs, hits, allhits, view);
 }
     
 //----------------------------------------------------------------------
-std::vector<double> BackTrackerTruth::HitToXYZ(art::Ptr<recob::Hit> const& hit) const
+std::vector<double> BackTrackerTruth::HitToXYZ(detinfo::DetectorClocksData const& clockData,
+                                               art::Ptr<recob::Hit> const& hit) const
 {
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->HitToXYZ(hit);
+    return backTracker->HitToXYZ(clockData, hit);
 }
     
 //----------------------------------------------------------------------
-std::vector<double> BackTrackerTruth::SpacePointToXYZ(art::Ptr<recob::SpacePoint>         const& spt,
+std::vector<double> BackTrackerTruth::SpacePointToXYZ(detinfo::DetectorClocksData         const&,
+                                                      art::Ptr<recob::SpacePoint>         const& spt,
                                                       art::Event                          const& evt,
                                                       std::string                         const& label) const
 {
@@ -359,13 +381,14 @@ std::vector<double> BackTrackerTruth::SpacePointToXYZ(art::Ptr<recob::SpacePoint
 }
     
 //----------------------------------------------------------------------
-std::vector<double> BackTrackerTruth::SpacePointHitsToXYZ(art::PtrVector<recob::Hit> const& hits) const
+std::vector<double> BackTrackerTruth::SpacePointHitsToXYZ(detinfo::DetectorClocksData const& clockData,
+                                                          art::PtrVector<recob::Hit>  const& hits) const
 {
     std::vector<art::Ptr<recob::Hit>> hitVec;
     for(size_t idx=0; idx<hits.size(); idx++) hitVec.push_back(hits.at(idx));
 
     art::ServiceHandle<cheat::BackTrackerService> backTracker;
-    return backTracker->SpacePointHitsToWeightedXYZ(hitVec);
+    return backTracker->SpacePointHitsToWeightedXYZ(clockData, hitVec);
 }
 
 //----------------------------------------------------------------------------

--- a/icaruscode/Analysis/tools/MCTruth/IMCTruthMatching.h
+++ b/icaruscode/Analysis/tools/MCTruth/IMCTruthMatching.h
@@ -25,6 +25,10 @@
 
 #include "lardataobj/RecoBase/Hit.h"
 
+namespace detinfo {
+  class DetectorClocksData;
+}
+
 namespace recob{
   class SpacePoint;
 }
@@ -63,60 +67,71 @@ public:
 
     // Return a pointer to the simb::MCParticle object corresponding to
     // the given TrackID
-    virtual const simb::MCParticle* TrackIDToParticle(int const& id)       const = 0;
-    virtual const simb::MCParticle* TrackIDToMotherParticle(int const& id) const = 0;
+    virtual const simb::MCParticle* TrackIDToParticle(int id)       const = 0;
+    virtual const simb::MCParticle* TrackIDToMotherParticle(int id) const = 0;
 
     // Get art::Ptr<> to simb::MCTruth and related information
-    virtual const art::Ptr<simb::MCTruth>&                TrackIDToMCTruth(int const& id)                        const = 0;
+    virtual const art::Ptr<simb::MCTruth>&                TrackIDToMCTruth(int id)                        const = 0;
     virtual const art::Ptr<simb::MCTruth>&                ParticleToMCTruth(const simb::MCParticle* p)           const = 0;
     virtual std::vector<const simb::MCParticle*>          MCTruthToParticles(art::Ptr<simb::MCTruth> const& mct) const = 0;
     virtual const std::vector< art::Ptr<simb::MCTruth> >& MCTruthVector()                                        const = 0;
 
     // this method will return the Geant4 track IDs of 
     // the particles contributing ionization electrons to the identified hit
-    virtual std::vector<sim::TrackIDE> HitToTrackID(recob::Hit const& hit)           const = 0;
-    virtual std::vector<sim::TrackIDE> HitToTrackID(art::Ptr<recob::Hit> const& hit) const = 0;
+    virtual std::vector<sim::TrackIDE> HitToTrackID(detinfo::DetectorClocksData const& clockData,
+                                                    recob::Hit const& hit)           const = 0;
+    virtual std::vector<sim::TrackIDE> HitToTrackID(detinfo::DetectorClocksData const& clockData,
+                                                    art::Ptr<recob::Hit> const& hit) const = 0;
     
     // method to return a subset of allhits that are matched to a list of TrackIDs
-    virtual const std::vector<std::vector<art::Ptr<recob::Hit>>> TrackIDsToHits(std::vector<art::Ptr<recob::Hit>> const& allhits,
-									std::vector<int> const& tkIDs) const = 0;
-    
+    virtual std::vector<std::vector<art::Ptr<recob::Hit>>> TrackIDsToHits(detinfo::DetectorClocksData const& clockData,
+                                                                          std::vector<art::Ptr<recob::Hit>> const& allhits,
+                                                                          std::vector<int> const& tkIDs) const = 0;
+
     // method to return the EveIDs of particles contributing ionization
     // electrons to the identified hit
-    virtual std::vector<sim::TrackIDE> HitToEveID(art::Ptr<recob::Hit> const& hit) const = 0;
-    
+    virtual std::vector<sim::TrackIDE> HitToEveID(detinfo::DetectorClocksData const& clockData,
+                                                  art::Ptr<recob::Hit> const& hit) const = 0;
+
     // method to return the XYZ position of the weighted average energy deposition for a given hit
-    virtual std::vector<double>  HitToXYZ(art::Ptr<recob::Hit> const& hit) const = 0;
-    
+    virtual std::vector<double> HitToXYZ(detinfo::DetectorClocksData const& clockData,
+                                          art::Ptr<recob::Hit> const& hit) const = 0;
+
     // method to return the XYZ position of a space point (unweighted average XYZ of component hits).
-    virtual std::vector<double> SpacePointToXYZ(art::Ptr<recob::SpacePoint> const& spt,
+    virtual std::vector<double> SpacePointToXYZ(detinfo::DetectorClocksData const& clockData,
+                                                art::Ptr<recob::SpacePoint> const& spt,
                                                 art::Event                  const& evt,
                                                 std::string                 const& label) const = 0;
 
     // method to return the XYZ position of a space point (unweighted average XYZ of component hits).
-    virtual std::vector<double> SpacePointHitsToXYZ(art::PtrVector<recob::Hit> const& hits) const = 0;
-    
-    // method to return the fraction of hits in a collection that come from the specified Geant4 track ids 
-    virtual double HitCollectionPurity(std::set<int>                              trackIDs,
+    virtual std::vector<double> SpacePointHitsToXYZ(detinfo::DetectorClocksData const& clockData,
+                                                    art::PtrVector<recob::Hit>  const& hits) const = 0;
+
+    // method to return the fraction of hits in a collection that come from the specified Geant4 track ids
+    virtual double HitCollectionPurity(detinfo::DetectorClocksData         const& clockData,
+                                       std::set<int>                       const& trackIDs,
                                        std::vector< art::Ptr<recob::Hit> > const& hits) const = 0;
     
     // method to return the fraction of all hits in an event from a specific set of Geant4 track IDs that are 
     // represented in a collection of hits
-    virtual double HitCollectionEfficiency(std::set<int>                              trackIDs,
+    virtual double HitCollectionEfficiency(detinfo::DetectorClocksData         const& clockData,
+                                           std::set<int>                       const& trackIDs,
                                            std::vector< art::Ptr<recob::Hit> > const& hits,
                                            std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                           geo::View_t                         const& view) const = 0;
+                                           geo::View_t                                view) const = 0;
 
-    // method to return the fraction of charge in a collection that come from the specified Geant4 track ids 
-    virtual double HitChargeCollectionPurity(std::set<int>                              trackIDs,
+    // method to return the fraction of charge in a collection that come from the specified Geant4 track ids
+    virtual double HitChargeCollectionPurity(detinfo::DetectorClocksData         const& clockData,
+                                             std::set<int>                       const& trackIDs,
                                              std::vector< art::Ptr<recob::Hit> > const& hits) const = 0;
     
     // method to return the fraction of all charge in an event from a specific set of Geant4 track IDs that are 
     // represented in a collection of hits
-    virtual double HitChargeCollectionEfficiency(std::set<int>                              trackIDs,
+    virtual double HitChargeCollectionEfficiency(detinfo::DetectorClocksData         const& clockData,
+                                                 std::set<int>                       const& trackIDs,
                                                  std::vector< art::Ptr<recob::Hit> > const& hits,
                                                  std::vector< art::Ptr<recob::Hit> > const& allhits,
-                                                 geo::View_t                         const& view) const = 0;
+                                                 geo::View_t                         const  view) const = 0;
   
     // method to return all EveIDs corresponding to the current sim::ParticleList
     virtual std::set<int> GetSetOfEveIDs() const = 0;
@@ -125,10 +140,12 @@ public:
     virtual std::set<int> GetSetOfTrackIDs() const = 0;
 
     // method to return all EveIDs corresponding to the given list of hits
-    virtual std::set<int> GetSetOfEveIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const = 0;
+    virtual std::set<int> GetSetOfEveIDs(detinfo::DetectorClocksData const& clockData,
+                                         std::vector< art::Ptr<recob::Hit> > const& hits) const = 0;
 
     // method to return all TrackIDs corresponding to the given list of hits
-    virtual std::set<int> GetSetOfTrackIDs(std::vector< art::Ptr<recob::Hit> > const& hits) const = 0;
+    virtual std::set<int> GetSetOfTrackIDs(detinfo::DetectorClocksData const& clockData,
+                                           std::vector< art::Ptr<recob::Hit> > const& hits) const = 0;
 };
     
 } // namespace

--- a/icaruscode/Analysis/tools/SpacePointAnalysis_tool.cc
+++ b/icaruscode/Analysis/tools/SpacePointAnalysis_tool.cc
@@ -1,4 +1,3 @@
-
 #include "icaruscode/Analysis/tools/IHitEfficiencyHistogramTool.h"
 
 #include "fhiclcpp/ParameterSet.h"
@@ -12,7 +11,7 @@
 #include "canvas/Persistency/Common/FindManyP.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 
@@ -57,7 +56,7 @@ namespace SpacePointAnalysis
     // Created by Tracy Usher (usher@slac.stanford.edu) on February 19, 2016
     //
     ////////////////////////////////////////////////////////////////////////
-    
+
 // The following typedefs will, obviously, be useful
 using HitPtrVec       = std::vector<art::Ptr<recob::Hit>>;
 using ViewHitMap      = std::map<size_t,HitPtrVec>;
@@ -172,13 +171,13 @@ private:
 };
 
 
-// Define object to keep track of hit/sim related tuple items 
+// Define object to keep track of hit/sim related tuple items
 class HitSimulationTupleObj
 {
 public:
     HitSimulationTupleObj() : fTree(nullptr) {}
 
-    void setBranches(TTree* tree) 
+    void setBranches(TTree* tree)
     {
         tree->Branch("TicksSimChannel",   "std::vector<int>",   &fTicksSimChannelVec);
         tree->Branch("TicksSimChanMost",  "std::vector<int>",   &fTicksSimChanMostVec);
@@ -194,7 +193,7 @@ public:
         tree->Branch("Multiplicity",      "std::vector<int>",   &fMultiplicityHitVec);       //< Multiplicity of the snippet the hit is on
         tree->Branch("LocalIndex",        "std::vector<int>",   &fLocalIndexHitVec);         //< The index of the hit within the snippet
         tree->Branch("TimeOrder",         "std::vector<int>",   &fTimeOrderHitVec);          //< Time order of the hit (selection variable)
-        tree->Branch("ChiSquare",         "std::vector<float>", &fChiSquareHitVec);          //< Chi square of fit 
+        tree->Branch("ChiSquare",         "std::vector<float>", &fChiSquareHitVec);          //< Chi square of fit
         tree->Branch("SummedADC",         "std::vector<float>", &fSummedADCHitVec);          //< Sum of all ADC values start/end of snippet
         tree->Branch("Integral",          "std::vector<float>", &fIntegralHitVec);           //< Integrated charge +/- n sigma about peak center
         tree->Branch("PulseHeight",       "std::vector<float>", &fPHHitVec);                 //< Pulse height of hit
@@ -317,12 +316,12 @@ public:
      *  @param  pset
      */
     explicit SpacePointAnalysis(fhicl::ParameterSet const & pset);
-    
+
     /**
      *  @brief  Destructor
      */
     ~SpacePointAnalysis();
-    
+
     // provide for initialization
     void configure(fhicl::ParameterSet const & pset) override;
 
@@ -347,17 +346,17 @@ public:
      *  @param int            number of events to use for normalization
      */
     void endJob(int numEvents) override;
-    
+
     /**
      *  @brief Interface for filling histograms
      */
     void fillHistograms(const art::Event&)  const override;
-    
+
 private:
-    
+
     // Clear mutable variables
     void clear() const;
-   
+
     // Create a struct allowing us to sort IDEs in a set by largest to smallest energy
     struct ideCompare
     {
@@ -377,7 +376,7 @@ private:
     using PlaneToTDCToIDESetMap    = std::map<unsigned short, TDCToIDESetMap>;
     using VoxelIDToPlaneTDCIDEMap  = std::map<sim::LArVoxelID, PlaneToTDCToIDESetMap>;
 
-    // The following creates a trackID mapping 
+    // The following creates a trackID mapping
     using TDCIDEPair               = std::pair<unsigned short, const sim::IDE*>;
     using TickTDCIDEVec            = std::vector<TDCIDEPair>;
     using ChanToTDCIDEMap          = std::unordered_map<raw::ChannelID_t,TickTDCIDEVec>;
@@ -398,9 +397,12 @@ private:
 
     void compareHitsToSim(const art::Event&, const ChanToTDCToIDEMap&, const ChanToChargeMap&, const ChanToTDCIDEMap&, const IDEToVoxelIDMap&, RecobHitToVoxelIDMap&) const;
 
-    void matchHitSim(const HitPointerVec&, const ChanToTDCToIDEMap&, const ChargeDepositVec&, const ChanToTDCIDEMap&, const IDEToVoxelIDMap&, RecobHitToVoxelIDMap&) const;
+    void matchHitSim(const detinfo::DetectorClocksData& clockData,
+                     const HitPointerVec&, const ChanToTDCToIDEMap&, const ChargeDepositVec&, const ChanToTDCIDEMap&, const IDEToVoxelIDMap&, RecobHitToVoxelIDMap&) const;
 
-    void compareSpacePointsToSim(const art::Event&, const RecobHitToVoxelIDMap&, const VoxelIDToPlaneTDCIDEMap&) const;
+    void compareSpacePointsToSim(const art::Event&,
+                                 const detinfo::DetectorClocksData& clockData,
+                                 const RecobHitToVoxelIDMap&, const VoxelIDToPlaneTDCIDEMap&) const;
 
     // Fcl parameters.
     std::vector<art::InputTag>  fRecobHitLabelVec;
@@ -412,10 +414,10 @@ private:
     std::vector<int>            fOffsetVec;              ///< Allow offsets for each plane
     float                       fSimChannelMinEnergy;
     float                       fSimEnergyMinEnergy;
-    
+
     // TTree variables
     mutable TTree*              fTree;
-    
+
     mutable std::vector<int>    fTPCVec;
     mutable std::vector<int>    fCryoVec;
     mutable std::vector<int>    fPlaneVec;
@@ -427,10 +429,8 @@ private:
 
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore*           fGeometry;             ///< pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;   ///< Detector properties service
-    const detinfo::DetectorClocks*     fClockService;         ///< Detector clocks service
 };
-    
+
 //----------------------------------------------------------------------------
 /// Constructor.
 ///
@@ -441,11 +441,9 @@ private:
 SpacePointAnalysis::SpacePointAnalysis(fhicl::ParameterSet const & pset) : fTree(nullptr)
 {
     fGeometry           = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    fClockService       = lar::providerFrom<detinfo::DetectorClocksService>();
-    
+
     configure(pset);
-    
+
     // Report.
     mf::LogInfo("SpacePointAnalysis") << "SpacePointAnalysis configured\n";
 }
@@ -485,7 +483,7 @@ void SpacePointAnalysis::initializeHists(art::ServiceHandle<art::TFileService>& 
 
     return;
 }
-    
+
 void SpacePointAnalysis::initializeTuple(TTree* tree)
 {
     // Access ART's TFileService, which will handle creating and writing
@@ -497,7 +495,7 @@ void SpacePointAnalysis::initializeTuple(TTree* tree)
     fTree->Branch("CryostataVec",       "std::vector<int>",   &fCryoVec);
     fTree->Branch("TPCVec",             "std::vector<int>",   &fTPCVec);
     fTree->Branch("PlaneVec",           "std::vector<int>",   &fPlaneVec);
-    
+
     // Set up specific branch for space points
     TTree* locTree = tfs->makeAndRegister<TTree>("SpacePoint_t","SpacePoint Tuple");
 
@@ -517,7 +515,7 @@ void SpacePointAnalysis::initializeTuple(TTree* tree)
 
     return;
 }
-    
+
 void SpacePointAnalysis::clear() const
 {
     fTPCVec.clear();
@@ -530,30 +528,30 @@ void SpacePointAnalysis::clear() const
 
     return;
 }
-     
+
 void SpacePointAnalysis::fillHistograms(const art::Event& event) const
 {
     // Ok... this is starting to grow too much and get out of control... we will need to break it up directly...
-    
+
     // Always clear the tuple
     clear();
-    
+
     art::Handle<std::vector<sim::SimChannel>> simChannelHandle;
     event.getByLabel(fSimChannelProducerLabel, simChannelHandle);
-    
+
     if (!simChannelHandle.isValid() || simChannelHandle->empty() ) return;
-    
+
     art::Handle<std::vector<sim::SimEnergyDeposit>> simEnergyHandle;
     event.getByLabel(fSimEnergyProducerLabel, simEnergyHandle);
-    
+
 //    if (!simEnergyHandle.isValid() || simEnergyHandle->empty()) return;
-    
+
     art::Handle<std::vector<simb::MCParticle>> mcParticleHandle;
     event.getByLabel(fMCParticleProducerLabel, mcParticleHandle);
 
     // If there is no sim channel informaton then exit
     if (!mcParticleHandle.isValid()) return;
-    
+
     mf::LogDebug("SpacePointAnalysis") << "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
 
     // First task is to build a map between ides and voxel ids (that we calcualate based on position)
@@ -579,9 +577,9 @@ void SpacePointAnalysis::fillHistograms(const art::Event& event) const
             for(const auto& ide : tdcide.second) //chanToTDCToIDEMap[simChannel.Channel()][tdcide.first] = ide;
             {
                 if (ide.energy < fSimChannelMinEnergy) continue;
-                
+
                 sim::LArVoxelID voxelID(ide.x,ide.y,ide.z,0.);
-                
+
                 ideToVoxelIDMap[&ide]    = voxelID;
                 voxelIDToIDEMap[voxelID].insert(&ide);
                 chanToTDCToIDEMap[simChannel.Channel()][tdcide.first].insert(&ide);
@@ -590,7 +588,7 @@ void SpacePointAnalysis::fillHistograms(const art::Event& event) const
                 trackIDChanToTDCIDEMap[ide.trackID][simChannel.Channel()].emplace_back(tdcide.first,&ide);
 
                 voxelIDToPlaneTDCIDEMap[voxelID][wireID.Plane][tdcide.first].insert(&ide);
-                
+
                 if (ide.energy < std::numeric_limits<float>::epsilon()) mf::LogDebug("SpacePointAnalysis") << ">> epsilon simchan deposited energy: " << ide.energy << std::endl;
             }
         }
@@ -610,7 +608,7 @@ void SpacePointAnalysis::fillHistograms(const art::Event& event) const
     // using the associated hits and would save time/memory)
     using VoxelIDSet           = std::set<sim::LArVoxelID>;
     using RecobHitToVoxelIDMap = std::unordered_map<const recob::Hit*, VoxelIDSet>;
-    
+
     RecobHitToVoxelIDMap recobHitToVoxelIDMap;
 
     ChanToTDCIDEMap& chanToTDCIDEMap = trackIDChanToTDCIDEMap[bestTrackID];
@@ -618,12 +616,13 @@ void SpacePointAnalysis::fillHistograms(const art::Event& event) const
     // Recover the "best" track info to start
     TrackToChanChargeMap::const_iterator chanToChargeMapItr = trackToChanChargeMap.find(bestTrackID);
 
-    // Process the hit/simulation 
+    // Process the hit/simulation
     compareHitsToSim(event, chanToTDCToIDEMap, chanToChargeMapItr->second, chanToTDCIDEMap, ideToVoxelIDMap, recobHitToVoxelIDMap);
 
     // Now do the space points
-    compareSpacePointsToSim(event, recobHitToVoxelIDMap, voxelIDToPlaneTDCIDEMap);
-    
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+    compareSpacePointsToSim(event, clockData, recobHitToVoxelIDMap, voxelIDToPlaneTDCIDEMap);
+
     // Make sure the output tuples are filled
     fHitSpacePointObj.fill();
 
@@ -632,7 +631,7 @@ void SpacePointAnalysis::fillHistograms(const art::Event& event) const
     return;
 }
 
-void SpacePointAnalysis::makeTrackToChanChargeMap(const TrackIDChanToTDCIDEMap& trackIDChanToTDCIDEMap, 
+void SpacePointAnalysis::makeTrackToChanChargeMap(const TrackIDChanToTDCIDEMap& trackIDChanToTDCIDEMap,
                                                   TrackToChanChargeMap&         trackToChanChargeMap,
                                                   float&                        bestTotDepEne,
                                                   int&                          bestTrackID) const
@@ -688,7 +687,7 @@ void SpacePointAnalysis::makeTrackToChanChargeMap(const TrackIDChanToTDCIDEMap& 
             chargeDepositVec.emplace_back(firstPair,peakPair,lastPair,snippetDepEne,snippetNumElectrons);
         }
 
-        if (trackTotDepE > bestTotDepEne) 
+        if (trackTotDepE > bestTotDepEne)
         {
             bestTrackID   = trackIDEPair.first;
             bestTotDepEne = trackTotDepE;
@@ -700,7 +699,7 @@ void SpacePointAnalysis::makeTrackToChanChargeMap(const TrackIDChanToTDCIDEMap& 
 
 void SpacePointAnalysis::compareHitsToSim(const art::Event&        event,                          // For recovering data from event store
                                           const ChanToTDCToIDEMap& chanToTDCToIDEMap,              // This gives us ability to retrieve total charge deposits
-                                          const ChanToChargeMap&   chanToChargeMap,                // Charge deposit for specific track 
+                                          const ChanToChargeMap&   chanToChargeMap,                // Charge deposit for specific track
                                           const ChanToTDCIDEMap&   chanToTDCIDEMap,                // Charge deposit for specific track
                                           const IDEToVoxelIDMap&   ideToVoxelIDMap,                // Mapping of ide info to voxels
                                           RecobHitToVoxelIDMap&    recobHitToVoxelIDMap) const     // The output info
@@ -733,10 +732,12 @@ void SpacePointAnalysis::compareHitsToSim(const art::Event&        event,       
                   [](const auto& left, const auto& right){return left->Channel() == right->Channel() ? left->PeakTime() < right->PeakTime() : left->Channel() < right->Channel();});
     }
 
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+
     // The idea is to loop over the input sim information so we can look at efficiency as well as resolution issues
     for(const auto& chanToChargePair : chanToChargeMap)
     {
-        // Recover the channel 
+        // Recover the channel
         raw::ChannelID_t channel = chanToChargePair.first;
 
         // Look up the hits associated to this channel
@@ -748,20 +749,20 @@ void SpacePointAnalysis::compareHitsToSim(const art::Event&        event,       
         // Recover channel information based on this hit
         const ChargeDepositVec& chargeDepositVec = chanToChargePair.second;
 
-        // Get the hits... 
+        // Get the hits...
         const HitPointerVec& hitPtrVec = chanToHitVecItr->second;
 
         short int lastSnippetStart(-1);
 
         HitPointerVec hitVec;
-        
+
         // Outer loop over hits in this hit collection
         for(const auto& hitPtr : hitPtrVec)
         {
-            // We want to collect together the hits that are on the same snippet. Hits will come grouped and in order 
+            // We want to collect together the hits that are on the same snippet. Hits will come grouped and in order
             // along the snippet, so we simply keep them in a local vector until we hit the end of the snippet...
             //
-            // ** It is worth noting this scheme as implemented will miss the last snippet of hits... so think about 
+            // ** It is worth noting this scheme as implemented will miss the last snippet of hits... so think about
             // that for the future
             short int snippetStart = hitPtr->StartTick();
 
@@ -770,12 +771,12 @@ void SpacePointAnalysis::compareHitsToSim(const art::Event&        event,       
                 lastSnippetStart = snippetStart;
 
                 hitVec.emplace_back(hitPtr);
-                
+
                 continue;
             }
 
             // Process the current list of hits (which will be on the same snippet)
-            matchHitSim(hitVec, chanToTDCToIDEMap, chargeDepositVec, chanToTDCIDEMap, ideToVoxelIDMap, recobHitToVoxelIDMap);
+            matchHitSim(clockData, hitVec, chanToTDCToIDEMap, chargeDepositVec, chanToTDCIDEMap, ideToVoxelIDMap, recobHitToVoxelIDMap);
 
             hitVec.clear();
             hitVec.emplace_back(hitPtr);
@@ -783,15 +784,16 @@ void SpacePointAnalysis::compareHitsToSim(const art::Event&        event,       
         }
 
         // Make sure to catch the last set of hits in the group
-        if (!hitVec.empty()) matchHitSim(hitVec, chanToTDCToIDEMap, chargeDepositVec, chanToTDCIDEMap, ideToVoxelIDMap, recobHitToVoxelIDMap);
+        if (!hitVec.empty()) matchHitSim(clockData, hitVec, chanToTDCToIDEMap, chargeDepositVec, chanToTDCIDEMap, ideToVoxelIDMap, recobHitToVoxelIDMap);
     }
 
     return;
 }
 
-void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,                  // Hits to match to simulation
+void SpacePointAnalysis::matchHitSim(const detinfo::DetectorClocksData& clockData,
+                                     const HitPointerVec&     hitPointerVec,                  // Hits to match to simulation
                                      const ChanToTDCToIDEMap& chanToTDCToIDEMap,              // This gives us ability to retrieve total charge deposits
-                                     const ChargeDepositVec&  chargeDepositVec,               // Charge deposit for specific track 
+                                     const ChargeDepositVec&  chargeDepositVec,               // Charge deposit for specific track
                                      const ChanToTDCIDEMap&   chanToTDCIDEMap,                // Charge deposit for specific track
                                      const IDEToVoxelIDMap&   ideToVoxelIDMap,                // Mapping of ide info to voxels
                                      RecobHitToVoxelIDMap&    recobHitToVoxelIDMap) const     // The output info
@@ -811,9 +813,9 @@ void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,    
         int startTick = std::max(   0,int(std::floor(hit->PeakTime() - 3. * hit->RMS())));
         int endTick   = std::min(4096,int(std::ceil(hit->PeakTime() + 3. * hit->RMS())));
 
-        int startTDC = fClockService->TPCTick2TDC(startTick - fOffsetVec[hit->WireID().Plane]);
-        int peakTDC  = fClockService->TPCTick2TDC(peakTick  - fOffsetVec[hit->WireID().Plane]);
-        int endTDC   = fClockService->TPCTick2TDC(endTick   - fOffsetVec[hit->WireID().Plane]);
+        int startTDC = clockData.TPCTick2TDC(startTick - fOffsetVec[hit->WireID().Plane]);
+        int peakTDC  = clockData.TPCTick2TDC(peakTick  - fOffsetVec[hit->WireID().Plane]);
+        int endTDC   = clockData.TPCTick2TDC(endTick   - fOffsetVec[hit->WireID().Plane]);
 
         maxPulseHeight = std::max(maxPulseHeight,hit->PeakAmplitude());
 
@@ -826,7 +828,7 @@ void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,    
         for(ChargeDepositVec::const_iterator chargeInfoItr = chargeDepositVec.begin(); chargeInfoItr != chargeDepositVec.end(); chargeInfoItr++)
         {
             // Require some amount of overlap between the hit and the sim info
-            if (endTDC > std::get<0>(*chargeInfoItr).first && startTDC < std::get<2>(*chargeInfoItr).first) 
+            if (endTDC > std::get<0>(*chargeInfoItr).first && startTDC < std::get<2>(*chargeInfoItr).first)
             {
                 const TDCIDEPair& peakTDCIDE = std::get<1>(*chargeInfoItr);
 
@@ -851,7 +853,7 @@ void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,    
         // Ok, now we sort this vector by smallest peak time
         std::sort(hitPeakTimeChargeVec.begin(),hitPeakTimeChargeVec.end(),[](const auto& left,const auto& right){return std::abs(std::get<0>(left)) < std::abs(std::get<0>(right));});
 
-        // Keep track of hit ordering on this snippet 
+        // Keep track of hit ordering on this snippet
         int hitOrder(0);
 
         HitSimulationTupleObj& hitObj = fHitSimObjVec[std::get<1>(hitPeakTimeChargeVec.front())->WireID().Plane];
@@ -867,9 +869,9 @@ void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,    
             int   startTick = std::max(   0,int(std::floor(hit->PeakTime() - 3. * hit->RMS())));
             int   endTick   = std::min(4096,int(std::ceil(hit->PeakTime() + 3. * hit->RMS())));
 
-            int   startTDC = fClockService->TPCTick2TDC(startTick - fOffsetVec[hit->WireID().Plane]);
-            int   peakTDC  = fClockService->TPCTick2TDC(peakTick  - fOffsetVec[hit->WireID().Plane]);
-            int   endTDC   = fClockService->TPCTick2TDC(endTick   - fOffsetVec[hit->WireID().Plane]);
+            int   startTDC = clockData.TPCTick2TDC(startTick - fOffsetVec[hit->WireID().Plane]);
+            int   peakTDC  = clockData.TPCTick2TDC(peakTick  - fOffsetVec[hit->WireID().Plane]);
+            int   endTDC   = clockData.TPCTick2TDC(endTick   - fOffsetVec[hit->WireID().Plane]);
 
             int   firstSimTick(std::get<0>(chargeDeposit).first);
             int   lastSimTick(std::get<2>(chargeDeposit).first);
@@ -877,7 +879,7 @@ void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,    
             float maxDepEneTick(std::get<1>(chargeDeposit).second->energy);
             float bestNumElectrons(std::get<4>(chargeDeposit));
             float bestDepEne(std::get<3>(chargeDeposit));
-            float totDepEne(0.); 
+            float totDepEne(0.);
             float totNumElectrons(0.);
             int   bestTicks(lastSimTick - firstSimTick + 1);
 
@@ -885,7 +887,7 @@ void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,    
             const TDCToIDEMap& tdcToIDEMap = chanToTDCToIDEMap.find(hit->Channel())->second;
             for(const auto& tdcToIDEPair : tdcToIDEMap)
             {
-                for(const auto& ide : tdcToIDEPair.second) 
+                for(const auto& ide : tdcToIDEPair.second)
                 {
                     totDepEne       += ide->energy;
                     totNumElectrons += ide->numElectrons;
@@ -954,7 +956,9 @@ void SpacePointAnalysis::matchHitSim(const HitPointerVec&     hitPointerVec,    
     return;
 }
 
-void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const RecobHitToVoxelIDMap& recobHitToVoxelIDMap, const VoxelIDToPlaneTDCIDEMap& voxelToPlaneTDCIDEMap) const
+void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event,
+                                                 const detinfo::DetectorClocksData& clockData,
+                                                 const RecobHitToVoxelIDMap& recobHitToVoxelIDMap, const VoxelIDToPlaneTDCIDEMap& voxelToPlaneTDCIDEMap) const
 {
     // Armed with these maps we can now process the SpacePoints...
     if (!recobHitToVoxelIDMap.empty())
@@ -970,7 +974,7 @@ void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const 
         {
             art::Handle< std::vector<recob::SpacePoint>> spacePointHandle;
             event.getByLabel(spacePointLabel, spacePointHandle);
-            
+
             if (!spacePointHandle.isValid()) continue;
 
             // Look up assocations to hits
@@ -981,15 +985,15 @@ void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const 
             for(size_t idx = 0; idx < spacePointHandle->size(); idx++)
             {
                 art::Ptr<recob::SpacePoint> spacePointPtr(spacePointHandle,idx);
-                
+
                 std::vector<art::Ptr<recob::Hit>> associatedHits(spHitAssnVec.at(spacePointPtr.key()));
-                
+
                 if (associatedHits.size() != 3)
                 {
                     mf::LogDebug("SpacePointAnalysis") << "I am certain this cannot happen... but here you go, space point with " << associatedHits.size() << " hits" << std::endl;
                     continue;
                 }
-                
+
                 // Retrieve the magic numbers from the space point
                 float spQuality   = spacePointPtr->Chisq();
                 float spCharge    = spacePointPtr->ErrXYZ()[1];
@@ -1000,7 +1004,7 @@ void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const 
                 float averagePH   = 0.;
                 float averagePT   = 0.;
                 float largestDelT = 0.;
-                
+
                 std::vector<int>            numIDEsHitVec;
                 std::vector<int>            simHitDeltaTVec = {0,0,0};
                 std::vector<float>          hitPeakTimeVec  = {-100.,-100.,-100.};
@@ -1013,18 +1017,18 @@ void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const 
                 std::vector<RecobHitToVoxelIDMap::const_iterator> recobHitToVoxelIterVec;
 
                 std::vector<const recob::Hit*> recobHitVec(3,nullptr);
-                
+
                 // Now we can use our maps to find out if the hits making up the SpacePoint are truly related...
                 for(const auto& hitPtr : associatedHits)
                 {
                     RecobHitToVoxelIDMap::const_iterator hitToVoxelItr = recobHitToVoxelIDMap.find(hitPtr.get());
-                    
+
                     float peakAmplitude = hitPtr->PeakAmplitude();
                     float peakTime      = hitPtr->PeakTime();
                     int   plane         = hitPtr->WireID().Plane;
 
                     recobHitVec[plane] = hitPtr.get();
-                    
+
                     numHits++;
                     averagePH += peakAmplitude;
                     averagePT += peakTime;
@@ -1033,60 +1037,60 @@ void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const 
                     largestPH  = std::max(peakAmplitude,largestPH);
 
                     if (hitPtr->DegreesOfFreedom() < 2) numLongHits++;
-                    
+
                     if (hitToVoxelItr == recobHitToVoxelIDMap.end())
                     {
                         numIDEsHitVec.push_back(0);
                         continue;
                     }
-                    
+
                     recobHitToVoxelIterVec.push_back(hitToVoxelItr);
                     numIDEsHitVec.push_back(hitToVoxelItr->second.size());
 
-                    hitPeakTimeVec[plane] = fClockService->TPCTick2TDC(peakTime);
+                    hitPeakTimeVec[plane] = clockData.TPCTick2TDC(peakTime);
                 }
 
                 Triplet hitTriplet(recobHitVec[0],recobHitVec[1],recobHitVec[2]);
 
                 tripletMap[hitTriplet].emplace_back(spacePointPtr.get());
-                
+
                 averagePH /= float(numHits);
                 averagePT /= float(numHits);
-                
+
                 for(const auto& hitPtr : associatedHits)
                 {
                     float delT = hitPtr->PeakTime() - averagePT;
-                    
+
                     if (std::abs(delT) > std::abs(largestDelT)) largestDelT = delT;
                 }
-                
+
                 // If a SpacePoint is made from "true" MC hits then we will have found the relations to the MC info for all three
                 // hits. If this condition is not satisfied it means one or more hits making the SpacePoint are noise hits
                 if (recobHitToVoxelIterVec.size() == 3)
                 {
                     // Find the intersection of the vectors of IDEs for the first two hits
                     std::vector<sim::LArVoxelID> firstIntersectionVec(recobHitToVoxelIterVec[0]->second.size()+recobHitToVoxelIterVec[1]->second.size());
-                    
+
                     std::vector<sim::LArVoxelID>::iterator firstIntersectionItr = std::set_intersection(recobHitToVoxelIterVec[0]->second.begin(),recobHitToVoxelIterVec[0]->second.end(),
                                                                                                         recobHitToVoxelIterVec[1]->second.begin(),recobHitToVoxelIterVec[1]->second.end(),
                                                                                                         firstIntersectionVec.begin());
-                    
+
                     firstIntersectionVec.resize(firstIntersectionItr - firstIntersectionVec.begin());
-                    
+
                     // No intersection means, of course, the hits did not come from the same MC energy deposit
                     if (!firstIntersectionVec.empty())
                     {
                         // Now find the intersection of the resultant intersection above and the third hit
                         std::vector<sim::LArVoxelID> secondIntersectionVec(firstIntersectionVec.size()+recobHitToVoxelIterVec[2]->second.size());
-                        
+
                         std::vector<sim::LArVoxelID>::iterator secondIntersectionItr = std::set_intersection(firstIntersectionVec.begin(),             firstIntersectionVec.end(),
                                                                                                              recobHitToVoxelIterVec[2]->second.begin(),recobHitToVoxelIterVec[2]->second.end(),
                                                                                                              secondIntersectionVec.begin());
-                        
+
                         secondIntersectionVec.resize(secondIntersectionItr - secondIntersectionVec.begin());
 
                         numIntersections++;
-                        
+
                         // Again, no IDEs in the intersection means it is a ghost space point but, of course, we are hoping
                         // there are common IDEs so we can call it a real SpacePoint
                         if (!secondIntersectionVec.empty())
@@ -1114,7 +1118,7 @@ void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const 
                                                     phBig  = ide->numElectrons;
                                                     tdcBig = tdcIDEPair.first;
                                                 }
-                                            } 
+                                            }
                                         }
 
                                         bigElecDepVec[plane] = phBig;
@@ -1175,12 +1179,12 @@ void SpacePointAnalysis::compareSpacePointsToSim(const art::Event& event, const 
     return;
 }
 
-    
+
 // Useful for normalizing histograms
 void SpacePointAnalysis::endJob(int numEvents)
 {
     return;
 }
-    
+
 DEFINE_ART_CLASS_TOOL(SpacePointAnalysis)
 }

--- a/icaruscode/CRT/CMakeLists.txt
+++ b/icaruscode/CRT/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(CRTUtils)
 add_subdirectory(CRTDecoder)
 
 art_make(
+    NO_PLUGINS
     EXCLUDE
         CRTChannelMapAlg.cxx
         CRTGeometryHelper_service.cc
@@ -17,7 +18,7 @@ art_make(
         CRTTrackProducer_module.cc
         CRTSimAnalysis_module.cc
         CRTDataAnalysis_module.cc
-	CrtOpHitMatchAnalysis_module.cc
+              CrtOpHitMatchAnalysis_module.cc
         CRTTruthMatchAnalysis_module.cc
         CRTAutoVeto_module.cc
         FlashResAna_module.cc
@@ -56,68 +57,48 @@ art_make_library(
         ${CETLIB}
 )
 
-simple_plugin( CRTGeometryHelper service
-        larcorealg_Geometry
-        icaruscode_CRT
-        ${ART_FRAMEWORK_CORE}
-        ${ART_FRAMEWORK_IO_SOURCES}
-        ${ART_FRAMEWORK_PRINCIPAL}
-        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-        canvas
-        cetlib_except
-        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-        ${MF_MESSAGELOGGER}
-        ${MF_UTILITIES}
-        ${ROOT_BASIC_LIB_LIST}
-        ${CETLIB}
+simple_plugin(CRTGeometryHelper service
+              larcorealg_Geometry
+              icaruscode_CRT
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
 )
 
-simple_plugin( CRTDetSim module
-        larcorealg_Geometry
-        icaruscode_CRT
-        icaruscode_CRTData
-        icaruscode_CRTProducts
-	icaruscode_CRTUtils
-        ${ART_FRAMEWORK_CORE}
-        ${ART_FRAMEWORK_IO_SOURCES}
-        ${ART_FRAMEWORK_PRINCIPAL}
-        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-        art_Persistency_Provenance
-        canvas
-        cetlib_except
-        lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-        nurandom_RandomUtils_NuRandomService_service
-        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-        ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
-        ${MF_MESSAGELOGGER}
-        ${MF_UTILITIES}
-        ${ROOT_BASIC_LIB_LIST}
-        ${CLHEP}
-        ${CETLIB}
+simple_plugin(CRTDetSim module
+              larcorealg_Geometry
+              icaruscode_CRT
+              icaruscode_CRTData
+              icaruscode_CRTProducts
+              icaruscode_CRTUtils
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              lardataalg_DetectorInfo
+              nurandom_RandomUtils_NuRandomService_service
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${CLHEP}
 )
 
-simple_plugin( CRTSimHitProducer module
-        larcorealg_Geometry
-        icaruscode_CRT
-        icaruscode_CRTData
-        icaruscode_CRTProducts
-        icaruscode_CRTUtils
-        ${ART_FRAMEWORK_CORE}
-        ${ART_FRAMEWORK_IO_SOURCES}
-        ${ART_FRAMEWORK_PRINCIPAL}
-        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-        art_Persistency_Provenance
-        canvas
-        cetlib_except
-        lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-        nurandom_RandomUtils_NuRandomService_service
-        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-        ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
-        ${MF_MESSAGELOGGER}
-        ${MF_UTILITIES}
-        ${ROOT_BASIC_LIB_LIST}
-        ${CLHEP}
-        ${CETLIB}
+simple_plugin(CRTSimHitProducer module
+              larcorealg_Geometry
+              icaruscode_CRT
+              icaruscode_CRTData
+              icaruscode_CRTProducts
+              icaruscode_CRTUtils
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              lardataalg_DetectorInfo
+              nurandom_RandomUtils_NuRandomService_service
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${CLHEP}
 )
 
 simple_plugin( CRTTrueHitProducer module
@@ -143,156 +124,110 @@ simple_plugin( CRTTrueHitProducer module
 )
 
 simple_plugin(CRTTzeroProducer module
-        larcorealg_Geometry
-        icaruscode_CRT
-        icaruscode_CRTData
-        icaruscode_CRTProducts
-        ${ART_FRAMEWORK_CORE}
-        ${ART_FRAMEWORK_IO_SOURCES}
-        ${ART_FRAMEWORK_PRINCIPAL}
-        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-        art_Persistency_Provenance
-        canvas
-        cetlib_except
-        lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-        nurandom_RandomUtils_NuRandomService_service
-        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-        ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
-        ${MF_MESSAGELOGGER}
-        ${MF_UTILITIES}
-        ${ROOT_BASIC_LIB_LIST}
-        ${CLHEP}
-        ${CETLIB}
+              larcorealg_Geometry
+              icaruscode_CRT
+              icaruscode_CRTData
+              icaruscode_CRTProducts
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              lardataalg_DetectorInfo
+              nurandom_RandomUtils_NuRandomService_service
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${CLHEP}
 )
 
 simple_plugin(CRTTrackProducer module
-        larcorealg_Geometry
-        icaruscode_CRT
-        icaruscode_CRTData
-        icaruscode_CRTProducts
-        icaruscode_CRTUtils
-        ${ART_FRAMEWORK_CORE}
-        ${ART_FRAMEWORK_IO_SOURCES}
-        ${ART_FRAMEWORK_PRINCIPAL}
-        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-        art_Persistency_Provenance
-        canvas
-        cetlib_except
-        lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-        nurandom_RandomUtils_NuRandomService_service
-        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-        ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
-        ${MF_MESSAGELOGGER}
-        ${MF_UTILITIES}
-        ${ROOT_BASIC_LIB_LIST}
-        ${CLHEP}
-        ${CETLIB}
+              larcorealg_Geometry
+              icaruscode_CRT
+              icaruscode_CRTData
+              icaruscode_CRTProducts
+              icaruscode_CRTUtils
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              lardataalg_DetectorInfo
+              nurandom_RandomUtils_NuRandomService_service
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${CLHEP}
 )
 
-simple_plugin( CRTSimAnalysis module
-                        icaruscode_CRTData
-                        icaruscode_CRT
-                        icaruscode_CRTProducts
-                        icaruscode_CRTUtils
-                        larcore_Geometry_Geometry_service
-                        larcorealg_Geometry
-                        nusimdata_SimulationBase
-                        ${ART_FRAMEWORK_CORE}
-                        ${ART_FRAMEWORK_PRINCIPAL}
-                        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-                        ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
-                        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-                        art_Persistency_Common
-                        art_Persistency_Provenance
-                        art_Utilities
-                        canvas
-                        ${MF_MESSAGELOGGER}
-                        ${MF_UTILITIES}
-                        cetlib cetlib_except
-                        ${ROOT_BASIC_LIB_LIST}
-                        ${ROOT_GEOM}
-                        ${ROOT_XMLIO}
-                        ${ROOT_GDML}              
-
+simple_plugin(CRTSimAnalysis module
+              icaruscode_CRTData
+              icaruscode_CRT
+              icaruscode_CRTProducts
+              icaruscode_CRTUtils
+              larcore_Geometry_Geometry_service
+              larcorealg_Geometry
+              nusimdata_SimulationBase
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${ROOT_GEOM}
+              ${ROOT_XMLIO}
+              ${ROOT_GDML}
 )
 
-simple_plugin( CRTDataAnalysis module
-                        icaruscode_CRTData
-                        icaruscode_CRT
-                        icaruscode_CRTProducts
-                        larcore_Geometry_Geometry_service
-                        larcorealg_Geometry
-                        nusimdata_SimulationBase
-                        ${ART_FRAMEWORK_CORE}
-                        ${ART_FRAMEWORK_PRINCIPAL}
-                        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-                        ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
-                        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-                        art_Persistency_Common
-                        art_Persistency_Provenance
-                        art_Utilities
-                        canvas
-                        ${MF_MESSAGELOGGER}
-                        ${MF_UTILITIES}
-                        cetlib cetlib_except
-                        ${ROOT_BASIC_LIB_LIST}
-                        ${ROOT_GEOM}
-                        ${ROOT_XMLIO}
-                        ${ROOT_GDML}              
+simple_plugin(CRTDataAnalysis module
+              icaruscode_CRTData
+              icaruscode_CRT
+              icaruscode_CRTProducts
+              larcore_Geometry_Geometry_service
+              larcorealg_Geometry
+              nusimdata_SimulationBase
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${ROOT_GEOM}
+              ${ROOT_XMLIO}
+              ${ROOT_GDML}
 )
 
-
-simple_plugin( CrtOpHitMatchAnalysis module
-                        icaruscode_CRTData
-                        icaruscode_CRT
-                        icaruscode_CRTProducts
-                        icaruscode_CRTUtils
-                        larcore_Geometry_Geometry_service
-                        larcorealg_Geometry
-                        nusimdata_SimulationBase
-			lardataobj_RecoBase
-                        #larsim_MCCheater_PhotonBackTrackerService_service
-                        ${ART_FRAMEWORK_CORE}
-                        ${ART_FRAMEWORK_PRINCIPAL}
-                        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-                        ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
-                        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-                        art_Persistency_Common
-                        art_Persistency_Provenance
-                        art_Utilities
-                        canvas
-		        lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-                        ${MF_MESSAGELOGGER}
-                        ${MF_UTILITIES}
-                        cetlib cetlib_except
-                        ${ROOT_BASIC_LIB_LIST}
-
+simple_plugin(CrtOpHitMatchAnalysis module
+              icaruscode_CRTData
+              icaruscode_CRT
+              icaruscode_CRTProducts
+              icaruscode_CRTUtils
+              larcore_Geometry_Geometry_service
+              larcorealg_Geometry
+              nusimdata_SimulationBase
+              lardataobj_RecoBase
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              lardataalg_DetectorInfo
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
 )
 
-simple_plugin( CRTTruthMatchAnalysis module
-                        icaruscode_CRTData
-                        icaruscode_CRT
-                        icaruscode_CRTProducts
-                        icaruscode_CRTUtils
-                        larcore_Geometry_Geometry_service
-                        larcorealg_Geometry
-                        nusimdata_SimulationBase
-                        ${ART_FRAMEWORK_CORE}
-                        ${ART_FRAMEWORK_PRINCIPAL}
-                        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-                        ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
-                        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-                        art_Persistency_Common
-                        art_Persistency_Provenance
-                        art_Utilities
-                        canvas
-                        ${MF_MESSAGELOGGER}
-                        ${MF_UTILITIES}
-                        cetlib cetlib_except
-                        ${ROOT_BASIC_LIB_LIST}
-                        ${ROOT_GEOM}
-                        ${ROOT_XMLIO}
-                        ${ROOT_GDML}              
+simple_plugin(CRTTruthMatchAnalysis module
+              icaruscode_CRTData
+              icaruscode_CRT
+              icaruscode_CRTProducts
+              icaruscode_CRTUtils
+              larcore_Geometry_Geometry_service
+              larcorealg_Geometry
+              nusimdata_SimulationBase
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${ROOT_GEOM}
+              ${ROOT_XMLIO}
+              ${ROOT_GDML}
 )
 
 simple_plugin( CRTAutoVeto module

--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -10,7 +10,6 @@
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Cluster.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larcore/Geometry/Geometry.h"
 #include "larcorealg/Geometry/GeometryCore.h"
@@ -254,10 +253,9 @@ namespace crt {
     // Get a pointer to the geometry service provider.
     fGeometryService = lar::providerFrom<geo::Geometry>();
     // The same for detector TDC clock services.
-    //fTimeService = lar::providerFrom<detinfo::DetectorClocksService>();
     // Access to detector properties.
-    const detinfo::DetectorProperties* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    fTriggerOffset = detprop->TriggerOffset();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    fTriggerOffset = trigger_offset(clockData);
   }
 
   void CRTDataAnalysis::FillFebMap() { 

--- a/icaruscode/CRT/CRTDetSim_module.cc
+++ b/icaruscode/CRT/CRTDetSim_module.cc
@@ -171,12 +171,13 @@ void icarus::crt::CRTDetSim::produce(art::Event& event) {
         <<"Number of AuxDetChannels = " << adChanList.size();
 
     int nide=0;
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(event);
     for(auto const& adsc : adChanList) {
 
         auto const& auxDetIDEs = adsc->AuxDetIDEs();
         if(auxDetIDEs.size()>0) {
             nide++;
-            detAlg.FillTaggers(adsc->AuxDetID(), adsc->AuxDetSensitiveID(), auxDetIDEs);
+            detAlg.FillTaggers(clockData, adsc->AuxDetID(), adsc->AuxDetSensitiveID(), auxDetIDEs);
         }
 
     }//loop over AuxDetSimChannels

--- a/icaruscode/CRT/CRTSimAnalysis_module.cc
+++ b/icaruscode/CRT/CRTSimAnalysis_module.cc
@@ -11,7 +11,6 @@
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Cluster.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larcore/Geometry/Geometry.h"
 #include "larcorealg/Geometry/GeometryCore.h"
@@ -337,13 +336,9 @@ namespace crt {
     , bt(p.get<fhicl::ParameterSet>("CRTBackTrack"))
     , fCrtutils(new CRTCommonUtils())
   {
-    // Get a pointer to the geometry service provider.
     fGeometryService = lar::providerFrom<geo::Geometry>();
-    // The same for detector TDC clock services.
-    //fTimeService = lar::providerFrom<detinfo::DetectorClocksService>();
-    // Access to detector properties.
-    const detinfo::DetectorProperties* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    fTriggerOffset = detprop->TriggerOffset();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    fTriggerOffset = sampling_rate(clockData);
   }
   
   //-----------------------------------------------------------------------

--- a/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
@@ -465,11 +465,11 @@ namespace icarus{
     // the number of ides from the end of the vector to include in the detector sim.
     // handles deposited energy -> light output at SiPM (including attenuation) 
     // -> PEs from the SiPM (or PMT in case of bottom CRT) with associated time stamps
-    void CRTDetSimAlg::FillTaggers(const uint32_t adid, const uint32_t adsid, const vector<sim::AuxDetIDE>& ides) {
+    void CRTDetSimAlg::FillTaggers(detinfo::DetectorClocksData const& clockData,
+                                   const uint32_t adid, const uint32_t adsid, const vector<sim::AuxDetIDE>& ides) {
 
         art::ServiceHandle<geo::Geometry> geoService;
-        art::ServiceHandle<detinfo::DetectorClocksService> detClocks;
-        detinfo::ElecClock trigClock = detClocks->provider()->TriggerClock();
+        detinfo::ElecClock trigClock = clockData.TriggerClock();
         fHasFilledTaggers = true;
 
         const geo::AuxDetGeo& adGeo = geoService->AuxDet(adid); //pointer to module object
@@ -861,8 +861,8 @@ namespace icarus{
         double t = t0 + tProp + tDelay;
     
         // Get clock ticks
-        clock.SetTime(t / 1e3);  // SetTime takes microseconds
-    
+        clock = clock.WithTime(t / 1e3);  // WithTime takes microseconds
+
         if (fUltraVerbose) mf::LogInfo("CRT")
           << "CRT TIMING: t0=" << t0
           << ", tDelayMean=" << tDelayMean << ", tDelayRMS=" << tDelayRMS

--- a/icaruscode/CRT/CRTUtils/CRTDetSimAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTDetSimAlg.h
@@ -7,7 +7,7 @@
 #include "nurandom/RandomUtils/NuRandomService.h"
 
 //larsoft includes
-#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
 #include "lardataalg/DetectorInfo/ElecClock.h"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
 #include "larcore/Geometry/Geometry.h"
@@ -75,7 +75,8 @@ class icarus::crt::CRTDetSimAlg {
 
     void ClearTaggers();
     //given a vector of AuxDetIDEs, fill a map of tagger objects with intermediate ChannelData + aux info
-    void FillTaggers(const uint32_t adid, const uint32_t adsid, const vector<AuxDetIDE>& ides);
+    void FillTaggers(detinfo::DetectorClocksData const& clockData,
+                     const uint32_t adid, const uint32_t adsid, const vector<AuxDetIDE>& ides);
     vector<pair<CRTData, vector<AuxDetIDE>>> CreateData();
 
 

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -7,23 +7,15 @@ CRTHitRecoAlg::CRTHitRecoAlg(const Config& config){
     this->reconfigure(config);
   
     fGeometryService  = lar::providerFrom<geo::Geometry>();
-    fDetectorClocks   = lar::providerFrom<detinfo::DetectorClocksService>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    fTrigClock = fDetectorClocks->TriggerClock();
     fCrtutils = new CRTCommonUtils();
 }
 
 //---------------------------------------------------------------------
 CRTHitRecoAlg::CRTHitRecoAlg(){
     fGeometryService = lar::providerFrom<geo::Geometry>();
-    fDetectorClocks = lar::providerFrom<detinfo::DetectorClocksService>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    fTrigClock = fDetectorClocks->TriggerClock();
     fCrtutils = new CRTCommonUtils();
 }
 
-
-CRTHitRecoAlg::~CRTHitRecoAlg(){}
 
 //---------------------------------------------------------------------
 void CRTHitRecoAlg::reconfigure(const Config& config){

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -1,4 +1,3 @@
-
 #ifndef CRTHITRECOALG_H_SEEN
 #define CRTHITRECOALG_H_SEEN
 ////////////////////////////////////////////////////////////////////
@@ -27,8 +26,6 @@
 #include "lardataobj/RecoBase/Track.h"
 #include "larcore/Geometry/Geometry.h"
 #include "larcorealg/Geometry/GeometryCore.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
-#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
 #include "larcore/Geometry/AuxDetGeometry.h"
 
@@ -109,9 +106,8 @@ class icarus::crt::CRTHitRecoAlg {
   //constructors
   CRTHitRecoAlg(const Config& config);
   CRTHitRecoAlg(const fhicl::ParameterSet& pset) :
-    CRTHitRecoAlg(fhicl::Table<Config>(pset, {})()) {}
-  CRTHitRecoAlg();  //default copy constructor
-  ~CRTHitRecoAlg(); //default desctructor
+    CRTHitRecoAlg{fhicl::Table<Config>{pset}()} {}
+  CRTHitRecoAlg();
 
   //configure module from fcl file
   void reconfigure(const Config& config);
@@ -125,11 +121,7 @@ class icarus::crt::CRTHitRecoAlg {
 
  private:
 
-  //pointers to services
   geo::GeometryCore const* fGeometryService;
-  detinfo::DetectorClocks const* fDetectorClocks;
-  detinfo::DetectorProperties const* fDetectorProperties;
-  detinfo::ElecClock fTrigClock;
 
   CRTCommonUtils* fCrtutils;
 

--- a/icaruscode/Decode/DaqDecoderICARUSTPC_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSTPC_module.cc
@@ -40,7 +40,7 @@
 #include "tbb/concurrent_vector.h"
 
 #include "larcore/Geometry/Geometry.h"
-
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataobj/RawData/RawDigit.h"
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/PhysCrateFragment.hh"
@@ -72,19 +72,23 @@ public:
     using ConcurrentRawDigitCol = tbb::concurrent_vector<raw::RawDigit>;
 
     // Function to do the work
-    void processSingleFragment(size_t, art::Handle<artdaq::Fragments>, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&) const;
+    void processSingleFragment(size_t,
+                               detinfo::DetectorClocksData const& clockData,
+                               art::Handle<artdaq::Fragments>, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&) const;
 
 private:
- 
-    class multiThreadFragmentProcessing 
+
+    class multiThreadFragmentProcessing
     {
     public:
         multiThreadFragmentProcessing(DaqDecoderICARUSTPC const&        parent,
-                                      art::Handle<artdaq::Fragments>& fragmentsHandle, 
+                                      detinfo::DetectorClocksData const& clockData,
+                                      art::Handle<artdaq::Fragments>& fragmentsHandle,
                                       ConcurrentRawDigitCol&          rawDigitCollection,
                                       ConcurrentRawDigitCol&          rawRawDigitCollection,
                                       ConcurrentRawDigitCol&          coherentCollection)
             : fDaqDecoderICARUSTPC(parent),
+              fClockData{clockData},
               fFragmentsHandle(fragmentsHandle),
               fRawDigitCollection(rawDigitCollection),
               fRawRawDigitCollection(rawRawDigitCollection),
@@ -94,10 +98,11 @@ private:
         void operator()(const tbb::blocked_range<size_t>& range) const
         {
             for (size_t idx = range.begin(); idx < range.end(); idx++)
-                fDaqDecoderICARUSTPC.processSingleFragment(idx, fFragmentsHandle, fRawDigitCollection, fRawRawDigitCollection, fCoherentCollection);
+              fDaqDecoderICARUSTPC.processSingleFragment(idx, fClockData, fFragmentsHandle, fRawDigitCollection, fRawRawDigitCollection, fCoherentCollection);
         }
     private:
         const DaqDecoderICARUSTPC&        fDaqDecoderICARUSTPC;
+        detinfo::DetectorClocksData const& fClockData;
         art::Handle<artdaq::Fragments>& fFragmentsHandle;
         ConcurrentRawDigitCol&          fRawDigitCollection;
         ConcurrentRawDigitCol&          fRawRawDigitCollection;
@@ -264,9 +269,11 @@ void DaqDecoderICARUSTPC::produce(art::Event & event, art::ProcessingFrame const
     ConcurrentRawDigitCol coherentRawDigits;
 
     // ... Launch multiple threads with TBB to do the deconvolution and find ROIs in parallel
-    multiThreadFragmentProcessing fragmentProcessing(*this, 
-                                                     daq_handle, 
-                                                     concurrentRawDigits, 
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(event);
+    multiThreadFragmentProcessing fragmentProcessing(*this,
+                                                     clockData,
+                                                     daq_handle,
+                                                     concurrentRawDigits,
                                                      concurrentRawRawDigits,
                                                      coherentRawDigits);
 
@@ -315,7 +322,8 @@ void DaqDecoderICARUSTPC::produce(art::Event & event, art::ProcessingFrame const
     return;
 }
 
-void DaqDecoderICARUSTPC::processSingleFragment(size_t                         idx, 
+void DaqDecoderICARUSTPC::processSingleFragment(size_t                         idx,
+                                                detinfo::DetectorClocksData const& clockData,
                                               art::Handle<artdaq::Fragments> fragmentHandle,
                                               ConcurrentRawDigitCol&         rawDigitCollection,
                                               ConcurrentRawDigitCol&         rawRawDigitCollection,
@@ -334,7 +342,7 @@ void DaqDecoderICARUSTPC::processSingleFragment(size_t                         i
     IDecoderFilter* decoderTool = fDecoderToolVec[tbb::this_task_arena::current_thread_index()].get();
 
     //process_fragment(event, rawfrag, product_collection, header_collection);
-    decoderTool->process_fragment(*fragmentPtr);
+    decoderTool->process_fragment(clockData, *fragmentPtr);
 
     // Useful numerology
     // convert fragment to Nevis fragment

--- a/icaruscode/Decode/DecoderTools/CMakeLists.txt
+++ b/icaruscode/Decode/DecoderTools/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cet_enable_asserts()
 
 cet_find_library(LIBWDA NAMES wda PATHS ENV LIBWDA_LIB NO_DEFAULT_PATH)
@@ -14,6 +13,7 @@ art_make(
                         larcorealg_Geometry
                         larcore_Geometry_Geometry_service
                         lardata_Utilities
+                        lardataalg_DetectorInfo
                         larevt_Filters
                         lardataobj_RawData
                         lardata_ArtDataHelper

--- a/icaruscode/Decode/DecoderTools/FakeParticle_tool.cc
+++ b/icaruscode/Decode/DecoderTools/FakeParticle_tool.cc
@@ -65,7 +65,8 @@ public:
      *
      *  @param waveforms  The waveform container to place fake particle on
      */
-    virtual void overlayFakeParticle(ArrayFloat& waveforms) override; 
+    virtual void overlayFakeParticle(detinfo::DetectorClocksData const& clockData,
+                                     ArrayFloat& waveforms) override;
 
 private:
 
@@ -119,12 +120,13 @@ void FakeParticle::configure(fhicl::ParameterSet const &pset)
     fPlaneToSimulate   = pset.get<size_t             >("PlaneToSimulate",                            2);
                                   
     fGeometry           = art::ServiceHandle<geo::Geometry const>{}.get();
-    fDetector           = lar::providerFrom<detinfo::DetectorPropertiesService>();
     fSignalShapingService = art::ServiceHandle<icarusutil::SignalShapingICARUSService>{}.get();
 
     // Convert ticks in us to mm by taking the drift velocity and multiplying by the tick period
-    double driftVelocity = fDetector->DriftVelocity() * 10.;   // should be mm/us
-    double samplingRate  = fDetector->SamplingRate() / 1000.;  // sampling rate returned in ns
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob(clockData);
+    double driftVelocity = detProp.DriftVelocity() * 10.;   // should be mm/us
+    double samplingRate  = sampling_rate(clockData) / 1000.;  // sampling rate returned in ns
 
     fMMPerTick = driftVelocity * samplingRate;
 
@@ -167,7 +169,7 @@ void FakeParticle::configure(fhicl::ParameterSet const &pset)
     return;
 }
 
-void FakeParticle::overlayFakeParticle(ArrayFloat& waveforms)
+void FakeParticle::overlayFakeParticle(detinfo::DetectorClocksData const& clockData, ArrayFloat& waveforms)
 {
     // We have assumed the input waveform array will have 576 wires... 
     // Our "range" must be contained within that. By assumption we start at wire 0, so really just need
@@ -178,7 +180,7 @@ void FakeParticle::overlayFakeParticle(ArrayFloat& waveforms)
 //    icarusutil::TimeVec tempWaveform(waveforms[0].size(),0.);
 
     // Also recover the gain
-    float asicGain = fSignalShapingService->GetASICGain(0) * fDetector->SamplingRate() / 1000.;  // something like 67.4
+    float asicGain = fSignalShapingService->GetASICGain(0) * sampling_rate(clockData) / 1000.;  // something like 67.4
 
     // Get a base channel number for the plane we want
     raw::ChannelID_t channel = fGeometry->PlaneWireToChannel(fPlaneToSimulate, 0);

--- a/icaruscode/Decode/DecoderTools/IDecoderFilter.h
+++ b/icaruscode/Decode/DecoderTools/IDecoderFilter.h
@@ -16,6 +16,9 @@
 
 // Algorithm includes
 #include "artdaq-core/Data/Fragment.hh"
+namespace detinfo {
+  class DetectorClocksData;
+}
 
 #include "icarus_signal_processing/ICARUSSigProcDefs.h"
 
@@ -46,7 +49,8 @@ public:
      *
      *  @param fragment            The artdaq fragment to process
      */
-    virtual void process_fragment(const artdaq::Fragment& fragment) = 0; 
+    virtual void process_fragment(detinfo::DetectorClocksData const& clockData,
+                                  const artdaq::Fragment& fragment) = 0;
 
     /**
      *  @brief Recover the channels for the processed fragment

--- a/icaruscode/Decode/DecoderTools/IFakeParticle.h
+++ b/icaruscode/Decode/DecoderTools/IFakeParticle.h
@@ -16,6 +16,9 @@
 
 // Algorithm includes
 #include "artdaq-core/Data/Fragment.hh"
+namespace detinfo {
+  class DetectorClocksData;
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -48,7 +51,8 @@ public:
     using VectorFloat  = std::vector<float>;
     using ArrayShort   = std::vector<VectorShort>;
     using ArrayFloat   = std::vector<VectorFloat>;
-    virtual void overlayFakeParticle(ArrayFloat& waveforms) = 0; 
+    virtual void overlayFakeParticle(detinfo::DetectorClocksData const& clockData,
+                                     ArrayFloat& waveforms) = 0;
 };
 
 } // namespace daq

--- a/icaruscode/Decode/DecoderTools/TPCDecoderFilter1D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCDecoderFilter1D_tool.cc
@@ -19,7 +19,6 @@
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/PhysCrateFragment.hh"
 
@@ -68,7 +67,8 @@ public:
      *
      *  @param fragment            The artdaq fragment to process
      */
-    virtual void process_fragment(const artdaq::Fragment&) override;
+    virtual void process_fragment(detinfo::DetectorClocksData const&,
+                                  const artdaq::Fragment&) override;
 
     /**
      *  @brief Recover the channels for the processed fragment
@@ -173,7 +173,6 @@ private:
     database::TPCReadoutBoardToChannelMap fReadoutBoardToChannelMap;
 
     const geo::Geometry*                  fGeometry;              //< pointer to the Geometry service
-    const detinfo::DetectorProperties*    fDetector;              //< Pointer to the detector properties
 };
 
 TPCDecoderFilter1D::TPCDecoderFilter1D(fhicl::ParameterSet const &pset)
@@ -219,9 +218,7 @@ void TPCDecoderFilter1D::configure(fhicl::ParameterSet const &pset)
     for(const auto& idPair : tempIDVec) fFragmentIDMap[idPair.first] = idPair.second;
 
     fFilterModeVec          = {'d','e','g'};
-
     fGeometry               = art::ServiceHandle<geo::Geometry const>{}.get();
-    fDetector               = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     cet::cpu_timer theClockFragmentIDs;
 
@@ -260,7 +257,8 @@ void TPCDecoderFilter1D::configure(fhicl::ParameterSet const &pset)
     return;
 }
 
-void TPCDecoderFilter1D::process_fragment(const artdaq::Fragment &fragment)
+void TPCDecoderFilter1D::process_fragment(detinfo::DetectorClocksData const&,
+                                          const artdaq::Fragment &fragment)
 {
     cet::cpu_timer theClockTotal;
 

--- a/icaruscode/Decode/DecoderTools/TPCDecoderFilter2D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCDecoderFilter2D_tool.cc
@@ -18,7 +18,6 @@
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/PhysCrateFragment.hh"
 
@@ -66,7 +65,8 @@ public:
      *
      *  @param fragment            The artdaq fragment to process
      */
-    virtual void process_fragment(const artdaq::Fragment&) override;
+    virtual void process_fragment(detinfo::DetectorClocksData const& clockData,
+                                  const artdaq::Fragment&) override;
 
     /**
      *  @brief Recover the channels for the processed fragment
@@ -160,7 +160,6 @@ private:
     icarus_signal_processing::VectorInt   fRangeBins;
 
     const geo::Geometry*                  fGeometry;              //< pointer to the Geometry service
-    const detinfo::DetectorProperties*    fDetector;              //< Pointer to the detector properties
 };
 
 TPCDecoderFilter2D::TPCDecoderFilter2D(fhicl::ParameterSet const &pset)
@@ -202,12 +201,12 @@ void TPCDecoderFilter2D::configure(fhicl::ParameterSet const &pset)
     fFilterModeVec         = {'d','e','g'};
 
     fGeometry              = art::ServiceHandle<geo::Geometry const>{}.get();
-    fDetector              = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     return;
 }
 
-void TPCDecoderFilter2D::process_fragment(const artdaq::Fragment &fragment)
+void TPCDecoderFilter2D::process_fragment(detinfo::DetectorClocksData const&,
+                                          const artdaq::Fragment &fragment)
 {
     // convert fragment to Nevis fragment
     icarus::PhysCrateFragment physCrateFragment(fragment);

--- a/icaruscode/Decode/DecoderTools/TPCDecoderOverlayFilter1D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCDecoderOverlayFilter1D_tool.cc
@@ -68,7 +68,8 @@ public:
      *
      *  @param fragment            The artdaq fragment to process
      */
-    virtual void process_fragment(const artdaq::Fragment&) override;
+    virtual void process_fragment(detinfo::DetectorClocksData const& clockData,
+                                  const artdaq::Fragment&) override;
 
     /**
      *  @brief Recover the channels for the processed fragment
@@ -166,7 +167,6 @@ private:
     std::unique_ptr<IFakeParticle>        fFakeParticleTool;
 
     const geo::Geometry*                  fGeometry;              //< pointer to the Geometry service
-    const detinfo::DetectorProperties*    fDetector;              //< Pointer to the detector properties
 };
 
 TPCDecoderOverlayFilter1D::TPCDecoderOverlayFilter1D(fhicl::ParameterSet const &pset)
@@ -209,14 +209,14 @@ void TPCDecoderOverlayFilter1D::configure(fhicl::ParameterSet const &pset)
     fFilterModeVec         = {'d','e','g'};
 
     fGeometry              = art::ServiceHandle<geo::Geometry const>{}.get();
-    fDetector              = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     fFakeParticleTool      = art::make_tool<IFakeParticle>(pset.get<fhicl::ParameterSet>("FakeParticle"));
 
     return;
 }
 
-void TPCDecoderOverlayFilter1D::process_fragment(const artdaq::Fragment &fragment)
+void TPCDecoderOverlayFilter1D::process_fragment(detinfo::DetectorClocksData const& clockData,
+                                                 const artdaq::Fragment &fragment)
 {
     cet::cpu_timer theClockTotal;
 
@@ -301,7 +301,7 @@ void TPCDecoderOverlayFilter1D::process_fragment(const artdaq::Fragment &fragmen
     theClockFake.start();
 
     // Overlay a fake particle on this array of waveforms
-    fFakeParticleTool->overlayFakeParticle(fPedCorWaveforms);
+    fFakeParticleTool->overlayFakeParticle(clockData, fPedCorWaveforms);
 
     theClockFake.stop();
 

--- a/icaruscode/Decode/DecoderTools/TPCDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCDecoder_tool.cc
@@ -18,7 +18,6 @@
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardataobj/RawData/RawDigit.h"
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/PhysCrateFragment.hh"
@@ -95,7 +94,6 @@ private:
     RawDigitCollectionPtr                       fRawDigitCollection;    //< The output data collection pointer
 
     const geo::Geometry*                        fGeometry;              //< pointer to the Geometry service
-    const detinfo::DetectorProperties*          fDetector;              //< Pointer to the detector properties
 };
 
 TPCDecoder::TPCDecoder(fhicl::ParameterSet const &pset)
@@ -120,7 +118,6 @@ void TPCDecoder::configure(fhicl::ParameterSet const &pset)
     fFragment_id_offset = pset.get<uint32_t>("fragment_id_offset");
 
     fGeometry = art::ServiceHandle<geo::Geometry const>{}.get();
-    fDetector = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     return;
 }

--- a/icaruscode/Decode/FilterNoiseICARUS_module.cc
+++ b/icaruscode/Decode/FilterNoiseICARUS_module.cc
@@ -40,7 +40,7 @@
 #include "tbb/concurrent_vector.h"
 
 #include "larcore/Geometry/Geometry.h"
-
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataobj/RawData/RawDigit.h"
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/PhysCrateFragment.hh"
@@ -72,19 +72,23 @@ public:
     using ConcurrentRawDigitCol = tbb::concurrent_vector<raw::RawDigit>;
 
     // Function to do the work
-    void processSingleFragment(size_t, art::Handle<artdaq::Fragments>, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&) const;
+    void processSingleFragment(size_t,
+                               detinfo::DetectorClocksData const& clockData,
+                               art::Handle<artdaq::Fragments>, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&, ConcurrentRawDigitCol&) const;
 
 private:
- 
-    class multiThreadFragmentProcessing 
+
+    class multiThreadFragmentProcessing
     {
     public:
         multiThreadFragmentProcessing(FilterNoiseICARUS const&        parent,
-                                      art::Handle<artdaq::Fragments>& fragmentsHandle, 
+                                      detinfo::DetectorClocksData const& clockData,
+                                      art::Handle<artdaq::Fragments>& fragmentsHandle,
                                       ConcurrentRawDigitCol&          rawDigitCollection,
                                       ConcurrentRawDigitCol&          rawRawDigitCollection,
                                       ConcurrentRawDigitCol&          coherentCollection)
             : fFilterNoiseICARUS(parent),
+              fClockData{clockData},
               fFragmentsHandle(fragmentsHandle),
               fRawDigitCollection(rawDigitCollection),
               fRawRawDigitCollection(rawRawDigitCollection),
@@ -94,10 +98,11 @@ private:
         void operator()(const tbb::blocked_range<size_t>& range) const
         {
             for (size_t idx = range.begin(); idx < range.end(); idx++)
-                fFilterNoiseICARUS.processSingleFragment(idx, fFragmentsHandle, fRawDigitCollection, fRawRawDigitCollection, fCoherentCollection);
+                fFilterNoiseICARUS.processSingleFragment(idx, fClockData, fFragmentsHandle, fRawDigitCollection, fRawRawDigitCollection, fCoherentCollection);
         }
     private:
         const FilterNoiseICARUS&        fFilterNoiseICARUS;
+      detinfo::DetectorClocksData const& fClockData;
         art::Handle<artdaq::Fragments>& fFragmentsHandle;
         ConcurrentRawDigitCol&          fRawDigitCollection;
         ConcurrentRawDigitCol&          fRawRawDigitCollection;
@@ -264,9 +269,11 @@ void FilterNoiseICARUS::produce(art::Event & event, art::ProcessingFrame const&)
     ConcurrentRawDigitCol coherentRawDigits;
 
     // ... Launch multiple threads with TBB to do the deconvolution and find ROIs in parallel
-    multiThreadFragmentProcessing fragmentProcessing(*this, 
-                                                     daq_handle, 
-                                                     concurrentRawDigits, 
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(event);
+    multiThreadFragmentProcessing fragmentProcessing(*this,
+                                                     clockData,
+                                                     daq_handle,
+                                                     concurrentRawDigits,
                                                      concurrentRawRawDigits,
                                                      coherentRawDigits);
 
@@ -315,7 +322,8 @@ void FilterNoiseICARUS::produce(art::Event & event, art::ProcessingFrame const&)
     return;
 }
 
-void FilterNoiseICARUS::processSingleFragment(size_t                         idx, 
+void FilterNoiseICARUS::processSingleFragment(size_t                         idx,
+                                              detinfo::DetectorClocksData const& clockData,
                                               art::Handle<artdaq::Fragments> fragmentHandle,
                                               ConcurrentRawDigitCol&         rawDigitCollection,
                                               ConcurrentRawDigitCol&         rawRawDigitCollection,
@@ -334,7 +342,7 @@ void FilterNoiseICARUS::processSingleFragment(size_t                         idx
     IDecoderFilter* decoderTool = fDecoderToolVec[tbb::this_task_arena::current_thread_index()].get();
 
     //process_fragment(event, rawfrag, product_collection, header_collection);
-    decoderTool->process_fragment(*fragmentPtr);
+    decoderTool->process_fragment(clockData, *fragmentPtr);
 
     // Useful numerology
     // convert fragment to Nevis fragment

--- a/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
+++ b/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
@@ -84,7 +84,7 @@ icarus::opdet::PMTsimulationAlg::PMTsimulationAlg
   (ConfigurationParameters_t const& config)
   : fParams(config)
   , fQE(fParams.QEbase / fParams.larProp->ScintPreScale())
-  , fSampling(fParams.timeService->OpticalClock().Frequency())
+  , fSampling(fParams.clockData->OpticalClock().Frequency())
   , fNsamples(fParams.readoutEnablePeriod * fSampling) // us * MHz cancels out
   , wsp(
     *(fParams.pulseFunction),
@@ -171,7 +171,7 @@ auto icarus::opdet::PMTsimulationAlg::CreateFullWaveform
     using namespace detinfo::timescales;
 
     detinfo::DetectorTimings const& timings
-      = detinfo::makeDetectorTimings(fParams.timeService);
+      = detinfo::makeDetectorTimings(fParams.clockData);
 
     tick const endSample = tick::castFrom(fNsamples);
 
@@ -297,7 +297,7 @@ auto icarus::opdet::PMTsimulationAlg::CreateFullWaveform
     using detinfo::timescales::trigger_time;
 
     detinfo::DetectorTimings const& timings
-      = detinfo::makeDetectorTimings(fParams.timeService);
+      = detinfo::makeDetectorTimings(fParams.clockData);
 
     std::vector<optical_tick> trigger_locations;
     trigger_locations.reserve(fParams.beamGateTriggerNReps);
@@ -388,7 +388,7 @@ icarus::opdet::PMTsimulationAlg::CreateFixedSizeOpDetWaveforms
   auto const posttrigSize = optical_time_ticks::castFrom(fParams.posttrigSize());
   
   detinfo::DetectorTimings const& timings
-    = detinfo::makeDetectorTimings(fParams.timeService);
+    = detinfo::makeDetectorTimings(fParams.clockData);
 
   // first viable tick number: since this is the item index in `wvfm`, it's 0
   optical_tick const firstTick { 0 };
@@ -712,7 +712,7 @@ icarus::opdet::PMTsimulationAlgMaker::PMTsimulationAlgMaker
 std::unique_ptr<icarus::opdet::PMTsimulationAlg>
 icarus::opdet::PMTsimulationAlgMaker::operator()(
   detinfo::LArProperties const& larProp,
-  detinfo::DetectorClocks const& detClocks,
+  detinfo::DetectorClocksData const& clockData,
   SinglePhotonResponseFunc_t const& SPRfunction,
   CLHEP::HepRandomEngine& mainRandomEngine,
   CLHEP::HepRandomEngine& darkNoiseRandomEngine,
@@ -721,7 +721,7 @@ icarus::opdet::PMTsimulationAlgMaker::operator()(
   ) const
 {
   return std::make_unique<PMTsimulationAlg>(makeParams(
-    larProp, detClocks,
+    larProp, clockData,
     SPRfunction,
     mainRandomEngine, darkNoiseRandomEngine, elecNoiseRandomEngine,
     trackSelectedPhotons
@@ -733,7 +733,7 @@ icarus::opdet::PMTsimulationAlgMaker::operator()(
 //-----------------------------------------------------------------------------
 auto icarus::opdet::PMTsimulationAlgMaker::makeParams(
   detinfo::LArProperties const& larProp,
-  detinfo::DetectorClocks const& detClocks,
+  detinfo::DetectorClocksData const& clockData,
   SinglePhotonResponseFunc_t const& SPRfunction,
   CLHEP::HepRandomEngine& mainRandomEngine,
   CLHEP::HepRandomEngine& darkNoiseRandomEngine,
@@ -752,7 +752,7 @@ auto icarus::opdet::PMTsimulationAlgMaker::makeParams(
   // set up parameters
   //
   params.larProp = &larProp;
-  params.timeService = &detClocks;
+  params.clockData = &clockData;
 
   params.pulseFunction = &SPRfunction;
 

--- a/icaruscode/PMT/Algorithms/PMTsimulationAlg.h
+++ b/icaruscode/PMT/Algorithms/PMTsimulationAlg.h
@@ -25,7 +25,7 @@
 #include "lardataobj/RawData/OpDetWaveform.h"
 #include "lardataobj/Simulation/SimPhotons.h"
 #include "lardataalg/DetectorInfo/LArProperties.h"
-#include "lardataalg/DetectorInfo/DetectorClocks.h"
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
 #include "lardataalg/DetectorInfo/DetectorTimingTypes.h"
 #include "lardataalg/Utilities/quantities_fhicl.h" // microsecond from FHiCL
 #include "lardataalg/Utilities/quantities/spacetime.h" // microsecond, ...
@@ -445,7 +445,8 @@ class icarus::opdet::PMTsimulationAlg {
 
 
     detinfo::LArProperties const* larProp = nullptr; ///< LarProperties service provider.
-    detinfo::DetectorClocks const* timeService = nullptr; ///< DetectorClocks service provider.
+
+    detinfo::DetectorClocksData const* clockData = nullptr;
 
     /// Single photon response function.
     SinglePhotonResponseFunc_t const* pulseFunction;
@@ -937,7 +938,7 @@ class icarus::opdet::PMTsimulationAlgMaker {
    */
   std::unique_ptr<PMTsimulationAlg> operator()(
     detinfo::LArProperties const& larProp,
-    detinfo::DetectorClocks const& detClocks,
+    detinfo::DetectorClocksData const& detClocks,
     SinglePhotonResponseFunc_t const& SPRfunction,
     CLHEP::HepRandomEngine& mainRandomEngine,
     CLHEP::HepRandomEngine& darkNoiseRandomEngine,
@@ -963,7 +964,7 @@ class icarus::opdet::PMTsimulationAlgMaker {
    */
   PMTsimulationAlg::ConfigurationParameters_t makeParams(
     detinfo::LArProperties const& larProp,
-    detinfo::DetectorClocks const& detClocks,
+    detinfo::DetectorClocksData const& clockData,
     SinglePhotonResponseFunc_t const& SPRfunction,
     CLHEP::HepRandomEngine& mainRandomEngine,
     CLHEP::HepRandomEngine& darkNoiseRandomEngine,
@@ -1080,4 +1081,3 @@ void icarus::opdet::PMTsimulationAlg::printConfiguration
 
 
 #endif // ICARUSCODE_PMT_ALGORITHMS_PMTSIMULATIONALG_H
-

--- a/icaruscode/PMT/OpReco/ICARUSMCOpFlash_module.cc
+++ b/icaruscode/PMT/OpReco/ICARUSMCOpFlash_module.cc
@@ -98,7 +98,6 @@ ICARUSMCOpFlash::ICARUSMCOpFlash(fhicl::ParameterSet const& p)
 
 void ICARUSMCOpFlash::produce(art::Event& e)
 {
-  auto const ts = lar::providerFrom<detinfo::DetectorClocksService>();
   auto const geop = lar::providerFrom<geo::Geometry>();
   auto opf_v = std::unique_ptr<std::vector<recob::OpFlash> >(new std::vector<recob::OpFlash>());
 
@@ -116,12 +115,13 @@ void ICARUSMCOpFlash::produce(art::Event& e)
     throw std::exception();
   }
 
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e);
   std::set<double> flash_time_s;
   for(auto const& mct : *mct_h) {
     for(int i=0; i<mct.NParticles(); ++i) {
       auto const& part = mct.GetParticle(i);
       if( (int)(part.StatusCode()) != 1 ) continue;
-      double flash_time = ts->G4ToElecTime(part.T()) - ts->TriggerTime();
+      double flash_time = clockData.G4ToElecTime(part.T()) - clockData.TriggerTime();
       flash_time_s.insert(flash_time);
     }
   }
@@ -161,7 +161,7 @@ void ICARUSMCOpFlash::produce(art::Event& e)
     if(pe_total < 0. && !_store_empty_flash) continue;
     double y,z,ywidth,zwidth;
     GetFlashLocation(pe_v,y,z,ywidth,zwidth);
-    recob::OpFlash f(flash_time, _merge_period, flash_time + ts->TriggerTime(), 0,
+    recob::OpFlash f(flash_time, _merge_period, flash_time + clockData.TriggerTime(), 0,
 		     pe_v, false, 0, 0, 0, 0, 0, 0);
     opf_v->emplace_back(std::move(f));
   }

--- a/icaruscode/PMT/OpReco/ICARUSMCOpHit_module.cc
+++ b/icaruscode/PMT/OpReco/ICARUSMCOpHit_module.cc
@@ -64,7 +64,6 @@ ICARUSMCOpHit::ICARUSMCOpHit(fhicl::ParameterSet const& p)
 
 void ICARUSMCOpHit::produce(art::Event& e)
 {
-  auto const* ts = lar::providerFrom<detinfo::DetectorClocksService>();
   auto oph_v = std::unique_ptr<std::vector<recob::OpHit> >(new std::vector<recob::OpHit>());
 
   art::Handle< std::vector< sim::SimPhotons > > simph_h;
@@ -75,6 +74,7 @@ void ICARUSMCOpHit::produce(art::Event& e)
   }
 
   std::vector<bool> processed_v;
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e);
   for(auto const& simph : *simph_h) {
     // Make sure channel number is unique (e.g. one sim::SimPhotons per op channel)
     size_t opch = simph.OpChannel();
@@ -92,7 +92,7 @@ void ICARUSMCOpHit::produce(art::Event& e)
     // Insert photon times into a sorted set
     std::map<double,size_t> time_m;
     for(auto const& oneph : simph) {
-      double this_time = ts->G4ToElecTime(oneph.Time) - ts->TriggerTime();
+      double this_time = clockData.G4ToElecTime(oneph.Time) - clockData.TriggerTime();
       time_m[this_time] += 1;
     }
 
@@ -104,7 +104,7 @@ void ICARUSMCOpHit::produce(art::Event& e)
       if(this_time > (oph_time + _merge_period) && in_window) {
 	recob::OpHit oph(opch, 
 			 oph_time,
-			 oph_time + ts->TriggerTime(),
+                         oph_time + clockData.TriggerTime(),
 			 0, // frame
 			 1., // width
 			 pe * _spe_area, // area,
@@ -123,7 +123,7 @@ void ICARUSMCOpHit::produce(art::Event& e)
     if(in_window) {
       recob::OpHit oph(opch, 
 		       oph_time,
-		       oph_time + ts->TriggerTime(),
+                       oph_time + clockData.TriggerTime(),
 		       0, // frame
 		       1., // width
 		       pe * _spe_area, // area,

--- a/icaruscode/PMT/PhotonPropogationICARUS_module.cc
+++ b/icaruscode/PMT/PhotonPropogationICARUS_module.cc
@@ -73,7 +73,6 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     geo::GeometryCore const* fGeometry = nullptr; ///< Pointer to Geometry service.
-//    detinfo::DetectorProperties const* fDetectorProperties = nullptr; ///< Detector properties service.
     CLHEP::HepRandomEngine&  fPhotonEngine;
     
     /// We don't keep more than this number of photons per `sim::SimPhoton`.

--- a/icaruscode/PMT/SimPMTIcarus_module.cc
+++ b/icaruscode/PMT/SimPMTIcarus_module.cc
@@ -302,12 +302,14 @@ SimPMTIcarus::SimPMTIcarus(Parameters const& config)
     auto const& pmtVector
       = *(e.getValidHandle< std::vector<sim::SimPhotons> >(fInputModuleName));
     
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e);
     //
     // prepare the algorithm
     //
     auto PMTsimulator = makePMTsimulator(
       *(lar::providerFrom<detinfo::LArPropertiesService>()),
-      *(lar::providerFrom<detinfo::DetectorClocksService>()),
+      clockData,
       *fSinglePhotonResponseFunc,
       fEfficiencyEngine,
       fDarkNoiseEngine,

--- a/icaruscode/PMT/Trigger/Algorithms/BeamGateMaker.h
+++ b/icaruscode/PMT/Trigger/Algorithms/BeamGateMaker.h
@@ -16,7 +16,7 @@
 // LArSoft libraries
 #include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // detinfo::timescales
-#include "lardataalg/DetectorInfo/DetectorClocks.h"
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
 
 
 
@@ -68,8 +68,8 @@ class icarus::trigger::BeamGateMaker {
     {}
   
   /// Constructor: uses the specified detector clocks service.
-  BeamGateMaker(detinfo::DetectorClocks const& detClocks)
-    : BeamGateMaker(detinfo::makeDetectorTimings(detClocks)) {}
+  BeamGateMaker(detinfo::DetectorClocksData const& clockData)
+    : BeamGateMaker(detinfo::makeDetectorTimings(clockData)) {}
   
   // --- BEGIN -- Start and end time -------------------------------------------
   /// @name Start and end time

--- a/icaruscode/PMT/Trigger/DiscriminatePMTwaveforms_module.cc
+++ b/icaruscode/PMT/Trigger/DiscriminatePMTwaveforms_module.cc
@@ -206,7 +206,7 @@ class icarus::trigger::DiscriminatePMTwaveforms: public art::EDProducer {
   
   
   // --- BEGIN Service variables -----------------------------------------------
-  
+  detinfo::DetectorClocksData fClockData;   // FIXME: this assumes that the cached clock data is valid for the whole job.
   detinfo::DetectorTimings fDetTimings;
   
   // --- END Service variables -------------------------------------------------
@@ -233,7 +233,8 @@ icarus::trigger::DiscriminatePMTwaveforms::DiscriminatePMTwaveforms
   // configuration
   , fOpDetWaveformTag(config().OpticalWaveforms())
   , fLogCategory(config().OutputCategory())
-  , fDetTimings(*lar::providerFrom<detinfo::DetectorClocksService>())
+  , fClockData{art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob()}
+  , fDetTimings{fClockData}
   , fTriggerGateBuilder
     (
       art::make_tool<icarus::trigger::TriggerGateBuilder>

--- a/icaruscode/PMT/Trigger/MajorityTriggerEfficiencyPlots_module.cc
+++ b/icaruscode/PMT/Trigger/MajorityTriggerEfficiencyPlots_module.cc
@@ -14,6 +14,7 @@
 #include "icaruscode/PMT/Trigger/Utilities/ROOTutils.h" // util::ROOT
 
 // LArSoft libraries
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/Utilities/TensorIndices.h" // util::MatrixIndices
 #include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // optical_time_ticks..
 #include "larcorealg/CoreUtils/zip.h"
@@ -381,6 +382,7 @@ class icarus::trigger::MajorityTriggerEfficiencyPlots
     std::size_t const thresholdIndex,
     TriggerGatesPerCryostat_t const& gates,
     EventInfo_t const& eventInfo,
+    detinfo::DetectorClocksData const& clockData,
     PlotSandboxRefs_t const& selectedPlots
     ) const override;
     
@@ -423,6 +425,7 @@ class icarus::trigger::MajorityTriggerEfficiencyPlots
   void plotResponses(
     std::size_t iThr, ADCCounts_t const threshold,
     PlotSandboxRefs_t const& plotSets, EventInfo_t const& eventInfo,
+    detinfo::DetectorClocksData const& clockData,
     TriggerGateData_t const& combinedTrigger
     ) const;
   
@@ -614,8 +617,10 @@ void icarus::trigger::MajorityTriggerEfficiencyPlots::initializePlotSet
   //
   // Triggering efficiency vs. requirements.
   //
+
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
   detinfo::timescales::optical_time_ticks const triggerResolutionTicks
-    { helper().detTimings().toOpticalTicks(helper().triggerTimeResolution()) };
+    { helper().detTimings(clockData).toOpticalTicks(helper().triggerTimeResolution()) };
   auto const& beamGateOpt = helper().beamGateTickRange();
   auto* TrigTime = plots.make<TH2F>(
     "TriggerTick",
@@ -668,6 +673,7 @@ void icarus::trigger::MajorityTriggerEfficiencyPlots::simulateAndPlot(
   std::size_t const thresholdIndex,
   TriggerGatesPerCryostat_t const& gates,
   EventInfo_t const& eventInfo,
+  detinfo::DetectorClocksData const& clockData,
   PlotSandboxRefs_t const& selectedPlots
 ) const {
   
@@ -681,6 +687,7 @@ void icarus::trigger::MajorityTriggerEfficiencyPlots::simulateAndPlot(
    */
   plotResponses(
     thresholdIndex, threshold, selectedPlots, eventInfo,
+    clockData,
     helper().applyBeamGate(combineTriggerPrimitives(gates, threshold))
     );
   
@@ -693,6 +700,7 @@ void icarus::trigger::MajorityTriggerEfficiencyPlots::plotResponses(
   icarus::trigger::ADCCounts_t const threshold,
   PlotSandboxRefs_t const& plotSets,
   EventInfo_t const& eventInfo,
+  detinfo::DetectorClocksData const& clockData,
   TriggerGateData_t const& combinedCount
 ) const {
   
@@ -726,7 +734,7 @@ void icarus::trigger::MajorityTriggerEfficiencyPlots::plotResponses(
   mf::LogTrace(helper().logCategory())
     << "Max primitive count in " << threshold << ": "
     << maxPrimitives.second << " at tick " << maxPrimitives.first << " ("
-    << helper().detTimings().toElectronicsTime
+    << helper().detTimings(clockData).toElectronicsTime
       (detinfo::DetectorTimings::optical_tick{ maxPrimitives.first })
     << ")"
     ;

--- a/icaruscode/PMT/Trigger/MakeTriggerSimulationTree_module.cc
+++ b/icaruscode/PMT/Trigger/MakeTriggerSimulationTree_module.cc
@@ -297,6 +297,7 @@ class icarus::trigger::MakeTriggerSimulationTree: public art::EDAnalyzer {
   // --- BEGIN Setup variables -------------------------------------------------
   
   geo::GeometryCore const& fGeom;
+  detinfo::DetectorClocksData fDetClocks;
   detinfo::DetectorTimings fDetTimings;
   
   // --- END Setup variables ---------------------------------------------------
@@ -475,7 +476,8 @@ icarus::trigger::MakeTriggerSimulationTree::MakeTriggerSimulationTree
   , fLogCategory(config().LogCategory())
   // setup
   , fGeom(*lar::providerFrom<geo::Geometry>())
-  , fDetTimings(*lar::providerFrom<detinfo::DetectorClocksService>())
+  , fDetClocks(art::ServiceHandle<detinfo::DetectorClocksService>()->DataForJob())
+  , fDetTimings(fDetClocks)
   // other data
   , fBeamGate(
       icarus::trigger::BeamGateMaker{ fDetTimings }

--- a/icaruscode/PMT/Trigger/SlidingWindowTriggerEfficiencyPlots_module.cc
+++ b/icaruscode/PMT/Trigger/SlidingWindowTriggerEfficiencyPlots_module.cc
@@ -15,6 +15,7 @@
 #include "icaruscode/Utilities/sortBy.h" // also icarus::util::sortCollBy()
 
 // LArSoft libraries
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/Utilities/TensorIndices.h" // util::MatrixIndices
 #include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // optical_time_ticks..
 #include "larcorealg/Geometry/GeometryCore.h"
@@ -643,6 +644,7 @@ class icarus::trigger::SlidingWindowTriggerEfficiencyPlots
     std::size_t const thresholdIndex,
     TriggerGatesPerCryostat_t const& gates,
     EventInfo_t const& eventInfo,
+    detinfo::DetectorClocksData const& clockData,
     PlotSandboxRefs_t const& selectedPlots
     ) const override;
     
@@ -1163,8 +1165,9 @@ void icarus::trigger::SlidingWindowTriggerEfficiencyPlots::initializePlotSet
   //
   // Triggering efficiency vs. requirements.
   //
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
   detinfo::timescales::optical_time_ticks const triggerResolutionTicks
-    { helper().detTimings().toOpticalTicks(helper().triggerTimeResolution()) };
+    { helper().detTimings(clockData).toOpticalTicks(helper().triggerTimeResolution()) };
   auto const& beamGateOpt = helper().beamGateTickRange();
   auto* TrigTime = plots.make<TH2F>(
     "TriggerTick",
@@ -1304,6 +1307,7 @@ void icarus::trigger::SlidingWindowTriggerEfficiencyPlots::simulateAndPlot(
   std::size_t const thresholdIndex,
   TriggerGatesPerCryostat_t const& gates,
   EventInfo_t const& eventInfo,
+  detinfo::DetectorClocksData const& clockData,
   PlotSandboxRefs_t const& selectedPlots
 ) const {
   
@@ -1371,7 +1375,7 @@ void icarus::trigger::SlidingWindowTriggerEfficiencyPlots::simulateAndPlot(
         << "Pattern '" << pattern.tag() << "' on window #" << iWindow
         << " (threshold: " << threshold
         << ") fired at tick " << windowResponse.atTick() << " ("
-        << helper().detTimings().toElectronicsTime
+        << helper().detTimings(clockData).toElectronicsTime
           (detinfo::DetectorTimings::optical_tick{ windowResponse.atTick() })
         << ")"
         ;

--- a/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.h
+++ b/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.h
@@ -916,8 +916,8 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
   geo::GeometryCore const& geometry() const { return fGeom; }
   
   /// Returns the detector timings helper.
-  detinfo::DetectorTimings const& detTimings() const { return fDetTimings; }
-  
+  detinfo::DetectorTimings detTimings(detinfo::DetectorClocksData const& clockData) const { return detinfo::DetectorTimings{clockData}; }
+
   /// Returns the resolution of trigger timing clock [ns]
   nanoseconds triggerTimeResolution() const { return fTriggerTimeResolution; }
   
@@ -1112,6 +1112,7 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
     std::size_t const thresholdIndex,
     TriggerGatesPerCryostat_t const& gates,
     EventInfo_t const& eventInfo,
+    detinfo::DetectorClocksData const& clockData,
     PlotSandboxRefs_t const& selectedPlots
     ) const = 0;
   
@@ -1191,8 +1192,6 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
   // --- BEGIN Service variables -----------------------------------------------
 
   geo::GeometryCore const& fGeom;
-  detinfo::DetectorClocks const& fDetClocks;
-  detinfo::DetectorTimings fDetTimings;
 
   /// ROOT directory where all the plots are written.
   art::TFileDirectory fOutputDir;
@@ -1201,7 +1200,10 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
 
   
   // --- BEGIN Internal variables ----------------------------------------------
-  
+  /// Detector clocks information that applies for the entire job.
+  detinfo::DetectorClocksData const fDetClocks;
+  detinfo::DetectorTimings const fDetTimings;
+
   /// Gate representing the time we expect light from beam interactions.
   icarus::trigger::OpticalTriggerGate const fBeamGate;
   

--- a/icaruscode/PMT/Trigger/TriggerEfficiencyPlots_module.cc
+++ b/icaruscode/PMT/Trigger/TriggerEfficiencyPlots_module.cc
@@ -1438,8 +1438,6 @@ class icarus::trigger::TriggerEfficiencyPlots: public art::EDAnalyzer {
   // --- BEGIN Service variables -----------------------------------------------
 
   geo::GeometryCore const& fGeom;
-  detinfo::DetectorClocks const& fDetClocks;
-  detinfo::DetectorTimings fDetTimings;
 
   /// ROOT directory where all the plots are written.
   art::TFileDirectory fOutputDir;
@@ -1448,9 +1446,6 @@ class icarus::trigger::TriggerEfficiencyPlots: public art::EDAnalyzer {
 
   
   // --- BEGIN Internal variables ----------------------------------------------
-  
-  /// Gate representing the time we expect light from beam interactions.
-  icarus::trigger::OpticalTriggerGate const fBeamGate;
   
   /// Beam gate start and stop tick in optical detector scale.
   std::pair
@@ -1477,13 +1472,13 @@ class icarus::trigger::TriggerEfficiencyPlots: public art::EDAnalyzer {
 
 
   /// Initializes all the plot sets, one per threshold.
-  void initializePlots(PlotCategories_t const& categories);
+  void initializePlots(detinfo::DetectorClocksData const& clockData, PlotCategories_t const& categories);
 
   /// Initializes full set of plots for (ADC threshold + category) into `plots`.
-  void initializePlotSet(PlotSandbox& plots) const;
+  void initializePlotSet(detinfo::DetectorClocksData const& clockData, PlotSandbox& plots) const;
 
   /// Initializes set of plots per complete trigger definition into `plots`.
-  void initializeEfficiencyPerTriggerPlots(PlotSandbox& plots) const;
+  void initializeEfficiencyPerTriggerPlots(detinfo::DetectorClocksData const& clockData, PlotSandbox& plots) const;
   
   /// Initializes a single, trigger-independent plot set into `plots`.
   void initializeEventPlots(PlotSandbox& plots) const;
@@ -1528,7 +1523,7 @@ class icarus::trigger::TriggerEfficiencyPlots: public art::EDAnalyzer {
    * and read in `extractEventInfo()` to be used within it.
    *
    */
-  EventInfo_t extractEventInfo(art::Event const& event) const;
+  EventInfo_t extractEventInfo(art::Event const& event, detinfo::DetectorClocksData const& clockData) const;
   
   /// Returns the TPC `point` is within, `nullptr` if none.
   geo::TPCGeo const* pointInTPC(geo::Point_t const& point) const;
@@ -1544,13 +1539,10 @@ class icarus::trigger::TriggerEfficiencyPlots: public art::EDAnalyzer {
     art::InputTag const& dataTag
     ) const;
 
-  /// Applies the beam gate coincidence to the specified trigger primitive.
-  template <typename GateObject>
-  GateObject applyBeamGate(GateObject gate) const;
-
   /// Adds all the `responses` (one per threshold) to the plots.
   void plotResponses(
     std::size_t iThr, icarus::trigger::ADCCounts_t const threshold,
+    detinfo::DetectorTimings const& detTimings,
     PlotSandboxRefs_t const& plots, EventInfo_t const& info,
     std::vector<TriggerGateData_t> const& primitiveCounts
     ) const;
@@ -1593,20 +1585,8 @@ icarus::trigger::TriggerEfficiencyPlots::TriggerEfficiencyPlots
   , fLogCategory          (config().LogCategory())
   // services
   , fGeom      (*lar::providerFrom<geo::Geometry>())
-  , fDetClocks (*lar::providerFrom<detinfo::DetectorClocksService>())
-  , fDetTimings(fDetClocks)
   , fOutputDir (*art::ServiceHandle<art::TFileService>())
   // cached
-  , fBeamGate(icarus::trigger::BeamGateMaker{ fDetClocks }(fBeamGateDuration))
-  , fBeamGateOpt(
-      fDetTimings.toOpticalTick(fDetTimings.BeamGateTime()),
-      fDetTimings.toOpticalTick(fDetTimings.BeamGateTime() + fBeamGateDuration)
-    )
-  , fBeamGateSim(
-      fDetTimings.toSimulationTime(fBeamGateOpt.first),
-      fDetTimings.toSimulationTime(fDetTimings.BeamGateTime())
-        + fBeamGateDuration
-    )
 {
   //
   // more complex parameter parsing
@@ -1660,15 +1640,19 @@ icarus::trigger::TriggerEfficiencyPlots::TriggerEfficiencyPlots
   //
   // initialization of plots and plot categories
   //
-  initializePlots(::PlotCategories);
-
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+  detinfo::DetectorTimings const detTimings{clockData};
+  auto const beam_gate_opt = std::make_pair(detTimings.toOpticalTick(detTimings.BeamGateTime()),
+                                            detTimings.toOpticalTick(detTimings.BeamGateTime() + fBeamGateDuration));
+  auto const beam_gate_sim = std::make_pair(detTimings.toSimulationTime(beam_gate_opt.first),
+                                            detTimings.toSimulationTime(beam_gate_opt.second));
+  initializePlots(clockData, ::PlotCategories);
   {
     mf::LogInfo log(fLogCategory);
     log << "\nConfigured " << fADCthresholds.size() << " thresholds:";
     for (auto const& [ threshold, dataTag ]: fADCthresholds)
       log << "\n * " << threshold << " ADC (from '" << dataTag.encode() << "')";
-    log << "\nBeam gate is " << fBeamGate << " (" << fBeamGateSim.first
-      << " -- " << fBeamGateSim.second << ")";
+    log << "\nBeam gate is " << beam_gate_sim.first << " -- " << beam_gate_sim.second;
   } // local block
 
 } // icarus::trigger::TriggerEfficiencyPlots::TriggerEfficiencyPlots()
@@ -1694,7 +1678,9 @@ void icarus::trigger::TriggerEfficiencyPlots::analyze(art::Event const& event) {
   //
   // 1. find out the features of the event and the categories it belongs to
   //
-  EventInfo_t const eventInfo = extractEventInfo(event);
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+  detinfo::DetectorTimings const detTimings{clockData};
+  EventInfo_t const eventInfo = extractEventInfo(event, clockData);
   
   bool const bPlot = shouldPlotEvent(eventInfo);
   if (bPlot) ++nPlottedEvents;
@@ -1723,6 +1709,9 @@ void icarus::trigger::TriggerEfficiencyPlots::analyze(art::Event const& event) {
   //
   // 2. for each threshold:
   //
+  /// Gate representing the time we expect light from beam interactions.
+  auto const beam_gate = icarus::trigger::BeamGateMaker{clockData}(fBeamGateDuration);
+
   for (auto&& [ iThr, thrPair, thrPlots ]
     : util::enumerate(fADCthresholds, fThresholdPlots)
   ) {
@@ -1741,7 +1730,7 @@ void icarus::trigger::TriggerEfficiencyPlots::analyze(art::Event const& event) {
 
     for (TriggerGateData_t combinedPrimitive : (combinedTriggerPrimitives)) {
       TriggerGateData_t const primitiveCount
-        = applyBeamGate(combinedPrimitive);
+        = combinedPrimitive.Mul(beam_gate);
 
       primitiveCounts.push_back(primitiveCount);
     }
@@ -1757,7 +1746,7 @@ void icarus::trigger::TriggerEfficiencyPlots::analyze(art::Event const& event) {
     }
     
     // 1.6. add the response to the appropriate plots
-    plotResponses(iThr, threshold, selectedPlots, eventInfo, primitiveCounts);
+    plotResponses(iThr, threshold, detTimings, selectedPlots, eventInfo, primitiveCounts);
     
   } // for thresholds
 
@@ -1782,7 +1771,7 @@ void icarus::trigger::TriggerEfficiencyPlots::endJob() {
 
 //------------------------------------------------------------------------------
 void icarus::trigger::TriggerEfficiencyPlots::initializePlots
-  (PlotCategories_t const& categories)
+  (detinfo::DetectorClocksData const& clockData, PlotCategories_t const& categories)
 {
   using namespace std::string_literals;
   
@@ -1801,7 +1790,7 @@ void icarus::trigger::TriggerEfficiencyPlots::initializePlots
         category.description()
         );
       
-      initializePlotSet(plots);
+      initializePlotSet(clockData, plots);
     }
     fThresholdPlots.push_back(std::move(thrPlots));
   } // for thresholds
@@ -1817,7 +1806,7 @@ void icarus::trigger::TriggerEfficiencyPlots::initializePlots
 
 //------------------------------------------------------------------------------
 void icarus::trigger::TriggerEfficiencyPlots::initializePlotSet
-  (PlotSandbox& plots) const
+  (detinfo::DetectorClocksData const& clockData, PlotSandbox& plots) const
 {
   
   // a variable binning for the required number of trigger primitives
@@ -1843,8 +1832,11 @@ void icarus::trigger::TriggerEfficiencyPlots::initializePlotSet
   //
   // Triggering efficiency vs. threshold.
   //
+  detinfo::DetectorTimings const detTimings{clockData};
   detinfo::timescales::optical_time_ticks const triggerResolutionTicks
-    { fDetTimings.toOpticalTicks(fTriggerTimeResolution) };
+    { detTimings.toOpticalTicks(fTriggerTimeResolution) };
+  auto const beam_gate_opt = std::make_pair(detTimings.toOpticalTick(detTimings.BeamGateTime()),
+                                            detTimings.toOpticalTick(detTimings.BeamGateTime() + fBeamGateDuration));
   auto* TrigTime = plots.make<TH2F>(
     "TriggerTick",
     "Trigger time tick"
@@ -1852,8 +1844,8 @@ void icarus::trigger::TriggerEfficiencyPlots::initializePlotSet
       ";optical time tick [ /" + util::to_string(triggerResolutionTicks) + " ]",
     minimumPrimBinning.size() - 1U, minimumPrimBinning.data(),
 //    fMinimumPrimitives.back(), 0, fMinimumPrimitives.back() + 1
-    (fBeamGateOpt.second - fBeamGateOpt.first) / triggerResolutionTicks,
-    fBeamGateOpt.first.value(), fBeamGateOpt.second.value()
+    (beam_gate_opt.second - beam_gate_opt.first) / triggerResolutionTicks,
+    beam_gate_opt.first.value(), beam_gate_opt.second.value()
     );
   
   util::ROOT::applyAxisLabels(TrigTime->GetXaxis(), minimumPrimBinningLabels);
@@ -1910,7 +1902,7 @@ void icarus::trigger::TriggerEfficiencyPlots::initializePlotSet
     PlotSandbox& reqBox = plots.addSubSandbox
       ("Req" + minCountStr, minCountStr + " channels required");
     
-    initializeEfficiencyPerTriggerPlots(reqBox);
+    initializeEfficiencyPerTriggerPlots(clockData, reqBox);
     
     for (auto const& [ name, desc ]: classes) {
       
@@ -1958,12 +1950,14 @@ void icarus::trigger::TriggerEfficiencyPlots::initializePlotSet
 
 //------------------------------------------------------------------------------
 void icarus::trigger::TriggerEfficiencyPlots::initializeEfficiencyPerTriggerPlots
-  (PlotSandbox& plots) const
+  (detinfo::DetectorClocksData const& clockData, PlotSandbox& plots) const
 {
-  
+  detinfo::DetectorTimings const detTimings{clockData};
   detinfo::timescales::optical_time_ticks const triggerResolutionTicks
-    { fDetTimings.toOpticalTicks(fTriggerTimeResolution) };
+    { detTimings.toOpticalTicks(fTriggerTimeResolution) };
   
+  auto const beam_gate_opt = std::make_pair(detTimings.toOpticalTick(detTimings.BeamGateTime()),
+                                            detTimings.toOpticalTick(detTimings.BeamGateTime() + fBeamGateDuration));
   //
   // Triggering efficiency vs. something else
   //
@@ -2003,8 +1997,8 @@ void icarus::trigger::TriggerEfficiencyPlots::initializeEfficiencyPerTriggerPlot
     "TriggerTick",
     "Trigger time tick"
       ";optical time tick [ /" + util::to_string(triggerResolutionTicks) + " ]",
-    (fBeamGateOpt.second - fBeamGateOpt.first) / triggerResolutionTicks,
-    fBeamGateOpt.first.value(), fBeamGateOpt.second.value()
+    (beam_gate_opt.second - beam_gate_opt.first) / triggerResolutionTicks,
+    beam_gate_opt.first.value(), beam_gate_opt.second.value()
     );
   
 } // initializeEfficiencyPerTriggerPlots()
@@ -2116,7 +2110,7 @@ icarus::trigger::TriggerEfficiencyPlots::selectPlotCategories
 
 //------------------------------------------------------------------------------
 auto icarus::trigger::TriggerEfficiencyPlots::extractEventInfo
-  (art::Event const& event) const -> EventInfo_t
+  (art::Event const& event, detinfo::DetectorClocksData const& clockData) const -> EventInfo_t
 {
   
   EventInfo_t info;
@@ -2187,6 +2181,11 @@ auto icarus::trigger::TriggerEfficiencyPlots::extractEventInfo
   GeV totalEnergy { 0.0 }, inSpillEnergy { 0.0 };
   GeV activeEnergy { 0.0 }, inSpillActiveEnergy { 0.0 };
   
+  detinfo::DetectorTimings const detTimings{clockData};
+  auto const beam_gate_opt = std::make_pair(detTimings.toOpticalTick(detTimings.BeamGateTime()),
+                                            detTimings.toOpticalTick(detTimings.BeamGateTime() + fBeamGateDuration));
+  auto const beam_gate_sim = std::make_pair(detTimings.toSimulationTime(beam_gate_opt.first),
+                                            detTimings.toSimulationTime(beam_gate_opt.second));
   for (art::InputTag const& edepTag: fEnergyDepositTags) {
     
     auto const& energyDeposits
@@ -2201,7 +2200,7 @@ auto icarus::trigger::TriggerEfficiencyPlots::extractEventInfo
       
       detinfo::timescales::simulation_time const t { edep.Time() };
       bool const inSpill
-        = (t >= fBeamGateSim.first) && (t <= fBeamGateSim.second);
+        = (t >= beam_gate_sim.first) && (t <= beam_gate_sim.second);
       
       totalEnergy += e;
       if (inSpill) inSpillEnergy += e;
@@ -2287,15 +2286,6 @@ auto icarus::trigger::TriggerEfficiencyPlots::combineTriggerPrimitives(
 
 
 //------------------------------------------------------------------------------
-template <typename GateObject>
-GateObject icarus::trigger::TriggerEfficiencyPlots::applyBeamGate
-  (GateObject gate) const
-{
-  return std::move(gate.Mul(fBeamGate));
-} // icarus::trigger::TriggerEfficiencyPlots::applyBeamGate()
-
-
-//------------------------------------------------------------------------------
 // out-of-order definition, needs to be before `plotResponses()`
 template <typename TrigGateColl>
 auto icarus::trigger::TriggerEfficiencyPlots::computeMaxGate
@@ -2318,6 +2308,7 @@ auto icarus::trigger::TriggerEfficiencyPlots::computeMaxGate
 void icarus::trigger::TriggerEfficiencyPlots::plotResponses(
   std::size_t iThr,
   icarus::trigger::ADCCounts_t const threshold,
+  detinfo::DetectorTimings const& detTimings,
   PlotSandboxRefs_t const& plotSets,
   EventInfo_t const& eventInfo,
   std::vector<TriggerGateData_t> const& primitiveCounts
@@ -2357,7 +2348,7 @@ void icarus::trigger::TriggerEfficiencyPlots::plotResponses(
   mf::LogTrace(fLogCategory)
     << "Max primitive count in " << threshold << ": "
     << maxPrimitives.second << " at tick " << maxPrimitives.first << " ("
-    << fDetTimings.toElectronicsTime
+    << detTimings.toElectronicsTime
       (detinfo::DetectorTimings::optical_tick{ maxPrimitives.first })
     << ")"
     ;

--- a/icaruscode/RecoUtils/RecoUtils.cc
+++ b/icaruscode/RecoUtils/RecoUtils.cc
@@ -1,10 +1,11 @@
 #include "RecoUtils.h"
 
-int RecoUtils::TrueParticleID(const art::Ptr<recob::Hit>& hit) {
+int RecoUtils::TrueParticleID(const detinfo::DetectorClocksData& clockData,
+                              const art::Ptr<recob::Hit>& hit) {
   double particleEnergy = 0;
   int likelyTrackID = 0;
   art::ServiceHandle<cheat::BackTrackerService> bt;
-  std::vector<sim::TrackIDE> trackIDs = bt->HitToTrackIDEs(hit);
+  std::vector<sim::TrackIDE> trackIDs = bt->HitToTrackIDEs(clockData, hit);
   for (unsigned int idIt = 0; idIt < trackIDs.size(); ++idIt) {
     if (trackIDs.at(idIt).energy > particleEnergy) {
       particleEnergy = trackIDs.at(idIt).energy;
@@ -15,12 +16,13 @@ int RecoUtils::TrueParticleID(const art::Ptr<recob::Hit>& hit) {
 }
 
 
-int RecoUtils::TrueParticleIDFromTotalTrueEnergy(const std::vector<art::Ptr<recob::Hit> >& hits) {
+int RecoUtils::TrueParticleIDFromTotalTrueEnergy(const detinfo::DetectorClocksData& clockData,
+                                                 const std::vector<art::Ptr<recob::Hit> >& hits) {
   art::ServiceHandle<cheat::BackTrackerService> bt;
   std::map<int,double> trackIDToEDepMap;
   for (std::vector<art::Ptr<recob::Hit> >::const_iterator hitIt = hits.begin(); hitIt != hits.end(); ++hitIt) {
     art::Ptr<recob::Hit> hit = *hitIt;
-    std::vector<sim::TrackIDE> trackIDs = bt->HitToTrackIDEs(hit);
+    std::vector<sim::TrackIDE> trackIDs = bt->HitToTrackIDEs(clockData, hit);
     for (unsigned int idIt = 0; idIt < trackIDs.size(); ++idIt) {
       trackIDToEDepMap[trackIDs[idIt].trackID] += trackIDs[idIt].energy;
     }
@@ -43,12 +45,13 @@ int RecoUtils::TrueParticleIDFromTotalTrueEnergy(const std::vector<art::Ptr<reco
 
 
 
-int RecoUtils::TrueParticleIDFromTotalRecoCharge(const std::vector<art::Ptr<recob::Hit> >& hits) {
+int RecoUtils::TrueParticleIDFromTotalRecoCharge(const detinfo::DetectorClocksData& clockData,
+                                                 const std::vector<art::Ptr<recob::Hit> >& hits) {
   // Make a map of the tracks which are associated with this object and the charge each contributes
   std::map<int,double> trackMap;
   for (std::vector<art::Ptr<recob::Hit> >::const_iterator hitIt = hits.begin(); hitIt != hits.end(); ++hitIt) {
     art::Ptr<recob::Hit> hit = *hitIt;
-    int trackID = TrueParticleID(hit);
+    int trackID = TrueParticleID(clockData, hit);
     trackMap[trackID] += hit->Integral();
   }
 
@@ -66,12 +69,13 @@ int RecoUtils::TrueParticleIDFromTotalRecoCharge(const std::vector<art::Ptr<reco
 
 
 
-int RecoUtils::TrueParticleIDFromTotalRecoHits(const std::vector<art::Ptr<recob::Hit> >& hits) {
+int RecoUtils::TrueParticleIDFromTotalRecoHits(const detinfo::DetectorClocksData& clockData,
+                                               const std::vector<art::Ptr<recob::Hit> >& hits) {
   // Make a map of the tracks which are associated with this object and the number of hits they are the primary contributor to
   std::map<int,int> trackMap;
   for (std::vector<art::Ptr<recob::Hit> >::const_iterator hitIt = hits.begin(); hitIt != hits.end(); ++hitIt) {
     art::Ptr<recob::Hit> hit = *hitIt;
-    int trackID = TrueParticleID(hit);
+    int trackID = TrueParticleID(clockData, hit);
     trackMap[trackID]++;
   }
 

--- a/icaruscode/RecoUtils/RecoUtils.h
+++ b/icaruscode/RecoUtils/RecoUtils.h
@@ -31,7 +31,9 @@
 //#include "lardataobj/AnalysisBase/ParticleID.h"
 #include "larsim/MCCheater/BackTrackerService.h"
 #include "larcore/Geometry/Geometry.h"
-
+namespace detinfo {
+  class DetectorClocksData;
+}
 
 // c++
 #include <vector>
@@ -42,10 +44,14 @@
 
 
 namespace RecoUtils{
-  int TrueParticleID(const art::Ptr<recob::Hit>& hit); //Returns the geant4 ID which contributes the most to a single reco hit.  The matching method looks for true particle which deposits the most true energy in the reco hit
-  int TrueParticleIDFromTotalTrueEnergy(const std::vector<art::Ptr<recob::Hit> >& hits); //Returns the geant4 ID which contributes the most to the vector of hits.  The matching method looks for which true particle deposits the most true energy in the reco hits
-  int TrueParticleIDFromTotalRecoCharge(const std::vector<art::Ptr<recob::Hit> >& hits);  //Returns the geant4 ID which contributes the most to the vector of hits.  The matching method looks for which true particle contributes the most reconstructed charge to the hit selection (the reco charge of each hit is correlated with each maximally contributing true particle and summed)
-  int TrueParticleIDFromTotalRecoHits(const std::vector<art::Ptr<recob::Hit> >& hits);  //Returns the geant4 ID which contributes the most to the vector of hits.  The matching method looks for which true particle maximally contributes to the most reco hits
+  int TrueParticleID(const detinfo::DetectorClocksData& clockData,
+                     const art::Ptr<recob::Hit>& hit); //Returns the geant4 ID which contributes the most to a single reco hit.  The matching method looks for true particle which deposits the most true energy in the reco hit
+  int TrueParticleIDFromTotalTrueEnergy(const detinfo::DetectorClocksData& clockData,
+                                        const std::vector<art::Ptr<recob::Hit> >& hits); //Returns the geant4 ID which contributes the most to the vector of hits.  The matching method looks for which true particle deposits the most true energy in the reco hits
+  int TrueParticleIDFromTotalRecoCharge(const detinfo::DetectorClocksData& clockData,
+                                        const std::vector<art::Ptr<recob::Hit> >& hits);  //Returns the geant4 ID which contributes the most to the vector of hits.  The matching method looks for which true particle contributes the most reconstructed charge to the hit selection (the reco charge of each hit is correlated with each maximally contributing true particle and summed)
+  int TrueParticleIDFromTotalRecoHits(const detinfo::DetectorClocksData& clockData,
+                                      const std::vector<art::Ptr<recob::Hit> >& hits);  //Returns the geant4 ID which contributes the most to the vector of hits.  The matching method looks for which true particle maximally contributes to the most reco hits
   bool IsInsideTPC(TVector3 position, double distance_buffer); //Checks if a position is within any of the TPCs in the geometry (user can define some distance buffer from the TPC walls)
 }
 

--- a/icaruscode/TPC/Calorimetry/Algorithms/CMakeLists.txt
+++ b/icaruscode/TPC/Calorimetry/Algorithms/CMakeLists.txt
@@ -13,6 +13,7 @@ art_make(
                           lardataobj_RawData
                           larevt_CalibrationDBI_IOVData
                           larevt_CalibrationDBI_Providers
+                          lardataalg_DetectorInfo
                           lardataobj_RecoBase
                           icaruscode_TPC_Utilities_SignalShapingICARUSService_service
                           ${ICARUS_FFTW_LIBRARIES}

--- a/icaruscode/TPC/Calorimetry/Algorithms/CalorimetryIcarusAlg.cxx
+++ b/icaruscode/TPC/Calorimetry/Algorithms/CalorimetryIcarusAlg.cxx
@@ -22,8 +22,6 @@ namespace calo{
   CalorimetryIcarusAlg::CalorimetryIcarusAlg(const Config& config)
   {
      this->reconfigure(config);
-
-     detprop = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->provider();
   }
 
   //--------------------------------------------------------------------
@@ -48,90 +46,112 @@ namespace calo{
   //------------------------------------------------------------------------------------//
   // Functions to calculate the dEdX based on the AMPLITUDE of the pulse
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AMP(art::Ptr< recob::Hit >  hit, double pitch, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                                        detinfo::DetectorPropertiesData const& detProp,
+                                        art::Ptr< recob::Hit >  hit, double pitch, double T0) const
   {
-    return dEdx_AMP(hit->PeakAmplitude()/pitch, hit->PeakTime(), hit->WireID().Plane, T0);
+    return dEdx_AMP(clockData, detProp, hit->PeakAmplitude()/pitch, hit->PeakTime(), hit->WireID().Plane, T0);
   }
 
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AMP(recob::Hit const&  hit, double pitch, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                                        detinfo::DetectorPropertiesData const& detProp,
+                                        recob::Hit const&  hit, double pitch, double T0) const
   {
-    return dEdx_AMP(hit.PeakAmplitude()/pitch, hit.PeakTime(), hit.WireID().Plane, T0);
+    return dEdx_AMP(clockData, detProp, hit.PeakAmplitude()/pitch, hit.PeakTime(), hit.WireID().Plane, T0);
   }
 
   ///\todo The plane argument should really be for a view instead
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AMP(double dQ, double time, double pitch, unsigned int plane, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                                        detinfo::DetectorPropertiesData const& detProp,
+                                        double dQ, double time, double pitch, unsigned int plane, double T0) const
   {
     double dQdx   = dQ/pitch;           // in ADC/cm
-    return dEdx_AMP(dQdx, time, plane, T0);
+    return dEdx_AMP(clockData, detProp, dQdx, time, plane, T0);
   }
 
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AMP(double dQdx,double time, unsigned int plane, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                                        detinfo::DetectorPropertiesData const& detProp,
+                                        double dQdx,double time, unsigned int plane, double T0) const
   {
     double fADCtoEl=1.;
 
     fADCtoEl = fCalAmpConstants[plane];
 
     double dQdx_e = dQdx/fADCtoEl;  // Conversion from ADC/cm to e/cm
-    return dEdx_from_dQdx_e(dQdx_e,time, T0);
+    return dEdx_from_dQdx_e(clockData, detProp, dQdx_e,time, T0);
   }
 
   //------------------------------------------------------------------------------------//
   // Functions to calculate the dEdX based on the AREA of the pulse
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AREA(art::Ptr< recob::Hit >  hit, double pitch, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                                         detinfo::DetectorPropertiesData const& detProp,
+                                         art::Ptr< recob::Hit >  hit, double pitch, double T0) const
   {
-    return dEdx_AREA(hit->Integral()/pitch, hit->PeakTime(), hit->WireID().Plane, T0);
+    return dEdx_AREA(clockData, detProp, hit->Integral()/pitch, hit->PeakTime(), hit->WireID().Plane, T0);
   }
 
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AREA(recob::Hit const&  hit, double pitch, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                                         detinfo::DetectorPropertiesData const& detProp,
+                                         recob::Hit const&  hit, double pitch, double T0) const
   {
-    return dEdx_AREA(hit.Integral()/pitch, hit.PeakTime(), hit.WireID().Plane, T0);
+    return dEdx_AREA(clockData, detProp, hit.Integral()/pitch, hit.PeakTime(), hit.WireID().Plane, T0);
   }
  //------------------------------------------------------------------------------------//
   // Functions to calculate the dEdX based on the AREA of the pulse
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_SUMADC(art::Ptr< recob::Hit >  hit, double pitch, double T0) const
+  double CalorimetryIcarusAlg::dEdx_SUMADC(detinfo::DetectorClocksData const& clockData,
+                                           detinfo::DetectorPropertiesData const& detProp,
+                                           art::Ptr< recob::Hit >  hit, double pitch, double T0) const
   {
-    return dEdx_AREA(hit->SummedADC()/pitch, hit->PeakTime(), hit->WireID().Plane, T0);
+    return dEdx_AREA(clockData, detProp, hit->SummedADC()/pitch, hit->PeakTime(), hit->WireID().Plane, T0);
   }
 
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_SUMADC(recob::Hit const&  hit, double pitch, double T0) const
+  double CalorimetryIcarusAlg::dEdx_SUMADC(detinfo::DetectorClocksData const& clockData,
+                                           detinfo::DetectorPropertiesData const& detProp,
+                                           recob::Hit const&  hit, double pitch, double T0) const
   {
-    return dEdx_AREA(hit.SummedADC()/pitch, hit.PeakTime(), hit.WireID().Plane, T0);
+    return dEdx_AREA(clockData, detProp, hit.SummedADC()/pitch, hit.PeakTime(), hit.WireID().Plane, T0);
   }
 
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AREA(double dQ,double time, double pitch, unsigned int plane, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                                         detinfo::DetectorPropertiesData const& detProp,
+                                         double dQ,double time, double pitch, unsigned int plane, double T0) const
   {
     double dQdx   = dQ/pitch;           // in ADC/cm
-    return dEdx_AREA(dQdx, time, plane, T0);
+    return dEdx_AREA(clockData, detProp, dQdx, time, plane, T0);
   }
 
   // ----------------------------------------------------------------------------------//
-  double CalorimetryIcarusAlg::dEdx_AREA(double dQdx,double time, unsigned int plane, double T0) const
+  double CalorimetryIcarusAlg::dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                                         detinfo::DetectorPropertiesData const& detProp,
+                                         double dQdx,double time, unsigned int plane, double T0) const
   {
     double fADCtoEl=1.;
 
     fADCtoEl = fCalAreaConstants[plane];
 
     double dQdx_e = dQdx/fADCtoEl;  // Conversion from ADC/cm to e/cm
-    return dEdx_from_dQdx_e(dQdx_e, time, T0);
+    return dEdx_from_dQdx_e(clockData, detProp, dQdx_e, time, T0);
   }
 
   // ----------------- apply Lifetime and recombination correction.  -----------------//
-  double CalorimetryIcarusAlg::dEdx_from_dQdx_e(double dQdx_e, double time, double T0) const
+  double CalorimetryIcarusAlg::dEdx_from_dQdx_e(detinfo::DetectorClocksData const& clockData,
+                                                detinfo::DetectorPropertiesData const& detProp,
+                                                double dQdx_e, double time, double T0) const
   {
     if (fDoLifeTimeCorrection)
-      dQdx_e *= LifetimeCorrection(time, T0);   // Lifetime Correction (dQdx_e in e/cm)
+      dQdx_e *= LifetimeCorrection(clockData, detProp, time, T0);   // Lifetime Correction (dQdx_e in e/cm)
     if(fUseModBox) {
-      return detprop->ModBoxCorrection(dQdx_e);
+      return detProp.ModBoxCorrection(dQdx_e);
     } else {
-      return detprop->BirksCorrection(dQdx_e);
+      return detProp.BirksCorrection(dQdx_e);
     }
   }
 
@@ -139,19 +159,21 @@ namespace calo{
   //------------------------------------------------------------------------------------//
   // for the time being copying from Calorimetry.cxx - should be decided where to keep it.
   // ----------------------------------------------------------------------------------//
-  double calo::CalorimetryIcarusAlg::LifetimeCorrection(double time, double T0) const
+  double calo::CalorimetryIcarusAlg::LifetimeCorrection(detinfo::DetectorClocksData const& clockData,
+                                                        detinfo::DetectorPropertiesData const& detProp,
+                                                        double time, double T0) const
   {
     float t = time;
 
-    double timetick = detprop->SamplingRate()*1.e-3;    //time sample in microsec
-    double presamplings = detprop->TriggerOffset();
+    double timetick = sampling_rate(clockData)*1.e-3;    //time sample in microsec
+    double presamplings = trigger_offset(clockData);
 
     t -= presamplings;
     time = t * timetick - T0*1e-3;  //  (in microsec)
 
     if (fLifeTimeForm==0){
       //Exponential form
-      double tau = detprop->ElectronLifetime();
+      double tau = detProp.ElectronLifetime();
 
       double correction = exp(time/tau);
       return correction;

--- a/icaruscode/TPC/Calorimetry/Algorithms/CalorimetryIcarusAlg.h
+++ b/icaruscode/TPC/Calorimetry/Algorithms/CalorimetryIcarusAlg.h
@@ -17,7 +17,10 @@
 #include "larcore/Geometry/Geometry.h"
 #include <vector>
 
-namespace detinfo { class DetectorProperties; }
+namespace detinfo {
+  class DetectorClocksData;
+  class DetectorPropertiesData;
+}
 
 namespace recob {
   class Hit;
@@ -72,32 +75,55 @@ namespace calo{
     void   reconfigure(const fhicl::ParameterSet& pset)
       { reconfigure(fhicl::Table<Config>(pset, {})()); }
 
-    double dEdx_AMP(art::Ptr< recob::Hit >  hit, double pitch, double T0=0) const;
-    double dEdx_AMP(recob::Hit const&  hit, double pitch, double T0=0) const;
-    double dEdx_AMP(double dQ, double time, double pitch, unsigned int plane, double T0=0) const;
-    double dEdx_AMP(double dQdx,double time, unsigned int plane, double T0=0) const;
+    double dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                    detinfo::DetectorPropertiesData const& detProp,
+                    art::Ptr< recob::Hit >  hit, double pitch, double T0=0) const;
+    double dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                    detinfo::DetectorPropertiesData const& detProp,
+                    recob::Hit const&  hit, double pitch, double T0=0) const;
+    double dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                    detinfo::DetectorPropertiesData const& detProp,
+                    double dQ, double time, double pitch, unsigned int plane, double T0=0) const;
+    double dEdx_AMP(detinfo::DetectorClocksData const& clockData,
+                    detinfo::DetectorPropertiesData const& detProp,
+                    double dQdx,double time, unsigned int plane, double T0=0) const;
 
-    double dEdx_AREA(art::Ptr< recob::Hit >  hit, double pitch, double T0=0) const;
-    double dEdx_AREA(recob::Hit const&  hit, double pitch, double T0=0) const;
-    double dEdx_AREA(double dQ,double time, double pitch, unsigned int plane, double T0=0) const;
-    double dEdx_AREA(double dQdx,double time, unsigned int plane, double T0=0) const;
+    double dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                     detinfo::DetectorPropertiesData const& detProp,
+                     art::Ptr< recob::Hit >  hit, double pitch, double T0=0) const;
+    double dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                     detinfo::DetectorPropertiesData const& detProp,
+                     recob::Hit const&  hit, double pitch, double T0=0) const;
+    double dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                     detinfo::DetectorPropertiesData const& detProp,
+                     double dQ,double time, double pitch, unsigned int plane, double T0=0) const;
+    double dEdx_AREA(detinfo::DetectorClocksData const& clockData,
+                     detinfo::DetectorPropertiesData const& detProp,
+                     double dQdx,double time, unsigned int plane, double T0=0) const;
 
-double dEdx_SUMADC(art::Ptr< recob::Hit >  hit, double pitch, double T0=0) const;
-    double dEdx_SUMADC(recob::Hit const&  hit, double pitch, double T0=0) const;
+    double dEdx_SUMADC(detinfo::DetectorClocksData const& clockData,
+                       detinfo::DetectorPropertiesData const& detProp,
+                       art::Ptr< recob::Hit >  hit, double pitch, double T0=0) const;
+    double dEdx_SUMADC(detinfo::DetectorClocksData const& clockData,
+                       detinfo::DetectorPropertiesData const& detProp,
+                       recob::Hit const&  hit, double pitch, double T0=0) const;
     double ElectronsFromADCPeak(double adc, unsigned short plane) const
     { return adc / fCalAmpConstants[plane]; }
 
     double ElectronsFromADCArea(double area, unsigned short plane) const
     { return area / fCalAreaConstants[plane]; }
 
-    double LifetimeCorrection(double time, double T0=0) const;
+    double LifetimeCorrection(detinfo::DetectorClocksData const& clockData,
+                              detinfo::DetectorPropertiesData const& detProp,
+                              double time, double T0=0) const;
 
   private:
 
     art::ServiceHandle<geo::Geometry const> geom;
-    const detinfo::DetectorProperties* detprop;
 
-    double dEdx_from_dQdx_e(double dQdx_e,double time, double T0=0) const;
+    double dEdx_from_dQdx_e(detinfo::DetectorClocksData const& clockData,
+                            detinfo::DetectorPropertiesData const& detProp,
+                            double dQdx_e,double time, double T0=0) const;
 
     std::vector< double > fCalAmpConstants;
     std::vector< double > fCalAreaConstants;

--- a/icaruscode/TPC/Calorimetry/CMakeLists.txt
+++ b/icaruscode/TPC/Calorimetry/CMakeLists.txt
@@ -7,6 +7,7 @@ art_make( MODULE_LIBRARIES
            larreco_Calorimetry
            lardataobj_RecoBase
            lardata_ArtDataHelper
+           lardataalg_DetectorInfo
            larcorealg_Geometry
            lardataobj_AnalysisBase
            ${ART_FRAMEWORK_SERVICES_REGISTRY}
@@ -25,4 +26,3 @@ art_make( MODULE_LIBRARIES
 install_headers()
 install_fhicl()
 install_source()
-

--- a/icaruscode/TPC/Calorimetry/CalorimetryICARUS_module.cc
+++ b/icaruscode/TPC/Calorimetry/CalorimetryICARUS_module.cc
@@ -96,7 +96,8 @@ private:
   bool BeginsOnBoundary(art::Ptr<recob::Track> lar_track);
   bool EndsOnBoundary(art::Ptr<recob::Track> lar_track);
 
-  void GetPitch(art::Ptr<recob::Hit> hit, std::vector<double> trkx, std::vector<double> trky, std::vector<double> trkz, std::vector<double> trkw, std::vector<double> trkx0, double *xyz3d, double &pitch, double TickT0);
+  void GetPitch(detinfo::DetectorPropertiesData const& detProp,
+                art::Ptr<recob::Hit> hit, std::vector<double> trkx, std::vector<double> trky, std::vector<double> trkz, std::vector<double> trkw, std::vector<double> trkx0, double *xyz3d, double &pitch, double TickT0);
 
   std::string fTrackModuleLabel;
   std::string fSpacePointModuleLabel;
@@ -148,9 +149,10 @@ calo::CalorimetryICARUS::CalorimetryICARUS(fhicl::ParameterSet const &pset)
 //------------------------------------------------------------------------------------//
 void calo::CalorimetryICARUS::produce(art::Event &evt)
 {
-//std::cout <<" producing calorimetry... " << std::endl;
-std::cout << " useintegral " << fUseIntegral << std::endl;
-  auto const *detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+  auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt, clockData);
+  //std::cout <<" producing calorimetry... " << std::endl;
+  std::cout << " useintegral " << fUseIntegral << std::endl;
   auto const *sce = lar::providerFrom<spacecharge::SpaceChargeService>();
 
   art::Handle<std::vector<recob::Track>> trackListHandle;
@@ -200,7 +202,7 @@ std::cout << " useintegral " << fUseIntegral << std::endl;
       std::vector<art::Ptr<anab::T0>> allT0 = fmt0.at(trkIter);
       if (allT0.size())
         T0 = allT0[0]->Time();
-      TickT0 = T0 / detprop->SamplingRate();
+      TickT0 = T0 / sampling_rate(clockData);
     }
 
     std::vector<std::vector<unsigned int>> hits(nplanes);
@@ -329,11 +331,11 @@ std::cout << " useintegral " << fUseIntegral << std::endl;
         {
 
           double t = allHits[hits[ipl][i]]->PeakTime() - TickT0; // Want T0 here? Otherwise ticks to x is wrong?
-          double x = detprop->ConvertTicksToX(t, allHits[hits[ipl][i]]->WireID().Plane, allHits[hits[ipl][i]]->WireID().TPC, allHits[hits[ipl][i]]->WireID().Cryostat);
+          double x = detProp.ConvertTicksToX(t, allHits[hits[ipl][i]]->WireID().Plane, allHits[hits[ipl][i]]->WireID().TPC, allHits[hits[ipl][i]]->WireID().Cryostat);
           double w = allHits[hits[ipl][i]]->WireID().Wire;
           if (TickT0)
           {
-            trkx.push_back(sptv[j]->XYZ()[0] - detprop->ConvertTicksToX(TickT0, allHits[hits[ipl][i]]->WireID().Plane, allHits[hits[ipl][i]]->WireID().TPC, allHits[hits[ipl][i]]->WireID().Cryostat));
+            trkx.push_back(sptv[j]->XYZ()[0] - detProp.ConvertTicksToX(TickT0, allHits[hits[ipl][i]]->WireID().Plane, allHits[hits[ipl][i]]->WireID().TPC, allHits[hits[ipl][i]]->WireID().Cryostat));
           }
           else
           {
@@ -368,7 +370,7 @@ std::cout << " useintegral " << fUseIntegral << std::endl;
         const size_t &hitIndex = allHits[hits[ipl][ihit]].key();
 
         double charge = allHits[hits[ipl][ihit]]->PeakAmplitude();
-        if (fUseArea) 
+        if (fUseArea)
         {
        //   std::cout << " integral " << allHits[hits[ipl][ihit]]->Integral() << std::endl;
 //std::cout << " sumadc " << allHits[hits[ipl][ihit]]->SummedADC() << std::endl;
@@ -442,7 +444,7 @@ std::cout << " useintegral " << fUseIntegral << std::endl;
           }
         }
         else
-          GetPitch(allHits[hits[ipl][ihit]], trkx, trky, trkz, trkw, trkx0, xyz3d, pitch, TickT0);
+          GetPitch(detProp, allHits[hits[ipl][ihit]], trkx, trky, trkz, trkw, trkx0, xyz3d, pitch, TickT0);
 
         if (fBadhit)
           continue;
@@ -479,12 +481,12 @@ std::cout << " useintegral " << fUseIntegral << std::endl;
         double dQdx = MIPs / pitch;
         double dEdx = 0;
         if (fUseArea) {
-                   if(fUseIntegral) dEdx = caloAlg.dEdx_AREA(allHits[hits[ipl][ihit]], pitch, T0);
-else dEdx = caloAlg.dEdx_SUMADC(allHits[hits[ipl][ihit]], pitch, T0);
+                   if(fUseIntegral) dEdx = caloAlg.dEdx_AREA(clockData, detProp, *allHits[hits[ipl][ihit]], pitch, T0);
+                   else dEdx = caloAlg.dEdx_SUMADC(clockData, detProp, allHits[hits[ipl][ihit]], pitch, T0);
 //std::cout << " ipl " << ipl << " ihit " << ihit << " charge " << charge << std::endl;
 }
         else
-          dEdx = caloAlg.dEdx_AMP(allHits[hits[ipl][ihit]], pitch, T0);
+          dEdx = caloAlg.dEdx_AMP(clockData, detProp, *allHits[hits[ipl][ihit]], pitch, T0);
 
         Kin_En = Kin_En + dEdx * pitch;
 
@@ -736,7 +738,8 @@ else dEdx = caloAlg.dEdx_SUMADC(allHits[hits[ipl][ihit]], pitch, T0);
   return;
 }
 
-void calo::CalorimetryICARUS::GetPitch(art::Ptr<recob::Hit> hit, std::vector<double> trkx, std::vector<double> trky, std::vector<double> trkz, std::vector<double> trkw, std::vector<double> trkx0, double *xyz3d, double &pitch, double TickT0)
+void calo::CalorimetryICARUS::GetPitch(detinfo::DetectorPropertiesData const& detProp,
+                                       art::Ptr<recob::Hit> hit, std::vector<double> trkx, std::vector<double> trky, std::vector<double> trkz, std::vector<double> trkw, std::vector<double> trkx0, double *xyz3d, double &pitch, double TickT0)
 {
   //Get 3d coordinates and track pitch for each hit
   //Find 5 nearest space points and determine xyz and curvature->track pitch
@@ -745,7 +748,6 @@ void calo::CalorimetryICARUS::GetPitch(art::Ptr<recob::Hit> hit, std::vector<dou
 
   // Get services
   art::ServiceHandle<geo::Geometry const> geom;
-  auto const *dp = lar::providerFrom<detinfo::DetectorPropertiesService>();
   auto const *sce = lar::providerFrom<spacecharge::SpaceChargeService>();
 
   //save distance to each spacepoint sorted by distance
@@ -756,7 +758,7 @@ void calo::CalorimetryICARUS::GetPitch(art::Ptr<recob::Hit> hit, std::vector<dou
   double wire_pitch = geom->WirePitch(0);
 
   double t0 = hit->PeakTime() - TickT0;
-  double x0 = dp->ConvertTicksToX(t0, hit->WireID().Plane, hit->WireID().TPC, hit->WireID().Cryostat);
+  double x0 = detProp.ConvertTicksToX(t0, hit->WireID().Plane, hit->WireID().TPC, hit->WireID().Cryostat);
   double w0 = hit->WireID().Wire;
 
   for (size_t i = 0; i < trkx.size(); ++i)

--- a/icaruscode/TPC/SignalProcessing/HitFinder/HitFinderTools/CandHitICARUS_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/HitFinder/HitFinderTools/CandHitICARUS_tool.cc
@@ -9,7 +9,6 @@
 #include "art/Utilities/make_tool.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "cetlib_except/exception.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larcore/Geometry/Geometry.h"
 
 #include <cmath>
@@ -22,10 +21,6 @@ class CandHitICARUS : ICandidateHitFinder
 {
 public:
     explicit CandHitICARUS(const fhicl::ParameterSet& pset);
-
-    ~CandHitICARUS();
-
-    void configure(const fhicl::ParameterSet& pset);
 
     void findHitCandidates(const recob::Wire::RegionsOfInterest_t::datarange_t&,
                            size_t,
@@ -72,15 +67,6 @@ private:
 //----------------------------------------------------------------------
 // Constructor.
 CandHitICARUS::CandHitICARUS(const fhicl::ParameterSet& pset)
-{
-    configure(pset);
-}
-
-CandHitICARUS::~CandHitICARUS()
-{
-}
-
-void CandHitICARUS::configure(const fhicl::ParameterSet& pset)
 {
     // Start by recovering the parameters
 

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitCharacterizationAlg.h
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitCharacterizationAlg.h
@@ -145,7 +145,7 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     art::ServiceHandle<geo::Geometry>  fGeometry;             ///< pointer to Geometry service
-    detinfo::DetectorProperties const* fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();   ///< Detector properties service
+   ///< Detector properties service
     const lariov::DetPedestalProvider& fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 };
 

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitCorrelatedCorrectionAlg.h
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitCorrelatedCorrectionAlg.h
@@ -33,7 +33,6 @@
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art_root_io/TFileService.h"
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 
 #include "TH1.h"
 #include "TH2.h"
@@ -99,7 +98,6 @@ private:
 
     // Useful services, keep copies for now (we can update during begin run periods)
     art::ServiceHandle<geo::Geometry>            fGeometry;             ///< pointer to Geometry service
-    detinfo::DetectorProperties const* fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();   ///< Detector properties service
 };
 
 } // end caldata namespace

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitFFTAlg.h
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitFFTAlg.h
@@ -51,13 +51,17 @@ public:
 
     // Provide for reinitialization if necessary
     void reconfigure(fhicl::ParameterSet const & pset);
-    void initializeHists(art::ServiceHandle<art::TFileService>&);
+    void initializeHists(detinfo::DetectorClocksData const& clockData,
+                         detinfo::DetectorPropertiesData const& detProp,
+                         art::ServiceHandle<art::TFileService>&);
     
     void getFFTCorrection(std::vector<T>&, double) const;
     
     void getFFTCorrection(std::vector<T>&, size_t) const;
     
-    void filterFFT(std::vector<short>&, size_t, size_t, float pedestal=0.);
+    void filterFFT(detinfo::DetectorClocksData const& clockData,
+                   detinfo::DetectorPropertiesData const& detProp,
+                   std::vector<short>&, size_t, size_t, float pedestal=0.);
     
 private:
     
@@ -84,7 +88,6 @@ private:
     std::unique_ptr<Eigen::FFT<float>>                     fEigenFFT;
 
     // Useful services, keep copies for now (we can update during begin run periods)
-    detinfo::DetectorProperties const* fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();   ///< Detector properties service
 };
     
 } // end caldata namespace

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitFilterAlg_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/Algorithms/RawDigitFilterAlg_tool.cc
@@ -54,7 +54,6 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     art::ServiceHandle<geo::Geometry>  fGeometry;             ///< pointer to Geometry service
-    detinfo::DetectorProperties const* fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();   ///< Detector properties service
 };
     
 //----------------------------------------------------------------------------

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/CMakeLists.txt
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/CMakeLists.txt
@@ -17,6 +17,7 @@ art_make(
                         lardata_Utilities
                         larevt_Filters
                         lardataobj_RawData
+                        lardataalg_DetectorInfo
                         larevt_CalibrationDBI_IOVData
                         larevt_CalibrationDBI_Providers
                         lardataobj_RecoBase

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/RawDigitSmoother_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/RawDigitSmoother_module.cc
@@ -30,7 +30,6 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalService.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalProvider.h"
 
@@ -89,7 +88,6 @@ private:
 
     // Useful services, keep copies for now (we can update during begin run periods)
     geo::GeometryCore const*             fGeometry;             ///< pointer to Geometry service
-    detinfo::DetectorProperties const*   fDetectorProperties;   ///< Detector properties service
     const lariov::DetPedestalProvider&   fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 };
 
@@ -109,7 +107,6 @@ RawDigitSmoother::RawDigitSmoother(fhicl::ParameterSet const & pset) : EDProduce
 {
     
     fGeometry = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
     
     configure(pset);
     produces<std::vector<raw::RawDigit>>("erosion");

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/mtRawDigitFilterICARUS_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/mtRawDigitFilterICARUS_module.cc
@@ -17,7 +17,6 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalService.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalProvider.h"
 #include "lardata/Utilities/LArFFTWPlan.h"
@@ -139,7 +138,6 @@ private:
 
     // Useful services, keep copies for now (we can update during begin run periods)
     geo::GeometryCore const*           fGeometry;             ///< pointer to Geometry service
-    detinfo::DetectorProperties const* fDetectorProperties;   ///< Detector properties service
     const lariov::DetPedestalProvider& fPedestalRetrievalAlg; ///< Keep track of an instance to the pedestal retrieval alg
 
     // mwang added
@@ -239,7 +237,6 @@ RawDigitFilterICARUS::RawDigitFilterICARUS(fhicl::ParameterSet const & pset, art
 {
 
     fGeometry = lar::providerFrom<geo::Geometry>();
-    fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();
 
     configure(pset);
     produces<std::vector<raw::RawDigit> >();
@@ -325,7 +322,6 @@ void RawDigitFilterICARUS::produce(art::Event & event, art::ProcessingFrame cons
   // ... Require a valid handle
   if (digitVecHandle.isValid() && digitVecHandle->size()>0 ){
     unsigned int maxChannels	= fGeometry->Nchannels();
-    //unsigned int maxTimeSamples = fDetectorProperties->NumberTimeSamples();
 
     // .. Let's first sort the rawDigitVec
     std::vector<const raw::RawDigit*> rawDigitVec;

--- a/icaruscode/TPC/SignalProcessing/RecoWire/CMakeLists.txt
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/CMakeLists.txt
@@ -16,6 +16,7 @@ art_make(
             larcorealg_Geometry
             larcore_Geometry_Geometry_service
             lardata_Utilities
+            lardataalg_DetectorInfo
             larevt_Filters
             lardataobj_RawData
             larevt_CalibrationDBI_IOVData
@@ -44,4 +45,3 @@ art_make(
 install_headers()
 install_fhicl()
 install_source()
-

--- a/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
@@ -41,6 +41,7 @@
 #include "lardataobj/RawData/RawDigit.h"
 #include "lardataobj/RawData/raw.h"
 #include "lardataobj/RecoBase/Wire.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/ArtDataHelper/WireCreator.h"
 #include "lardata/Utilities/AssociationUtil.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalService.h"
@@ -497,7 +498,8 @@ void  Decon1DROI::processChannel(size_t                                  idx,
         deconROIVec.push_back(icarus_tool::IROIFinder::CandidateROI(0,rawAdcLessPedVec.size()));
         
         // Do the deconvolution on the full waveform
-        fDeconvolution->Deconvolve(rawAdcLessPedVec, channel, deconROIVec, deconVec);
+        auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+        fDeconvolution->Deconvolve(rawAdcLessPedVec, sampling_rate(clockData), channel, deconROIVec, deconVec);
         
         // Recover the deconvolved waveform
         const std::vector<float>& deconvolvedWaveform = deconVec.get_ranges().front().data();

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/CMakeLists.txt
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/CMakeLists.txt
@@ -9,6 +9,7 @@ art_make(
                           lardataobj_RecoBase
                           larcore_Geometry_Geometry_service
                           lardata_Utilities
+                          lardataalg_DetectorInfo
                           icaruscode_TPC_Utilities_SignalShapingICARUSService_service
                           nurandom_RandomUtils_NuRandomService_service
                           ${ART_FRAMEWORK_CORE}

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/IDeconvolution.h
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/IDeconvolution.h
@@ -35,6 +35,7 @@ namespace icarus_tool
         
         // Find the ROI's
         virtual void Deconvolve(IROIFinder::Waveform const&,
+                                double samplingRate,
                                 raw::ChannelID_t,
                                 IROIFinder::CandidateROIVec const&,
                                 recob::Wire::RegionsOfInterest_t& ) const = 0;

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/ROIDeconvolution_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/ROIDeconvolution_tool.cc
@@ -35,6 +35,7 @@ public:
     void initializeHistograms(art::TFileDirectory&)        const override;
     
     void Deconvolve(const IROIFinder::Waveform&,
+                    double samplingRate,
                     raw::ChannelID_t,
                     IROIFinder::CandidateROIVec const&,
                     recob::Wire::RegionsOfInterest_t& )    const override;
@@ -108,14 +109,14 @@ void ROIDeconvolution::configure(const fhicl::ParameterSet& pset)
     // Get signal shaping service.
     fSignalShaping = art::ServiceHandle<icarusutil::SignalShapingICARUSService>();
 
-    auto const* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
-
     // Now set up our plans for doing the convolution
-    fFFT = std::make_unique<icarus_signal_processing::ICARUSFFT<double>>(detprop->NumberTimeSamples());
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob();
+    fFFT = std::make_unique<icarus_signal_processing::ICARUSFFT<double>>(detProp.NumberTimeSamples());
     
     return;
 }
 void ROIDeconvolution::Deconvolve(const IROIFinder::Waveform&        waveform,
+                                  double const                       samplingRate,
                                   raw::ChannelID_t                   channel,
                                   IROIFinder::CandidateROIVec const& roiVec,
                                   recob::Wire::RegionsOfInterest_t&  ROIVec) const
@@ -139,7 +140,7 @@ void ROIDeconvolution::Deconvolve(const IROIFinder::Waveform&        waveform,
         }
         
         // In theory, most ROI's are around the same size so this should mostly be a noop
-        fSignalShaping->SetDecon(deconSize, channel);
+        fSignalShaping->SetDecon(samplingRate, deconSize, channel);
         
         deconSize = fFFTSize;
         

--- a/icaruscode/TPC/SignalProcessing/RecoWire/RecoWireROIICARUS_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/RecoWireROIICARUS_module.cc
@@ -41,6 +41,7 @@
 #include "lardataobj/RawData/RawDigit.h"
 #include "lardataobj/RawData/raw.h"
 #include "lardataobj/RecoBase/Wire.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/ArtDataHelper/WireCreator.h"
 #include "lardata/Utilities/AssociationUtil.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalService.h"
@@ -230,6 +231,8 @@ void RecoWireROIICARUS::produce(art::Event& evt)
     
     const lariov::ChannelStatusProvider& chanFilt = art::ServiceHandle<lariov::ChannelStatusService>()->GetProvider();
     
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+    double const samplingRate = sampling_rate(clockData);
     // loop over all wires
     wirecol->reserve(digitVecHandle->size());
     for(size_t rdIter = 0; rdIter < digitVecHandle->size(); ++rdIter)
@@ -290,7 +293,7 @@ void RecoWireROIICARUS::produce(art::Event& evt)
             fROIFinderVec.at(planeID.Plane)->FindROIs(rawAdcLessPedVec, channel, fEventCount, raw_noise, candRoiVec);
             
             // Do the deconvolution
-            fDeconvolution->Deconvolve(rawAdcLessPedVec, channel, candRoiVec, ROIVec);
+            fDeconvolution->Deconvolve(rawAdcLessPedVec, samplingRate, channel, candRoiVec, ROIVec);
             
             // Make some histograms?
             if (fOutputHistograms)

--- a/icaruscode/TPC/SignalProcessing/RecoWire/RecoWireROI_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/RecoWireROI_module.cc
@@ -41,6 +41,8 @@
 #include "lardataobj/RawData/RawDigit.h"
 #include "lardataobj/RawData/raw.h"
 #include "lardataobj/RecoBase/Wire.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/ArtDataHelper/WireCreator.h"
 #include "lardata/Utilities/AssociationUtil.h"
 #include "icaruscode/TPC/Utilities/SignalShapingICARUSService_service.h"
@@ -206,10 +208,9 @@ void RecoWireROI::reconfigure(fhicl::ParameterSet const& p)
       }
     }
 
-    auto const* detprop      = lar::providerFrom<detinfo::DetectorPropertiesService>();
-	
     // Now set up our plans for doing the convolution
-    fFFT = std::make_unique<icarus_signal_processing::ICARUSFFT<double>>(detprop->NumberTimeSamples());
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob();
+    fFFT = std::make_unique<icarus_signal_processing::ICARUSFFT<double>>(detProp.NumberTimeSamples());
 }
 
 //-------------------------------------------------
@@ -248,8 +249,8 @@ void RecoWireROI::produce(art::Event& evt)
     
     raw::ChannelID_t channel = raw::InvalidChannelID; // channel number
 
-    auto const* detprop      = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    double      samplingRate = detprop->SamplingRate()/1000.;
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
+    double      samplingRate = sampling_rate(clockData)/1000.;
     double      deconNorm    = fSignalServices.GetDeconNorm();
 
     // We'll need to set the transform size once we get the waveform and know its size
@@ -299,7 +300,7 @@ void RecoWireROI::produce(art::Event& evt)
             //   unless the FFT vector length changes (which it shouldn't for a run)
             if (!transformSize)
             {
-                fSignalServices.SetDecon(dataSize, channel);
+                fSignalServices.SetDecon(samplingRate, dataSize, channel);
                 transformSize = dataSize;
             }
             

--- a/icaruscode/TPC/SignalProcessing/RecoWire/SimTestPulse/SimTestPulseWire_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/SimTestPulse/SimTestPulseWire_module.cc
@@ -97,9 +97,8 @@ SimTestPulseWire::SimTestPulseWire(fhicl::ParameterSet const & p)
     produces< std::vector<raw::Trigger> >();
     produces< sumdata::RunData, art::InRun >();
     
-    auto const* ts = lar::providerFrom<detinfo::DetectorClocksService>();
-    
-    fTriggerTime = ts->TriggerTime();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataForJob();
+    fTriggerTime = clockData.TriggerTime();
 
     // Assume 3 planes
     fWiresByPlaneVec.resize(3);
@@ -172,8 +171,7 @@ void SimTestPulseWire::produce(art::Event & e)
     
     double xyz[3] = {0., 0., 0.};
 
-    art::ServiceHandle<detinfo::DetectorClocksService> tss;
-    auto const* ts = tss->provider();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(e);
     art::ServiceHandle<geo::Geometry> geo;
 
     for(size_t idx = 0; idx < fPlaneChannelVec.size(); idx++)
@@ -189,8 +187,8 @@ void SimTestPulseWire::produce(art::Event & e)
 
     for(size_t index=0; index < fSimTime_v.size(); ++index) {
         
-        int tdc = fSimTime_v[index] / ts->TPCClock().TickPeriod();
-        fTick_v.push_back(ts->TPCTDC2Tick(tdc));
+        int tdc = fSimTime_v[index] / clockData.TPCClock().TickPeriod();
+        fTick_v.push_back(clockData.TPCTDC2Tick(tdc));
         
         if(fVerbose)
             std::cout << "[BUFFOON!] Charge injection id " << index << " @ TDC=" << tdc
@@ -206,7 +204,7 @@ void SimTestPulseWire::produce(art::Event & e)
         alternative::TruthHit pulse_record;
         pulse_record.tdc = tdc;
         pulse_record.num_electrons = fNumElectrons_v[index];
-        pulse_record.tick = ts->TPCTDC2Tick(tdc);
+        pulse_record.tick = clockData.TPCTDC2Tick(tdc);
 
         for(size_t plane=0; plane<3; ++plane) 
         {

--- a/icaruscode/TPC/Simulation/DetSim/CMakeLists.txt
+++ b/icaruscode/TPC/Simulation/DetSim/CMakeLists.txt
@@ -41,6 +41,7 @@ simple_plugin(SimWireICARUS "module"
                            larsim_Simulation 
                            nug4_ParticleNavigation lardataobj_Simulation
                            lardata_Utilities
+                           lardataalg_DetectorInfo
                            larevt_Filters
                            lardataobj_RawData
                            icaruscode_TPC_Utilities_SignalShapingICARUSService_service

--- a/icaruscode/TPC/Simulation/DetSim/SimWireICARUS_module.cc
+++ b/icaruscode/TPC/Simulation/DetSim/SimWireICARUS_module.cc
@@ -10,17 +10,6 @@
 //
 ////////////////////////////////////////////////////////////////////////
 
-/**
- * If defined, a hack to make sure DetectorClocksService knows about the new
- * hardware trigger time is enabled.
- * This is violating art/LArSoft recommended practices, and it is not even
- * useful in ICARUS where the
- * @ref DetectorClocksElectronicsStartTime "electronics time start"
- * is _determined_ by the hardware trigger.
- */
-#undef ICARUSCODE_SIMWIREICARUS_TRIGGERTIMEHACK
-
-
 // C/C++ standard library
 #include <stdexcept> // std::range_error
 #include <vector>
@@ -64,9 +53,6 @@
 #include "lardata/Utilities/LArFFT.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
-#ifdef ICARUSCODE_SIMWIREICARUS_TRIGGERTIMEHACK
-#include "lardata/DetectorInfoServices/DetectorClocksServiceStandard.h" // FIXME: this is not portable
-#endif // ICARUSCODE_SIMWIREICARUS_TRIGGERTIMEHACK
 #include "icaruscode/TPC/Utilities/SignalShapingICARUSService_service.h"
 #include "lardataobj/Simulation/sim.h"
 #include "larevt/CalibrationDBI/Interface/DetPedestalService.h"
@@ -214,10 +200,8 @@ void SimWireICARUS::reconfigure(fhicl::ParameterSet const& p)
     fShapingTimeOrder = { {0.6, 0}, {1, 1}, {1.3, 2}, {3.0, 3} };
 
     //detector properties information
-    //detector properties information
-    auto const* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    
-    fNTimeSamples = detprop->NumberTimeSamples();
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob();
+    fNTimeSamples = detProp.NumberTimeSamples();
     
     fSignalShapingService = art::ServiceHandle<icarusutil::SignalShapingICARUSService>{}.get();
 
@@ -276,14 +260,7 @@ void SimWireICARUS::produce(art::Event& evt)
     //channel status for simulating dead channels
     const lariov::ChannelStatusProvider& ChannelStatusProvider = art::ServiceHandle<lariov::ChannelStatusService>()->GetProvider();
     
-#ifdef ICARUSCODE_SIMWIREICARUS_TRIGGERTIMEHACK
-    // In case trigger simulation is run in the same job...
-    // FIXME:  You should not be calling preProcessEvent
-    art::ServiceHandle<detinfo::DetectorClocksServiceStandard>()
-      ->preProcessEvent(evt,art::ScheduleContext::invalid());
-#endif // ICARUSCODE_SIMWIREICARUS_TRIGGERTIMEHACK
-
-    auto const* ts = lar::providerFrom<detinfo::DetectorClocksService>();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
     
     // get the geometry to be able to figure out signal types and chan -> plane mappings
     const raw::ChannelID_t maxChannel = fGeometry.Nchannels();
@@ -329,7 +306,7 @@ void SimWireICARUS::produce(art::Event& evt)
     if (chargeWork.size() < fNTimeSamples) throw std::range_error("SimWireICARUS: chargeWork vector too small");
     
     //detector properties information
-    auto const* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(evt);
     
     // Let the tools know to update to the next event
     for(const auto& noiseTool : fNoiseToolVec) noiseTool->nextEvent();
@@ -415,7 +392,7 @@ void SimWireICARUS::produce(art::Event& evt)
             double noise_factor(0.);
             auto   tempNoiseVec = fSignalShapingService->GetNoiseFactVec();
             double shapingTime  = fSignalShapingService->GetShapingTime(channel);
-            double gain         = fSignalShapingService->GetASICGain(channel) * detprop->SamplingRate() * 1.e-3; // Gain returned is electrons/us, this converts to electrons/tick
+            double gain         = fSignalShapingService->GetASICGain(channel) * sampling_rate(clockData) * 1.e-3; // Gain returned is electrons/us, this converts to electrons/tick
             int    timeOffset   = fSignalShapingService->ResponseTOffset(channel);
             
             // Recover the response function information for this channel
@@ -439,6 +416,7 @@ void SimWireICARUS::produce(art::Event& evt)
             fNoiseToolVec[plane]->generateNoise(fUncNoiseEngine,
                                                 fCorNoiseEngine,
                                                 noisetmp,
+                                                detProp,
                                                 noise_factor,
                                                 channel);
             
@@ -453,7 +431,7 @@ void SimWireICARUS::produce(art::Event& evt)
                 // loop over the tdcs and grab the number of electrons for each
                 for(size_t tick = 0; tick < fNTimeSamples; tick++)
                 {
-                    int tdc = ts->TPCTick2TDC(tick);
+                    int tdc = clockData.TPCTick2TDC(tick);
                     
                     // continue if tdc < 0
                     if( tdc < 0 ) continue;

--- a/icaruscode/TPC/Simulation/DetSim/tools/CMakeLists.txt
+++ b/icaruscode/TPC/Simulation/DetSim/tools/CMakeLists.txt
@@ -10,6 +10,7 @@ art_make(
 			              lardataobj_RecoBase
 			              larcore_Geometry_Geometry_service
 			              lardata_Utilities
+                                      lardataalg_DetectorInfo
 			              nurandom_RandomUtils_NuRandomService_service
                           ${ICARUS_FFTW_LIBRARIES}
   			              ${ART_FRAMEWORK_CORE}

--- a/icaruscode/TPC/Simulation/DetSim/tools/CorrelatedNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/CorrelatedNoise_tool.cc
@@ -11,6 +11,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "cetlib_except/exception.h"
 #include "larcore/CoreUtils/ServiceUtil.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "art_root_io/TFileService.h"
 
@@ -50,6 +51,7 @@ public:
     void generateNoise(CLHEP::HepRandomEngine& noise_engine,
                        CLHEP::HepRandomEngine& cornoise_engine,
                        icarusutil::TimeVec& noise,
+                       detinfo::DetectorPropertiesData const&,
                        double noise_factor,
                        unsigned int wire) override;
     
@@ -103,9 +105,6 @@ private:
     
     // Keep instance of the eigen FFT
     Eigen::FFT<double>                          fEigenFFT;
-    
-    // Useful services, keep copies for now (we can update during begin run periods)
-    detinfo::DetectorProperties const* fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();   ///< Detector properties service
 };
     
 //----------------------------------------------------------------------
@@ -142,7 +141,8 @@ void CorrelatedNoise::configure(const fhicl::ParameterSet& pset)
     fCorrAmpHistogramName   = pset.get< std::string >("CorrAmpHistogramName");
     
     // Initialize the work vector
-    fNoiseFrequencyVec.resize(fDetectorProperties->NumberTimeSamples(),std::complex<float>(0.,0.));
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob();
+    fNoiseFrequencyVec.resize(detProp.NumberTimeSamples(),std::complex<float>(0.,0.));
 
     // Set up to input the histogram with the overall noise spectrum
     std::string fullFileName;
@@ -201,8 +201,9 @@ void CorrelatedNoise::configure(const fhicl::ParameterSet& pset)
         // Make a directory for these histograms
         art::TFileDirectory dir = histDirectory->mkdir(Form("CorNoisePlane%1zu",fPlane));
         
-        float sampleRate  = fDetectorProperties->SamplingRate();
-        float readOutSize = fDetectorProperties->ReadOutWindowSize();
+        auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+        float sampleRate  = sampling_rate(clockData);
+        float readOutSize = detProp.ReadOutWindowSize();
         float maxFreq     = 1.e6 / (2. * sampleRate);
         float minFreq     = 1.e6 / (2. * sampleRate * readOutSize);
         int   numSamples  = readOutSize / 2;
@@ -228,6 +229,7 @@ void CorrelatedNoise::nextEvent()
 void CorrelatedNoise::generateNoise(CLHEP::HepRandomEngine& engine_unc,
                                     CLHEP::HepRandomEngine& engine_corr,
                                     icarusutil::TimeVec&    noise,
+                                    detinfo::DetectorPropertiesData const&,
                                     double                  noise_factor,
                                     unsigned int            channel)
 {
@@ -372,13 +374,15 @@ void CorrelatedNoise::SelectContinuousSpectrum()
     fCoherentNoiseVec.clear();
     fCoherentNoiseVec.resize(peakVec.size(),0.);
     
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    auto const samplingRate = sampling_rate(clockData);
     for(size_t idx = 0; idx < peakVec.size(); idx++)
     {
         if (peakVec[idx] > threshold) fCoherentNoiseVec[idx] = peakVec[idx];
         
         if (fStoreHistograms)
         {
-            float freq = 1.e6 * float(idx)/ (2. * fDetectorProperties->SamplingRate() * fCoherentNoiseVec.size());
+            float freq = 1.e6 * float(idx)/ (2. * samplingRate * fCoherentNoiseVec.size());
             
             fInputNoiseHist->Fill(freq,fNoiseHistVec.at(idx),1.);
             fMedianNoiseHist->Fill(freq,fIncoherentNoiseVec.at(idx),1.);

--- a/icaruscode/TPC/Simulation/DetSim/tools/IGenNoise.h
+++ b/icaruscode/TPC/Simulation/DetSim/tools/IGenNoise.h
@@ -16,6 +16,10 @@
 #include "CLHEP/Random/RandomEngine.h"
 #include "icaruscode/TPC/Utilities/tools/SignalProcessingDefs.h"
 
+namespace detinfo {
+  class DetectorPropertiesData;
+}
+
 class TComplex;
 
 namespace icarus_tool
@@ -31,7 +35,9 @@ namespace icarus_tool
         
         virtual void generateNoise(CLHEP::HepRandomEngine& noise_engine,
                                    CLHEP::HepRandomEngine& cornoise_engine,
-                                   icarusutil::TimeVec&, double, unsigned int = 0) = 0;
+                                   icarusutil::TimeVec&,
+                                   detinfo::DetectorPropertiesData const& detProp,
+                                   double, unsigned int = 0) = 0;
     };
 }
 

--- a/icaruscode/TPC/Simulation/DetSim/tools/NoNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/NoNoise_tool.cc
@@ -25,7 +25,9 @@ public:
 
     void generateNoise(CLHEP::HepRandomEngine&,
                        CLHEP::HepRandomEngine&,
-                       icarusutil::TimeVec&, double, unsigned int) override;
+                       icarusutil::TimeVec&,
+                       detinfo::DetectorPropertiesData const&,
+                       double, unsigned int) override;
     
 private:
 
@@ -51,6 +53,7 @@ void NoNoise::configure(const fhicl::ParameterSet& pset)
 void NoNoise::generateNoise(CLHEP::HepRandomEngine&,
                             CLHEP::HepRandomEngine&,
                             icarusutil::TimeVec& noise,
+                            detinfo::DetectorPropertiesData const&,
                             double noise_factor,
                             unsigned int channel)
 {

--- a/icaruscode/TPC/Simulation/DetSim/tools/NoiseFromHist_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/NoiseFromHist_tool.cc
@@ -46,7 +46,9 @@ public:
 
     void generateNoise(CLHEP::HepRandomEngine&,
                        CLHEP::HepRandomEngine&,
-                       icarusutil::TimeVec&, double, unsigned int) override;
+                       icarusutil::TimeVec&,
+                       detinfo::DetectorPropertiesData const&,
+                       double, unsigned int) override;
     
 private:
     // Member variables from the fhicl file
@@ -60,7 +62,6 @@ private:
     // with the likely false hope this will be faster...
     std::vector<double> fNoiseHistVec;
 
-    const detinfo::DetectorProperties*                fDetector;              //< Pointer to the detector properties
     std::unique_ptr<icarus_signal_processing::ICARUSFFT<double>> fFFT;
 };
     
@@ -105,10 +106,9 @@ void NoiseFromHist::configure(const fhicl::ParameterSet& pset)
     // Close the input file
     inputFile.Close();
 
-    fDetector = lar::providerFrom<detinfo::DetectorPropertiesService>();
-
     // Now set up our plans for doing the convolution
-    int numberTimeSamples = fDetector->NumberTimeSamples();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob();
+    int numberTimeSamples = clockData.NumberTimeSamples();
 
     fFFT = std::make_unique<icarus_signal_processing::ICARUSFFT<double>>(numberTimeSamples);
    
@@ -118,12 +118,13 @@ void NoiseFromHist::configure(const fhicl::ParameterSet& pset)
 void NoiseFromHist::generateNoise(CLHEP::HepRandomEngine& engine,
                                   CLHEP::HepRandomEngine&,
                                   icarusutil::TimeVec& noise,
+                                  detinfo::DetectorPropertiesData const& detProp,
                                   double noise_factor,
                                   unsigned int channel)
 {    
     CLHEP::RandFlat flat(engine,-1,1);
     
-    size_t nFFTTicks = fDetector->NumberTimeSamples();
+    size_t nFFTTicks = detProp.NumberTimeSamples();
     
     if(noise.size() != nFFTTicks)
         throw cet::exception("SimWireICARUS")

--- a/icaruscode/TPC/Simulation/DetSim/tools/RandomNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/RandomNoise_tool.cc
@@ -35,6 +35,7 @@ public:
     void generateNoise(CLHEP::HepRandomEngine& engine,
                        CLHEP::HepRandomEngine&,
                        icarusutil::TimeVec&,
+                       detinfo::DetectorPropertiesData const&,
                        double,
                        unsigned int) override;
     
@@ -68,6 +69,7 @@ void RandomNoise::configure(const fhicl::ParameterSet& pset)
 void RandomNoise::generateNoise(CLHEP::HepRandomEngine& engine,
                                 CLHEP::HepRandomEngine&,
                                 icarusutil::TimeVec& noise,
+                                detinfo::DetectorPropertiesData const&,
                                 double noise_factor,
                                 unsigned int)
 {

--- a/icaruscode/TPC/Simulation/DetSim/tools/SBNNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/SBNNoise_tool.cc
@@ -51,6 +51,7 @@ public:
     void generateNoise(CLHEP::HepRandomEngine& noise_engine,
                        CLHEP::HepRandomEngine& cornoise_engine,
                        icarusutil::TimeVec& noise,
+                       detinfo::DetectorPropertiesData const&,
                        double noise_factor,
                        unsigned int wire) override;
     
@@ -112,8 +113,6 @@ float totalRMS;
     // Keep instance of the eigen FFT
     Eigen::FFT<double>                          fEigenFFT;
     
-    // Useful services, keep copies for now (we can update during begin run periods)
-    detinfo::DetectorProperties const* fDetectorProperties = lar::providerFrom<detinfo::DetectorPropertiesService>();   ///< Detector properties service
 };
     
 //----------------------------------------------------------------------
@@ -149,7 +148,9 @@ void SBNNoise::configure(const fhicl::ParameterSet& pset)
     fUncorrelatedRMSHistoName  = pset.get< std::string >("UncorrelatedRMSHistoName");
     fTotalRMSHistoName         = pset.get< std::string >("TotalRMSHistoName");
     // Initialize the work vector
-    fNoiseFrequencyVec.resize(fDetectorProperties->NumberTimeSamples(),std::complex<float>(0.,0.));
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob(clockData);
+    fNoiseFrequencyVec.resize(detProp.NumberTimeSamples(),std::complex<float>(0.,0.));
 
     // Set up to input the histogram with the overall noise spectrum
     std::string fullFileName;
@@ -210,8 +211,8 @@ std::cout << " after filling vectors " << std::endl;
         // Make a directory for these histograms
         art::TFileDirectory dir = histDirectory->mkdir(Form("CorNoisePlane%1zu",fPlane));
         
-        float sampleRate  = fDetectorProperties->SamplingRate();
-        float readOutSize = fDetectorProperties->ReadOutWindowSize();
+        float sampleRate  = sampling_rate(clockData);
+        float readOutSize = detProp.ReadOutWindowSize();
         float maxFreq     = 1.e6 / (2. * sampleRate);
         float minFreq     = 1.e6 / (2. * sampleRate * readOutSize);
         int   numSamples  = readOutSize / 2;
@@ -237,6 +238,7 @@ void SBNNoise::nextEvent()
 void SBNNoise::generateNoise(CLHEP::HepRandomEngine& engine_unc,
                                     CLHEP::HepRandomEngine& engine_corr,
                                     icarusutil::TimeVec&     noise,
+                             detinfo::DetectorPropertiesData const&,
                                     double                  noise_factor,
                                     unsigned int            channel)
 {

--- a/icaruscode/TPC/Simulation/Overlay/CMakeLists.txt
+++ b/icaruscode/TPC/Simulation/Overlay/CMakeLists.txt
@@ -8,6 +8,7 @@ art_make(
                            lardata_Utilities
                            larevt_Filters
                            lardataobj_RawData
+                           lardataalg_DetectorInfo
                            icaruscode_TPC_Utilities_SignalShapingICARUSService_service
 		           larevt_CalibrationDBI_Providers
                            nurandom_RandomUtils_NuRandomService_service

--- a/icaruscode/TPC/Simulation/Overlay/OverlayICARUS_module.cc
+++ b/icaruscode/TPC/Simulation/Overlay/OverlayICARUS_module.cc
@@ -146,11 +146,11 @@ void OverlayICARUS::reconfigure(fhicl::ParameterSet const& p)
     fDriftEModuleLabel = p.get< art::InputTag >("DriftEModuleLabel", "largeant");
 
     //detector properties information
-    auto const* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
+    auto const detprop = art::ServiceHandle<detinfo::DetectorPropertiesService>()->DataForJob();
     
     fSignalShapingService = art::ServiceHandle<icarusutil::SignalShapingICARUSService>{}.get();
 
-    fFFT = std::make_unique<icarus_signal_processing::ICARUSFFT<double>>(detprop->NumberTimeSamples());
+    fFFT = std::make_unique<icarus_signal_processing::ICARUSFFT<double>>(detprop.NumberTimeSamples());
     
     return;
 }
@@ -178,8 +178,6 @@ void OverlayICARUS::produce(art::Event& evt)
     // Get all of the services we will be using
     //
     //--------------------------------------------------------------------
-
-    auto const* ts = lar::providerFrom<detinfo::DetectorClocksService>();
 
     // Recocver the input RawDigits we are going to add our signal too
     art::Handle<std::vector<raw::RawDigit>> inputRawDigitHandle;
@@ -211,7 +209,7 @@ void OverlayICARUS::produce(art::Event& evt)
     icarusutil::TimeVec zeroCharge;
     
     //detector properties information
-    auto const* detprop = lar::providerFrom<detinfo::DetectorPropertiesService>();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(evt);
     
     // The outer loop is over the input RawDigits which will always be written out
     for(const auto& rawDigit : *inputRawDigitHandle)        
@@ -252,7 +250,7 @@ void OverlayICARUS::produce(art::Event& evt)
                 icarusutil::TimeVec chargeWork(adcvec.size(),0.);
 
                 // Need the to convert from deposited number of electrons to ADC units
-                double gain = fSignalShapingService->GetASICGain(channel) * detprop->SamplingRate() * 1.e-3; // Gain returned is electrons/us, this converts to electrons/tick
+                double gain = fSignalShapingService->GetASICGain(channel) * sampling_rate(clockData) * 1.e-3; // Gain returned is electrons/us, this converts to electrons/tick
 
                 // Loop through the simchannel energy deposits
                 for(const auto& tdcide : simChan->TDCIDEMap())
@@ -260,7 +258,7 @@ void OverlayICARUS::produce(art::Event& evt)
                     unsigned int tdc = tdcide.first;
 
                     // We need to convert this to a tick...
-                    int tick = ts->TPCTDC2Tick(tdc);
+                    int tick = clockData.TPCTDC2Tick(tdc);
 
                     // If out of range what is right thing to do?
                     if (tick < 0 ||tick > int(adcvec.size()))

--- a/icaruscode/TPC/Simulation/Overlay/tools/CMakeLists.txt
+++ b/icaruscode/TPC/Simulation/Overlay/tools/CMakeLists.txt
@@ -8,6 +8,7 @@ art_make(
 			              lardataobj_RecoBase
 			              larcore_Geometry_Geometry_service
 			              lardata_Utilities
+                                      lardataalg_DetectorInfo
 			              nurandom_RandomUtils_NuRandomService_service
                           ${ICARUS_FFTW_LIBRARIES}
   			              ${ART_FRAMEWORK_CORE}

--- a/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.cc
+++ b/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.cc
@@ -122,13 +122,15 @@ void SignalShapingICARUSService::init()
         // ICARUS response and filter functions.
         art::ServiceHandle<geo::Geometry> geo;
 
+        auto const samplingRate = sampling_rate(art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob());
+
         // Get the normalization from the field response for the collection plane
         double integral = fPlaneToResponseMap.at(fPlaneForNormalization).front().get()->getFieldResponse()->getIntegral();
         double weight   = 1. / integral;
         
         for(size_t planeIdx = 0; planeIdx < geo->Nplanes(); planeIdx++)
         {
-            fPlaneToResponseMap[planeIdx].front().get()->setResponse(weight);                
+          fPlaneToResponseMap[planeIdx].front().get()->setResponse(samplingRate, weight);
         }
         
         // Check to see if we want histogram output
@@ -143,7 +145,7 @@ void SignalShapingICARUSService::init()
             art::TFileDirectory dir = tfs->mkdir("SignalShaping");
             
             // Loop through response tools first
-            for(const auto& response: fPlaneToResponseMap) response.second.front().get()->outputHistograms(dir);
+            for(const auto& response: fPlaneToResponseMap) response.second.front().get()->outputHistograms(samplingRate, dir);
 
         }
 
@@ -153,7 +155,8 @@ void SignalShapingICARUSService::init()
     return;
 }
 
-void SignalShapingICARUSService::SetDecon(size_t fftsize, size_t channel)
+void SignalShapingICARUSService::SetDecon(double const samplingRate,
+                                          size_t fftsize, size_t channel)
 {
     art::ServiceHandle<geo::Geometry> geo;
     
@@ -165,7 +168,7 @@ void SignalShapingICARUSService::SetDecon(size_t fftsize, size_t channel)
     
     for(size_t planeIdx = 0; planeIdx < geo->Nplanes(); planeIdx++)
     {
-        fPlaneToResponseMap.at(planeIdx).front()->setResponse(weight);
+        fPlaneToResponseMap.at(planeIdx).front()->setResponse(samplingRate, weight);
     }
 }
 

--- a/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.h
+++ b/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.h
@@ -117,7 +117,7 @@ public:
      
     int                           ResponseTOffset(unsigned int const channel)        const;
     
-    void                          SetDecon(size_t fftsize, size_t channel);
+    void                          SetDecon(double samplingRate, size_t fftsize, size_t channel);
     double                        GetDeconNorm() {return fDeconNorm;};
     
     
@@ -151,5 +151,3 @@ private:
 
 DECLARE_ART_SERVICE(icarusutil::SignalShapingICARUSService, SHARED)
 #endif
-
-

--- a/icaruscode/TPC/Utilities/tools/CMakeLists.txt
+++ b/icaruscode/TPC/Utilities/tools/CMakeLists.txt
@@ -10,6 +10,7 @@ art_make(
             lardataobj_RecoBase
             larcore_Geometry_Geometry_service
             lardata_Utilities
+            lardataalg_DetectorInfo
             ${ICARUS_FFTW_LIBRARIES}
             ${ART_FRAMEWORK_CORE}
             ${ART_FRAMEWORK_PRINCIPAL}

--- a/icaruscode/TPC/Utilities/tools/Filter_tool.cc
+++ b/icaruscode/TPC/Utilities/tools/Filter_tool.cc
@@ -10,7 +10,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "cetlib_except/exception.h"
 #include "larcore/CoreUtils/ServiceUtil.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
 
 #include "TF1.h"
 #include "TProfile.h"
@@ -71,8 +71,9 @@ void Filter::configure(const fhicl::ParameterSet& pset)
 void Filter::setResponse(size_t numBins, double correct3D, double timeScaleFctr)
 {
     // Note that here we are working in frequency space, not in the time domain...
-    auto const* detprop      = lar::providerFrom<detinfo::DetectorPropertiesService>();
-    double      samplingRate = 1.e-3 * detprop->SamplingRate(); // Note sampling rate is in ns, convert to us
+    // FIXME: Assumes that the job-level clock data is sufficient.
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    double      samplingRate = 1.e-3 * sampling_rate(clockData); // Note sampling rate is in ns, convert to us
     double      maxFreq      = 1.e3 / (2. * samplingRate);      // highest frequency in cycles/us (MHz)
     double      freqRes      = maxFreq / double(numBins/2);     // frequency resolution in cycles/us
     
@@ -129,9 +130,9 @@ void Filter::outputHistograms(art::TFileDirectory& histDir) const
     
     art::TFileDirectory dir = histDir.mkdir(dirName.c_str());
     
-    auto const* detprop      = lar::providerFrom<detinfo::DetectorPropertiesService>();
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
+    double      samplingRate = 1.e-3 * sampling_rate(clockData); // Note sampling rate is in ns, convert to us
     double      numBins      = fFilterVec.size();
-    double      samplingRate = 1.e-3 * detprop->SamplingRate(); // Sampling time in us
     double      maxFreq      = 1.e3 / samplingRate;      // Max frequency in MHz
     double      minFreq      = maxFreq / numBins;
     std::string histName     = "FilterPlane_" + std::to_string(fPlane);

--- a/icaruscode/TPC/Utilities/tools/IResponse.h
+++ b/icaruscode/TPC/Utilities/tools/IResponse.h
@@ -36,16 +36,16 @@ class IResponse
 {
 public:
     virtual ~IResponse() noexcept = default;
-    
+
     /**
      *  @brief Setup routines
      *
      *  @param output                the object containting the art output
      *  @param clusHitPairVector     List of 3D hits to output as "extreme" space points
      */
-    virtual void                                    configure(const fhicl::ParameterSet& pset)   = 0;
-    virtual void                                    setResponse(double weight)                   = 0;
-    virtual void                                    outputHistograms(art::TFileDirectory&) const = 0;
+    virtual void configure(const fhicl::ParameterSet& pset)   = 0;
+    virtual void setResponse(double sampling_rate, double weight) = 0; // rate in ns
+    virtual void outputHistograms(double sampling_rate, art::TFileDirectory&) const = 0;
 
     /**
      *  @brief Return the plane these functions represent

--- a/icaruscode/gallery/MCTruthBase/CMakeLists.txt
+++ b/icaruscode/gallery/MCTruthBase/CMakeLists.txt
@@ -2,6 +2,7 @@ cet_enable_asserts()
 
 art_make( LIB_LIBRARIES lardataobj_RecoBase
                         larcorealg_Geometry
+                        lardataalg_DetectorInfo
                         nusimdata_SimulationBase
                         canvas
                         ${MF_MESSAGELOGGER}

--- a/icaruscode/gallery/MCTruthBase/MCTruthAssociations.cpp
+++ b/icaruscode/gallery/MCTruthBase/MCTruthAssociations.cpp
@@ -38,12 +38,10 @@ MCTruthAssociations::MCTruthAssociations(const fhicl::ParameterSet& config)
 void MCTruthAssociations::setup(const HitParticleAssociationsVec&  partToHitAssnsVec,
                                 const MCParticleVec&               mcPartVec,
                                 const MCTruthAssns&                truthToPartAssns,
-                                const geo::GeometryCore&           geometry,
-                                const detinfo::DetectorProperties& detectorProperties)
+                                const geo::GeometryCore&           geometry)
 {
     // Keep track of input services
     fGeometry           = &geometry;
-    fDetectorProperties = &detectorProperties;
     
     fHitPartAssnsVec.clear();
     
@@ -555,7 +553,8 @@ double MCTruthAssociations::length(const recob::Track* track) const
 
 // Length of MC particle.
 //----------------------------------------------------------------------------
-double MCTruthAssociations::length(const simb::MCParticle& part, double dx,
+double MCTruthAssociations::length(const detinfo::DetectorPropertiesData& detProp,
+                                   const simb::MCParticle& part, double dx,
                                    TVector3& start, TVector3& end, TVector3& startmom, TVector3& endmom,
                                    unsigned int tpc, unsigned int cstat) const
 {
@@ -567,7 +566,7 @@ double MCTruthAssociations::length(const simb::MCParticle& part, double dx,
     double zmin = -0.1;
     double zmax = fGeometry->DetLength() + 0.1;
     
-    double readOutWindowSize = fDetectorProperties->ReadOutWindowSize();
+    double readOutWindowSize = detProp.ReadOutWindowSize();
     
     double result = 0.;
     TVector3 disp;
@@ -594,7 +593,7 @@ double MCTruthAssociations::length(const simb::MCParticle& part, double dx,
            pos.Z() <= zmax)
         {
             pos[0] += dx;
-            double ticks = fDetectorProperties->ConvertXToTicks(pos[0], 0, 0, 0);
+            double ticks = detProp.ConvertXToTicks(pos[0], 0, 0, 0);
             
             if(ticks >= 0. && ticks < readOutWindowSize)
             {
@@ -620,4 +619,3 @@ double MCTruthAssociations::length(const simb::MCParticle& part, double dx,
 }
     
 } // end of namespace
-

--- a/icaruscode/gallery/MCTruthBase/MCTruthAssociations.h
+++ b/icaruscode/gallery/MCTruthBase/MCTruthAssociations.h
@@ -12,7 +12,7 @@
 
 // LArSoft libraries
 #include "larcorealg/Geometry/GeometryCore.h"
-#include "lardataalg/DetectorInfo/DetectorProperties.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "lardataobj/RecoBase/Track.h"
@@ -22,6 +22,9 @@
 //#include "lardataobj/Simulation/SimChannel.h"   // need this for TrackIDE definition
 #include "canvas/Persistency/Common/Assns.h"
 #include "canvas/Persistency/Common/FindOneP.h"
+namespace detinfo {
+  class DetectorPropertiesData;
+}
 
 // nutools
 #include "icaruscode/gallery/MCTruthBase/MCTruthParticleList.h"
@@ -67,8 +70,7 @@ public:
     void setup(const HitParticleAssociationsVec&,
                const MCParticleVec&,
                const MCTruthAssns&,
-               const geo::GeometryCore&,
-               const detinfo::DetectorProperties&);
+               const geo::GeometryCore&);
     
     const MCTruthParticleList& getParticleList() const;
 
@@ -159,7 +161,8 @@ private:
 
     int    calculateEvdID(int) const;
     double length(const recob::Track*) const;
-    double length(const simb::MCParticle& part, double dx,
+    double length(const detinfo::DetectorPropertiesData& detProp,
+                  const simb::MCParticle& part, double dx,
                   TVector3& start, TVector3& end, TVector3& startmom, TVector3& endmom,
                   unsigned int tpc = 0, unsigned int cstat = 0) const;
     
@@ -174,7 +177,7 @@ private:
                                                                ///< based on hit collections
 
     geo::GeometryCore const*           fGeometry           = nullptr;
-    const detinfo::DetectorProperties* fDetectorProperties = nullptr;   ///< Detector properties service
+
 }; // class MCTruthAssociations
     
 }  // End of namespace

--- a/icaruscode/gallery/galleryAnalysis/HitAnalysisAlg.cpp
+++ b/icaruscode/gallery/galleryAnalysis/HitAnalysisAlg.cpp
@@ -1,4 +1,3 @@
-
 #include "HitAnalysisAlg.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
@@ -45,12 +44,10 @@ void HitAnalysisAlg::reconfigure(fhicl::ParameterSet const & pset)
 //----------------------------------------------------------------------------
 /// Begin job method.
 void HitAnalysisAlg::setup(const geo::GeometryCore&           geometry,
-                           const detinfo::DetectorProperties& detectorProperties,
                            TDirectory*                        rootDirectory)
 {
     // Get geometry and detector properties
     fGeometry           = &geometry;
-    fDetectorProperties = &detectorProperties;
     fRootDirectory      = rootDirectory->mkdir(fLocalDirName.c_str());
 
     // Make a directory for these histograms

--- a/icaruscode/gallery/galleryAnalysis/HitAnalysisAlg.h
+++ b/icaruscode/gallery/galleryAnalysis/HitAnalysisAlg.h
@@ -20,7 +20,6 @@
 #include "fhiclcpp/ParameterSet.h"
 
 #include "larcorealg/Geometry/GeometryCore.h"
-#include "lardataalg/DetectorInfo/DetectorProperties.h"
 
 #include "lardataobj/RecoBase/Hit.h"
 
@@ -48,7 +47,7 @@ public:
 
     // provide for initialization
     void reconfigure(fhicl::ParameterSet const & pset);
-    void setup(const geo::GeometryCore&, const detinfo::DetectorProperties&, TDirectory*);
+    void setup(const geo::GeometryCore&, TDirectory*);
     void endJob(int numEvents);
     
     void fillHistograms(const TrackPlaneHitMap&) const;
@@ -93,7 +92,6 @@ private:
     
     // Useful services, keep copies for now (we can update during begin run periods)
     const geo::GeometryCore*           fGeometry;             ///< pointer to Geometry service
-    const detinfo::DetectorProperties* fDetectorProperties;   ///< Detector properties service
 };
 
 } // end of namespace caldata

--- a/icaruscode/gallery/galleryAnalysis/MCAssociations.h
+++ b/icaruscode/gallery/galleryAnalysis/MCAssociations.h
@@ -47,7 +47,7 @@ public:
     MCAssociations(fhicl::ParameterSet const& config);
   
     void setup(const geo::GeometryCore&,
-               const detinfo::DetectorProperties&,
+               const detinfo::DetectorPropertiesData&,
                TDirectory*);
   
     void prepare();
@@ -69,7 +69,7 @@ private:
     std::string              fLocalDirName;
     
     geo::GeometryCore const*           fGeometry           = nullptr;
-    const detinfo::DetectorProperties* fDetectorProperties = nullptr;   ///< Detector properties service
+    std::unique_ptr<detinfo::DetectorPropertiesData const> fDetectorProperties;
     TDirectory*                        fDir                = nullptr;
     
     std::unique_ptr<TH1>      fNTracks;

--- a/icaruscode/gallery/galleryAnalysis/galleryAnalysis.cpp
+++ b/icaruscode/gallery/galleryAnalysis/galleryAnalysis.cpp
@@ -104,8 +104,9 @@ int galleryAnalysis(std::string const& configFile, std::vector<std::string> cons
     auto detclk = testing::setupProvider<detinfo::DetectorClocksStandard>(config.get<fhicl::ParameterSet>("services.DetectorClocksService"));
   
     // DetectorProperties setup
-    auto detp = testing::setupProvider<detinfo::DetectorPropertiesStandard>(config.get<fhicl::ParameterSet>("services.DetectorPropertiesService"), detinfo::DetectorPropertiesStandard::providers_type{geom.get(),static_cast<detinfo::LArProperties const*>(larp.get()), // TODO type cast is required until issue #18001 is solved
-        static_cast<detinfo::DetectorClocks const*>(detclk.get())});
+    auto detp = testing::setupProvider<detinfo::DetectorPropertiesStandard>(config.get<fhicl::ParameterSet>("services.DetectorPropertiesService"),
+                                                                            detinfo::DetectorPropertiesStandard::providers_type{geom.get(),
+                                                                              static_cast<detinfo::LArProperties const*>(larp.get())}); // TODO type cast is required until issue #18001 is solved
   
     // ***************************************************************************
     // ***  SERVICE PROVIDER SETUP END    ****************************************
@@ -143,11 +144,11 @@ int galleryAnalysis(std::string const& configFile, std::vector<std::string> cons
     
     HitAnalysis::HitAnalysisAlg hitAnalysisAlg(analysisConfig.get<fhicl::ParameterSet>("hitAnalysisAlg"));
     
-    hitAnalysisAlg.setup(*geom, *detp, pHistFile.get());
+    hitAnalysisAlg.setup(*geom, pHistFile.get());
     
     MCAssociations mcAssociations(analysisConfig.get<fhicl::ParameterSet>("mcAssociations"));
-    
-    mcAssociations.setup(*geom, *detp, pHistFile.get());
+    auto const detProp = detp->DataFor(detclk->DataForJob());
+    mcAssociations.setup(*geom, detProp, pHistFile.get());
     mcAssociations.prepare();
     
     int numEvents(0);
@@ -207,4 +208,3 @@ int main(int argc, char** argv) {
 } // main()
 
 #endif // !__CLING__
-

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -34,7 +34,7 @@ table_fragment_end
 # Add the dependent product and version
 
 product             version
-larsoft                   v08_62_00
+larsoft                   v09_00_00_rc1
 icarusutil                v08_51_00
 icarus_signal_processing  v08_61_00
 icarus_data               v08_62_00


### PR DESCRIPTION
This includes all of the thread-safety changes for detector clocks/properties services.

Unfortunately, an earlier version of this PR (#2) was prematurely merged, thus confusing the Git history.  The changes in this PR include all changes required for use LArSoft v9.  Careful resolutions of commit conflicts will be required because of the commit confusion.