### PR TITLE
Added module to dump PMT configuration from data files.

### DIFF
--- a/fcl/utilities/dump_pmtconfig_icarus.fcl
+++ b/fcl/utilities/dump_pmtconfig_icarus.fcl
@@ -1,0 +1,73 @@
+#
+# File:     dump_pmtconfig_icarus.fcl
+# Purpose:  Dump on screen PMT configuration from DAQ.
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     March 17, 2021
+# Version:  1.0
+#
+# This module extracts and then dumps the PMT configuration stored in the
+# FHiCL configuration of that file(s), one per run.
+#
+#
+# Input: (data) files with FHiCL configuration of PMT.
+#
+# Service dependencies:
+# - message facility
+# 
+# Changes:
+# 20210317 (petrillo@slac.stanford.edu) [v1.0]
+#   first version
+#
+
+#include "messages_icarus.fcl"
+#include "geometry_icarus.fcl"
+#include "channelmapping_icarus.fcl"
+
+
+# ------------------------------------------------------------------------------
+process_name: DumpPMTcfg
+
+
+# ------------------------------------------------------------------------------
+services: {
+  
+  message: @local::icarus_message_services_interactive
+  
+                     @table::icarus_geometry_services
+  IICARUSChannelMap: @local::icarus_channelmappinggservice
+  
+} # services
+
+
+# ------------------------------------------------------------------------------
+source: {
+  module_type: RootInput
+  maxEvents:  -1            # number of events to read
+} # source
+
+
+# ------------------------------------------------------------------------------
+physics: {
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  producers: {
+    pmtconfig: { module_type: PMTconfigurationExtraction }
+  }
+  
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  analyzers: {
+    dumppmtconfig: {
+      module_type:  DumpPMTconfiguration
+      
+      PMTconfigurationTag: "pmtconfig"
+      
+    } # dumppmtconfig
+  } # analyzers
+  
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  extractors: [ pmtconfig ]
+  dumpers:    [ dumppmtconfig ]
+  
+} # physics
+
+
+# ------------------------------------------------------------------------------

