### PR TITLE
Cosmic ray generation altitude elevated by +10%.

### DIFF
--- a/fcl/gen/corsika/corsika_icarus.fcl
+++ b/fcl/gen/corsika/corsika_icarus.fcl
@@ -11,19 +11,33 @@ BEGIN_PROLOG
 #
 # Thus, run from -1.5ms -> 1.3ms
 
-icarus_corsika_p:                  @local::standard_CORSIKAGen_protons
-icarus_corsika_p.SampleTime:       2.9e-3
-icarus_corsika_p.ShowerInputFiles: [ "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/p_*.db" ]
-icarus_corsika_p.TimeOffset:       -1.5e-3
-icarus_corsika_p.BufferBox:        [ -500.0, 500.0,-300.0,300.0,-600.0,600.0 ]   #in cm
-icarus_corsika_p.ProjectToHeight:  1800  #height to which particles are projected in cm
+icarus_corsika_settings: {
+  # override of settings for ICARUS (baseline is LArSoft settings)
+ 
+  SampleTime:          2.9e-3
+  TimeOffset:         -1.5e-3
+  BufferBox:           [ -500.0, 500.0, -300.0, 300.0, -600.0, 600.0 ]   #in cm
+  ProjectToHeight:     1800 # cm; height to which particles are projected
+  
+} # icarus_corsika_settings
 
-icarus_corsika_cmc:                @local::standard_CORSIKAGen_CMC
-icarus_corsika_cmc.SampleTime:     2.9e-3
-icarus_corsika_cmc.ShowerInputFiles: [ "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/p_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/He_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/N_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/Mg_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/Fe_showers_*.db" ]
-icarus_corsika_cmc.TimeOffset:     -1.5e-3
-icarus_corsika_cmc.BufferBox:        [ -500.0, 500.0,-300.0,300.0,-600.0,600.0 ]   #in cm
-icarus_corsika_cmc.ProjectToHeight:  1800  #height to which particles are projected in cm
+
+icarus_corsika_p: {
+  @table::standard_CORSIKAGen_protons
+  @table::icarus_corsika_settings
+  
+  ShowerInputFiles:    [ "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/p_*.db" ]
+
+} # icarus_corsika_p
+
+
+icarus_corsika_cmc: {
+  @table::standard_CORSIKAGen_CMC
+  @table::icarus_corsika_settings
+  
+  ShowerInputFiles: [ "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/p_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/He_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/N_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/Mg_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/Fe_showers_*.db" ]
+
+} # icarus_corsika_cmc
 
 #README: the directory written here are the place where you can find the files... you can download them and then change the "ShowerInputFiles" parameter to take into account of the path where you locally put the files
 

--- a/fcl/gen/corsika/corsika_icarus.fcl
+++ b/fcl/gen/corsika/corsika_icarus.fcl
@@ -17,7 +17,8 @@ icarus_corsika_settings: {
   SampleTime:          2.9e-3
   TimeOffset:         -1.5e-3
   BufferBox:           [ -500.0, 500.0, -300.0, 300.0, -600.0, 600.0 ]   #in cm
-  ProjectToHeight:     1800 # cm; height to which particles are projected
+  ProjectToHeight:     2000 # cm; height to which particles are projected
+  ShowerAreaExtension: 1200 # cm
   
 } # icarus_corsika_settings
 


### PR DESCRIPTION
ICARUS building wall currently (20201107) reaches up to y = +18.2 m.
Generation surface for CORSIKA has been increased by 2 m.
The accepted area on the detector has been proportionally extended.

This request is paired with pull request SBNSoftware/icarusalg#11 on geometry update.