### PR TITLE
Added utilities to find duplicate files and events.

### DIFF
--- a/fcl/utilities/list_duplicate_events.fcl
+++ b/fcl/utilities/list_duplicate_events.fcl
@@ -1,0 +1,64 @@
+#
+# File:    list_duplicate_events.fcl
+# Purpose: Runs through all events in a sample, looking for duplicates.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    May 18, 2021
+# Version: 1.0
+# 
+# Use as:
+#     
+#     lar -c list_duplicate_events.fcl -S input.filelist
+#     
+# and find the result in "DuplicateEventList.log".
+# 
+#
+
+process_name: FindDupl
+
+services: {
+
+  DuplicateEventTracker: {
+
+    # just emit a warning on screen instead of throwing an exception
+    WarningOnly: false
+
+    # print a summary of the duplicate events at end of job (default)
+    SkipSummary: false
+
+    ## in case of duplicate, wait until the end of job to throw an exception
+    ExceptionAtEnd: true
+
+    ## tag of output category used by this service to the message facility
+    LogCategory: "DuplicateEventTracker"
+    
+  } # DuplicateEventTracker
+  
+  
+  message: {
+    destinations: {
+      Console: {
+        type:      cout
+        threshold: WARNING
+      }
+      DuplicatesLog: {
+        type:      file
+        filename: "DuplicateEventList.log"
+        threshold: INFO
+        format: {
+          timestamp:      "none"
+          wantModule:      false
+          wantSubroutine:  false
+          wantSomeContext: true
+          wantText:        true
+          noLineBreaks:    true
+        }
+        categories: {
+          DuplicateEventTracker: { limit: -1 }
+          default:               { limit: 0 }
+        }
+      }
+    } # destinations
+  } # message
+
+} # services
+

--- a/scripts/sortDataLoggerFiles.py
+++ b/scripts/sortDataLoggerFiles.py
@@ -9,6 +9,8 @@
 # Changes:
 # 20210411 (petrillo@slac.fnal.gov) [1.0]
 #   first public version
+# 20210518 (petrillo@slac.fnal.gov) [1.1]
+#   added options for duplicate events
 #
 
 import sys, os
@@ -40,7 +42,7 @@ for duplication altogether.
 
 __author__ = 'Gianluca Petrillo (petrillo@slac.stanford.edu)'
 __date__ = 'February 26, 2021'
-__version__ = '1.0'
+__version__ = '1.1'
 
 
 class CycleCompareClass:
@@ -292,7 +294,7 @@ if __name__ == "__main__":
   for iSource, file_ in enumerate(inputFiles):
     isSingleFile = isinstance(file_, list) and len(file_) <= 1
     for iLine, line in enumerate(file_):
-      info = FileInfoClass(line, source=( iSource, None if isSingleFile else iLine ))
+      info = FileInfoClass(line, source=( iSource, None if isSingleFile else iLine + 1 ))
       if not info.is_file:
         if not info.path or info.path.startswith('#'):
           (postComments if fileInfo else preComments).append(info.line)
@@ -312,7 +314,6 @@ if __name__ == "__main__":
     firstPassFiles = findFirstCycle(fileInfo)
     assert firstPassFiles
     firstLogger = detectFirstLogger(firstPassFiles)
-    
   else: firstLogger = args.firstlogger if args.firstlogger is None else 4
   
   FileInfoClass.setFirstDataLogger(firstLogger)
@@ -329,16 +330,17 @@ if __name__ == "__main__":
     duplicateFiles = [] if makeDuplicateList else None
     # we rely on insertion-ordered dictionary guarantee of Python 3.7
     for fileList in fileIndex.values():
-      if uniqueFiles is not None: uniqueFiles.append(fileList[0])
+      mainInfo = fileList[0]
+      if uniqueFiles is not None: uniqueFiles.append(mainInfo)
       if len(fileList) > 1:
         nDuplicates += len(fileList) - 1
         if duplicateFiles is not None: duplicateFiles.extend(fileList[1:])
         if printDuplicates:
-          firstSource = fileList[0].source[0]
-          msg = f"Run {info.run} cycle {info.pass_} data logger {info.dataLogger} with {len(fileList) - 1} duplicates of"
+          firstSource = mainInfo.source[0]
+          msg = f"Run {mainInfo.run} cycle {mainInfo.pass_} data logger {mainInfo.dataLogger} with {len(fileList) - 1} duplicates of"
           
-          if len(sources) > 1: msg += f" {sources[fileList[0].source[0]]}"
-          if fileList[0].source[1] is not None: msg += f" line {fileList[0].source[1]}"
+          if len(sources) > 1: msg += f" {sources[mainInfo.source[0]]}"
+          if mainInfo.source[1] is not None: msg += f" line {mainInfo.source[1]}"
           msg += ":"
           for info in fileList[1:]:
             if info.source[0] != firstSource: msg += f"{sources[info.source[0]]}"

