### PR TITLE
Updates for interim release

### DIFF
--- a/fcl/reco/reco_icarus.fcl
+++ b/fcl/reco/reco_icarus.fcl
@@ -345,17 +345,17 @@ icarus_reco_pandoraICARUS:         [ pandoraICARUS,
 ]
 
 icarus_reco_pandoraICARUSCryo0:    [ pandoraICARUSCryo0,
-                                     pandoraTrackICARUSCryo0,
+                                     pandoraTrackICARUSCryo0
 #                                     pandoraShowerICARUSCryo0,
-                                     pandoraKalmanTrackICARUSCryo0
+#                                     pandoraKalmanTrackICARUSCryo0
 #,                                    mcsICARUSRawCryo0,
 #                                     mcsstandardRawCryo0
 ]
 
 icarus_reco_pandoraICARUSCryo1:    [ pandoraICARUSCryo1,
-                                     pandoraTrackICARUSCryo1,
+                                     pandoraTrackICARUSCryo1
 #                                     pandoraShowerICARUSCryo1,
-                                     pandoraKalmanTrackICARUSCryo1
+#                                     pandoraKalmanTrackICARUSCryo1
 #,                                    mcsICARUSRawCryo1,
 #                                     mcsstandardRawCryo1
 ]

--- a/icaruscode/Decode/DecoderTools/PMTDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/PMTDecoder_tool.cc
@@ -145,7 +145,7 @@ void PMTDecoder::initializeDataProducts()
 
 void PMTDecoder::process_fragment(const artdaq::Fragment &artdaqFragment)
 {
-    size_t fragment_id = artdaqFragment.fragmentID();
+    size_t fragment_id = artdaqFragment.fragmentID() & 0x0fff;
 
     // convert fragment to Nevis fragment
     sbndaq::CAENV1730Fragment         fragment(artdaqFragment);

--- a/icaruscode/Decode/stage0_raw_single_icarus.fcl
+++ b/icaruscode/Decode/stage0_raw_single_icarus.fcl
@@ -1,0 +1,27 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0raw
+
+## Use the following to run the full defined stage0 set of modules
+#physics.reco: [@sequence::icarus_stage0_single]
+
+## Use the following to run only the decoding and noise filtering
+## ==> Set as default for production processing for lifetime measurements - Jan, 2021
+#physics.reco: [ daqTPC ]
+
+# Custom list
+physics.reco: [ recowireraw,
+                icarushit
+              ]
+
+## boiler plate...
+physics.trigger_paths: [ reco ]
+outputs.out1.fileName: "%ifb_%tc-%p.root"
+outputs.out1.dataTier: "reconstructed"
+
+# Drop the artdaq format files on output
+outputs.out1.outputCommands: ["keep *_*_*_*"]

--- a/icaruscode/Decode/stage0_single_icarus.fcl
+++ b/icaruscode/Decode/stage0_single_icarus.fcl
@@ -15,9 +15,7 @@ process_name: stage0
 
 # Custom list
 physics.reco: [ daqTPC,
-#                daqPMT,
-                recowireraw,
-                icarushit,
+                daqPMT,
                 decon1droi,
 #                decon2droi,
                 roifinder,
@@ -31,7 +29,7 @@ outputs.out1.fileName: "%ifb_%tc-%p.root"
 outputs.out1.dataTier: "reconstructed"
 
 # Drop the artdaq format files on output
-outputs.out1.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*" ]
+outputs.out1.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*" ]
 
 # Add a few temporary overrides that will either be dropped or made default in the future.
 #physics.producers.daqTPC.DecoderTool.DiagnosticOutput:                       true               # This turns on lots of diagnostic messages... LOTS. S
@@ -48,6 +46,7 @@ physics.producers.decon1droi.ROIFinderToolVec.ROIFinderToolPlane2:           @lo
 
 # This to study 2D ROI finding
 #physics.producers.roifinder.WireModuleLabel:                                "decon2droi:gauss"
+physics.producers.roifinder.OutputMorphed:                                   false
 
 physics.producers.gaushit.CalDataModuleLabel:                                "roifinder" #decon2droi:gauss" #"roifinder"
 physics.producers.gaushit.HitFinderToolVec.CandidateHitsPlane0:              @local::candhitfinder_standard      # Sets hit finding for plane 0

--- a/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
@@ -459,7 +459,7 @@ void  Decon1DROI::processChannel(size_t                                  idx,
             return;
         }
         
-        const geo::PlaneID&      planeID = wids[0].planeID();
+        const geo::PlaneID& planeID = wids[0].planeID();
 
         // vector holding uncompressed adc values
         std::vector<short> rawadc(dataSize);
@@ -498,7 +498,7 @@ void  Decon1DROI::processChannel(size_t                                  idx,
         // Make a dummy candidate roi vec
         icarus_tool::IROIFinder::CandidateROIVec deconROIVec;
         
-        deconROIVec.push_back(icarus_tool::IROIFinder::CandidateROI(0,rawAdcLessPedVec.size()));
+        deconROIVec.push_back(icarus_tool::IROIFinder::CandidateROI(0,rawAdcLessPedVec.size() - 1));
         
         // Do the deconvolution on the full waveform
         auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
@@ -513,13 +513,13 @@ void  Decon1DROI::processChannel(size_t                                  idx,
         // Now find the candidate ROI's
         fROIFinderVec.at(planeID.Plane)->FindROIs(deconvolvedWaveform, channel, fEventCount, raw_noise, candRoiVec);
         
-        icarusutil::TimeVec holder;
+        std::vector<float> holder;
         
         // We need to copy the deconvolved (and corrected) waveform ROI's
         for(const auto& candROI : candRoiVec)
         {
             // First up: copy out the relevent ADC bins into the ROI holder
-            size_t roiLen = candROI.second - candROI.first;
+            size_t roiLen = candROI.second - candROI.first + 1;
             
             holder.resize(roiLen);
             

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/BaselineMostProbAve_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/BaselineMostProbAve_tool.cc
@@ -27,13 +27,13 @@ public:
     
     ~BaselineMostProbAve();
     
-    void configure(const fhicl::ParameterSet& pset)                                         override;
-    void outputHistograms(art::TFileDirectory&)                                       const override;
+    void configure(const fhicl::ParameterSet& pset)                                        override;
+    void outputHistograms(art::TFileDirectory&)                                      const override;
     
-    float GetBaseline(const icarusutil::TimeVec&, raw::ChannelID_t, size_t, size_t)   const override;
+    float GetBaseline(const std::vector<float>&, raw::ChannelID_t, size_t, size_t)   const override;
     
 private:
-    std::pair<float,int> GetBaseline(const icarusutil::TimeVec&, int, size_t, size_t) const;
+    std::pair<float,int> GetBaseline(const std::vector<float>&, int, size_t, size_t) const;
     
     size_t fMaxROILength;    ///< Maximum length for calculating Most Probable Value
 
@@ -65,10 +65,10 @@ void BaselineMostProbAve::configure(const fhicl::ParameterSet& pset)
 }
 
     
-float BaselineMostProbAve::GetBaseline(const icarusutil::TimeVec& holder,
-                                       raw::ChannelID_t           channel,
-                                       size_t                     roiStart,
-                                       size_t                     roiLen) const
+float BaselineMostProbAve::GetBaseline(const std::vector<float>& holder,
+                                       raw::ChannelID_t          channel,
+                                       size_t                    roiStart,
+                                       size_t                    roiLen) const
 {
     float base(0.);
 
@@ -108,10 +108,10 @@ float BaselineMostProbAve::GetBaseline(const icarusutil::TimeVec& holder,
     return base;
 }
     
-std::pair<float,int> BaselineMostProbAve::GetBaseline(const icarusutil::TimeVec& holder,
-                                                      int                        binRange,
-                                                      size_t                     roiStart,
-                                                      size_t                     roiStop) const
+std::pair<float,int> BaselineMostProbAve::GetBaseline(const std::vector<float>& holder,
+                                                      int                       binRange,
+                                                      size_t                    roiStart,
+                                                      size_t                    roiStop) const
 {
     std::pair<double,int> base(0.,1);
     int                   nTrunc;

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/BaselineStandard_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/BaselineStandard_tool.cc
@@ -26,10 +26,10 @@ public:
     
     ~BaselineStandard();
     
-    void configure(const fhicl::ParameterSet& pset)                                       override;
-    void outputHistograms(art::TFileDirectory&)                                     const override;
+    void configure(const fhicl::ParameterSet& pset)                                      override;
+    void outputHistograms(art::TFileDirectory&)                                    const override;
     
-    float GetBaseline(icarusutil::TimeVec const&, raw::ChannelID_t, size_t, size_t) const override;
+    float GetBaseline(std::vector<float> const&, raw::ChannelID_t, size_t, size_t) const override;
     
 private:
     // fhicl parameters
@@ -61,10 +61,10 @@ void BaselineStandard::configure(const fhicl::ParameterSet& pset)
 }
 
     
-float BaselineStandard::GetBaseline(icarusutil::TimeVec const& holder,
-                                    raw::ChannelID_t           channel,
-                                    size_t                     roiStart,
-                                    size_t                     roiLen) const
+float BaselineStandard::GetBaseline(std::vector<float> const& holder,
+                                    raw::ChannelID_t          channel,
+                                    size_t                    roiStart,
+                                    size_t                    roiLen) const
 {
     float base=0;
     //1. Check Baseline match?

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/FullWireDeconvolution_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/FullWireDeconvolution_tool.cc
@@ -113,7 +113,7 @@ void FullWireDeconvolution::configure(const fhicl::ParameterSet& pset)
 }
     
 void FullWireDeconvolution::Deconvolve(IROIFinder::Waveform const&        waveform,
-                                       double const samplingRate,
+                                       double const                       samplingRate,
                                        raw::ChannelID_t                   channel,
                                        IROIFinder::CandidateROIVec const& roiVec,
                                        recob::Wire::RegionsOfInterest_t&  ROIVec) const
@@ -148,11 +148,11 @@ void FullWireDeconvolution::Deconvolve(IROIFinder::Waveform const&        wavefo
         const auto& roi = roiVec[roiIdx];
         
         // First up: copy out the relevent ADC bins into the ROI holder
-        size_t roiLen = roi.second - roi.first;
+        size_t roiLen = roi.second - roi.first + 1;
         
         holder.resize(roiLen);
         
-        std::copy(rawAdcLessPedVec.begin()+binOffset+roi.first, rawAdcLessPedVec.begin()+binOffset+roi.second, holder.begin());
+        std::copy(rawAdcLessPedVec.begin()+binOffset+roi.first, rawAdcLessPedVec.begin()+binOffset+roiLen, holder.begin());
         if (applyNormFactor) std::transform(holder.begin(),holder.end(),holder.begin(), std::bind(std::multiplies<float>(),std::placeholders::_1,normFactor));
         
         // Get the truncated mean and rms

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/IBaseline.h
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/IBaseline.h
@@ -32,7 +32,7 @@ namespace icarus_tool
         virtual void outputHistograms(art::TFileDirectory&)                                     const = 0;
         
         // Find the baseline
-        virtual float GetBaseline(icarusutil::TimeVec const&, raw::ChannelID_t, size_t, size_t) const = 0;
+        virtual float GetBaseline(std::vector<float> const&, raw::ChannelID_t, size_t, size_t) const = 0;
     };
 }
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/NoBaseline_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/NoBaseline_tool.cc
@@ -22,10 +22,10 @@ public:
     
     ~NoBaseline();
     
-    void configure(const fhicl::ParameterSet& pset)                                       override;
-    void outputHistograms(art::TFileDirectory&)                                     const override;
+    void configure(const fhicl::ParameterSet& pset)                                      override;
+    void outputHistograms(art::TFileDirectory&)                                    const override;
     
-    float GetBaseline(const icarusutil::TimeVec&, raw::ChannelID_t, size_t, size_t) const override;
+    float GetBaseline(const std::vector<float>&, raw::ChannelID_t, size_t, size_t) const override;
     
 private:
 };
@@ -47,10 +47,10 @@ void NoBaseline::configure(const fhicl::ParameterSet& pset)
 }
 
     
-float NoBaseline::GetBaseline(const icarusutil::TimeVec& holder,
-                              raw::ChannelID_t           channel,
-                              size_t                     roiStart,
-                              size_t                     roiLen) const
+float NoBaseline::GetBaseline(const std::vector<float>& holder,
+                              raw::ChannelID_t          channel,
+                              size_t                    roiStart,
+                              size_t                    roiLen) const
 {
     return 0.;
 }

--- a/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/ROIDeconvolution_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/DeconTools/ROIDeconvolution_tool.cc
@@ -143,11 +143,11 @@ void ROIDeconvolution::Deconvolve(const IROIFinder::Waveform&        waveform,
         fSignalShaping->SetDecon(samplingRate, deconSize, channel);
         
         deconSize = fFFTSize;
-        
-        icarusutil::TimeVec holder(deconSize);
+
+        icarusutil::TimeVec deconVec(deconSize);
         
         // Pad with zeroes if the deconvolution buffer is larger than the input waveform
-        if (deconSize > waveform.size()) holder.resize(deconSize, 0.);
+        if (deconSize > waveform.size()) deconVec.resize(deconSize, 0.);
         
         // Watch for the case where the input ROI is long enough to want an deconvolution buffer that is
         // larger than the input waveform.
@@ -187,13 +187,15 @@ void ROIDeconvolution::Deconvolve(const IROIFinder::Waveform&        waveform,
         size_t holderOffset = 0; //deconSize > waveform.size() ? (deconSize - waveform.size()) / 2 : 0;
         
         // Fill the buffer and do the deconvolution
-        std::copy(waveform.begin()+firstOffset, waveform.begin()+secondOffset, holder.begin() + holderOffset);
+        std::copy(waveform.begin()+firstOffset, waveform.begin()+secondOffset, deconVec.begin() + holderOffset);
         
         // Deconvolute the raw signal using the channel's nominal response
-        fFFT->deconvolute(holder, fSignalShaping->GetResponse(channel).getDeconvKernel(), fSignalShaping->ResponseTOffset(channel));
+        fFFT->deconvolute(deconVec, fSignalShaping->GetResponse(channel).getDeconvKernel(), fSignalShaping->ResponseTOffset(channel));
+
+        std::vector<float>  holder(deconVec.size());
         
         // Get rid of the leading and trailing "extra" bins needed to keep the FFT happy
-        if (roiStart > 0 || holderOffset > 0) std::copy(holder.begin() + holderOffset + roiStart, holder.begin() + holderOffset + roiStop, holder.begin());
+        if (roiStart > 0 || holderOffset > 0) std::copy(deconVec.begin() + holderOffset + roiStart, deconVec.begin() + holderOffset + roiStop, holder.begin());
         
         // Resize the holder to the ROI length
         holder.resize(roiLen);


### PR DESCRIPTION
Covering a few unrelated topics here:
1) Apply a mask to the PMT fragment ID before looking up in channel map database
2) Updates to the stage0, stage1 fhicl files for processing of unbiased trigger full readout data taking (and introduction of a file to run the "raw" signal processing after stage 0),
3) Addressing issue https://github.com/SBNSoftware/icaruscode/issues/136 by temporarily turning off the kalman track fit for the "icarus hit" path. 