### PR TITLE
sbndaq_artdaq_core direct dep removal, plus some c7 compile fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ cet_cmake_env()
 cet_set_compiler_flags(DIAGS CAUTIOUS
   WERROR
   NO_UNDEFINED
-  EXTRA_FLAGS -pedantic -I $ENV{CLANG_FQ_DIR}/include/c++/v1
+  EXTRA_FLAGS -pedantic -I $ENV{CLANG_FQ_DIR}/include/c++/v1 
 )
 
 cet_report_compiler_flags()

--- a/icaruscode/Analysis/tools/BasicRawDigitAnalysis_tool.cc
+++ b/icaruscode/Analysis/tools/BasicRawDigitAnalysis_tool.cc
@@ -185,7 +185,7 @@ void BasicRawDigitAnalysis::configure(fhicl::ParameterSet const & pset)
     fFFTFitFuncVec  = pset.get<std::vector<std::string>>        ("FFTFunctionVec",             std::vector<std::string>()={"1","1","1"});
     fParameterVec   = pset.get<std::vector<std::vector<double>>>("FFTFuncParamsVec", std::vector<std::vector<double>>() = {{1},{1},{1}});
 
-    const fhicl::ParameterSet& waveformParamSet = pset.get<fhicl::ParameterSet>("WaveformTool");
+    //const fhicl::ParameterSet& waveformParamSet = pset.get<fhicl::ParameterSet>("WaveformTool");
 }
 
 //----------------------------------------------------------------------------

--- a/icaruscode/CRT/CRTDecoder/AnaProducer_module.cc
+++ b/icaruscode/CRT/CRTDecoder/AnaProducer_module.cc
@@ -296,7 +296,7 @@ icarus::crt::AnaProducer::AnaProducer(Parameters const& config)
   fLostfpga = 0;
   fTs0 = 0;
   fTs1 = 0;
-  fAdc[32] = 0;
+  for(int i=0; i<32; ++i) fAdc[i] = 0;
   fCoinc = 0;
   fRun_start_time = 0;
   fThis_poll_start = 0;

--- a/icaruscode/CRT/CRTDecoder/CrtCal.cc
+++ b/icaruscode/CRT/CRTDecoder/CrtCal.cc
@@ -246,7 +246,7 @@ void CrtCal::PedCal(){
 		delete h;
 	}
 
-	delete statarr;
+	delete[] statarr;
 	fHasPedCal = true;
 
 	return;
@@ -283,7 +283,7 @@ void CrtCal::GainCal(){
 		delete h;
 	}
 
-	delete statarr;
+	delete[] statarr;
 	fHasGainCal = true;
 	return;
 }
@@ -675,14 +675,14 @@ void CrtCal::GainFit(TH1F* h, size_t chan, float** statsarr, bool save){
 		statsarr[14][i]   = peakNdf[i];
 	}
 	
