### PR TITLE
Patch typos in shower reco config and add two additional ones that we might consider switching to!

### DIFF
--- a/fcl/configurations/showerfindermodules_icarus.fcl
+++ b/fcl/configurations/showerfindermodules_icarus.fcl
@@ -13,8 +13,10 @@ ShowerSlidingStandardCalodEdx:                                  @local::showertr
 ShowerSlidingStandardCalodEdx.CalorimetryAlg:                   @local::icarus_calorimetryalgmc
 
 standard_sbnshower_stan:                                        @local::standard_pandoraModularShowerCreation
+advanced_sbnshower:                                             @local::standard_pandoraModularShowerCreation
+intermediate_sbnshower:                                         @local::standard_pandoraModularShowerCreation
 
-standard_sbndshower_stan.ShowerTools: [
+standard_sbnshower_stan.ShowerFinderTools: [
 				        @local::showerpfpvertexstartposition,
 					@local::showerpcadirection,
 					@local::showerlinearenergy,
@@ -22,5 +24,84 @@ standard_sbndshower_stan.ShowerTools: [
 					@local::showerpandoraslidingfittrackfinder,
 					@local::showerunidirectiondedx
                                       ]
+
+# See doc-db 19390 - tools and overrides
+advanced_sbnshower.ShowerFinderTools: [
+					@local::showerpfpvertexstartposition,
+					@local::showerpcadirection,
+    					@local::showerlinearenergy,
+    					@local::showerincrementaltrackhitfinder,
+    					@local::showerunidirectiondedx,
+    					@local::showerpandoraslidingfittrackfinder,
+    					@local::showertrajpointdedx,
+    					@local::showerbayesiantrucatingdedx,
+    					@local::showerlengthpercentile
+]
+
+advanced_sbnshower.ShowerFinderTools[1].ChargeWeighted:	  true		          #defualt was changed to false for some reason, was true before.
+
+advanced_sbnshower.ShowerFinderTools[2].Gradients:          [0.00246564, 0.00245335, 0.00247403]
+advanced_sbnshower.ShowerFinderTools[2].Intercepts:         [13.9334, 13.1386, 10.845]
+
+advanced_sbnshower.ShowerFinderTools[3].ForwardHitsOnly:            false                       #since not using Vertex BDT
+advanced_sbnshower.ShowerFinderTools[3].UseShowerDirection:         false                       #is true in default but false in fcl used in doc-db 19390
+advanced_sbnshower.ShowerFinderTools[3].MaxAverageResidual:         1.0
+advanced_sbnshower.ShowerFinderTools[3].MaxResidualDiff:            0.3
+advanced_sbnshower.ShowerFinderTools[3].NMissPoints:                9                           #turning value from doc-db 13930 into an int
+advanced_sbnshower.ShowerFinderTools[3].StartFitSize:               20                          #turning value from doc-db 13930 into an int
+advanced_sbnshower.ShowerFinderTools[3].TrackMaxAdjacentSPDistance: 5.0
+
+advanced_sbnshower.ShowerFinderTools[4].CalorimetryAlg:                  @local::icarus_calorimetryalgmc
+advanced_sbnshower.ShowerFinderTools[4].CalorimetryAlg.CalAreaConstants: [1.56e-2, 1.575e-2, 1.59e-2]    #see doc-db 18991-v2, but with the second plane using an interpolation...
+#advanced_sbnshower.ShowerFinderTools[4].dEdxTrackLength:                 0.0                            #maximizal test run apparently turned this off - not sure why, leaving as default...
+
+advanced_sbnshower.ShowerFinderTools[5].SlidingFitHalfWindow: 7     #turning value from doc-db 13930 into an int
+
+advanced_sbnshower.ShowerFinderTools[6].CalorimetryAlg:                  @local::icarus_calorimetryalgmc
+advanced_sbnshower.ShowerFinderTools[6].CalorimetryAlg.CalAreaConstants: [1.56e-2, 1.575e-2, 1.59e-2]
+advanced_sbnshower.ShowerFinderTools[6].MinAngleToWire:                  0.26                            #we used this for the tuning, ~15 degrees
+advanced_sbnshower.ShowerFinderTools[6].CutStartPosition:                true                            #is false in default but true in fcl used in doc-db 19390
+advanced_sbnshower.ShowerFinderTools[6].MaxDist:                         5.0
+advanced_sbnshower.ShowerFinderTools[6].MinDistCutOff:                   0.0
+advanced_sbnshower.ShowerFinderTools[6].dEdxTrackLength:                 2.869371600119094
+
+advanced_sbnshower.ShowerFinderTools[7].NumSeedHits:     10        #turning value from doc-db 13930 into an int
+#advanced_sbnshower.ShowerFinderTools[7].ProbSeedCut:     0.001     #formerly ProbDiff
+advanced_sbnshower.ShowerFinderTools[7].ProbDiff:        0.001
+#advanced_sbnshower.ShowerFinderTools[7].ProbPointCut:    0.0001    #formerly ProbDiffSeed
+advanced_sbnshower.ShowerFinderTools[7].ProbDiffSeed:    0.0001
+advanced_sbnshower.ShowerFinderTools[7].nSkipHits:       4         #turning value from doc-db 13930 into an int
+advanced_sbnshower.ShowerFinderTools[7].DefineBestPlane: true      #is false in default but true in fcl used in doc-db 19390
+
+# "Intermediate" settings...
+# Less advanced than the "advanced" setup above, but more customized than the more "default" one above
+# Should be similar to the one used in previous studies but with a few changes...
+intermediate_sbnshower.ShowerFinderTools: [
+                                        @local::showerpfpvertexstartposition,
+                                        @local::showerpcadirection,
+                                        @local::showerlinearenergy,
+                                        @local::shower3dcylindertrackhitfinder,
+                                        @local::showerunidirectiondedx,
+                                        @local::showerpandoraslidingfittrackfinder,
+                                        @local::showertrajpointdedx,
+                                        @local::showerlengthpercentile
+]
+
+intermediate_sbnshower.ShowerFinderTools[1].ChargeWeighted:     true                    #defualt was changed to false for some reason, was true before.
+
+intermediate_sbnshower.ShowerFinderTools[2].Gradients:          [0.00246564, 0.00245335, 0.00247403]
+intermediate_sbnshower.ShowerFinderTools[2].Intercepts:         [13.9334, 13.1386, 10.845]
+
+intermediate_sbnshower.ShowerFinderTools[3].ForwardHitsOnly:            false                       #since not using Vertex BDT
+
+intermediate_sbnshower.ShowerFinderTools[4].CalorimetryAlg:                  @local::icarus_calorimetryalgmc  #this tool not previously run with the "intermediate" set, but can be added
+intermediate_sbnshower.ShowerFinderTools[4].CalorimetryAlg.CalAreaConstants: [1.56e-2, 1.575e-2, 1.59e-2]     #see doc-db 18991-v2, but with the second plane using an interpolation...
+
+intermediate_sbnshower.ShowerFinderTools[6].CalorimetryAlg:                  @local::icarus_calorimetryalgmc
+intermediate_sbnshower.ShowerFinderTools[6].CalorimetryAlg.CalAreaConstants: [1.56e-2, 1.575e-2, 1.59e-2]
+intermediate_sbnshower.ShowerFinderTools[6].MinAngleToWire:                  0.26                             #require ~15 degrees
+intermediate_sbnshower.ShowerFinderTools[6].CutStartPosition:                true                             #is false by default but we've used true before
+intermediate_sbnshower.ShowerFinderTools[6].MinDistCutOff:                   1.28
+
 
 END_PROLOG

--- a/fcl/reco/reco_icarus.fcl
+++ b/fcl/reco/reco_icarus.fcl
@@ -157,9 +157,9 @@ icarus_reco_producers:
   pandoraKalmanTrackICARUSCryo1:  @local::icarus_pandora_kalmantrack
 
   ## Shower finding modules
-  SBNShowerGaus:                  @local::standard_sbnshower_stan
-  SBNShowerGausCryo0:             @local::standard_sbnshower_stan
-  SBNShowerGausCryo1:             @local::standard_sbnshower_stan
+  SBNShowerGaus:                  @local::standard_sbnshower_stan #@local::intermediate_sbnshower
+  SBNShowerGausCryo0:             @local::standard_sbnshower_stan #@local::intermediate_sbnshower
+  SBNShowerGausCryo1:             @local::standard_sbnshower_stan #@local::intermediate_sbnshower
 
 
   ## MCS modules


### PR DESCRIPTION
Do not delete branch after PR is finalized!!

This commit fixes typos in the standard "default" shower config that's there (in one place was written sbn and in the other sbnd. Also it said ShowerTools: when it should have said ShowerFinderTools:)

This commit also adds an intermediate shower reco configuration and an 'advanced' shower reco configuration. The reco fcl is still set up to do the 'default' one, but we may want to switch to one of the more advanced ones... I do have a couple questions to ask Ed/Dom offline, even about the intermediate one. However, right now the intermediate one seems to at least work and give dE/dx values. The advanced one DOESN'T work right now -- the Bayes tool has a bug in fcl params. This can be fixed easily in the job fcl. More problematic is that the priors for the Bayes tool are not located somewhere shared by default.