### PR TITLE
Scripts for SAM/decoder file lists

### DIFF
--- a/scripts/runFilesFromSAM.sh
+++ b/scripts/runFilesFromSAM.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+#
+# Creates file lists from a run number, or SAM definition, or just SAM files.
+#
+# Run with `--help` for usage instructions
+#
+# Author: Gianluca Petrillo (petrillo@slac.fnal.gov)
+# Date:   March 2021
+#
+# Changes:
+# 20210411 (petrillo@slac.fnal.gov) [1.0]
+#   first public version
+#
+#
+
+SCRIPTNAME="$(basename "$0")"
+SCRIPTVERSION="1.0"
+
+declare -r RawType='raw'
+declare -r DecodeType='decoded'
+declare -r XRootDschema='root'
+declare -r dCacheLocation='dcache'
+declare -r TapeLocation='enstore'
+
+declare -r DefaultType="$DecodeType"
+declare -r DefaultSchema="$XRootDschema"
+declare -r DefaultLocation="$dCacheLocation"
+declare -r DefaultDecoderStageName="stage0" # used to be 'decoder' up to a certain time
+
+declare -r DefaultOutputPattern="%TYPE%-run%RUN%%DASHSCHEMA%%DASHLOCATION%.filelist"
+
+# ------------------------------------------------------------------------------
+function isFlagSet() {
+  local VarName="$1"
+  [[ -n "${!VarName//0}" ]]
+} # isFlagSet()
+
+function isDebugging() {
+  local -i Level="${1:-1}"
+  [[ "$DEBUG" -ge "$Level" ]]
+} # isDebugging()
+
+function DBGN() {
+  local -i Level="$1"
+  shift
+  isDebugging "$Level" && STDERR "DBG[${Level}]| $*" ; 
+}
+function DBG() { DBGN 1 "$*" ; }
+
+function STDERR() { echo "$*" >&2 ; }
+
+function WARN() { STDERR "WARNING: $*" ; }
+function INFO() { isFlagSet DoQuiet || STDERR "$*" ; }
+
+function FATAL() {
+  local -i Code=$1
+  shift
+  STDERR "FATAL(${Code}): $*"
+  exit $Code
+} # FATAL()
+
+function LASTFATAL() {
+  local -i res=$?
+  [[ $res == 0 ]] || FATAL "$res" "$@"
+} # LASTFATAL()
+
+
+function PrintHelp() {
+
+  cat <<EOH
+Queries SAM for all the files in a run and translates each file into a URL.
+
+Usage:  ${SCRIPTNAME}  [options] Spec [Spec ...] > run.filelist
+
+Each specification may be a run number, a SAM definition (preceded by \`@\`,
+e.g. \`@icarus_run005300_raw\`) or a file name.
+In all cases, run, definition or file, they must be known to SAM.
+
+Options:
+--type=<${RawType}|${DecodeType}|...>  [${DefaultType}]
+--decode , --decoded , -D
+--raw , -R
+--stage=STAGE
+    select the type of files to query (raw from DAQ, decoded...);
+    if the stage is explicitly selected, it is used as constraint in SAM query
+--schema=<${XRootDschema}|...>  [${DefaultSchema}]
+--xrootd , --root , -X
+    select the type of URL (XRootD, ...)
+--location=<${dCacheLocation}|${TapeLocation}>  [${DefaultLocation}]
+--tape , --enstore , -T
+--disk , --dcache , -C
+    select the storage type
+
+--output=OUTPUTFILE
+    use OUTPUTFILE for all output file lists
+--outputdir=OUTPUTDIR
+    prepend all output filelist paths with this directory
+-O
+    create a list per run, with the pattern specified by \`--outputpattern\`:
+--outputpattern=PATTERN  [${DefaultOutputPattern}]
+    use PATTERN for the standard output file list (see option \`-O\` above);
+    the following tags in PATTERN are replaced: \`%RUN%\` by the run number;
+    \`%SCHEMA%\` by the URL schema; \`%LOCATION%\` by the storage location;
+    \`%TYPE%\` by the file content type; and all tags prepended by \`DASH\`
+    (e.g. \`%DASHTYPE%\`) are replaced by a dash (\`-\`) and the value of the
+    tag only if the content of that tag is not empty
+
+--quiet , -q
+    do not print non-fatal information on screen while running
+--debug[=LEVEL]
+    enable debugging printout (optionally with the specified verbosity LEVEL)
+--version, -V
+--help , -h , -?
+    print this help message
+
+EOH
+
+} # PrintHelp()
+
+
+function PrintVersion() {
+  cat <<EOV
+
+${SCRIPTNAME} version ${SCRIPTVERSION}
+
+EOV
+} # PrintVersion()
+
+
+# ------------------------------------------------------------------------------
+function AddPathToList() {
+  
+  local Path="$1"
+  
+  DBGN 2 "Adding: '${Path}'"
+  if [[ -n "$OutputFile" ]]; then
+    echo "$Path" >> "$OutputFile"
+  else
+    echo "$Path"
+  fi
+  
+} # AddPathToList()
+
+
+declare -a TempFiles
+function DeclareTempFile() {
+  local Run="$1"
+  
+  local TemplateName="${SCRIPTNAME%.sh}-run${Run}.tmp.XXXXXX"
+  local TempFile
+  TempFile="$(mktemp --tmpdir "$TemplateName")"
+  LASTFATAL "Failed to create a temporary file (after '${TemplateName}') for run ${Run}."
+  TempFiles+=( "$TempFile" )
+  
+  echo "$TempFile"
+  
+} # DeclareTempFile()
+
+function Cleanup() {
+  rm -f "${TempFiles[@]}"
+} # Cleanup()
+
+
+function isRunNumber() { [[ "$1" =~ ^[[:digit:]]+$ ]]; }
+function isSAMdefName() { [[ "${1:0:1}" == '@' ]]; }
+function isSAMfile() { [[ "${1: -5}" == '.root' ]]; }
+function SpecType() {
+  local Spec="$1"
+  local -Ar Tests=(
+    ['run']='isRunNumber'
+    ['SAMdef']='isSAMdefName'
+    ['SAMfile']='isSAMfile'
+  )
+  local Type
+  for Type in "${!Tests[@]}" ; do
+    "${Tests[$Type]}" "$Spec" || continue
+    echo "$Type"
+    return 0
+  done
+  return 1
+} # SpecType()
+
+
+function BuildOutputFilePath() {
+  local Pattern="$1"
+  local Run="$2"
+  
+  local OutputName="$Pattern"
+  
+  local -A Replacements
+  local VarName VarValue
+  for VarName in Run Type Schema Location ; do
+    VarValue="${!VarName}"
+    Replacements["${VarName^^}"]="$VarValue"
+    Replacements["DASH${VarName^^}"]="${VarValue:+"-${VarValue}"}"
+  done
+  local TagName
+  for TagName in "${!Replacements[@]}" ; do  
+    OutputName="${OutputName//%${TagName}%/${Replacements["$TagName"]}}"
+  done
+  
+  echo "${OutputDir:+"${OutputDir%/}/"}${OutputName}"
+} # BuildOutputFilePath()
+
+
+# ------------------------------------------------------------------------------
+function RunSAM() {
+  local -a Cmd=( 'samweb' "$@" )
+  
+  DBG "${Cmd[@]}"
+  "${Cmd[@]}"
+  
+} # RunSAM()
+
+
+# ------------------------------------------------------------------------------
+declare -a Specs
+declare -i UseDefaultOutputFile=0 DoQuiet=0
+declare OutputFile
+declare Type="$DefaultType"
+declare Schema="$DefaultSchema"
+declare Location="$DefaultLocation"
+declare OutputPattern="$DefaultOutputPattern" # not an option yet
+declare -i iParam
+for (( iParam=1 ; iParam <= $# ; ++iParam )); do
+  Param="${!iParam}"
+  if [[ "${Param:0:1}" == '-' ]]; then
+    case "$Param" in
+      ( '--raw' | '-R' )                  Type="$RawType" ;;
+      ( '--decoded' | '--decode' | '-D' ) Type="$DecodeType" ;;
+      ( '--type='* )                      Type="${Param#--*=}" ;;
+      ( '--stage='* )                     Type="${Param#--*=}" ;;
+      
+      ( '--schema='* | '--scheme='* )     Schema="${Param#--*=}" ;;
+      ( '--xrootd' | '--XRootD' | '--root' | '--ROOT' | '-X' ) Schema="$XRootDschema" ;;
+      
+      ( '--loc='* | '--location='* )      Location="${Param#--*=}" ;;
+      ( '--dcache' | '--dCache' | '-C' )  Location="$dCacheLocation" ;;
+      ( '--tape' | '--enstore' | '-T' )   Location="$TapeLocation" ;;
+      
+      ( "--output="* )                    OutputFile="${Param#--*=}" ;;
+      ( "--outputpattern="* )             OutputPattern="${Param#--*=}" ;;
+      ( "--outputdir="* )                 OutputDir="${Param#--*=}" ;;
+      ( "-O" )                            UseDefaultOutputFile=1 ;;
+      
+      ( '--debug' )                       DEBUG=1 ;;
+      ( '--debug='* )                     DEBUG="${Param#--*=}" ;;
+      ( '--quiet' | '-q' )                DoQuiet=1 ;;
+      ( '--version' | '-V' )              DoVersion=1 ;;
+      ( '--help' | '-h' | '-?' )          DoHelp=1 ;;
+      
+      ( * )
+        PrintHelp
+        echo
+        FATAL 1 "Invalid option #${iParam} ('${Param}')."
+        ;;
+    esac
+  else
+    Specs+=( "$Param" )
+    LASTFATAL "Parameter #${iParam} ('${Param}') is not a valid (run) number."
+  fi
+done
+
+if isFlagSet UseDefaultOutputFile && [[ -n "$OutputFile" ]]; then
+  FATAL 1 "Options \`-O\` and \`--outputfile\` (value: '${OutputFile}') are exclusive."
+fi
+
+if isFlagSet DoVersion ; then
+  PrintVersion
+  [[ "${ExitWithCode:-0}" -gt 0 ]] || ExitWithCode=0
+fi
+
+if isFlagSet DoHelp ; then
+  PrintHelp
+  [[ "${ExitWithCode:-0}" -gt 0 ]] || ExitWithCode=0
+fi
+
+[[ -n "$ExitWithCode" ]] && exit "$ExitWithCode"
+
+
+trap Cleanup EXIT
+
+declare Constraints=''
+case "${Type,,}" in
+  ( 'raw' )     Constraints+=" and data_tier=raw" ;;
+  ( * )
+    if [[ "${Type,,}" == 'decoded' ]]; then
+      Stage="$DefaultDecoderStageName"
+    else
+      Stage="$Type"
+    fi
+    Constraints+=" and icarus_project.stage=${Stage}"
+    ;;
+#   echo "Type '${Type}' not supported!" >&2
+#   exit 1
+esac
+
+
+declare -i nErrors=0
+
+declare Spec
+[[ -n "$OutputDir" ]] && mkdir -p "$OutputDir"
+if [[ -n "$OutputFile" ]]; then
+  [[ "${OutputFile:0:1}" == '/' ]] || OutputFile="${OutputDir%/}/${OutputFile}"
+  rm -f "$OutputFile"
+fi
+for Spec in "${Specs[@]}" ; do
+
+  declare FileList="$(DeclareTempFile "$Spec")"
+  if isFlagSet UseDefaultOutputFile ; then
+    OutputFile="$(BuildOutputFilePath "$OutputPattern" "$Spec")"
+    rm -f "$OutputFile"
+  fi
+  
+  unset Run SAMdefName
+  case "$(SpecType "$Spec")" in
+    ( 'run' )
+      Run="$Spec"
+      JobTag="Run ${Run}"
+      declare Query="run_number=${Run}${Constraints}"
+      RunSAM list-files "$Query" > "$FileList"
+      LASTFATAL "getting run ${Run} file list (SAM query: '${Query}')."
+      ;;
+    ( 'SAMdef' )
+      SAMdefName="${Spec:1}"
+      JobTag="SAM definition ${SAMdefName}"
+      RunSAM list-definition-files "$SAMdefName" > "$FileList"
+      LASTFATAL "getting ${JobTag} file list."
+      ;;
+    ( 'SAMfile' )
+      FileName="$Spec"
+      JobTag="SAM-declared file '${FileName}'"
+      echo "$FileName" > "$FileList"
+      ;;
+    ( * )
+      ERROR "Unknown type for specification '${Spec}'."
+      let ++nErrors
+      ;;
+  esac
+  
+  declare -i nFiles="$(wc -l "$FileList" | cut -d' ' -f1)"
+  declare FileName
+  declare -i iFile=0
+  declare -a FileURL
+  INFO "${JobTag}: ${nFiles} files${OutputFile:+" => '${OutputFile}'"}"
+  while read FileName ; do
+    INFO "[$((++iFile))/${nFiles}] '${FileName}'"
+    FileURL=( $(RunSAM get-file-access-url ${Schema:+"--schema=${Schema}"} ${Location:+"--location=${Location}"} "$FileName") )
+    LASTFATAL "getting file '${FileName}' location from SAM."
+    [[ "${#FileURL[@]}" == 0 ]] && FATAL 2 "failed getting file '${FileName}' location from SAM."
+    [[ "${#FileURL[@]}" -gt 1 ]] && WARN "File '${FileName}' matched ${#FileURL[@]} locations (only the first one included):$(printf -- "\n- '%s'" "${FileURL[@]}")"
+    AddPathToList "${FileURL[0]}"
+  done < "$FileList"
+  
+done
+
+[[ $nErrors -gt 0 ]] && FATAL 1 "${nErrors} error(s) accumulated while processing."
+
+exit 0

--- a/scripts/sortDataLoggerFiles.py
+++ b/scripts/sortDataLoggerFiles.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+#
+# Documentation can be rendered in python interactive session with
+# `import sortDataLoggerFiles; help(sortDataLoggerFiles)` and on command line
+# with `sortDataLoggerFiles --help`.
+# 
+# It may require ROOT.
+# 
+# Changes:
+# 20210411 (petrillo@slac.fnal.gov) [1.0]
+#   first public version
+#
+
+import sys, os
+import re
+import logging
+
+__doc__ = """Sorts a list of data logger output files.
+
+File paths are read from all the specified file lists in sequence, or from
+standard input if no file list is specified.
+
+If a line is encountered that does not match the typical file name pattern,
+that line is ignored and a warning is printed.
+
+Comments and empty lines at the beginning of the first file list are printed
+at the top of the output as they are. All other comments and empty lines are
+printed at the end of the output.
+
+Note that it is possible to sort "in place" by specifying the same file list as
+input and output.
+"""
+
+__author__ = 'Gianluca Petrillo (petrillo@slac.stanford.edu)'
+__date__ = 'February 26, 2021'
+__version__ = '1.0'
+
+
+class CycleCompareClass:
+  """Provides less() to compare numbers with a single offset cycle.
+  
+  For example, with offset 3 the order of [0:20] would be, from the lowest:
+  [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 1, 2, ]
+  """
+  def __init__(self, first): self.first = first
+  def less(self, a, b): return (a < b) == ((a < self.first) == (b < self.first))
+# class CycleCompareClass
+
+class FileInfoClass:
+  """This class collects information about a input file, including a sorting
+  criterium.
+  """
+  
+  XRootDprotocolHead = 'root://fndca1.fnal.gov:1094/'
+  XRootDprotocolDir = 'pnfs/fnal.gov/usr'
+  POSIXprotocolHead = '/'
+  POSIXprotocolDir = 'pnfs'
+  
+  Pattern = re.compile(r"data_dl(\d+)_run(\d+)_(\d+)_(.*)\.root")
+  POSIXPattern = re.compile(
+    POSIXprotocolHead.replace('.', r'\.')
+    + POSIXprotocolDir.replace('.', r'\.')
+    + r"/([^/]+)/(.*)")
+  XRootDPattern = re.compile(
+    XRootDprotocolHead.replace('.', r'\.')
+    + XRootDprotocolDir.replace('.', r'\.')
+    + r"/(.*)"
+    )
+  _DataLoggerSorter = CycleCompareClass(first=4)
+  
+  @staticmethod
+  def getFirstDataLogger(index): return FileInfoClass._DataLoggerSorter.first
+  @staticmethod
+  def setFirstDataLogger(index):
+    FileInfoClass._DataLoggerSorter = CycleCompareClass(first=index)
+  
+  def __init__(self, line: "input file line (should include endline)"):
+    """Constructor: use and parse the specified input file line."""
+    self.line = line
+    self.path = line.strip()
+    self.protocolAndDir, self.name = os.path.split(self.path)
+    match = FileInfoClass.Pattern.match(self.name)
+    self.is_file = match is not None
+    if self.is_file: self.dataLogger, self.run, self.pass_ = map(int, match.group(1, 2, 3))
+  # __init__()
+  
+  def __lt__(self, other):
+    """Comparison: run, then pass, then (offset cycled) data logger number."""
+    if not self.is_file:
+      raise RuntimeError \
+        ("Sorting not supported for non-file objects ('%s')" % self.path)
+    # if
+    if self.run < other.run: return True
+    if self.run > other.run: return False
+    
+    if self.pass_ < other.pass_: return True
+    if self.pass_ > other.pass_: return False
+    
+    return \
+      FileInfoClass._DataLoggerSorter.less(self.dataLogger, other.dataLogger)
+  # __lt__()
+  
+  def pathToXRootD(self) -> "stored file path in XRootD format":
+    if not self.is_file:
+      raise RuntimeError(
+       "XRootD conversion not supported for non-file objects ('%s')" % self.path
+       )
+    # if not file
+    match = FileInfoClass.POSIXPattern.match(self.path)
+    return os.path.join(
+      FileInfoClass.XRootDprotocolHead, FileInfoClass.XRootDprotocolDir,
+      *match.group(1, 2)
+      ) if match else self.path
+    
+  # pathToXRootD()
+  
+  def pathToPOSIX(self) -> "stored file path in POSIX (PNFS local) format":
+    if not self.is_file:
+      raise RuntimeError(
+       "XRootD conversion not supported for non-file objects ('%s')" % self.path
+       )
+    # if not file
+    match = FileInfoClass.XRootDPattern.match(self.path)
+    return os.path.join(
+        FileInfoClass.POSIXprotocolHead, FileInfoClass.POSIXprotocolDir,
+        match.group(1)
+      ) if match else self.path
+    
+  # pathToXRootD()
+  
+# class FileInfoClass
+
+
+class MinimumAccumulator:
+  def add(self, data, key = None):
+    if key is None: key = data
+    try:
+      if key >= self.minKey: return False
+    except AttributeError: pass # no self.minKey yet?
+    self.minKey = key
+    self.minData = data
+    return True
+  # add()
+  def min(self): return self.minData
+# class MinimumAccumulator
+
+
+def findFirstCycle(files):
+  firstLogger = None
+  firstPassFiles = []
+  wrapped = False
+  for info in fileInfo:
+    if firstLogger == info.dataLogger: break # cycle completed
+    if wrapped and info.dataLogger > firstLogger: break # cycle completed
+    
+    if firstLogger is None: firstLogger = info.dataLogger
+    elif not wrapped and info.dataLogger < firstLogger: wrapped = True
+    
+    firstPassFiles.append(info)
+    logging.debug("Added cycle %d logger %d to first cycle list",
+      info.pass_, info.dataLogger)
+  # for
+  return firstPassFiles
+# findFirstCycle()
+
+
+def extractFirstEvent(filePath):
+  try: import ROOT
+  except ImportError:
+    raise RuntimeError("""ROOT python module could not be loaded.
+      In this condition, you'll have to skip the autodetection of the first logger
+      by explicitly specifying its number as option to the script."""
+      )
+  # try ... except
+  logging.debug("Opening '%s' for event number check...", filePath)
+  srcFile = ROOT.TFile.Open(filePath, "READ")
+  if not srcFile:
+    raise RuntimeError \
+      ("Failed to open '%s' for event number extraction." % filePath)
+  #
+  firstEvent = next(iter(srcFile.Events)) # go PyROOT
+  firstEventNumber = firstEvent.EventAuxiliary.event() # keep going PyROOT
+  
+  logging.debug("First event from '%s': %d", filePath, firstEventNumber)
+  return firstEventNumber
+# extractFirstEvent()
+
+
+def detectFirstLogger(fileInfo):
+  lowestEvent = MinimumAccumulator()
+  for info in fileInfo:
+    firstEvent = extractFirstEvent(info.pathToXRootD())
+    lowestEvent.add(info, key=firstEvent)
+  firstLogger = lowestEvent.min().dataLogger
+  logging.debug("Detected first logger: %d", firstLogger)
+  return firstLogger
+# detectFirstLogger()
+
+
+if __name__ == "__main__":
+  
+  logging.basicConfig(level=logging.INFO)
+  
+  import argparse
+  
+  parser = argparse.ArgumentParser(description=__doc__)
+  
+  parser.add_argument('inputFiles', nargs="*", metavar='inputFileNames',
+    help='input file lists [one from stdin by default]')
+  parser.add_argument('--firstLogger', type=int,
+    help='index of the first data logger in the cycle')
+  parser.add_argument('--output', '-o', default=None,
+    help=
+     'name of the file to write the resulting list into (overwritten!) [stdout]'
+    )
+  parser.add_argument('--xrootd', '--root', '-X', action="store_true",
+    help='convert the paths to XRootD URL')
+  parser.add_argument('--posix', '-P', action="store_true",
+    help='convert the paths to local POSIX path')
+  parser.add_argument('--debug', action="store_true",
+    help='prints out debugging messages')
+  parser.add_argument \
+    ('--version', '-V', action='version', version='%(prog)s ' + __version__)
+
+  args = parser.parse_args()
+  
+  if args.debug: logging.getLogger().setLevel(logging.DEBUG)
+  
+  if args.xrootd and args.posix:
+    raise RuntimeError("XRootD and POSIX output format options are exclusive.")
+  
+  inputFiles = (
+      [ file_ ] if file_.endswith('.root') else open(file_, 'r')
+        for file_ in args.inputFiles 
+    ) if args.inputFiles else [ sys.stdin, ]
+  
+  # example: /pnfs/icarus/persistent/users/ascarpel/trigger/4989/decoded/17247391_0/data_dl2_run4989_1_20210219T015125_20210219T200434-decode.root
+  
+  preComments = []
+  postComments = []
+  fileInfo = []
+  for file_ in inputFiles:
+    
+    for iLine, line in enumerate(file_):
+      
+      info = FileInfoClass(line)
+      if not info.is_file:
+        if not info.path or info.path.startswith('#'):
+          (postComments if fileInfo else preComments).append(info.line)
+          continue
+        else:
+          logging.warning \
+           ("Line %d ('%s') does not match file pattern." % (iLine, info.path))
+          continue
+      # if not file
+      fileInfo.append(info)
+    # for line in file
+  # for input files
+  
+  if fileInfo and (args.firstLogger is None):
+    # uses internal FileInfoClass ordering (firstLogger not set: any will do)
+    fileInfo.sort()
+    firstPassFiles = findFirstCycle(fileInfo)
+    assert firstPassFiles
+    firstLogger = detectFirstLogger(firstPassFiles)
+    
+  else: firstLogger = args.firstLogger if args.firstLogger is None else 4
+  
+  FileInfoClass.setFirstDataLogger(firstLogger)
+  
+  fileInfo.sort() # uses internal FileInfoClass ordering
+  
+  #
+  # print everything
+  #
+  
+  # NOTE: keep this after all the input has been read,
+  #       so that input files can be safely overwritten
+  outputFile = open(args.output, 'w') if args.output else sys.stdout
+  
+  # <CR> were not removed from `line`
+  for line in preComments: outputFile.write(line)
+  for info in fileInfo:
+    if args.posix: line = info.pathToPOSIX() + '\n'
+    elif args.xrootd: line = info.pathToXRootD() + '\n'
+    else: line = info.line
+    outputFile.write(line)
+  for line in postComments: outputFile.write(line)
+  
+  if outputFile is not sys.stdout:
+    logging.info \
+      ("%d file entries written into '%s'." % (len(fileInfo), outputFile.name))
+    del outputFile
+  # if
+  
+  sys.exit(0)
+  
+# main


### PR DESCRIPTION
I am offering two scripts that I ended up using quite often when processing data:

* `runFilesFromSAM.sh` creates a list of files which are already known to SAM, either from a run, a SAM definition, or bare file names; the entries in the list are paths that can be processed with _art_ via XRootD or other protocols;
* `sortDataLoggerFiles.py` creates a new file list sorting an existing one; the input file list is a list of ICARUS data files (may be raw, or processed, as long as they keep the file base name format of the raw file), and the output is a list where the first event of each file is expected to be lower then the one of the next file. In other words, it sorts the files in time.

Both scripts have options that can be learned by running them with `--help` option.