--- a/icaruscode/Decode/CMakeLists.txt
+++ b/icaruscode/Decode/CMakeLists.txt
@@ -3,6 +3,7 @@ cet_enable_asserts()
 art_make(
           EXCLUDE
                         PMTconfigurationExtraction_module.cc
+                        DumpPMTconfiguration_module.cc
           MODULE_LIBRARIES
                         sbndaq-artdaq-core_Overlays_ICARUS 
                         artdaq-core_Utilities
@@ -34,6 +35,13 @@ simple_plugin(PMTconfigurationExtraction module
   icaruscode_Decode_DecoderTools
   sbnobj_Common_PMT_Data
   art_Framework_Services_Registry
+  fhiclcpp
+  cetlib_except
+  )
+
+simple_plugin(DumpPMTconfiguration module
+  sbnobj_Common_PMT_Data
+  ${MF_MESSAGELOGGER}
   fhiclcpp
   cetlib_except
   )

--- a/icaruscode/Decode/DumpPMTconfiguration_module.cc
+++ b/icaruscode/Decode/DumpPMTconfiguration_module.cc
@@ -1,0 +1,185 @@
+/**
+ * @file   DumpPMTconfiguration_module.cc
+ * @brief  Dumps on console the content of `sbn::PMTconfiguration` data product.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 17, 2021
+ */
+
+// SBN libraries
+#include "sbnobj/Common/PMT/Data/PMTconfiguration.h"
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Principal/Run.h"
+#include "canvas/Persistency/Provenance/RunID.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <set>
+#include <string>
+#include <sstream> // std::ostringstream
+
+
+//------------------------------------------------------------------------------
+namespace sbn { class DumpPMTconfiguration; }
+
+/**
+ * @brief Dumps on console the content of `sbn::PMTconfiguration` data product.
+ * 
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * * `sbn::PMTconfiguration`: configuration of PMT in `art::Run` data product.
+ *     See e.g. `icarus::PMTconfigurationExtraction` module.
+ * 
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * A terse description of the parameters is printed by running
+ * `lar --print-description DumpPMTconfiguration`.
+ * 
+ * * `PMTconfigurationTag` (data product input tag): the tag identifying the
+ *     data product to dump; this data product must be in `art::Run`.
+ * * `Verbosity` (integral, default: maximum): verbosity level used in the
+ *     dump; see `sbn::PMTconfiguration::dump()` for details.
+ * * `SkipDuplicateRuns` (flag, default: `true`): multiple files can contain
+ *     information from the same run; with this flag set, only the first time
+ *     a run is encountered its PMT configuration is dumped; otherwise, each
+ *     time a run is opened by _art_, its configuration is printed.
+ * * `OutputCategory` (string, default: `DumpPMTconfiguration`): name of the
+ *     message facility output stream to dump the information into
+ * 
+ */
+class sbn::DumpPMTconfiguration: public art::EDAnalyzer {
+  
+    public:
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Atom<art::InputTag> PMTconfigurationTag {
+      Name("PMTconfigurationTag"),
+      Comment("tag of PMT configuration data product (from art::Run)")
+      };
+
+    fhicl::Atom<unsigned int> Verbosity {
+      Name("Verbosity"),
+      Comment("verbosity level [default: maximum]"),
+      sbn::PMTconfiguration::MaxDumpVerbosity // default
+      };
+
+    fhicl::Atom<bool> SkipDuplicateRuns {
+      Name("SkipDuplicateRuns"),
+      Comment("print only one PMT configuration from each run"),
+      true // default
+      };
+    
+    fhicl::Atom<std::string> OutputCategory {
+      Name("OutputCategory"),
+      Comment("name of the category used for the output"),
+      "DumpPMTconfiguration"
+      };
+
+  }; // struct Config
+  
+  using Parameters = art::EDAnalyzer::Table<Config>;
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  // --- BEGIN Constructors ----------------------------------------------------
+  explicit DumpPMTconfiguration(Parameters const& config);
+  
+  // --- END Constructors ------------------------------------------------------
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Dumps the data product.
+  virtual void beginRun(art::Run const& run) override;
+  
+  /// Does nothing, but it is mandatory.
+  virtual void analyze(art::Event const& event) override {}
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  art::InputTag const fPMTconfigurationTag; ///< Input PMT configuration tag.
+  
+  unsigned int const fVerbosity; ///< Verbosity level used for dumping.
+  
+  bool const fSkipDuplicateRuns; ///< Print only once from each run.
+
+  /// Category used for message facility stream.
+  std::string const fOutputCategory;
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+  std::set<art::RunID> fRuns; ///< Set of runs already encountered.
+  
+}; // sbn::DumpPMTconfiguration
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+//--- sbn::DumpPMTconfiguration
+//------------------------------------------------------------------------------
+sbn::DumpPMTconfiguration::DumpPMTconfiguration
+  (Parameters const& config)
+  : art::EDAnalyzer(config)
+  // configuration
+  , fPMTconfigurationTag(config().PMTconfigurationTag())
+  , fVerbosity          (config().Verbosity())
+  , fSkipDuplicateRuns  (config().SkipDuplicateRuns())
+  , fOutputCategory     (config().OutputCategory())
+{
+  
+  consumes<sbn::PMTconfiguration, art::InRun>(fPMTconfigurationTag);
+  
+} // sbn::DumpPMTconfiguration::DumpPMTconfiguration()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpPMTconfiguration::beginRun(art::Run const& run) {
+  
+  if (fSkipDuplicateRuns) {
+    art::RunID const& id = run.id();
+    if (fRuns.count(id)) {
+      mf::LogTrace(fOutputCategory) << id << " has already been encountered.";
+      return;
+    }
+    fRuns.insert(id);
+  } // if skip duplicates
+  
+  auto const& config
+    = run.getByLabel<sbn::PMTconfiguration>(fPMTconfigurationTag);
+  
+  std::ostringstream sstr;
+  config.dump(sstr, "  ", "", fVerbosity);
+  
+  mf::LogVerbatim(fOutputCategory) << run.id() << ": " << sstr.str();
+  
+
+} // sbn::DumpPMTconfiguration::beginRun()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(sbn::DumpPMTconfiguration)
+
+
+//------------------------------------------------------------------------------


### PR DESCRIPTION
A job configuration extracting and then dumping the PMT configuration is provided as `dump_pmtconfig_icarus.fcl`.