### PR TITLE
Added DuplicateEventTracker service

### DIFF
--- a/icaruscode/Utilities/CMakeLists.txt
+++ b/icaruscode/Utilities/CMakeLists.txt
@@ -1,4 +1,10 @@
 
+art_make(
+  EXCLUDE
+    "SaveConfigurationIntoTFile_module.cc"
+    "DuplicateEventTracker_service.cc"
+  LIB_LIBRARIES
+)
 
 simple_plugin(SaveConfigurationIntoTFile "module"
               ${ART_ROOT_IO_TFILESERVICE_SERVICE}
@@ -12,6 +18,13 @@ simple_plugin(SaveConfigurationIntoTFile "module"
               ${FHICLCPP}
               ${CETLIB}
               ${ROOT_CORE}
+)
+
+
+simple_plugin(DuplicateEventTracker "service"
+              icaruscode_Utilities
+              ${ART_FRAMEWORK_PRINCIPAL}
+              ${MF_MESSAGELOGGER}
 )
 
 

--- a/icaruscode/Utilities/DuplicateEventTracker.h
+++ b/icaruscode/Utilities/DuplicateEventTracker.h
@@ -1,0 +1,196 @@
+/**
+ * @file   icaruscode/Utilities/DuplicateEventTracker.h
+ * @brief  Service keeping track of _art_ event IDs.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   January 22, 2021
+ * @see    icaruscode/Utilities/DuplicateEventTracker_service.cc
+ * 
+ * Usage of the basic service functionality does not require this header:
+ * it suffices to configure the service for execution in _art_ configuration
+ * file.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_DUPLICATEEVENTTRACKER_H
+#define ICARUSCODE_UTILITIES_DUPLICATEEVENTTRACKER_H
+
+
+// library header
+#include "icaruscode/Utilities/EventRegistry.h"
+
+// framework libraries
+#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Services/Registry/ServiceTable.h"
+#include "fhiclcpp/types/Atom.h"
+#include "cetlib_except/exception.h" // courtesy
+
+// C/C++ standard libraries
+#include <string>
+#include <atomic>
+
+
+// -----------------------------------------------------------------------------
+// forward declarations
+namespace art {
+  class ActivityRegistry;
+  class ScheduleContext; // actually unused
+  class Event;
+} // namespace art
+
+// -----------------------------------------------------------------------------
+namespace sbn { class DuplicateEventTracker; }
+/**
+ * @brief Keeps track of duplicate events in the job.
+ * 
+ * This _art_ service maintains a record of all the processed events, and it
+ * takes action when one is processed more than once.
+ * The main purpose of the service is to detect the duplication as soon as
+ * possible and in such case to interrupt the job with an error, so that the
+ * input can be amended.
+ * 
+ * The default action is to immediately throw an exception.
+ * Alternatively, a warning message can be emitted each time an event is
+ * reprocessed, and a summary of all duplication can be emitted at the end of
+ * the job.
+ * 
+ * The service also offers an interface, to receive the current list of events
+ * that have been processed so far.
+ * 
+ * See `sbn::EventRegistry` for a description of the (large) memory usage of
+ * this service.
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * * **WarningOnly** (flag, default: `false`): this flag has effect on warning
+ *     messages and on exception throwing:
+ *     * warning messages: if this flag is set to `true`, the service will emit
+ *       a warning on each duplicate event encountered, otherwise it will not
+ *       emit any warning (summary will still describe the duplicates if not
+ *       skipped);
+ *     * exception in case of duplicate events: if set to `false`, an exception
+ *       will be thrown at the first duplicate event, unless `ExceptionAtEnd` is
+ *       set, in which case the exception will be thrown at the end; if the flag
+ *       is set to `true`, an exception is thrown at the end if `ExceptionAtEnd`
+ *       is set, otherwise no exception is thrown at all
+ * * **SkipSummary** (flag, default: `false`): when set to `true`, it disables
+ *     the printout of the duplicate events at the end of the job; unless
+ *     `WarningOnly` is also set, this summary is going to be one-entry only
+ * * **ExceptionAtEnd** (flag, default: `false`): if duplicate events are
+ *     detected, an exception is thrown _at the end of the job_ instead of
+ *     at the first duplicate event; this allows to assess all the duplicate
+ *     events at once; if set, it is recommended that `SkipSummary` be disabled;
+ *     note that with this option enabled, if duplicate events are detected an
+ *     exception is _always_ thrown (at the end of the job), regardless the
+ *     setting of `WarningOnly`
+ *     end of the job) 
+ * * **LogCategory** (text, default: `"DuplicateEventTracker"`): tag of the
+ *     output category used by this service to the message facility
+ * 
+ * 
+ * Multi-threading notes
+ * ======================
+ * 
+ * This service is designed to work with the concurrent processing of events
+ * _from the same file_. Reading multiple files is not supported (but _art_ 3
+ * doesn't do that anyway).
+ * 
+ */
+class sbn::DuplicateEventTracker {
+  
+    public:
+  
+  /// Service configuration.
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    
+    fhicl::Atom<bool> WarningOnly {
+      Name("WarningOnly"),
+      Comment("just emit a warning on screen instead of throwing an exception"),
+      false // default
+      };
+    
+    fhicl::Atom<bool> SkipSummary {
+      Name("SkipSummary"),
+      Comment("do not print a summary of the duplicate events at end of job"),
+      false // default
+      };
+    
+    fhicl::Atom<bool> ExceptionAtEnd {
+      Name("ExceptionAtEnd"),
+      Comment
+        ("in case of duplicate, wait until the end of job to throw an exception"),
+      false // default
+      };
+    
+    fhicl::Atom<std::string> LogCategory {
+      Name("LogCategory"),
+      Comment
+        ("tag of output category used by this service to the message facility"),
+      "DuplicateEventTracker" // default
+      };
+    
+    
+  }; // Config
+  
+  using Parameters = art::ServiceTable<Config>;
+  
+  /// Constructor: reads the configuration.
+  DuplicateEventTracker(Parameters const& config, art::ActivityRegistry& reg);
+
+  
+  /// Prints a summary of the current duplicates.
+  void printSummary() const;
+
+
+    protected:
+  
+  // --- BEGIN -- Configuration variables --------------------------------------
+      
+  bool const fWarningOnly; ///< Only warning, no exception.
+  bool const fSkipSummary; ///< Do not print the summary of duplicate events.
+  bool const fExceptionAtEnd; ///< Throw exception as late as possible.
+  
+  std::string const fLogCategory;  ///< Message service category tag.
+  
+  // --- END -- Configuration variables ----------------------------------------
+  
+  /// ID in the event registry of the current input file.
+  sbn::EventRegistry::FileID_t fCurrentInputFileID
+    = sbn::EventRegistry::NoFileID;
+  
+  sbn::EventRegistry fEventRegistry; ///< Record of all events and their source.
+  
+  std::atomic<unsigned int> fNDuplicateEvents{ 0U }; ///< Duplicate event count.
+  
+  
+  // --- BEGIN -- Callback functions -------------------------------------------
+  /// @name Callback functions
+  /// @{
+  
+  /// Records the event and throws an exception depending on the configuration.
+  void postEventReading(art::Event const& event, art::ScheduleContext);
+  
+  /// Records the current file name.
+  void postOpenFile(std::string const& fileName);
+  
+  /// Prints the summary and throws an exception depending on the configuration.
+  void postEndJob();
+  
+  /// @}
+  // --- END -- Callback functions ---------------------------------------------
+  
+  
+}; // sbn::DuplicateEventTracker
+
+
+// -----------------------------------------------------------------------------
+DECLARE_ART_SERVICE(sbn::DuplicateEventTracker, SHARED)
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_UTILITIES_DUPLICATEEVENTTRACKER_H

