### PR TITLE
Canny Edge Detector updates

### DIFF
--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
@@ -108,11 +108,11 @@ private:
                                            std::vector<recob::Wire>&   wireColVec,
                                            std::vector<recob::Wire>&   morphedVec)
             : fROIFinder(parent),
-            fEvent(event),
-            fPlaneIDVec(planeIDVec),
-            fPlaneIDToDataPairMap(planeIDToDataPairMap),
-            fWireColVec(wireColVec),
-            fMorphedVec(morphedVec)
+              fEvent(event),
+              fPlaneIDVec(planeIDVec),
+              fPlaneIDToDataPairMap(planeIDToDataPairMap),
+              fWireColVec(wireColVec),
+              fMorphedVec(morphedVec)
         {}
         void operator()(const tbb::blocked_range<size_t>& range) const
         {
@@ -139,13 +139,13 @@ private:
     // This is for the baseline...
     float getMedian(const icarus_signal_processing::VectorFloat, const unsigned int) const;
 
-    std::vector<art::InputTag>                     fWireModuleLabelVec;         ///< vector of modules that made digits
-    bool                                           fOutputMorphed;              ///< Output the morphed waveforms
-    size_t                                         fEventCount;                 ///< count of event processed
+    std::vector<art::InputTag>                                 fWireModuleLabelVec;         ///< vector of modules that made digits
+    bool                                                       fOutputMorphed;              ///< Output the morphed waveforms
+    size_t                                                     fEventCount;                 ///< count of event processed
     
-    std::unique_ptr<icarus_tool::IROILocator>      fROITool;
+    std::map<size_t,std::unique_ptr<icarus_tool::IROILocator>> fROIToolMap;
 
-    const geo::GeometryCore*                       fGeometry = lar::providerFrom<geo::Geometry>();
+    const geo::GeometryCore*                                   fGeometry = lar::providerFrom<geo::Geometry>();
     
 }; // class ROIFinder
 
@@ -176,10 +176,18 @@ void ROIFinder::reconfigure(fhicl::ParameterSet const& pset)
     fWireModuleLabelVec  = pset.get<std::vector<art::InputTag>>("WireModuleLabelVec",  std::vector<art::InputTag>()={"decon1droi"});
     fOutputMorphed       = pset.get< bool                     >("OutputMorphed",                                              true);
     
-    // Recover the baseline tool 
-    fhicl::ParameterSet roiFinderParams = pset.get<fhicl::ParameterSet>("ROIFinder");
+    // Recover the list of ROI finding tools
+    const fhicl::ParameterSet& roiFinderTools = pset.get<fhicl::ParameterSet>("ROIFinderToolVec");
 
-    fROITool = art::make_tool<icarus_tool::IROILocator> (roiFinderParams);
+    // Make a mapping between plane id and a plane's ROI finder
+    // This allows different ROI finders per plane but, more important, different parameters
+    for(const std::string& roiFinderTool : roiFinderTools.get_pset_names())
+    {
+        const fhicl::ParameterSet& roiFinderToolParamSet = roiFinderTools.get<fhicl::ParameterSet>(roiFinderTool);
+        size_t                     planeIdx              = roiFinderToolParamSet.get<size_t>("Plane");
+        
+        fROIToolMap[planeIdx] = art::make_tool<icarus_tool::IROILocator> (roiFinderToolParamSet);
+    }
     
     return;
 }
@@ -262,14 +270,12 @@ void ROIFinder::produce(art::Event& evt)
                 mapItr->second.second.addWire(wireID.Wire, wire);
             }
         }
-    
+   
         // Reserve the room for the output
         wireCol->reserve(wireVecHandle->size());
     
         // ... Launch multiple threads with TBB to do the deconvolution and find ROIs in parallel
         multiThreadDeconvolutionProcessing deconvolutionProcessing(*this, evt, planeIDVec, planeIDToDataPairMap, *wireCol, *morphedCol);
-
-        std::cout << "ROIFinder has " << planeIDToDataPairMap.size() << " images to analyze" << std::endl;
     
         tbb::parallel_for(tbb::blocked_range<size_t>(0, planeIDVec.size()), deconvolutionProcessing);
         
