### PR TITLE
Updated photon library (20201209)

### DIFF
--- a/fcl/services/photpropservices_icarus.fcl
+++ b/fcl/services/photpropservices_icarus.fcl
@@ -39,7 +39,7 @@ icarus_photonvisibilityservice_direct: {
   
   @table::photon_propagation_timing_icarus # from photon_propogation_timing_icarus.fcl
   
-  LibraryFile:      "PhotonLibrary/PhotonLibrary-20200925.root"
+  LibraryFile:      "PhotonLibrary/PhotonLibrary-20201209.root"
   UseCryoBoundary:  false
   DoNotLoadLibrary: false
   


### PR DESCRIPTION
This commit sets the default configuration of photon visibility (`PhotonVisibilityService`) to the photon library 20201209.
Relevant documentation about it is in the ICARUS wiki ([ICARUS wiki > Physics simulation > photon visibility map](https://sbnsoftware.github.io/icaruscode_wiki/physics/PhotonLibrary.html)) and on [SBN DocDB 19958](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=19958) version 2.

**This commit requires an update of `icarus_data` as well.**
(a copy of the new photon library can be currently found in ICARUS dCache at `/pnfs/icarus/persistent/users/petrillo/data/PhotonLibrary/PhotonLibrary-20201209.root`).