--- a/icaruscode/Utilities/DuplicateEventTracker_service.cc
+++ b/icaruscode/Utilities/DuplicateEventTracker_service.cc
@@ -1,0 +1,155 @@
+/**
+ * @file   sbncode/Utilities/DuplicateEventTracker_service.cc
+ * @brief  Service keeping track of _art_ event IDs.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   January 22, 2021
+ * @see sbncode/Utilities/DuplicateEventTracker.h
+ */
+
+
+// library header
+#include "icaruscode/Utilities/DuplicateEventTracker.h"
+
+// framework libraries
+#include "art/Framework/Services/Registry/ActivityRegistry.h"
+#include "art/Framework/Principal/Event.h" 
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "messagefacility/MessageLogger/MessageLogger.h" 
+
+// C/C++ standard libraries
+#include <set>
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+sbn::DuplicateEventTracker::DuplicateEventTracker
+  (Parameters const& config, art::ActivityRegistry& reg)
+  // configuration parameters
+  : fWarningOnly(config().WarningOnly())
+  , fSkipSummary(config().SkipSummary())
+  , fExceptionAtEnd(config().ExceptionAtEnd())
+  , fLogCategory(config().LogCategory())
+{
+  
+  reg.sPostOpenFile.watch(this, &DuplicateEventTracker::postOpenFile);
+  
+  reg.sPostSourceEvent.watch(this, &DuplicateEventTracker::postEventReading);
+  
+  reg.sPostEndJob.watch(this, &DuplicateEventTracker::postEndJob);
+
+} // sbn::DuplicateEventTracker::DuplicateEventTracker()
+
+
+// -----------------------------------------------------------------------------
+void sbn::DuplicateEventTracker::printSummary() const {
+  
+  mf::LogInfo log(fLogCategory);
+  log << "Summary of duplicate events encountered:";
+  
+  std::set<sbn::EventRegistry::FileID_t> duplicateFileIDs;
+  unsigned int nDuplicateEvents = 0U;
+  auto eventRecords = fEventRegistry.records();
+  std::sort(eventRecords.begin(), eventRecords.end(),
+    [](auto const& A, auto const& B){ return A.first < B.first; });
+  for (auto const& [ eventID, record ]: eventRecords) {
+    if (record.sourceFiles.size() <= 1U) continue;
+    ++nDuplicateEvents;
+    
+    log << "\n  " << eventID << " from " << record.sourceFiles.size()
+      << " sources:";
+    for (auto const fileID: record.sourceFiles) {
+      log << " [" << fileID << "]";
+      duplicateFileIDs.insert(fileID);
+    }
+  } // for
+  
+  if (!duplicateFileIDs.empty()) {
+    log << "\nDuplicate events from " << duplicateFileIDs.size() << " files:";
+    for (auto const fileID: duplicateFileIDs) {
+      // a bit cheating multithreading: we assume that between the copy of the
+      // event records and the source file list no source has been moved or
+      // removed; with the current interface, this is assured
+      auto const sourceName = fEventRegistry.sourceName(fileID);
+      log << "\n  [" << fileID << "]";
+      if (sourceName) log << " '" << *sourceName << "'";
+      else log << " N/A"; // should not happen though
+    } // for sources
+  } // if duplicates
+  
+  if (nDuplicateEvents > 0U) {
+    log << "\nCounted " << nDuplicateEvents << " duplicate events from "
+      << duplicateFileIDs.size() << " source files.";
+  }
+  else log << "\nNo duplicate events found.";
+  
+} // sbn::DuplicateEventTracker::printSummary()
+
+
+// -----------------------------------------------------------------------------
+void sbn::DuplicateEventTracker::postOpenFile(std::string const& fileName) {
+  
+  // register the current input file; if it exists already,
+  // we just get its ID again (but that's troublesome anyway)
+  fCurrentInputFileID = fEventRegistry.recordSource(fileName);
+  
+} // sbn::DuplicateEventTracker::postOpenFile()
+
+
+// -----------------------------------------------------------------------------
+void sbn::DuplicateEventTracker::postEventReading
+  (art::Event const& event, art::ScheduleContext)
+{
+  
+  sbn::EventRegistry::EventRecord_t const eventInfo
+    = fEventRegistry.recordEvent(event.id(), fCurrentInputFileID);
+  assert(eventInfo.sourceFiles.size() > 0U);
+  if (eventInfo.sourceFiles.size() == 1U) return; // all done, no new duplicates
+  
+  ++fNDuplicateEvents;
+  
+  if (fWarningOnly) {
+    mf::LogWarning(fLogCategory) 
+      << "WARNING: event " << event.id() << " encountered "
+      << eventInfo.sourceFiles.size() << " times,"
+      << "\n  now from '"
+      << fEventRegistry.sourceNameOr(eventInfo.sourceFiles.back(), "<?>")
+      << "',"
+      << "\n  first time from '"
+      << fEventRegistry.sourceNameOr(eventInfo.sourceFiles.front(), "<?>")
+      << "'"
+      ;
+    return;
+  }
+  
+  if (fExceptionAtEnd) return;
+  
+  assert(eventInfo.sourceFiles.size() == 2U);
+  throw cet::exception(fLogCategory)
+    << "Duplicate event " << event.id() << " encountered"
+    << "\n  first in '"
+    << fEventRegistry.sourceNameOr(eventInfo.sourceFiles.front(), "<?>") << "'"
+    << "\n  and now in '"
+    << fEventRegistry.sourceNameOr(eventInfo.sourceFiles.back(), "<?>") << "'\n"
+    ;
+  
+} // sbn::DuplicateEventTracker::postEventReading()
+
+
+// -----------------------------------------------------------------------------
+void sbn::DuplicateEventTracker::postEndJob() {
+  
+  if (!fSkipSummary) printSummary();
+  
+  if (fExceptionAtEnd && (fNDuplicateEvents > 0U)) {
+    throw cet::exception(fLogCategory)
+      << "Found " << fNDuplicateEvents << " duplicate events in the job.\n";
+  }
+  
+} // sbn::DuplicateEventTracker::postEndJob()
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_SERVICE(sbn::DuplicateEventTracker)
+
+// -----------------------------------------------------------------------------
+

