### PR TITLE
filter_genie_active.fcl renamed and moved.

### DIFF
--- a/fcl/gen/genie/filter_genie_active_icarus.fcl
+++ b/fcl/gen/genie/filter_genie_active_icarus.fcl
@@ -1,5 +1,5 @@
 #
-# File:    filter_genie_active.fcl
+# File:    filter_genie_active_icarus.fcl
 # Purpose: Filters out all events with no neutrino interaction in active volume.
 # Authors: Christian Farnese (farnese@pd.infn.it), Gianluca Petrillo (petrillo@slac.stanford.edu)
 # Date:    May 6, 2020
@@ -9,6 +9,8 @@
 # The events in the input file are filtered with the requirement that at least
 # one neutrino interaction happens within the active volume of the detector.
 # See `FilterNeutrinosActiveVolume` documentation for more details.
+#
+# The standard ICARUS geometry configuration is used.
 #
 #
 # Input

--- a/fcl/gen/genie/filter_genie_active_icarus_overburden.fcl
+++ b/fcl/gen/genie/filter_genie_active_icarus_overburden.fcl
@@ -1,6 +1,7 @@
-#include "filter_genie_active.fcl"
+#include "filter_genie_active_icarus.fcl"
 
-   services: {
-     @table::services
-     @table::icarus_split_induction_overburden_geometry_services
-   } # services
+services: {
+  @table::services
+  @table::icarus_split_induction_overburden_geometry_services
+} # services
+


### PR DESCRIPTION
The job configuration in `filter_genie_active.fcl` contains ICARUS-specific details (i.e. geometry).
So I am renaming it to show it's ICARUS-specific.
Also, I have moved it into the common job configuration area.