### PR TITLE
Energy deposition storage from LArG4 enabled experiment-wide.

### DIFF
--- a/fcl/g4/intime_g4_icarus.fcl
+++ b/fcl/g4/intime_g4_icarus.fcl
@@ -66,9 +66,6 @@ outputs:
  }
 }
 
-# turn on the SimEnergyDeposit output
-services.LArG4Parameters.FillSimEnergyDeposits:       true
-
 services.LArG4Parameters.ParticleKineticEnergyCut: 0.0005
 physics.producers.larg4outtime.KeepParticlesInVolumes: [ "volDetEnclosure" ]
 physics.producers.larg4outtime.InputLabels: [ "GenInTimeSorter:outtime" ]

--- a/fcl/g4/intime_g4_icarus_sce_on.fcl
+++ b/fcl/g4/intime_g4_icarus_sce_on.fcl
@@ -66,9 +66,6 @@ outputs:
  }
 }
 
-# turn on the SimEnergyDeposit output
-services.LArG4Parameters.FillSimEnergyDeposits:       true
-
 services.LArG4Parameters.ParticleKineticEnergyCut: 0.0005
 physics.producers.larg4outtime.KeepParticlesInVolumes: [ "volDetEnclosure" ]
 physics.producers.larg4outtime.InputLabels: [ "GenInTimeSorter:outtime" ]

--- a/fcl/g4/standard_g4_icarus.fcl
+++ b/fcl/g4/standard_g4_icarus.fcl
@@ -65,9 +65,6 @@ outputs:
 
 #physics.producers.largeant.KeepParticlesInVolumes: ["volCryostat"] #only keep MCParticles that cross the cryostat
 
-# turn on the SimEnergyDeposit output
-services.LArG4Parameters.FillSimEnergyDeposits:       true
-
 services.message.destinations :
 {
   STDCOUT:

--- a/fcl/services/simulationservices_icarus.fcl
+++ b/fcl/services/simulationservices_icarus.fcl
@@ -19,7 +19,6 @@ icarus_largeantparameters: {
     StoreTrajectories:        true
     VisualizationEnergyCut:   10.e-3  #depricated, in GeV
     VisualizeNeutrals:        false   #depricated
-    UseCustomPhysics:         false   #Whether to use a custom list of physics processes or the default
     ModifyProtonCut:          false   #Whether to modify the default proton cut
     NewProtonCut:             0.0     #new ProtonCut value, ModifyProtonCut must be set to set new value
     KeepEMShowerDaughters:    true    #save secondary, tertiary, etc particles in EM showers
@@ -39,6 +38,7 @@ icarus_largeantparameters: {
     CosmogenicXSMNBiasFactor: 1 # Not more than 5-ish cuz of numerical instabilities.
     DisableWireplanes:        false #if set true, charge drift simulation does not run - used for optical sim jobs OR just when you don't wanna drift the e's.
     SkipWireSignalInTPCs:     []     # put here TPC id's which should not receive ionization electrons - used to simulate TPC geom volumes which are actually dead LAr volumes in protoDUNE
+    FillSimEnergyDeposits:    true
     UseModBoxRecomb:          true   # use Modified Box recombination instead of Birks
     # IonAndScintCalculator: "NEST"
 
@@ -65,6 +65,8 @@ icarus_largeantparameters: {
                                   [-60, 3, 0.15],
                                   [  0, 3, 0.15] ] ]
     UseLitePhotons: false
+
+    
 }
 
 


### PR DESCRIPTION
While `standard_g4_icarus.fcl` and most related configurations set locally the option to same energy deposits into their output, the option, which is driven by `LArG4Parameters` service, was turned off by default.
Since `LArG4Parameters` is how some modules find out about the availability of energy depositions, this causes an inconsistency where energy depositions are available but user code is not aware of it.

This commit enables saving energy depositions in `LArG4Parameters`, which is what we want as general behaviour.
The standard `G4` job configurations do not override that setting any more, but rather they inherit its default (i.e. "enabled").