--- a/icaruscode/Utilities/EventRegistry.cxx
+++ b/icaruscode/Utilities/EventRegistry.cxx
@@ -1,0 +1,150 @@
+/**
+ * @file   icaruscode/Utilities/EventRegistry.cxx
+ * @brief  Class keeping track of _art_ event IDs (implementation file).
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   January 22, 2021
+ * @see    icaruscode/Utilities/EventRegistry.h
+ * 
+ * 
+ * 
+ * 
+ */
+
+// library header
+#include "icaruscode/Utilities/EventRegistry.h"
+
+
+// C/C++ standard libraries
+#include <algorithm> // std::copy()
+#include <iterator> // std::distance()
+
+
+// -----------------------------------------------------------------------------
+auto sbn::EventRegistry::recordSource(std::string const& fileName) -> FileID_t {
+  
+  auto const fileID = sourceID(fileName);
+  if (fileID) return fileID.value();
+  
+  fSourceFiles.push_back(fileName);
+  return indexToFileID(fSourceFiles.size() - 1U);
+  
+} // sbn::EventRegistry::recordSource()
+
+
+// -----------------------------------------------------------------------------
+bool sbn::EventRegistry::hasSource(FileID_t const& fileID) const
+  { return fileIDtoIndex(fileID) < fSourceFiles.size(); }
+
+
+// -----------------------------------------------------------------------------
+bool sbn::EventRegistry::hasSource(std::string const& fileName) const
+  { return findSource(fileName) != fSourceFiles.end(); }
+
+
+// -----------------------------------------------------------------------------
+auto sbn::EventRegistry::sourceID(std::string const& fileName) const
+  -> std::optional<FileID_t>
+{
+  auto const iSource = findSource(fileName);
+  return (iSource != fSourceFiles.end())
+    ? std::optional{indexToFileID(std::distance(fSourceFiles.begin(), iSource))}
+    : std::nullopt
+    ;
+} // sbn::EventRegistry::sourceID()
+
+
+// -----------------------------------------------------------------------------
+std::optional<std::string> sbn::EventRegistry::sourceName
+  (FileID_t const& fileID) const
+{
+  return hasSource(fileID)
+    ? std::optional{ fSourceFiles[fileIDtoIndex(fileID)] }: std::nullopt;
+} // sbn::EventRegistry::sourceName()
+
+
+// -----------------------------------------------------------------------------
+std::string sbn::EventRegistry::sourceNameOr
+  (FileID_t const& fileID, std::string const& defName) const
+  { return sourceName(fileID).value_or(defName); }
+
+
+// -----------------------------------------------------------------------------
+auto sbn::EventRegistry::records() const -> std::vector<EventIDandRecord_t> {
+  
+  std::vector<EventIDandRecord_t> recordCopy;
+  copyEventRecordsInto(recordCopy);
+  return recordCopy;
+  
+} // sbn::EventRegistry::records()
+
+
+// -----------------------------------------------------------------------------
+auto sbn::EventRegistry::eventRecord(art::EventID const& event) const
+  -> std::optional<EventRecord_t>
+{
+  
+  auto const lg = lockEventRegistry();
+  // BEGIN needs lock
+  auto const iRecord = fEventRegistry.find(event);
+  return (iRecord != fEventRegistry.end())
+    ? std::optional{ iRecord->second }: std::nullopt;
+  // END needs lock
+  
+} // sbn::EventRegistry::eventRecord()
+
+
+// -----------------------------------------------------------------------------
+auto sbn::EventRegistry::recordEvent
+  (EventID_t const& event, FileID_t sourceFileID) -> EventRecord_t
+{
+  auto const lg = lockEventRegistry();
+  // BEGIN needs lock
+  auto& record = fEventRegistry[event];
+  record.sourceFiles.push_back(sourceFileID);
+  return record;
+  // END needs lock
+  
+} // sbn::EventRegistry::recordEvent()
+
+
+// -----------------------------------------------------------------------------
+auto sbn::EventRegistry::findSource(std::string const& fileName)
+  -> FileRegistry_t::iterator
+  { return std::find(fSourceFiles.begin(), fSourceFiles.end(), fileName); }
+
+auto sbn::EventRegistry::findSource(std::string const& fileName) const
+  -> FileRegistry_t::const_iterator
+  { return std::find(fSourceFiles.begin(), fSourceFiles.end(), fileName); }
+
+
+// -----------------------------------------------------------------------------
+void sbn::EventRegistry::copyEventRecordsInto
+  (std::vector<EventIDandRecord_t>& recordCopy) const
+{
+  recordCopy.reserve(fEventRegistry.size()); // bet size does not change
+  auto const lg = lockEventRegistry();
+  // BEGIN needs lock
+  recordCopy.reserve(fEventRegistry.size()); // has size() changed already?
+  std::copy(fEventRegistry.cbegin(), fEventRegistry.cend(),
+    std::back_inserter(recordCopy));
+  // END needs lock
+} // sbn::EventRegistry::records()
+
+
+// -----------------------------------------------------------------------------
+std::lock_guard<std::mutex> sbn::EventRegistry::lockEventRegistry() const
+  { return std::lock_guard{ fEventRegistryLock }; }
+
+
+// -----------------------------------------------------------------------------
+auto sbn::EventRegistry::indexToFileID(std::size_t index) -> FileID_t
+  { return static_cast<FileID_t>(index); }
+
+
+// -----------------------------------------------------------------------------
+std::size_t sbn::EventRegistry::fileIDtoIndex(FileID_t fileID)
+  { return static_cast<std::size_t>(fileID); }
+
+
+// -----------------------------------------------------------------------------
+

