### PR TITLE
Increased PMT digitisation threshold from 4 to 18 ADC counts.

### DIFF
--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -142,12 +142,14 @@ icarus_pmtsimulationalg_standard: {
   PreTrigFraction:           0.25           # fraction
 
   ##Threshold in ADC counts for a PMT self-trigger.
+  # 18 ADC = 6x 3 ADC (RMS, see AmpNoise above),~35% of standard SPR (55 ADC);
+  # number of noise samples above 18 ADC: ~0.35 samples for 2 ms x 360 channels
   ##NOTE this is assumed to be positive-going and ABOVE BASELINE! Pulse polarity is corrected before determining trigger.
-  ThresholdADC:              4              #ADC counts
+  ThresholdADC:              18             # ADC counts
 
   PulsePolarity:             -1             #Pulse polarity (1 = positive, -1 = negative)
-  TriggerOffsetPMT:          "-1.15 ms"      #Time relative to trigger that readout begins
-  ReadoutEnablePeriod:       "2.55 ms"       #Time for which pmt readout is enabled
+  TriggerOffsetPMT:          "-1.15 ms"     #Time relative to trigger when readout begins
+  ReadoutEnablePeriod:       "2.55 ms"      #Time for which pmt readout is enabled
   CreateBeamGateTriggers:    true           #Option to create unbiased readout around beam spill
   BeamGateTriggerRepPeriod:  "2.0 us"       #Repetition Period for BeamGateTriggers
   BeamGateTriggerNReps:      10             #Number of beamgate trigger reps to produce


### PR DESCRIPTION
Arbitrary, but motivated by the updated single photon response
(average amplitude 55 ADC).

This is a (mild) **breaking change** in terms of physics.