### PR TITLE
add wirecell decon into stage0

### DIFF
--- a/icaruscode/Decode/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/stage0_icarus_defs.fcl
@@ -9,6 +9,7 @@
 #include "recowire_icarus.fcl"
 #include "hitfindermodules_icarus.fcl"
 #include "icarus_ophitfinder.fcl"
+#include "wcls-decode-to-sig-base.fcl"
 
 BEGIN_PROLOG
 
@@ -37,6 +38,13 @@ icarus_stage0_producers:
   recoWireRawTPC2:                @local::icarus_recowireraw
   recoWireRawTPC3:                @local::icarus_recowireraw
 
+  ### wire-cell decon producers
+  decon2droi:                     @local::standard_wirecell_sigproc
+  decon2DroiTPC0:                 @local::standard_wirecell_sigproc
+  decon2DroiTPC1:                 @local::standard_wirecell_sigproc
+  decon2DroiTPC2:                 @local::standard_wirecell_sigproc
+  decon2DroiTPC3:                 @local::standard_wirecell_sigproc
+
   ### hit-finder producers
   gaushit:                        @local::gaus_hitfinder_icarus
   gaushitTPC0:                    @local::gaus_hitfinder_icarus
@@ -64,6 +72,7 @@ icarus_reco_filters:
 icarus_stage0_single:              [ daqTPC,
                                      daqPMT,
                                      decon1droi,
+                                     decon2droi,
                                      gaushit
                                    ]
 
@@ -93,6 +102,11 @@ icarus_stage0_producers.daqTPC3.FragmentsLabel:                                 
 
 ### Set up for single deconvolution
 icarus_stage0_producers.decon1droi.DigitModuleLabel:                                           "daqTPC"
+
+icarus_stage0_producers.decon2droi.wcls_main.inputers:                                         ["wclsRawFrameSource:rfsrc0"]
+icarus_stage0_producers.decon2droi.wcls_main.outputers:                                        ["wclsFrameSaver:spsaver0"]
+icarus_stage0_producers.decon2droi.wcls_main.params.raw_input_label:                           "daqTPC"
+icarus_stage0_producers.decon2droi.wcls_main.params.tpc_volume_label:                          0
 
 ### Set up for multiple TPC readout
 icarus_stage0_producers.decon1DroiTPC0.DigitModuleLabel:                                       "daqTPC0"

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
@@ -108,7 +108,7 @@ local wcls_output = {
       anode: wc.tn(mega_anode),
       digitize: false,  // true means save as RawDigit, else recob::Wire
       frame_tags: ['gauss', 'wiener'],
-      frame_scale: [0.1, 0.1],
+      frame_scale: [0.025, 0.025],
       // nticks: params.daq.nticks,
       chanmaskmaps: [],
       nticks: -1,
@@ -154,7 +154,7 @@ local nfsp_pipes = [
                chsel_pipes[n],
                // magnifyio.orig_pipe[n],
 
-               nf_pipes[n],
+               // nf_pipes[n],
                // magnifyio.raw_pipe[n],
 
                sp_pipes[n],


### PR DESCRIPTION
Add the wirecell 2D deconvolution in the stage0 configuration. Two data products of recob::Wire are available: `decon2droi:gauss` and `decon2droi:wiener`. They are derived with different software filters, usually the `decon2droi:gauss` can be fed to the gaus hit finder.

Here is the consistency check between 1D and 2D decon:
![image](https://user-images.githubusercontent.com/10663117/99841960-fdbd3600-2b3c-11eb-92fa-9b44616ad22c.png)
