### PR TITLE
Updated CRT geometry sorting (and mapping)

### DIFF
--- a/icaruscode/Geometry/GeoObjectSorterICARUS.cxx
+++ b/icaruscode/Geometry/GeoObjectSorterICARUS.cxx
@@ -7,6 +7,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include "icaruscode/Geometry/GeoObjectSorterICARUS.h"
+#include "icaruscode/Geometry/details/AuxDetSorting.h"
 
 #include "larcorealg/Geometry/AuxDetGeo.h"
 #include "larcorealg/Geometry/AuxDetSensitiveGeo.h"
@@ -16,72 +17,6 @@
 #include "larcorealg/Geometry/WireGeo.h"
 
 namespace geo{
-
-  //----------------------------------------------------------------------------
-  // Define sort order for cryostats in standard configuration
-  static bool sortAuxDetStandard(const AuxDetGeo& ad1, const AuxDetGeo& ad2)
-  {
-    std::string type1 = "", type2 = "";
-    switch (ad1.NSensitiveVolume()) {
-        case 20 : type1 = "MINOS"; break;
-        case 16 : type1 = "CERN"; break;
-        case 64 : type1 = "DC"; break;
-    }
-    switch (ad2.NSensitiveVolume()) {
-        case 20 : type2 = "MINOS"; break;
-        case 16 : type2 = "CERN"; break;
-        case 64 : type2 = "DC"; break;
-    }
-
-    // sort based off of GDML name, module number
-    std::string ad1name = (ad1.TotalVolume())->GetName();
-    std::string ad2name = (ad2.TotalVolume())->GetName();
-    // assume volume name is "volAuxDet_<type>_module_###_<region>"
-    std::string base1 = "volAuxDet_"+type1+"_module_";
-    std::string base2 = "volAuxDet_"+type2+"_module_";
-
-    int ad1Num = atoi( ad1name.substr( base1.size(), 3).c_str() );
-    int ad2Num = atoi( ad2name.substr( base2.size(), 3).c_str() );
-
-    return ad1Num < ad2Num;
-
-  }
-
-  //----------------------------------------------------------------------------
-  // Define sort order for cryostats in standard configuration
-  static bool sortAuxDetSensitiveStandard(const AuxDetSensitiveGeo& ad1, const AuxDetSensitiveGeo& ad2)
-  {
-    std::string type1 = "", type2 = "";
-
-    // sort based off of GDML name, assuming ordering is encoded
-    std::string ad1name = (ad1.TotalVolume())->GetName();
-    std::string ad2name = (ad2.TotalVolume())->GetName();
-
-    if ( ad1name.find("MINOS") != std::string::npos ) type1 = "MINOS";
-    if ( ad1name.find("CERN") != std::string::npos ) type1 = "CERN";
-    if ( ad1name.find("DC") != std::string::npos ) type1 = "DC";
-    if ( ad2name.find("MINOS") != std::string::npos ) type2 = "MINOS";
-    if ( ad2name.find("CERN") != std::string::npos ) type2 = "CERN";
-    if ( ad2name.find("DC") != std::string::npos ) type2 = "DC";
-
-    // assume volume name is "volAuxDetSensitive_<type>_module_###_strip_##"
-    std::string baseMod1 = "volAuxDetSensitive_"+type1+"module_";
-    std::string baseStr1 = "volAuxDetSensitive_"+type1+"module_###_strip_";
-    std::string baseMod2 = "volAuxDetSensitive_"+type2+"module_";
-    std::string baseStr2 = "volAuxDetSensitive_"+type2+"module_###_strip_";
-
-    int ad1Num = atoi( ad1name.substr( baseMod1.size(), 3).c_str() );
-    int ad2Num = atoi( ad2name.substr( baseMod2.size(), 3).c_str() );
-
-    if(ad1Num!=ad2Num) return ad1Num < ad2Num;
-
-    ad1Num = atoi( ad1name.substr( baseStr1.size(), 2).c_str() );
-    ad2Num = atoi( ad2name.substr( baseStr2.size(), 2).c_str() );
-
-
-    return ad1Num < ad2Num;
-
-  }
 
   //----------------------------------------------------------------------------
   // Define sort order for cryostats in standard configuration
@@ -157,13 +92,13 @@ namespace geo{
   //----------------------------------------------------------------------------
   void GeoObjectSorterICARUS::SortAuxDets(std::vector<geo::AuxDetGeo> & adgeo) const
   {
-    std::sort(adgeo.begin(), adgeo.end(), sortAuxDetStandard);
+    icarus::SortAuxDetsStandard(adgeo);
   }
 
   //----------------------------------------------------------------------------
   void GeoObjectSorterICARUS::SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo> & adsgeo) const
   {
-    std::sort(adsgeo.begin(), adsgeo.end(), sortAuxDetSensitiveStandard);
+    icarus::SortAuxDetSensitiveStandard(adsgeo);
   }
 
   //----------------------------------------------------------------------------

--- a/icaruscode/Geometry/GeoObjectSorterPMTasTPC.cxx
+++ b/icaruscode/Geometry/GeoObjectSorterPMTasTPC.cxx
@@ -1,84 +1,15 @@
 /**
  * @file icaruscode/Geometry/GeoObjectSorterPMTasTPC.cxx
- * @brief  Geometry obect sorter with PMT following TPC wire order.
+ * @brief  Geometry object sorter with PMT following TPC wire order.
  * @date   April 26, 2020
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @see    icaruscode/Geometry/GeoObjectSorterPMTasTPC.h
+ * 
+ * Nothing, really.
  */
 
 
 // library header
 #include "icaruscode/Geometry/GeoObjectSorterPMTasTPC.h"
-
-// LArSoft libraries
-// #include "larcorealg/CoreUtils/span.h"
-
-// C/C++ standard libraries
-#include <vector>
-#include <iterator>
-#include <algorithm> // std::sort()
-#include <cassert>
-
-
-// -----------------------------------------------------------------------------
-void icarus::GeoObjectSorterPMTasTPC::SortOpDets
-  (std::vector<geo::OpDetGeo>& opDets) const
-{
-  assert(opDets.size() % 2 == 0); // must be even!
-  
-  /*
-   * 1. sort all optical detectors by _x_
-   * 2. split them by plane
-   * 3. sort the detectors within each plane.
-   */
-  
-  //
-  // 1. sort all optical detectors by _x_
-  //
-  std::sort(begin(opDets), end(opDets), fSmallerCenterX);
-  
-  //
-  // 2. split them by plane: we take a horrible shortcut here...
-  //
-  
-  std::vector<OpDetSpan_t> OpDetsPerPlane;
-  
-  // just split the list in two
-  auto const middle = std::next(opDets.begin(), opDets.size() / 2U);
-  assert(fSmallerCenterX(*std::prev(middle), *middle));
-  
-  OpDetsPerPlane.emplace_back(opDets.begin(), middle);
-  OpDetsPerPlane.emplace_back(middle, opDets.end());
-  assert(OpDetsPerPlane[0].size() == OpDetsPerPlane[1].size());
-  
-  //
-  // 3. sort the detectors within each plane.
-  //
-  for (auto const& planeOpDets: OpDetsPerPlane)
-    sortOpDetsInPlane(util::make_span(planeOpDets));
-  
-  // all done in place, no return
-  
-} // icarus::GeoObjectSorterPMTasTPC::SortOpDets()
-
-
-// -----------------------------------------------------------------------------
-void icarus::GeoObjectSorterPMTasTPC::sortOpDetsInPlane
-  (OpDetSpan_t const& opDets) const
-{
-  /*
-   * 0. assume it's already sorted by _x_
-   * 1. sort by vertical coordinate (_y_)
-   * 2. stable sort by beam coordinate (_z_)
-   */
-  
-  // 1. sort by vertical coordinate (_y_)
-  std::stable_sort(begin(opDets), end(opDets), fSmallerCenterY);
-  
-  // 2. stable sort by beam coordinate (_z_)
-  std::stable_sort(begin(opDets), end(opDets), fSmallerCenterZ);
-  
-} // icarus::GeoObjectSorterPMTasTPC::sortOpDetsInPlane()
-
 
 // -----------------------------------------------------------------------------

--- a/icaruscode/Geometry/GeoObjectSorterPMTasTPC.cxx
+++ b/icaruscode/Geometry/GeoObjectSorterPMTasTPC.cxx
@@ -12,4 +12,23 @@
 // library header
 #include "icaruscode/Geometry/GeoObjectSorterPMTasTPC.h"
 
-// -----------------------------------------------------------------------------
+// ICARUS libraries
+#include "icaruscode/Geometry/details/AuxDetSorting.h"
+
+
+//------------------------------------------------------------------------------
+void icarus::GeoObjectSorterPMTasTPC::SortAuxDets
+  (std::vector<geo::AuxDetGeo>& adgeo) const
+{
+  icarus::SortAuxDetsStandard(adgeo);
+}
+
+//------------------------------------------------------------------------------
+void icarus::GeoObjectSorterPMTasTPC::SortAuxDetSensitive
+  (std::vector<geo::AuxDetSensitiveGeo>& adsgeo) const
+{
+  icarus::SortAuxDetSensitiveStandard(adsgeo);
+}
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/Geometry/GeoObjectSorterPMTasTPC.h
+++ b/icaruscode/Geometry/GeoObjectSorterPMTasTPC.h
@@ -1,6 +1,6 @@
 /**
  * @file icaruscode/Geometry/GeoObjectSorterPMTasTPC.h
- * @brief  Geometry obect sorter with PMT following TPC wire order.
+ * @brief  Geometry object sorter with PMT following TPC wire order.
  * @date   April 26, 2020
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @see    icaruscode/Geometry/GeoObjectSorterPMTasTPC.cxx
@@ -9,6 +9,9 @@
 #ifndef ICARUSCODE_GEOMETRY_GEOOBJECTSORTERPMTASTPC_H
 #define ICARUSCODE_GEOMETRY_GEOOBJECTSORTERPMTASTPC_H
 
+// ICARUS libraries
+#include "icaruscode/Geometry/details/PMTsorting.h" // icarus::PMTsorterStandard
+
 // LArSoft libraries
 #include "larcorealg/Geometry/GeoObjectSorterStandard.h"
 #include "larcorealg/Geometry/OpDetGeo.h"
@@ -16,6 +19,7 @@
 #include "larcorealg/CoreUtils/span.h" // util::span
 
 // framework libraries
+#include "fhiclcpp/types/Table.h"
 #include "fhiclcpp/ParameterSet.h"
 
 // C/C++ standard libraries
@@ -31,7 +35,8 @@ namespace icarus { class GeoObjectSorterPMTasTPC; }
  * This class sorts the elements of the LArSoft detector description.
  * The TPC elements are sorted according to the "standard" algorithm
  * (`geo::GeoObjectSorterStandard`). The PMT are arranged so that their channels
- * mimic the order of the TPC channels.
+ * mimic the order of the TPC channels (delegated to `icarus::PMTsorter`
+ * algorithm).
  * 
  * The algorithm for assigning channels to the wires follows the criteria:
  * 
@@ -64,61 +69,24 @@ namespace icarus { class GeoObjectSorterPMTasTPC; }
  * (`geo::GeoObjectSorterStandard`), this sorter supports the following
  * parameters:
  * 
- * * `ToleranceX`, `ToleranceY`, `ToleranceZ` (double, default: `1.0`):
- *   rounding used for sorting optical detector position, in centimeters;
- *   if the coordinate of two optical detectors are closer than the tolerance
- *   for that coordinate (absolute), they two detectors are considered to be at
- *   the same position in that coordinate
- *   (note that the default value is very generous).
+ * * `OpDetSorter` (configuration table; default: empty): configures the
+ *   PMT sorter object (see `icarus::PMTsorter` for details)
  * 
  */
 class icarus::GeoObjectSorterPMTasTPC: public geo::GeoObjectSorterStandard {
   
-  /// List of optical detector pointers for sorting.
-  using OpDetList_t = std::vector<geo::OpDetGeo>;
+  /// The sorting algorithm we use.
+  using PMTsorter_t = icarus::PMTsorterStandard;
   
-  /// Part of list of optical detector pointers for sorting.
-  using OpDetSpan_t = util::span<OpDetList_t::iterator>;
+  using PMTsorterConfigTable = fhicl::Table<PMTsorter_t::Config>;
   
     public:
-  
-  /*
-  // not using configuration validation
-  // because we could not pass the configuration to the base class
-  
-  struct Config {
-    
-    using Name = fhicl::Name;
-    using Comment = fhicl::Comment;
-    
-    fhicl::Atom<double> ToleranceX {
-      Name("ToleranceX"),
-      Comment("tolerance when sorting optical detectors on x coordinate [cm]"),
-      1.0 // default
-      };
-    
-    fhicl::Atom<double> ToleranceY {
-      Name("ToleranceY"),
-      Comment("tolerance when sorting optical detectors on x coordinate [cm]"),
-      1.0 // default
-      };
-    
-    fhicl::Atom<double> ToleranceZ {
-      Name("ToleranceZ"),
-      Comment("tolerance when sorting optical detectors on x coordinate [cm]"),
-      1.0 // default
-      };
-    
-  }; // Config
-  */
-  
   
   /// Constructor: passes the configuration to the base class.
   GeoObjectSorterPMTasTPC(fhicl::ParameterSet const& pset)
     : geo::GeoObjectSorterStandard(pset)
-    , fSmallerCenterX{ pset.get("ToleranceX", 1.0) }
-    , fSmallerCenterY{ pset.get("ToleranceY", 1.0) }
-    , fSmallerCenterZ{ pset.get("ToleranceZ", 1.0) }
+    , fPMTsorter
+      (PMTsorterConfigTable{ pset.get("OpDetSorter", fhicl::ParameterSet{}) }())
     {}
   
   
@@ -136,45 +104,13 @@ class icarus::GeoObjectSorterPMTasTPC: public geo::GeoObjectSorterStandard {
    * @note The current implementation is very sensitive to rounding errors!
    * 
    */
-  virtual void SortOpDets(std::vector<geo::OpDetGeo>& opDets) const override;
+  virtual void SortOpDets(std::vector<geo::OpDetGeo>& opDets) const override
+    { fPMTsorter.sort(opDets); }
   
   
     private:
   
-  /// `geo::OpDetGeo` comparer according to one coordinate of their center.
-  /// Accomodates for some tolerance.
-  template <double (geo::Point_t::*Coord)() const>
-  struct OpDetGeoCenterCoordComparer {
-    
-    /// Object used for comparison; includes a tolerance.
-    lar::util::RealComparisons<double> const fCmp;
-    
-    /// Constructor: fixes the tolerance for the comparison.
-    OpDetGeoCenterCoordComparer(double tol = 0.0): fCmp(tol) {}
-    
-    /// Returns whether `A` has a center coordinate `Coord` smaller than `B`.
-    bool operator() (geo::OpDetGeo const& A, geo::OpDetGeo const& B) const
-      {
-        return fCmp.strictlySmaller
-            ((A.GetCenter().*Coord)(), (B.GetCenter().*Coord)());
-      }
-    
-  }; // OpDetGeoCenterCoordComparer
-  
-  
-  /// Sorting criterium according to _x_ coordinate of `geo::OpDetGeo` center.
-  OpDetGeoCenterCoordComparer<&geo::Point_t::X> const fSmallerCenterX;
-  
-  /// Sorting criterium according to _y_ coordinate of `geo::OpDetGeo` center.
-  OpDetGeoCenterCoordComparer<&geo::Point_t::Y> const fSmallerCenterY;
-  
-  /// Sorting criterium according to _z_ coordinate of `geo::OpDetGeo` center.
-  OpDetGeoCenterCoordComparer<&geo::Point_t::Z> const fSmallerCenterZ;
-  
-  
-  /// Sorts the `geo::OpDetGeo` assuming they belong to the same plane.
-  void sortOpDetsInPlane(OpDetSpan_t const& opDets) const;
-  
+  PMTsorter_t fPMTsorter; ///< PMT sorting algorithm.
   
 }; // icarus::GeoObjectSorterPMTasTPC
 

--- a/icaruscode/Geometry/GeoObjectSorterPMTasTPC.h
+++ b/icaruscode/Geometry/GeoObjectSorterPMTasTPC.h
@@ -108,6 +108,13 @@ class icarus::GeoObjectSorterPMTasTPC: public geo::GeoObjectSorterStandard {
     { fPMTsorter.sort(opDets); }
   
   
+  /// Custom ICARUS sorting of CRT.
+  virtual void SortAuxDets(std::vector<geo::AuxDetGeo>& adgeo) const override;
+  
+  /// Custom ICARUS sorting of CRT submodules.
+  virtual void SortAuxDetSensitive
+    (std::vector<geo::AuxDetSensitiveGeo> & adsgeo) const override;
+  
     private:
   
   PMTsorter_t fPMTsorter; ///< PMT sorting algorithm.

--- a/icaruscode/Geometry/details/AuxDetSorting.cxx
+++ b/icaruscode/Geometry/details/AuxDetSorting.cxx
@@ -1,0 +1,114 @@
+/**
+ * @file   icaruscode/Geometry/details/AuxDetSorting.cxx
+ * @brief  Functions for sorting ICARUS CRT modules (auxiliary detectors).
+ * @author Chris Hilgenberg, Gianluca Petrillo (refactoring only)
+ * @date   August 7, 2018
+ * @see    icaruscode/Geometry/details/AuxDetSorting.h
+ */
+
+// library header
+#include "icaruscode/Geometry/details/AuxDetSorting.h"
+
+// LArSoft libraries
+#include "larcorealg/Geometry/AuxDetGeo.h"
+#include "larcorealg/Geometry/AuxDetSensitiveGeo.h"
+
+// C/C++ standard libraries
+#include <string>
+#include <algorithm> // std::sort()
+#include <cstdlib> // std::atoi()
+
+
+namespace {
+  
+  //--------------------------------------------------------------------------
+  /// Define sort order for CRT modules in standard configuration.
+  bool AuxDetStandardSortingRule
+    (const geo::AuxDetGeo& ad1, const geo::AuxDetGeo& ad2)
+  {
+    
+    std::string type1 = "", type2 = "";
+    switch (ad1.NSensitiveVolume()) {
+        case 20 : type1 = "MINOS"; break;
+        case 16 : type1 = "CERN"; break;
+        case 64 : type1 = "DC"; break;
+    }
+    switch (ad2.NSensitiveVolume()) {
+        case 20 : type2 = "MINOS"; break;
+        case 16 : type2 = "CERN"; break;
+        case 64 : type2 = "DC"; break;
+    }
+
+    // sort based off of GDML name, module number
+    std::string ad1name = (ad1.TotalVolume())->GetName();
+    std::string ad2name = (ad2.TotalVolume())->GetName();
+    // assume volume name is "volAuxDet_<type>_module_###_<region>"
+    std::string base1 = "volAuxDet_"+type1+"_module_";
+    std::string base2 = "volAuxDet_"+type2+"_module_";
+
+    int ad1Num = std::atoi( ad1name.substr( base1.size(), 3).c_str() );
+    int ad2Num = std::atoi( ad2name.substr( base2.size(), 3).c_str() );
+
+    return ad1Num < ad2Num;
+
+  } // AuxDetStandardSortingRule()
+  
+  
+  //----------------------------------------------------------------------------
+  /// Define sort order for CRT submodules in standard configuration.
+  bool AuxDetSensitiveStandardSortingRule
+    (const geo::AuxDetSensitiveGeo& ad1, const geo::AuxDetSensitiveGeo& ad2)
+  {
+    std::string type1 = "", type2 = "";
+
+    // sort based off of GDML name, assuming ordering is encoded
+    std::string ad1name = (ad1.TotalVolume())->GetName();
+    std::string ad2name = (ad2.TotalVolume())->GetName();
+
+    if ( ad1name.find("MINOS") != std::string::npos ) type1 = "MINOS";
+    if ( ad1name.find("CERN") != std::string::npos ) type1 = "CERN";
+    if ( ad1name.find("DC") != std::string::npos ) type1 = "DC";
+    if ( ad2name.find("MINOS") != std::string::npos ) type2 = "MINOS";
+    if ( ad2name.find("CERN") != std::string::npos ) type2 = "CERN";
+    if ( ad2name.find("DC") != std::string::npos ) type2 = "DC";
+
+    // assume volume name is "volAuxDetSensitive_<type>_module_###_strip_##"
+    std::string baseMod1 = "volAuxDetSensitive_"+type1+"module_";
+    std::string baseStr1 = "volAuxDetSensitive_"+type1+"module_###_strip_";
+    std::string baseMod2 = "volAuxDetSensitive_"+type2+"module_";
+    std::string baseStr2 = "volAuxDetSensitive_"+type2+"module_###_strip_";
+
+    int ad1Num = atoi( ad1name.substr( baseMod1.size(), 3).c_str() );
+    int ad2Num = atoi( ad2name.substr( baseMod2.size(), 3).c_str() );
+
+    if(ad1Num!=ad2Num) return ad1Num < ad2Num;
+
+    ad1Num = std::atoi( ad1name.substr( baseStr1.size(), 2).c_str() );
+    ad2Num = std::atoi( ad2name.substr( baseStr2.size(), 2).c_str() );
+
+
+    return ad1Num < ad2Num;
+
+  } // AuxDetSensitiveStandardSortingRule()
+  
+  
+  //----------------------------------------------------------------------------
+  
+} // local namespace
+
+
+//------------------------------------------------------------------------------
+void icarus::SortAuxDetsStandard(std::vector<geo::AuxDetGeo> & adgeo) {
+  std::sort(adgeo.begin(), adgeo.end(), AuxDetStandardSortingRule);
+}
+
+
+//------------------------------------------------------------------------------
+void icarus::SortAuxDetSensitiveStandard
+  (std::vector<geo::AuxDetSensitiveGeo>& adsgeo)
+{
+  std::sort(adsgeo.begin(), adsgeo.end(), AuxDetSensitiveStandardSortingRule);
+}
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/Geometry/details/AuxDetSorting.h
+++ b/icaruscode/Geometry/details/AuxDetSorting.h
@@ -1,0 +1,39 @@
+/**
+ * @file   icaruscode/Geometry/details/AuxDetSorting.h
+ * @brief  Functions for sorting ICARUS CRT modules (auxiliary detectors).
+ * @author Chris Hilgenberg, Gianluca Petrillo (refactoring only)
+ * @date   August 7, 2018
+ * @see    icaruscode/Geometry/details/AuxDetSorting.cxx
+ */
+
+#ifndef ICARUSCODE_GEOMETRY_DETAILS_AUXDETSORTING_H
+#define ICARUSCODE_GEOMETRY_DETAILS_AUXDETSORTING_H
+
+
+// LArSoft libraries
+#include "larcorealg/Geometry/AuxDetGeo.h"
+#include "larcorealg/Geometry/AuxDetSensitiveGeo.h"
+
+// C/C++ standard libraries
+#include <vector>
+
+
+namespace icarus {
+  
+  //----------------------------------------------------------------------------
+  /// Sorts ICARUS CRT modules in standard configuration.
+  void SortAuxDetsStandard(std::vector<geo::AuxDetGeo>& adgeo);
+  
+  
+  //----------------------------------------------------------------------------
+  /// Sorts ICARUS CRT submodules in standard configuration.
+  void SortAuxDetSensitiveStandard
+    (std::vector<geo::AuxDetSensitiveGeo>& adsgeo);
+  
+  
+  //----------------------------------------------------------------------------
+  
+} // namespace icarus
+
+
+#endif // ICARUSCODE_GEOMETRY_DETAILS_AUXDETSORTING_H

--- a/icaruscode/Geometry/details/PMTsorting.cxx
+++ b/icaruscode/Geometry/details/PMTsorting.cxx
@@ -1,0 +1,80 @@
+/**
+ * @file   icaruscode/Geometry/details/PMTsorting.cxx
+ * @brief  PMT sorting functions for ICARUS.
+ * @date   April 26, 2020
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    icaruscode/Geometry/details/PMTsorting.h
+ */
+
+
+// library header
+#include "icaruscode/Geometry/details/PMTsorting.h"
+
+// LArSoft libraries
+// #include "larcorealg/CoreUtils/span.h"
+
+// C/C++ standard libraries
+#include <vector>
+#include <iterator> // std::next(), std::prev()
+#include <algorithm> // std::sort(), std::stable_sort()
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+void icarus::PMTsorterStandard::sort(std::vector<geo::OpDetGeo>& opDets) const {
+  assert(opDets.size() % 2 == 0); // must be even!
+  
+  /*
+   * 1. sort all optical detectors by _x_
+   * 2. split them by plane
+   * 3. sort the detectors within each plane.
+   */
+  
+  //
+  // 1. sort all optical detectors by _x_
+  //
+  std::sort(begin(opDets), end(opDets), fSmallerCenterX);
+  
+  //
+  // 2. split them by plane: we take a horrible shortcut here...
+  //
+  
+  std::vector<OpDetSpan_t> OpDetsPerPlane;
+  
+  // just split the list in two
+  auto const middle = std::next(opDets.begin(), opDets.size() / 2U);
+  assert(fSmallerCenterX(*std::prev(middle), *middle));
+  
+  OpDetsPerPlane.emplace_back(opDets.begin(), middle);
+  OpDetsPerPlane.emplace_back(middle, opDets.end());
+  assert(OpDetsPerPlane[0].size() == OpDetsPerPlane[1].size());
+  
+  //
+  // 3. sort the detectors within each plane.
+  //
+  for (auto const& planeOpDets: OpDetsPerPlane)
+    sortInPlane(util::make_span(planeOpDets));
+  
+  // all done in place, no return
+  
+} // icarus::PMTsorterStandard::sort()
+
+
+// -----------------------------------------------------------------------------
+void icarus::PMTsorterStandard::sortInPlane(OpDetSpan_t const& opDets) const {
+  /*
+   * 0. assume it's already sorted by _x_
+   * 1. sort by vertical coordinate (_y_)
+   * 2. stable sort by beam coordinate (_z_)
+   */
+  
+  // 1. sort by vertical coordinate (_y_)
+  std::stable_sort(begin(opDets), end(opDets), fSmallerCenterY);
+  
+  // 2. stable sort by beam coordinate (_z_)
+  std::stable_sort(begin(opDets), end(opDets), fSmallerCenterZ);
+  
+} // icarus::PMTsorterStandard::sortInPlane()
+
+
+// -----------------------------------------------------------------------------

--- a/icaruscode/Geometry/details/PMTsorting.h
+++ b/icaruscode/Geometry/details/PMTsorting.h
@@ -1,0 +1,170 @@
+/**
+ * @file   icaruscode/Geometry/details/PMTsorting.h
+ * @brief  Geometry obect sorter with PMT following TPC wire order.
+ * @date   April 26, 2020
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    icaruscode/Geometry/details/PMTsorting.cxx
+ */
+
+#ifndef ICARUSCODE_GEOMETRY_DETAILS_PMTSORTING_H
+#define ICARUSCODE_GEOMETRY_DETAILS_PMTSORTING_H
+
+
+// LArSoft libraries
+#include "larcorealg/Geometry/OpDetGeo.h"
+#include "larcorealg/CoreUtils/RealComparisons.h"
+#include "larcorealg/CoreUtils/span.h" // util::span
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h" // geo::Point_t
+
+// framework libraries
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <vector>
+
+
+// -----------------------------------------------------------------------------
+namespace icarus { class PMTsorterStandard; }
+
+/**
+ * @brief Sorter sorting PMT to follow the same order as TPC (standard).
+ * 
+ * This class sorts the elements of the LArSoft detector description.
+ * The "standard" algorithm (`geo::GeoObjectSorterStandard`) arranges TPC
+ * elements with x, then z, then y. The PMT are arranged so that their channels
+ * mimic the order of the TPC channels.
+ * 
+ * The algorithm for assigning channels to the PMT follows the criteria:
+ * 
+ * * PMT are ordered by increasing _x_ (related to drift direction);
+ * * channels are assigned value ranges increasing with _x_ coordinate;
+ * * within a wire plane, PMT number increases with its _z_ (beam direction)
+ *   coordinate;
+ * * in case of same _z_ (in ICARUS all PMT are in 2- or 3-PMT "towers"), an
+ *   increasing _y_ order (geographical vertical, toward the sky) is chosen.
+ * 
+ * PMT channels are assigned by a fixed LArSoft algorithm, cryostat by cryostat
+ * with increasing cryostat number (first `C:0`, then `C:1`, ...).
+ * 
+ * 
+ * Configuration parameters
+ * -------------------------
+ * 
+ * This sorter supports the following parameters:
+ * 
+ * * `ToleranceX`, `ToleranceY`, `ToleranceZ` (double, default: `1.0`):
+ *   rounding used for sorting optical detector position, in centimeters;
+ *   if the coordinate of two optical detectors are closer than the tolerance
+ *   for that coordinate (absolute), they two detectors are considered to be at
+ *   the same position in that coordinate
+ *   (note that the default value is very generous).
+ * 
+ */
+class icarus::PMTsorterStandard {
+  
+  /// List of optical detector pointers for sorting.
+  using OpDetList_t = std::vector<geo::OpDetGeo>;
+  
+  /// Part of list of optical detector pointers for sorting.
+  using OpDetSpan_t = util::span<OpDetList_t::iterator>;
+  
+    public:
+  
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Atom<double> ToleranceX {
+      Name("ToleranceX"),
+      Comment("tolerance when sorting optical detectors on x coordinate [cm]"),
+      1.0 // default
+      };
+    
+    fhicl::Atom<double> ToleranceY {
+      Name("ToleranceY"),
+      Comment("tolerance when sorting optical detectors on x coordinate [cm]"),
+      1.0 // default
+      };
+    
+    fhicl::Atom<double> ToleranceZ {
+      Name("ToleranceZ"),
+      Comment("tolerance when sorting optical detectors on x coordinate [cm]"),
+      1.0 // default
+      };
+    
+  }; // Config
+  
+  
+  /// Constructor: passes the configuration to the base class.
+  PMTsorterStandard(Config const& config)
+    : fSmallerCenterX{ config.ToleranceX() }
+    , fSmallerCenterY{ config.ToleranceY() }
+    , fSmallerCenterZ{ config.ToleranceZ() }
+    {}
+  
+  
+  // @{
+  /**
+   * @brief Sorts the specified optical detectors.
+   * @param opDets collection of pointers to all optical detectors in a cryostat
+   * 
+   * The collection `opDets` of optical detectors is sorted in place.
+   * Sorting criteria are documented in `icarus::GeoObjectSorterPMTasTPC` class
+   * documentation.
+   * 
+   * This algorithm requires all optical detectors to have their center defined
+   * (`geo::OpDetGeo::GetCenter()`). No other information is used.
+   * 
+   * @note The current implementation is very sensitive to rounding errors!
+   * 
+   */
+  void sort(std::vector<geo::OpDetGeo>& opDets) const;
+  
+  void operator() (std::vector<geo::OpDetGeo>& opDets) const { sort(opDets); }
+  // @}
+  
+  
+    private:
+  
+  /// `geo::OpDetGeo` comparer according to one coordinate of their center.
+  /// Accomodates for some tolerance.
+  template <double (geo::Point_t::*Coord)() const>
+  struct OpDetGeoCenterCoordComparer {
+    
+    /// Object used for comparison; includes a tolerance.
+    lar::util::RealComparisons<double> const fCmp;
+    
+    /// Constructor: fixes the tolerance for the comparison.
+    OpDetGeoCenterCoordComparer(double tol = 0.0): fCmp(tol) {}
+    
+    /// Returns whether `A` has a center coordinate `Coord` smaller than `B`.
+    bool operator() (geo::OpDetGeo const& A, geo::OpDetGeo const& B) const
+      {
+        return fCmp.strictlySmaller
+            ((A.GetCenter().*Coord)(), (B.GetCenter().*Coord)());
+      }
+    
+  }; // OpDetGeoCenterCoordComparer
+  
+  
+  /// Sorting criterium according to _x_ coordinate of `geo::OpDetGeo` center.
+  OpDetGeoCenterCoordComparer<&geo::Point_t::X> const fSmallerCenterX;
+  
+  /// Sorting criterium according to _y_ coordinate of `geo::OpDetGeo` center.
+  OpDetGeoCenterCoordComparer<&geo::Point_t::Y> const fSmallerCenterY;
+  
+  /// Sorting criterium according to _z_ coordinate of `geo::OpDetGeo` center.
+  OpDetGeoCenterCoordComparer<&geo::Point_t::Z> const fSmallerCenterZ;
+  
+  
+  /// Sorts the `geo::OpDetGeo` assuming they belong to the same plane.
+  void sortInPlane(OpDetSpan_t const& opDets) const;
+  
+}; // icarus::PMTsorterStandard
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_GEOMETRY_DETAILS_PMTSORTING_H


### PR DESCRIPTION
The adoption of the split wire geometry channel mapping has caused the auxiliary detector order in ICARUS to change.
The order was customised for ICARUS, but the new channel mapping included a new sorting which used the "standard" LArSoft sorting for `AuxDetGeo` and `AuxDetSensitiveGeo` objects (i.e. CRT modules and submodules).
This commit moves the sorting code of PMT and of CRT out of the geometry sorters, and makes both sorters call the old CRT sorting so refactored (the new sorter also calls the PMT new sorting algorithm).