### PR TITLE
Added DuplicateEventTracker to default services

### DIFF
--- a/fcl/services/services_common_icarus.fcl
+++ b/fcl/services/services_common_icarus.fcl
@@ -81,6 +81,8 @@ icarus_art_services: {
     }
   }
 
+  DuplicateEventTracker: {}
+
 } # icarus_art_services
 
 


### PR DESCRIPTION
This is a proposed solution for issue #147.
It adds `DuplicateEventTracker` service to the `icarus_art_services`, which is included in any ICARUS configuration even vaguely official. The configuration of the service is such that an exception is thrown on the first duplicate event encountered.

This is a GitHub commit (i.e. made with GitHub web editor).