--- a/scripts/sortDataLoggerFiles.py
+++ b/scripts/sortDataLoggerFiles.py
@@ -29,6 +29,13 @@ printed at the end of the output.
 
 Note that it is possible to sort "in place" by specifying the same file list as
 input and output.
+
+Duplicate files are files on the same run, data logger cycle and data logger
+number. By default, only the first of the duplicate files is written into the
+output list, and only the number of duplicates is printed. Options allow to
+write a detailed list of duplicate files on screen and on disk, or not to check
+for duplication altogether.
+
 """
 
 __author__ = 'Gianluca Petrillo (petrillo@slac.stanford.edu)'
@@ -74,9 +81,13 @@ class FileInfoClass:
   def setFirstDataLogger(index):
     FileInfoClass._DataLoggerSorter = CycleCompareClass(first=index)
   
-  def __init__(self, line: "input file line (should include endline)"):
+  def __init__(self,
+               line: "input file line (should include endline)",
+               source: "an arbitrary identifier to track the origin of the line" = None,
+               ):
     """Constructor: use and parse the specified input file line."""
     self.line = line
+    self.source = source
     self.path = line.strip()
     self.protocolAndDir, self.name = os.path.split(self.path)
     match = FileInfoClass.Pattern.match(self.name)
@@ -197,6 +208,18 @@ def detectFirstLogger(fileInfo):
 # detectFirstLogger()
 
 
+def buildFileIndex(
+  fileInfo: "list with information from all files",
+  ) -> "a dictionary: { key -> list of files }":
+  
+  fileKey = lambda info: ( info.run, info.pass_, info.dataLogger )
+  index = {}
+  for info in fileInfo:
+    index.setdefault(fileKey(info), []).append(info)
+  return index
+# buildFileIndex()
+
+
 if __name__ == "__main__":
   
   logging.basicConfig(level=logging.INFO)
@@ -204,15 +227,33 @@ if __name__ == "__main__":
   import argparse
   
   parser = argparse.ArgumentParser(description=__doc__)
+  parser.set_defaults(skipDuplicates=True)
   
   parser.add_argument('inputFiles', nargs="*", metavar='inputFileNames',
     help='input file lists [one from stdin by default]')
-  parser.add_argument('--firstLogger', type=int,
+  parser.add_argument('--firstlogger', type=int,
     help='index of the first data logger in the cycle')
   parser.add_argument('--output', '-o', default=None,
     help=
      'name of the file to write the resulting list into (overwritten!) [stdout]'
     )
+  parser.add_argument('--nooutput', action="store_true",
+    help='do not print on screen nor write to file the files in input')
+  
+  duplGroup = parser.add_argument_group(title="duplicate file options")
+  duplGroup.add_argument('--printduplicates', '-d', action="store_true",
+    help='print duplicate files on screen')
+  duplGroup.add_argument('--skipduplicates', '-S', dest='skipDuplicates',
+    action="store_true",
+    help='do not include duplicate files in the list (default)'
+    )
+  duplGroup.add_argument('--keepduplicates', '-K', dest='skipDuplicates',
+    action="store_false",
+    help='include also duplicate files in the list (default)'
+    )
+  duplGroup.add_argument('--duplicatelist', '-D', type=str, default=None,
+    help='name of a file list to be created with duplicate entries')
+  
   parser.add_argument('--xrootd', '--root', '-X', action="store_true",
     help='convert the paths to XRootD URL')
   parser.add_argument('--posix', '-P', action="store_true",
@@ -229,6 +270,14 @@ if __name__ == "__main__":
   if args.xrootd and args.posix:
     raise RuntimeError("XRootD and POSIX output format options are exclusive.")
   
+  printDuplicates = args.printduplicates
+  skipDuplicates = args.skipDuplicates
+  makeDuplicateList = args.duplicatelist
+  
+  # "sources" are given directly as input (None = sys.stdin)
+  sources = args.inputFiles if args.inputFiles else [ "<stdin>" ]
+  
+  # "inputFiles" are all the files found in the sources
   inputFiles = (
       [ file_ ] if file_.endswith('.root') else open(file_, 'r')
         for file_ in args.inputFiles 
@@ -239,11 +288,11 @@ if __name__ == "__main__":
   preComments = []
   postComments = []
   fileInfo = []
-  for file_ in inputFiles:
-    
+  sourceNames = []
+  for iSource, file_ in enumerate(inputFiles):
+    isSingleFile = isinstance(file_, list) and len(file_) <= 1
     for iLine, line in enumerate(file_):
-      
-      info = FileInfoClass(line)
+      info = FileInfoClass(line, source=( iSource, None if isSingleFile else iLine ))
       if not info.is_file:
         if not info.path or info.path.startswith('#'):
           (postComments if fileInfo else preComments).append(info.line)
@@ -257,18 +306,60 @@ if __name__ == "__main__":
     # for line in file
   # for input files
   
-  if fileInfo and (args.firstLogger is None):
+  if fileInfo and (args.firstlogger is None):
     # uses internal FileInfoClass ordering (firstLogger not set: any will do)
     fileInfo.sort()
     firstPassFiles = findFirstCycle(fileInfo)
     assert firstPassFiles
     firstLogger = detectFirstLogger(firstPassFiles)
     
-  else: firstLogger = args.firstLogger if args.firstLogger is None else 4
+  else: firstLogger = args.firstlogger if args.firstlogger is None else 4
   
   FileInfoClass.setFirstDataLogger(firstLogger)
   
   fileInfo.sort() # uses internal FileInfoClass ordering
+  
+  #
+  # deal with duplicates
+  #
+  if printDuplicates or makeDuplicateList or skipDuplicates:
+    nDuplicates = 0
+    fileIndex = buildFileIndex(fileInfo)
+    uniqueFiles = [] if skipDuplicates else None
+    duplicateFiles = [] if makeDuplicateList else None
+    # we rely on insertion-ordered dictionary guarantee of Python 3.7
+    for fileList in fileIndex.values():
+      if uniqueFiles is not None: uniqueFiles.append(fileList[0])
+      if len(fileList) > 1:
+        nDuplicates += len(fileList) - 1
+        if duplicateFiles is not None: duplicateFiles.extend(fileList[1:])
+        if printDuplicates:
+          firstSource = fileList[0].source[0]
+          msg = f"Run {info.run} cycle {info.pass_} data logger {info.dataLogger} with {len(fileList) - 1} duplicates of"
+          
+          if len(sources) > 1: msg += f" {sources[fileList[0].source[0]]}"
+          if fileList[0].source[1] is not None: msg += f" line {fileList[0].source[1]}"
+          msg += ":"
+          for info in fileList[1:]:
+            if info.source[0] != firstSource: msg += f"{sources[info.source[0]]}"
+            if info.source[1] is not None: msg += f" line {info.source[1]}"
+            msg += ";"
+          # for
+          logging.info(msg)
+        # if print duplicates
+      # if duplicates
+    # for
+    if nDuplicates: logging.info(f"Found {nDuplicates} duplicate files.")
+    if duplicateFiles:
+      with open(makeDuplicateList, 'w') as DuplicateListFile:
+        for info in duplicateFiles: # lines still have their <CR>
+          print(info.line, file=DuplicateListFile, end='')
+      logging.info(f"{nDuplicates} duplicate file names written in '{makeDuplicateList}'.")
+    # if we have duplicates and we write them
+  # if print or store duplicates
+  
+  fileListContent = uniqueFiles if skipDuplicates else fileInfo
+  
   
   #
   # print everything
@@ -276,22 +367,26 @@ if __name__ == "__main__":
   
   # NOTE: keep this after all the input has been read,
   #       so that input files can be safely overwritten
-  outputFile = open(args.output, 'w') if args.output else sys.stdout
-  
-  # <CR> were not removed from `line`
-  for line in preComments: outputFile.write(line)
-  for info in fileInfo:
-    if args.posix: line = info.pathToPOSIX() + '\n'
-    elif args.xrootd: line = info.pathToXRootD() + '\n'
-    else: line = info.line
-    outputFile.write(line)
-  for line in postComments: outputFile.write(line)
-  
-  if outputFile is not sys.stdout:
-    logging.info \
-      ("%d file entries written into '%s'." % (len(fileInfo), outputFile.name))
-    del outputFile
-  # if
+  if not args.nooutput:
+    outputFile = open(args.output, 'w') if args.output else sys.stdout
+    
+    # <CR> were not removed from `line`
+    for line in preComments: outputFile.write(line)
+    for info in fileListContent:
+      if args.posix: line = info.pathToPOSIX() + '\n'
+      elif args.xrootd: line = info.pathToXRootD() + '\n'
+      else: line = info.line
+      outputFile.write(line)
+    for line in postComments: outputFile.write(line)
+    
+    if outputFile is not sys.stdout:
+      logging.info \
+        (f"{len(fileListContent)} file entries written into '{outputFile.name}'.")
+      del outputFile
+    # if
+  else:
+    logging.info(f"Found {len(fileListContent)} file entries.")
+  # if ... else
   
   sys.exit(0)
   


### PR DESCRIPTION
In this pull request:
* new jon configuration file `list_duplicate_events.fcl` will list all duplicate events (based on event ID) in the input
* `sortDataLoggerFiles.py` updated to skip and print duplicate events when sorting a data file list

About `sortDataLoggerFiles.py`
----------------------------------------------

This utility sorts the files in a list so that their first event is in increasing order. It relies on ICARUS data file name convention.
Now it can also utilize its name parsing features to detect duplicate files in a list.
Duplicates file are file which stem from the same raw file (same run, same data logger cycle, same data logger).
By default, now duplicate files are skipped from the output, and their number (if any) is printed.
Options (`sortDataLoggerFiles.py --help`) allow to customize the behaviour, for example making it print the source file and line where duplication occurred (so that the original list can be edited) or writing the list of duplicates into a file (so that they can be undeclared from SAM).
The script does not depend on `icaruscode` but it requires a Python version at least as new as the ones in there (i.e. 3.8).