-	delete peakXsqr;
-	delete peakMean;
-	delete peakMeanErr;
-	delete peakNorm;
-	delete peakNormErr;
-	delete peakSigma;
-	delete peakSigmaErr;
-	delete peakNdf;
+	delete[] peakXsqr;
+	delete[] peakMean;
+	delete[] peakMeanErr;
+	delete[] peakNorm;
+	delete[] peakNormErr;
+	delete[] peakSigma;
+	delete[] peakSigmaErr;
+	delete[] peakNdf;
 
         if ( save )
         {

--- a/icaruscode/CRT/CRTTruthMatchAnalysis_module.cc
+++ b/icaruscode/CRT/CRTTruthMatchAnalysis_module.cc
@@ -98,9 +98,9 @@ class icarus::crt::CRTTruthMatchAnalysis : public art::EDAnalyzer {
     TH1F* fNTrueHitMu_top;
     TH1F* fNTrueHitMu_side;
     TH1F* fNTrueHitMu_bot;
-    TH1F* fNDataMu_top;
-    TH1F* fNDataMu_side;
-    TH1F* fNDataMu_bot;
+//     TH1F* fNDataMu_top;
+//     TH1F* fNDataMu_side;
+//     TH1F* fNDataMu_bot;
     TH1F* fNSimHitMu_top;
     TH1F* fNSimHitMu_side;
     TH1F* fNSimHitMu_bot;

--- a/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
@@ -114,7 +114,7 @@ namespace icarus{
             ChanData *chanTmpData(nullptr);
             set<int> trackNHold = {}; //set of channels close in time to triggered readout above threshold
             set<int> layerNHold = {}; //layers with channels above threshold (used for checking layer-layer coincidence)
-            if(trg.first==INT_MAX) std::cout << "WARNING: bad mac5 found!" << std::endl;
+            if((int)trg.first==INT_MAX) std::cout << "WARNING: bad mac5 found!" << std::endl;
             bool minosPairFound = false, istrig=false;
             vector<ChanData> passingData; //data to be included in "readout" of FEB
             vector<AuxDetIDE> passingIDE;

--- a/icaruscode/Decode/DaqDecoderICARUSPMTold_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMTold_module.cc
@@ -83,8 +83,9 @@ private:
     art::InputTag _tag;
     Config        _config;
     // keeping track of incrementing numbers
-    uint32_t      _last_event_number;
-    uint32_t      _last_trig_frame_number;
+    // commented out while unused
+    //uint32_t      _last_event_number;
+    //uint32_t      _last_trig_frame_number;
 };
 
 
@@ -93,9 +94,9 @@ DEFINE_ART_MODULE(daq::DaqDecoderIcarusPMTold)
 DaqDecoderIcarusPMTold::DaqDecoderIcarusPMTold(fhicl::ParameterSet const & param): 
     art::EDProducer{param},
     _tag(param.get<art::InputTag>("FragmentsLabel", "daq:CAENV1730")),
-    _config(param),
-    _last_event_number(0),
-    _last_trig_frame_number(0)
+    _config(param)//,
+    //_last_event_number(0),
+    //_last_trig_frame_number(0)
 {
   
     // produce stuff

--- a/icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.cxx
+++ b/icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.cxx
@@ -36,8 +36,14 @@ auto icarus::opdet::DiscretePhotoelectronPulse::sampleShape(
   // the two functions (lambda) are of different type, so they are being wrapped
   // in the common `std::function` type
 
+  // FIXME Clang 7.0.0 can't figure out the parameters of std::function
+  // (GCC 8.2 can): specifying them explicitly...
   auto const isBelowThreshold = (pulseShape.polarity() == +1)
+#if defined(__clang__) && (__clang_major__ < 8)
+    ? std::function<bool(nanoseconds, ADCcount)>(
+#else // not Clang <8
     ? std::function(
+#endif // defined(__clang__) && (__clang_major__ < 8)
       [baseline=pulseShape.baseline(), threshold](nanoseconds, ADCcount s)
         {
           return
@@ -46,7 +52,11 @@ auto icarus::opdet::DiscretePhotoelectronPulse::sampleShape(
             ;
         }
       )
+#if defined(__clang__) && (__clang_major__ < 8)
+    : std::function<bool(nanoseconds, ADCcount)>(
+#else // not Clang <8
     : std::function(
+#endif // defined(__clang__) && (__clang_major__ < 8)
       [baseline=pulseShape.baseline(), threshold](nanoseconds, ADCcount s)
         {
           return

--- a/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
+++ b/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
@@ -50,7 +50,9 @@ class icarus::opdet::PhotoelectronPulseFunction {
   using ADCcount = util::quantities::counts_f;
 
   using Time = T; ///< Type of time being used.
-
+  
+  
+  virtual ~PhotoelectronPulseFunction() = default;
 
   /**
     * @brief Evaluates the pulse at the given time.

--- a/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
+++ b/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
@@ -19,7 +19,7 @@
 #include <iosfwd> // std::ostream
 #include <string>
 #include <utility> // std::move()
-
+#include <sstream>
 
 // -----------------------------------------------------------------------------
 namespace icarus::opdet {

--- a/icaruscode/PMT/SinglePhotonPulseFunctionTool.h
+++ b/icaruscode/PMT/SinglePhotonPulseFunctionTool.h
@@ -59,6 +59,8 @@ struct icarus::opdet::SinglePhotonPulseFunctionTool {
     = icarus::opdet::PhotoelectronPulseFunction<nanoseconds>;
   
   
+  virtual ~SinglePhotonPulseFunctionTool() = default;
+  
   /**
    * @brief Returns an instance of the pulse function.
    * 
@@ -98,7 +100,7 @@ inline auto icarus::opdet::SinglePhotonPulseFunctionTool::getPulseFunction()
 {
   auto ptr = doGetPulseFunction();
   assert(ptr);
-  return std::move(ptr);
+  return ptr;
 } // icarus::opdet::SinglePhotonPulseFunctionTool::getPulseFunction() &&
 
 

--- a/icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.h
+++ b/icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.h
@@ -256,8 +256,10 @@ class icarus::trigger::details::EventInfoExtractor {
 
 // -----------------------------------------------------------------------------
 /// A helper class creating a `EventInfoExtractor` with a specific setup.
-struct icarus::trigger::details::EventInfoExtractorMaker {
-
+class icarus::trigger::details::EventInfoExtractorMaker {
+  
+    public:
+  
   using TimeSpan_t = EventInfoExtractor::TimeSpan_t;
   
   /// Constructor: stores parameters for construction of `EventInfoExtractor`.

--- a/icaruscode/TPC/Simulation/SpaceCharge/SpaceChargeICARUS.cxx
+++ b/icaruscode/TPC/Simulation/SpaceCharge/SpaceChargeICARUS.cxx
@@ -237,7 +237,7 @@ void spacecharge::SpaceChargeICARUS::fixCoords(double* xx, double* yy, double* z
   //handle the edge cases by projecting SCE corrections onto boundaries
   //using tpcid to disambiguate hits that cross cathode due to SCE
   //need to do some fancy flipping of the TPC ids as well because the use of abs()
-  if (xx < 0) { *tpcid = abs(*tpcid - 1); }
+  if (*xx < 0) { *tpcid = abs(*tpcid - 1); }
   *xx = abs(*xx);
   if(*xx<71.94){*xx=71.94;}
   if(*xx>368.49){*xx=368.489;}

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -42,7 +42,6 @@ icarus_data               v09_07_00
 genie_xsec                v3_00_04a
 fftw                      v3_3_8a
 libwda                    v2_28_0
-sbndaq_artdaq_core        v0_07_00_of0
 
 cetbuildtools	          v7_17_01	-	only_for_build
 end_product_list
@@ -51,13 +50,13 @@ end_product_list
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make a table by adding columns before "notes".
 # e15  - with gcc 6.4.0 and -std=c++1y
-qualifier  sbncode    icarusalg    icarusutil   icarus_signal_processing   icarus_data  sbndaq_artdaq_core   genie_xsec               fftw        libwda notes
-e19:debug  e19:debug  e19:debug    e19:debug    e19:debug                  -nq-         e19:debug            G1810a0211a:k250:e1000   debug       -nq-
-e19:opt	   e19:opt    e19:opt      e19:opt      e19:opt                    -nq-         e19:opt	     	     G1810a0211a:k250:e1000   opt         -nq-
-e19:prof   e19:prof   e19:prof     e19:prof     e19:prof                   -nq-         e19:prof       	     G1810a0211a:k250:e1000   prof        -nq-
-c7:debug   c7:debug   c7:debug     c7:debug     c7:debug                   -nq-         c7:debug       	     G1810a0211a:k250:e1000   debug       -nq-
-c7:opt     c7:opt     c7:opt       c7:opt       c7:opt                     -nq-         c7:opt	             G1810a0211a:k250:e1000   opt         -nq-
-c7:prof    c7:prof    c7:prof      c7:prof      c7:prof                    -nq-         c7:prof	    	     G1810a0211a:k250:e1000   prof        -nq-
+qualifier  sbncode    icarusalg    icarusutil   icarus_signal_processing   icarus_data  genie_xsec               fftw        libwda notes
+e19:debug  e19:debug  e19:debug    e19:debug    e19:debug                  -nq-         G1810a0211a:k250:e1000   debug       -nq-
+e19:opt	   e19:opt    e19:opt      e19:opt      e19:opt                    -nq-         G1810a0211a:k250:e1000   opt         -nq-
+e19:prof   e19:prof   e19:prof     e19:prof     e19:prof                   -nq-         G1810a0211a:k250:e1000   prof        -nq-
+c7:debug   c7:debug   c7:debug     c7:debug     c7:debug                   -nq-         G1810a0211a:k250:e1000   debug       -nq-
+c7:opt     c7:opt     c7:opt       c7:opt       c7:opt                     -nq-         G1810a0211a:k250:e1000   opt         -nq-
+c7:prof    c7:prof    c7:prof      c7:prof      c7:prof                    -nq-         G1810a0211a:k250:e1000   prof        -nq-
 end_qualifier_list
 
 # Preserve tabs and formatting in emacs and vi / vim:


### PR DESCRIPTION
Once the new larsoft release (and new sbncode release) comes out, we should have sbndaq_artaq_core build separately and setup via sbncode --> can remove the dependency in icaruscode.