### PR TITLE
Updated channel mapping access of PMT configuration extractor

### DIFF
--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
@@ -381,6 +381,11 @@ class icarus::PMTconfigurationExtractor
   std::optional<fhicl::ParameterSet> readBoardConfig
     (fhicl::ParameterSet const& pset, std::string const& key) const;
   
+  
+  /// Returns the fragment ID of the specified board as known by the database.
+  static unsigned int readoutBoardDBfragmentID
+    (sbn::V1730Configuration const& boardConfig);
+  
 }; // icarus::PMTconfigurationExtractor
 
 

--- a/icaruscode/PMT/PMTWaveformBaselinesFromReadoutConfiguration_module.cc
+++ b/icaruscode/PMT/PMTWaveformBaselinesFromReadoutConfiguration_module.cc
@@ -327,7 +327,7 @@ void icarus::PMTWaveformBaselinesFromReadoutConfiguration::beginRun
   
   std::vector<Baseline_t> newBaselines;
   std::tie(fConfigured, newBaselines)
-     = extractBaselinesFromConfiguration(PMTconfig);
+    = extractBaselinesFromConfiguration(PMTconfig);
   
   bool const changed = (fBaselines != newBaselines);
   fBaselines = std::move(newBaselines);


### PR DESCRIPTION
The fragment ID needs now to be masked.
This fix is not needed if the suggestion in issue #151 is adopted (but since I need this to work _now_ I am pushing it anyway).