@@ -314,7 +320,7 @@ void  ROIFinder::processPlane(size_t                      idx,
     icarus_signal_processing::ArrayFloat outputArray(dataArray.size(),icarus_signal_processing::VectorFloat(dataArray[0].size(),0.));
     icarus_signal_processing::ArrayBool  selectedVals(dataArray.size(),icarus_signal_processing::VectorBool(dataArray[0].size(),false));
 
-    fROITool->FindROIs(dataArray, mapItr->first, outputArray, selectedVals);
+    fROIToolMap.at(planeID.Plane)->FindROIs(dataArray, mapItr->first, outputArray, selectedVals);
 
 //    icarus_signal_processing::ArrayFloat morphedWaveforms(dataArray.size());
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
@@ -122,7 +122,7 @@ void ROICannyEdgeDetection::FindROIs(const ArrayFloat& inputImage, const geo::Pl
     std::vector<int> weakEdgeRows;
     std::vector<int> weakEdgeCols;
 
-    fEdgeDetection->HysteresisThresholdingFast(output, fLowThreshold, fHighThreshold, rois);
+    fEdgeDetection->SparseHysteresisThresholding(output, fLowThreshold, fHighThreshold, rois);
 
     std::cout << "==> Final Step: get dilation, numChannels: " << numChannels << ", rois: " << rois.size() << ", output: " << outputROIs.size() << std::endl;
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
@@ -38,31 +38,9 @@ public:
     
 private:
 
-    std::unique_ptr<icarus_signal_processing::HighPassButterworthFilter> fButterworthFilter;
-    std::unique_ptr<icarus_signal_processing::IMorphologicalFunctions2D> fMorphologicalFilter;
-    std::unique_ptr<icarus_signal_processing::IDenoiser2D>               fDenoiser2D;
-    std::unique_ptr<icarus_signal_processing::BilateralFilters>          fBilateralFilters;
-    std::unique_ptr<icarus_signal_processing::EdgeDetection>             fEdgeDetection;
-    std::unique_ptr<icarus_signal_processing::IROIFinder2D>              fROIFinder2D;
-
-    // fhicl parameters
-    std::vector<size_t>  fStructuringElement;         ///< Structuring element for morphological filter
-    std::vector<float>   fThreshold;                  ///< Threshold to apply for saving signal
-
-    // Start with parameters for Butterworth Filter
-    unsigned int         fButterworthOrder;           ///< Order parameter for Butterworth filter
-    unsigned int         fButterworthThreshold;       ///< Threshold for Butterworth filter
-
-    // Parameters for the 2D morphological filter
-    unsigned int         fMorph2DStructuringElementX; ///< Structuring element in X
-    unsigned int         fMorph2DStructuringElementY; ///< Structuring element in Y
-
-    // Parameters for the denoiser
-    unsigned int         fCoherentNoiseGrouping;      ///< Number of consecutive channels in coherent noise subtraction
-    unsigned int         fCoherentNoiseOffset;        ///< Offset for the midplane...
-    unsigned int         fMorphologicalWindow;        ///< Window size for filter
-    bool                 fOutputStats;                ///< Output of timiing statistics?
-    float                fCoherentThresholdFactor;    ///< Threshold factor for coherent noise removal
+    std::unique_ptr<icarus_signal_processing::BilateralFilters> fBilateralFilters;
+    std::unique_ptr<icarus_signal_processing::EdgeDetection>    fEdgeDetection;
+    std::unique_ptr<icarus_signal_processing::IROIFinder2D>     fROIFinder2D;
 
     // Parameters for the ROI finding
     unsigned int         fADFilter_SX;                ///< 
@@ -74,10 +52,6 @@ private:
     float                fHighThreshold;              ///<
     unsigned int         fBinaryDilation_SX;          ///<
     unsigned int         fBinaryDilation_SY;          ///<
-
-    // We need to give to the denoiser the "threshold vector" we will fill during our data loop
-    icarus_signal_processing::VectorFloat  fThresholdVec;  ///< "threshold vector" filled during decoding loop
-
 };
     
 //----------------------------------------------------------------------
@@ -93,29 +67,6 @@ ROICannyEdgeDetection::~ROICannyEdgeDetection()
     
 void ROICannyEdgeDetection::configure(const fhicl::ParameterSet& pset)
 {
-    // Start by recovering the parameters
-    fStructuringElement = pset.get<std::vector<size_t> >("StructuringElement", std::vector<size_t>()={8,16});
-    fThreshold          = pset.get<std::vector<float>  >("Threshold",          std::vector<float>()={2.75,2.75,2.75});
-
-    fButterworthOrder     = pset.get<unsigned int>("ButterworthOrder",     2);
-    fButterworthThreshold = pset.get<unsigned int>("ButterworthThreshld", 30);
-
-    fButterworthFilter = std::make_unique<icarus_signal_processing::HighPassButterworthFilter>(fButterworthThreshold,fButterworthOrder,4096);
-
-    fMorph2DStructuringElementX = pset.get<unsigned int>("Morph2DStructuringElementX", 7);
-    fMorph2DStructuringElementY = pset.get<unsigned int>("Morph2DStructuringElementX", 28);
-
-    fMorphologicalFilter = std::make_unique<icarus_signal_processing::Dilation2D>(fMorph2DStructuringElementX,fMorph2DStructuringElementY);
-
-    fCoherentNoiseGrouping   = pset.get<unsigned int>("CoherentNoiseGrouping",    32);
-    fCoherentNoiseOffset     = pset.get<unsigned int>("CoherentNoiseOffset",      24);
-    fMorphologicalWindow     = pset.get<unsigned int>("MorphologicalWindow",      10);
-    fCoherentThresholdFactor = pset.get<float       >("CoherentThresholdFactor", 2.5);
-
-    fThresholdVec.resize(6560/fCoherentNoiseGrouping,fCoherentThresholdFactor);
-
-    fDenoiser2D = std::make_unique<icarus_signal_processing::Denoiser2D_Hough>(fMorphologicalFilter.get(), fThresholdVec, fCoherentNoiseGrouping, fCoherentNoiseOffset, fMorphologicalWindow);
-
     fADFilter_SX           = pset.get<unsigned int>("ADFilter_SX",         7);
     fADFilter_SY           = pset.get<unsigned int>("ADFilter_SY",         7);
     fSigma_x               = pset.get<float       >("Sigma_x",          10.0);
@@ -130,20 +81,6 @@ void ROICannyEdgeDetection::configure(const fhicl::ParameterSet& pset)
 
     fBilateralFilters = std::make_unique<icarus_signal_processing::BilateralFilters>();
     fEdgeDetection    = std::make_unique<icarus_signal_processing::EdgeDetection>();
-
-    fROIFinder2D = std::make_unique<icarus_signal_processing::ROICannyFilter>(fButterworthFilter.get(), 
-                                                                              fDenoiser2D.get(), 
-                                                                              fBilateralFilters.get(),
-                                                                              fEdgeDetection.get(), 
-                                                                              fADFilter_SX,
-                                                                              fADFilter_SY,
-                                                                              fSigma_x,
-                                                                              fSigma_y,
-                                                                              fSigma_r,
-                                                                              fLowThreshold,
-                                                                              fHighThreshold,
-                                                                              fBinaryDilation_SX,
-                                                                              fBinaryDilation_SY);
     
     return;
 }
@@ -152,19 +89,9 @@ void ROICannyEdgeDetection::FindROIs(const ArrayFloat& inputImage, const geo::Pl
 {
     unsigned int numChannels = inputImage.size();
     unsigned int numTicks    = inputImage[0].size();
-
-//    icarus_signal_processing::ArrayFloat waveLessCoherent(inputImage.size(),icarus_signal_processing::VectorFloat(4096,0.));
-//    icarus_signal_processing::ArrayFloat medianVals(inputImage.size(),icarus_signal_processing::VectorFloat(4096,0.));
-//    icarus_signal_processing::ArrayFloat coherentRMS(inputImage.size(),icarus_signal_processing::VectorFloat(4096,0.));
-//    icarus_signal_processing::ArrayFloat morphedWaveforms(inputImage.size(),icarus_signal_processing::VectorFloat(4096,0.));
-    icarus_signal_processing::ArrayFloat finalErosion(numChannels,icarus_signal_processing::VectorFloat(4096,0.));
-    icarus_signal_processing::ArrayFloat fullEvent(numChannels,icarus_signal_processing::VectorFloat(4096,0.));
-
-//    (*fROIFinder2D)(inputImage,fullEvent,outputROIs,waveLessCoherent,medianVals,coherentRMS,morphedWaveforms,finalErosion);data_dl17_run5392_48_20210327T233602_20210409T191447-stage0.root
   
     // 5. Directional Smoothing
     std::cout << "++> Step 5: Directional smoothing" << std::endl;
-    icarus_signal_processing::ArrayFloat buffer0  (numChannels, icarus_signal_processing::VectorFloat(numTicks,0.));
     icarus_signal_processing::ArrayFloat buffer   (numChannels, icarus_signal_processing::VectorFloat(numTicks,0.));
     icarus_signal_processing::ArrayFloat sobelX   (numChannels, icarus_signal_processing::VectorFloat(numTicks,0.));
     icarus_signal_processing::ArrayFloat sobelY   (numChannels, icarus_signal_processing::VectorFloat(numTicks,0.));
@@ -176,69 +103,30 @@ void ROICannyEdgeDetection::FindROIs(const ArrayFloat& inputImage, const geo::Pl
 
     std::cout << "==> Step 6: Apply bilateral filter" << std::endl;
 
-    fBilateralFilters->directional(inputImage, direction, buffer0, fADFilter_SX, fADFilter_SY, fSigma_x, fSigma_y, fSigma_r, 360);
+    fBilateralFilters->directional(inputImage, direction, buffer, fADFilter_SX, fADFilter_SY, fSigma_x, fSigma_y, fSigma_r, 360);
 
     std::cout << "==> Step 7: Apply Second Morphological Enhancing" << std::endl;
 
-    icarus_signal_processing::Dilation2D(fADFilter_SX,fADFilter_SY)(buffer0.begin(), numChannels, buffer.begin());
-
-//    output = buffer;
+    icarus_signal_processing::Dilation2D(fADFilter_SX,fADFilter_SY)(buffer.begin(), numChannels, output.begin());
 
     std::cout << "==> Step 8: Perform Canny Edge Detection" << std::endl;
 
     // 6. Apply Canny Edge Detection
-//    fEdgeDetection->Canny(buffer, rois, fADFilter_SX, fADFilter_SY, fSigma_x, fSigma_y, fSigma_r, fLowThreshold, fHighThreshold, 'd');  // Since we run on deconvolved waveforms, use dilation 
-
     for(auto& gradVec : gradient) std::fill(gradVec.begin(),gradVec.end(),0.);
 
-    fEdgeDetection->SepSobel(buffer, sobelX, sobelY, gradient, direction);
-    fEdgeDetection->EdgeNMSInterpolation(gradient, sobelX, sobelY, direction, buffer);
+    fEdgeDetection->SepSobel(output, sobelX, sobelY, gradient, direction);
+    fEdgeDetection->EdgeNMSInterpolation(gradient, sobelX, sobelY, direction, output);
 
     std::vector<int> strongEdgeRows;
     std::vector<int> strongEdgeCols;
     std::vector<int> weakEdgeRows;
     std::vector<int> weakEdgeCols;
 
-    std::cout << "==> DoubleThresholding with low threshold: " << fLowThreshold << ", high threshold: " << fHighThreshold << std::endl;
+    fEdgeDetection->HysteresisThresholdingFast(output, fLowThreshold, fHighThreshold, rois);
 
-    fEdgeDetection->HysteresisThresholdingFast(buffer, fLowThreshold, fHighThreshold, rois);
-
-//    fEdgeDetection->DoubleThresholding(buffer, rois, strongEdgeRows, strongEdgeCols, weakEdgeRows, weakEdgeCols, fLowThreshold, fHighThreshold);
-
-//    fEdgeDetection->HysteresisThresholding(rois, strongEdgeRows, strongEdgeCols, weakEdgeRows, weakEdgeCols, outputROIs);
     std::cout << "==> Final Step: get dilation, numChannels: " << numChannels << ", rois: " << rois.size() << ", output: " << outputROIs.size() << std::endl;
 
     icarus_signal_processing::Dilation2D(fBinaryDilation_SX,fBinaryDilation_SY)(rois.begin(), numChannels, outputROIs.begin());
-
-//    fEdgeDetection->getDilation2D(rois, fBinaryDilation_SX,fBinaryDilation_SY, outputROIs);
-
-//    for (size_t i = 0; i < strongEdgeRows.size(); ++i)
-//    {
-//        //output[strongEdgeRows[i]][strongEdgeCols[i]] = 1.;
-//        output[strongEdgeRows[i]][strongEdgeCols[i]] = 10.;
-//    }
-
-//    for (size_t i = 0; i < weakEdgeRows.size(); ++i)
-//    {
-//        //output[strongEdgeRows[i]][strongEdgeCols[i]] = 1.;
-//        output[weakEdgeRows[i]][weakEdgeCols[i]] = 10.;
-//    }
-
-    std::cout << "==> DONE!! returning to calling module..." << std::endl;
-
-//    for(size_t rowIdx; rowIdx < output.size(); rowIdx++) 
-//    {
-//        for(size_t colIdx = 0; colIdx < output[rowIdx].size(); colIdx++) output[rowIdx][colIdx] = 10. * direction[rowIdx][colIdx];
-//    }
-
-//    for(size_t rowIdx = 0; rowIdx < numChannels; rowIdx++)
-//    {
-//        for(size_t colIdx = 0; colIdx < numTicks; colIdx++)
-//            output[rowIdx][colIdx] = outputROIs[rowIdx][colIdx] ? 10. : 0.;
-//    }
-
-//    output     = buffer;
-//    outputROIs = rois;
 
     std::cout << "--> ROICannyEdgeDetection finished!" << std::endl;
      

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIMorphological2D_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIMorphological2D_tool.cc
@@ -66,7 +66,7 @@ void ROIMorphological2D::configure(const fhicl::ParameterSet& pset)
 
 void ROIMorphological2D::FindROIs(const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs) const
 {
-    icarus_signal_processing::ArrayFloat morphedWaveforms(inputImage.size());
+    icarus_signal_processing::ArrayFloat morphedWaveforms(inputImage.size(),icarus_signal_processing::VectorFloat(inputImage[0].size(),0.));
 
     // Use this to get the 2D Dilation of each waveform
     icarus_signal_processing::Dilation2D(fStructuringElement[0],fStructuringElement[1])(inputImage.begin(),inputImage.size(),morphedWaveforms.begin());

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/roiTools_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/roiTools_icarus.fcl
@@ -3,22 +3,44 @@ BEGIN_PROLOG
 icarus_morphologicalroifinder:
 {
     tool_type:           ROIMorphological2D
+    Plane:               0
     StructuringElement:  [8, 16]
     Threshold:           [2.75,2.75,2.75]
 }
 
+morphologicalfinder_0:       @local::icarus_morphologicalroifinder
+
+morphologicalfinder_1:       @local::icarus_morphologicalroifinder
+morphologicalfinder_1.Plane: 1
+
+morphologicalfinder_2:       @local::icarus_morphologicalroifinder
+morphologicalfinder_2.Plane: 2
+
 icarus_cannyedgedetector:
 {
     tool_type:                    ROICannyEdgeDetection
-    StructuringElement:           [8, 16]
-    Threshold:                    [2.75,2.75,2.75]
-    ButterworthOrder:             2
-    ButterworthThreshold:         30
-    Morph2DStructuringElementX:   7
-    Morph2DStructuringElementY:   28
-    CoherentNoiseGrouping:        32
-    MorphologicalWindow:          10
-    CoherentThresholdFactor:      2.5
+    Plane:                        0
+    ADFilter_SX:                  7
+    ADFilter_SY:                  7
+    Sigma_x:                      10.0
+    Sigma_y:                      10.0
+    Sigma_r:                      30.0
+    LowThreshold:                 15.0
+    HighThreshold:                35.0 
+    BinaryDilation_SX:            31
+    BinaryDilation_SY:            31
 }
+
+cannyedgedetector_0:        @local::icarus_cannyedgedetector
+
+cannyedgedetector_1:        @local::icarus_cannyedgedetector
+
+cannyedgedetector_1.Plane:  1
+
+cannyedgedetector_2:        @local::icarus_cannyedgedetector
+
+cannyedgedetector_2.Plane:  2
+cannyedgedetector_2.LowThreshold:   15.0
+cannyedgedetector_2.HighThreshold:  30.0
 
 END_PROLOG

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -90,12 +90,12 @@ icarus_roifinder:
     module_type:        ROIFinder
     WireModuleLabel:    "decon1droi"
     ROIFinderToolVec: {
-        ROIFinderPlane0: @local::morphologicalfinder_0
-        ROIFinderPlane1: @local::morphologicalfinder_1
-        ROIFinderPlane2: @local::morphologicalfinder_2
-#        ROIFinderPlane0: @local::cannyedgedetector_0
-#        ROIFinderPlane1: @local::cannyedgedetector_1
-#        ROIFinderPlane2: @local::cannyedgedetector_2
+#        ROIFinderPlane0: @local::morphologicalfinder_0
+#        ROIFinderPlane1: @local::morphologicalfinder_1
+#        ROIFinderPlane2: @local::morphologicalfinder_2
+        ROIFinderPlane0: @local::cannyedgedetector_0
+        ROIFinderPlane1: @local::cannyedgedetector_1
+        ROIFinderPlane2: @local::cannyedgedetector_2
     }
 }
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -90,12 +90,12 @@ icarus_roifinder:
     module_type:        ROIFinder
     WireModuleLabel:    "decon1droi"
     ROIFinderToolVec: {
-#        ROIFinderPlane0: @local::morphologicalfinder_0
-#        ROIFinderPlane1: @local::morphologicalfinder_1
-#        ROIFinderPlane2: @local::morphologicalfinder_2
-        ROIFinderPlane0: @local::cannyedgedetector_0
-        ROIFinderPlane1: @local::cannyedgedetector_1
-        ROIFinderPlane2: @local::cannyedgedetector_2
+        ROIFinderPlane0: @local::morphologicalfinder_0
+        ROIFinderPlane1: @local::morphologicalfinder_1
+        ROIFinderPlane2: @local::morphologicalfinder_2
+#        ROIFinderPlane0: @local::cannyedgedetector_0
+#        ROIFinderPlane1: @local::cannyedgedetector_1
+#        ROIFinderPlane2: @local::cannyedgedetector_2
     }
 }
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -87,10 +87,16 @@ icarus_recowireraw:
 
 icarus_roifinder:
 {
-    module_type:     ROIFinder
-    WireModuleLabel: "decon1droi"
-    ROIFinder:       @local::icarus_morphologicalroifinder
-#    ROIFinder:       @local::icarus_cannyedgedetector
+    module_type:        ROIFinder
+    WireModuleLabel:    "decon1droi"
+    ROIFinderToolVec: {
+        ROIFinderPlane0: @local::morphologicalfinder_0
+        ROIFinderPlane1: @local::morphologicalfinder_1
+        ROIFinderPlane2: @local::morphologicalfinder_2
+#        ROIFinderPlane0: @local::cannyedgedetector_0
+#        ROIFinderPlane1: @local::cannyedgedetector_1
+#        ROIFinderPlane2: @local::cannyedgedetector_2
+    }
 }
 
 END_PROLOG


### PR DESCRIPTION
Latest updates reflecting code changes in icarus_signal_processing. Canny Edge detection tool in icaruscode for running the edge finder on deconvolved waveforms. Default is still using the old 2D morphological filter approach. 