--- a/icaruscode/Utilities/EventRegistry.h
+++ b/icaruscode/Utilities/EventRegistry.h
@@ -1,0 +1,209 @@
+/**
+ * @file   icaruscode/Utilities/EventRegistry.h
+ * @brief  Class keeping track of _art_ event IDs.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   January 22, 2021
+ * @see    icaruscode/Utilities/EventRegistry.cxx
+ * 
+ * 
+ * 
+ * 
+ */
+
+#ifndef ICARUSCODE_UTILITIES_EVENTREGISTRY_H
+#define ICARUSCODE_UTILITIES_EVENTREGISTRY_H
+
+
+// framework libraries
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "cetlib_except/exception.h"
+
+// C/C++ standard libraries
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+#include <utility> // std::pair<>
+#include <string>
+#include <functional> // std::hash<>
+#include <optional>
+#include <limits> // std::numeric_limits<>
+#include <cstddef> // std::size_t
+
+
+// -----------------------------------------------------------------------------
+namespace std {
+  
+  template <>
+  struct hash<art::EventID> {
+    
+    std::size_t operator() (art::EventID const& ID) const noexcept
+      {
+        return std::hash<std::uint64_t>{}(
+            (std::uint64_t{ ID.run() } << 40U)     // run:    24 bits (16M)
+          + (std::uint64_t{ ID.subRun() } << 22U)  // subrun: 18 bits (256k)
+          + (std::uint64_t{ ID.event() })          // event:  22 bits (4M)
+          );
+      }
+    
+  }; // hash<art::EventID>
+  
+} // namespace std
+
+
+// -----------------------------------------------------------------------------
+namespace sbn { class EventRegistry; }
+/**
+ * @brief Keeps a record of all registered events and their source.
+ * 
+ * This registry object will keep track of every time an event is "registered".
+ * An event is represented by its ID (`art::EventID`), and it is associated to
+ * the input file(s) it is stored in.
+ * 
+ * Input files can be registered separately by file name, or at the same time
+ * with the event.
+ * 
+ * 
+ * Thread safety
+ * --------------
+ * 
+ * Registration of events can happen concurrently (thread-safe).
+ * Registration of source files, instead, is not protected.
+ * 
+ * It is guaranteed that the source file records are never modified once
+ * registered (i.e. neither removed from the registry, nor the path of a source
+ * record changed).
+ * 
+ */
+class sbn::EventRegistry {
+  
+    public:
+  
+  using EventID_t = art::EventID; ///< Type used to identify an event.
+  
+  using FileID_t = std::size_t; ///< Type used to identify a source file.
+  
+  /// Element of the registry for an event.
+  struct EventRecord_t {
+    
+    std::vector<FileID_t> sourceFiles; ///< List of ID of source files.
+    
+  }; // EventRecord_t
+  
+  /// Type with event ID (`first`) and event record information (`second`).
+  using EventIDandRecord_t = std::pair<EventID_t, EventRecord_t>;
+  
+  
+  /// Mnemonic for no file ID.
+  static constexpr FileID_t NoFileID = std::numeric_limits<FileID_t>::max();
+  
+  
+  // -- BEGIN -- Source interface ----------------------------------------------
+  /// @name Source interface
+  /// @{
+  
+  /**
+   * @brief Registers a source file and returns its ID in the registry.
+   * @param fileName the name of the source file to be registered
+   * @return the internal ID this registry will refer to `fileName` with
+   * 
+   * If `fileName` has already been registered, the existing ID is returned and
+   * no other action is performed.
+   */
+  FileID_t recordSource(std::string const& fileName);
+  
+  /// Returns whether the specified file ID is registered as a source.
+  bool hasSource(FileID_t const& fileID) const;
+  
+  /// Returns whether the specified file name is registered as a source.
+  bool hasSource(std::string const& fileName) const;
+  
+  /// Returns the ID of the source with the specified file name (slow!).
+  /// @return the ID of the source, or unset if `fileID` is not registered
+  std::optional<FileID_t> sourceID(std::string const& fileName) const;
+  
+  /// Returns the name of the source associated to the specified file ID.
+  /// @return the name of the source, or unset if `fileID` is not registered
+  std::optional<std::string> sourceName(FileID_t const& fileID) const;
+  
+  /// Returns the name of the source associated to the specified file ID.
+  /// @return the name of the source, or `defName` if `fileID` is not registered
+  std::string sourceNameOr
+    (FileID_t const& fileID, std::string const& defName) const;
+  
+  /// @}
+  // -- END -- Source interface ------------------------------------------------
+  
+  
+  // -- BEGIN -- Event interface -----------------------------------------------
+  /// @name Event interface
+  /// @{
+  
+  /// Returns a copy of all event records.
+  std::vector<EventIDandRecord_t> records() const;
+  
+  /// Returns a copy of the specified event record.
+  /// @return the record for `event`, or unset if `event` is not registered
+  std::optional<EventRecord_t> eventRecord(art::EventID const& event) const;
+  
+  /**
+   * @brief Registers an event and returns a copy of its record.
+   * @param event ID of the event to be registered
+   * @param sourceFileID ID of the source file to be associated with the `event`
+   * @return the current copy, just updated, of the record of the `event`
+   * @throw cet::exception (category: `"sbn::EventRegistry"`) if `sourceFileID`
+   *        dose not match a registered source file
+   * @see `recordEvent(EventID_t const&, std::string const&)`
+   * 
+   * The record of the specified `event` is updated adding `sourceFileID` among
+   * its sources. A single `sourceFileID` can appear multiple times for the same
+   * event, indicating a duplicate event in the same source file.
+   * 
+   * A source with `sourceFileID` must have been registered already
+   * (`recordSource()`).
+   * 
+   */
+  EventRecord_t recordEvent(EventID_t const& event, FileID_t sourceFileID);
+  
+  /// @}
+  // -- END -- Event interface -------------------------------------------------
+  
+  
+    private:
+  
+  /// Type for source file registry.
+  using FileRegistry_t = std::vector<std::string>;
+  
+  /// Registered source file, by file ID key.
+  std::vector<std::string> fSourceFiles;
+  
+  /// Registry of all events.
+  std::unordered_map<EventID_t, EventRecord_t> fEventRegistry;
+  
+  mutable std::mutex fEventRegistryLock; ///< Lock for `fEventRegistry`.
+  
+  //@{
+  /// Returns an iterator pointing to the specified file registry entry.
+  FileRegistry_t::iterator findSource(std::string const& fileName);
+  FileRegistry_t::const_iterator findSource(std::string const& fileName) const;
+  //@}
+  
+  /// Copies all event records into `recordCopy`.
+  void copyEventRecordsInto(std::vector<EventIDandRecord_t>& recordCopy) const;
+
+  /// Returns a lock guard around `fEventRegistry`.
+  std::lock_guard<std::mutex> lockEventRegistry() const;
+  
+  
+  /// Converts an internal index in file source registry into a `FileID_t`.
+  static FileID_t indexToFileID(std::size_t index);
+
+  /// Converts a `FileID_t` into an internal index in file source registry.
+  static std::size_t fileIDtoIndex(FileID_t fileID);
+
+}; // sbn::EventRegistry
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_UTILITIES_EVENTREGISTRY_H


### PR DESCRIPTION
Jobs merging different input files may end up processing multiple events with the same ID.
Output files with duplicate events will throw exceptions when processed afterward.
I introduce a simple service, `DuplicateEventTracker`, which can detect duplicate events and by default throws an exception as soon as a duplicate event is seen. This draconian action is intended to inform the user of the problem when it's easier to be fixed.
