### PR TITLE
Stage1 configuration for data decoded with v09_18_00 or earlier

### DIFF
--- a/icaruscode/Decode/fcl/stage1_single_icarus_gauss.fcl
+++ b/icaruscode/Decode/fcl/stage1_single_icarus_gauss.fcl
@@ -37,5 +37,13 @@ services.message.destinations :
        }
      }
   }
+  ErrorStream:
+  {
+     type:      "cerr"      #tells the message service to output this destination to standard error stream
+     threshold: "CRITICAL"  #tells the message service that this destination applies to the most CRITICAL level messages only
+     categories: {
+       default: { limit: -1 }
+     }
+  }
 }
 

--- a/icaruscode/Decode/fcl/stage1_single_icarus_gauss_pre091800.fcl
+++ b/icaruscode/Decode/fcl/stage1_single_icarus_gauss_pre091800.fcl
@@ -1,0 +1,14 @@
+#
+# "Stage 1" configuration for data files decoded with icaruscode older than v09_18_00.
+# See https://sbnsoftware.github.io/icaruscode_wiki/Detector_geometry.html
+# for details.
+#
+
+#include "stage1_single_icarus_gauss.fcl"
+
+# setting the older geometry
+services: {
+  @table::services
+  @table::icarus_geometry_services_legacy_icarus_splitwires
+}
+

--- a/icaruscode/Decode/fcl/stage1_single_icarus_gauss_v091800.fcl
+++ b/icaruscode/Decode/fcl/stage1_single_icarus_gauss_v091800.fcl
@@ -1,0 +1,29 @@
+#
+# "Stage 1" configuration for data files decoded with icaruscode v09_18_00[_01].
+# See https://sbnsoftware.github.io/icaruscode_wiki/Detector_geometry.html
+# for details.
+# 
+# This configuration is special in that the geometry was changed, but its
+# version tag was not. So to process them correctly we have to have the new
+# geometry and the old version set.
+# 
+# Runs known to have been decoded with these versions:
+#   5295, 5300-5305, 5313-5315, 5317, 5318.
+# (samweb list-files --summary "icarus_project.stage 'stage0' and version 'v09_18_00%'")
+# 
+# Runs known to have been reconstructed with these versions:
+#   5233, 5295, 5300, 5301, 5304, 5305, 5313-5315, 5317, 5318.
+# (samweb list-files --summary "icarus_project.stage 'stage1' and version 'v09_18_00%'")
+# 
+#
+
+#include "stage1_single_icarus_gauss_pre091800.fcl"
+
+# setting the older geometry name (geometry is a newer one though)
+services.Geometry: {
+  @table::services.Geometry
+  
+  GDML: "icarus_complete_20210311_no_overburden_rotUV.gdml"
+  ROOT: "icarus_complete_20210311_no_overburden_rotUV.gdml"
+  
+}


### PR DESCRIPTION
Introducing two configurations for `stage1` processing of data decoded (i.e. `stage0`) with `icaruscode` `v09_18_00` or earlier.

Decoded files have a geometry recorded in them at `stage0`, and following processing must happen with the same geometry version.
With the breaking change in geometry on `v09_18_00`, data decoded with geometry pre-`v09_18_00` needs to be processed with a legacy geometry, which is what `stage1_single_icarus_gauss_pre091800.fcl` does.
Special special case is data decoded with `icaruscode` version `v09_18_00` and `v09_18_00_01` exactly, which have the new geometry but leave a track of using the old one. A special special configuration is necessary for processing these files (`fcl/stage1_single_icarus_gauss_v091800.fcl`).
