### PR TITLE
Added configurations for cosmics and BNB + cosmics, proton primary only.

### DIFF
--- a/fcl/gen/corsika/prodcorsika_protononly_icarus.fcl
+++ b/fcl/gen/corsika/prodcorsika_protononly_icarus.fcl
@@ -1,0 +1,36 @@
+#
+# File:    prodcorsika_protononly_icarus.fcl
+# Purpose: Generation of cosmic rays using only proton primaries (not CMC).
+# Author:  Gianluca Petrillo (petrillo@slac.standard.edu)
+# Date:    March 10, 2021
+#
+# This job configuration generates cosmic ray events in ICARUS with a
+# configuration similar to `prodcorsika_standard_icarus.fcl`, but using
+# a proton-only primary composition instead of the Constant Mass Composition.
+# 
+# Output
+# -------
+# 
+# See `prodcorsika_standard_icarus.fcl`.
+# The main output is an _art_ ROOT file with content:
+#  * `generator`: generated cosmic rays from CORSIKA (`simb::MCTruth` collection)
+# 
+
+#include "prodcorsika_standard_icarus.fcl"
+
+
+process_name: Gen
+
+#
+# change comsic ray model
+#
+
+physics.producers.generator: @local::icarus_corsika_p
+
+#
+# output file names
+#
+
+services.TFileService.fileName: "Supplemental-prodcorsika_protononly_icarus_%tc-%p.root"
+outputs.out1.fileName:    "prodcorsika_protononly_icarus_%tc-%p.root"
+

--- a/fcl/gen/genie/prodcorsika_genie_protononly_icarus.fcl
+++ b/fcl/gen/genie/prodcorsika_genie_protononly_icarus.fcl
@@ -1,0 +1,38 @@
+#
+# File:    prodcorsika_genie_protononly_icarus.fcl
+# Purpose: Generation of interactions of neutrinos from BNB and cosmic rays.
+# Author:  Gianluca Petrillo (petrillo@slac.standard.edu)
+# Date:    March 10, 2021
+#
+# This job configuration generates events with the same neutrino configuration 
+# as `prodcorsika_genie_standard_icarus.fcl`, but with a different cosmic
+# ray model (proton rays only).
+# 
+# Output
+# -------
+# 
+# See `prodcorsika_genie_standard_icarus.fcl`.
+# The main output is an _art_ ROOT file with content:
+#  * `generator`: neutrino interaction(s) from GENIE
+#                 (with flux, GENIE truth and beam gate information)
+#  * `cosmgen`:   generated cosmic rays from CORSIKA
+# 
+
+#include "prodcorsika_genie_standard_icarus.fcl"
+
+
+process_name: GenBNBbkgr
+
+#
+# change comsic ray model
+#
+
+physics.producers.cosmgen: @local::icarus_corsika_p
+
+#
+# output file names
+#
+
+services.TFileService.fileName: "Supplemental-prodcorsika_genie_protononly_icarus_%tc-%p.root"
+outputs.out1.fileName:    "prodcorsika_genie_protononly_icarus_%tc-%p.root"
+

--- a/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi.fcl
+++ b/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi.fcl
@@ -1,0 +1,35 @@
+#
+# File:    prodcorsika_genie_protononly_icarus_numi.fcl
+# Purpose: Generation of interactions of neutrinos from NuMI and cosmic rays.
+# Author:  Gianluca Petrillo (petrillo@slac.standard.edu)
+# Date:    March 2, 2021
+#
+# This job configuration generates events with the same neutrino configuration 
+# as `prodcorsika_genie_standard_icarus_numi.fcl`, but with a different cosmic
+# ray model (proton rays only).
+# 
+# Output
+# -------
+# 
+# See `prodcorsika_genie_standard_icarus_numi.fcl`.
+# The main output is an _art_ ROOT file with content:
+# 
+
+#include "prodcorsika_genie_standard_icarus_numi.fcl"
+
+
+process_name: GenNuMIbkgr
+
+#
+# change comsic ray model
+#
+
+physics.producers.cosmicrays: @local::icarus_corsika_p
+
+#
+# output file names
+#
+
+services.TFileService.fileName: "Supplemental-prodcorsika_genie_protononly_icarus_numi_%tc-%p.root"
+outputs.rootoutput.fileName:    "prodcorsika_genie_protononly_icarus_numi_%tc-%p.root"
+


### PR DESCRIPTION
These commits add job configurations to generate cosmic rays from proton primary only, as opposed to using the Constant Mass Composition which is the model of choice in the current `standard` ICARUS configuration:
* `prodcorsika_protononly_icarus.fcl` (background: cosmic rays only)
* `prodcorsika_genie_protononly_icarus.fcl` (BNB neutrino interactions)
* `prodcorsika_genie_standard_icarus_numi.fcl` (NuMI neutrino interactions)

All configurations are equivalent to the corresponding `standard` ones except for the cosmic ray model.