### PR TITLE
Temporarily restore definition of Amplitude for MCOpHit

### DIFF
--- a/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
@@ -26,6 +26,7 @@ ICARUSMCOpHit: {
     MergePeriod: 0.01
     SimPhotonsProducer: "largeant"
     SPEArea: @local::SPE.Area
+    SPEAmplitude: @local::SPE.Amplitude
 }
 
 ICARUSMCOpFlash: {

--- a/icaruscode/PMT/OpReco/fcl/icarus_spe.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_spe.fcl
@@ -3,6 +3,7 @@ BEGIN_PROLOG
 
 SPE: {
   Area: 212.
+  Amplitude: 49.18
   Shift: 0.
 }
 


### PR DESCRIPTION
Gianluca reports failures of sim/recon with a missing fhicl definition for MCOptHit. This is meant to temporarily patch the problem until experts have time to consider an alternative (if one). 