### PR TITLE
Take 3: added required library into FilterNeutrinosActiveVolume link list

### DIFF
--- a/icaruscode/Filters/CMakeLists.txt
+++ b/icaruscode/Filters/CMakeLists.txt
@@ -25,6 +25,7 @@ art_make(
                         ${FHICLCPP}
                         ${CETLIB}
                         ${CETLIB_EXCEPT}
+                        ROOT::EG
                         ${ROOT_GEOM}
                         ${ROOT_XMLIO}
                         ${ROOT_GDML}


### PR DESCRIPTION
After merging and reverting, trying again.
Note that this is already in `develop`, but was afterwards reverted in `master` only.

Previous pull requests: #125, #126 and #127.