### PR TITLE
Feature/jzettleNewFMObject

### DIFF
--- a/fcl/configurations/flashmatch_simple_icarus.fcl
+++ b/fcl/configurations/flashmatch_simple_icarus.fcl
@@ -19,8 +19,11 @@ icarus_simple_flashmatch_0: {
   InputFileName: "FlashMatch/fm_metrics_icarus.root"
   NoAvailableMetrics: false
   MakeTree: false
-  MinFlashPE: 0.
+  MinHitQ: 0.
+  MinSliceQ: 0.
   QScale:  0.001
+  MinOpHPE: 0.
+  MinFlashPE: 0.
   PEScale: 1.0
   ChargeToNPhotonsShower: 1.0
   ChargeToNPhotonsTrack: 1.0

--- a/fcl/configurations/flashmatch_simple_icarus.fcl
+++ b/fcl/configurations/flashmatch_simple_icarus.fcl
@@ -10,19 +10,20 @@ icarus_simple_flashmatch_0: {
   OpHitProducer: "ophit"
   BeamWindowStart: -0.2 # us
   BeamWindowEnd: 2.0 # us
-  LightWindowStart: -0.02 # us, wrt flash time
-  LightWindowEnd: 0.08 # us, wrt flash time
+  FlashStart: -0.02 # us, wrt flash time
+  FlashEnd: 0.08 # us, wrt flash time
   SelectNeutrino: true
+  OnlyPrimaries: true
   UseOppVolMetric: true
   # UseCalo: false
   InputFileName: "FlashMatch/fm_metrics_icarus.root"
   NoAvailableMetrics: false
   MakeTree: false
   MinFlashPE: 0.
-  PEscale: 1.0
+  QScale:  0.001
+  PEScale: 1.0
   ChargeToNPhotonsShower: 1.0
   ChargeToNPhotonsTrack: 1.0
-  VUVToVIS: 1.
 
   ThresholdTerm: 30.
 


### PR DESCRIPTION
Pull request for the addition of a new sbn::SimpleFlashMatch data product replacing the anab::T0 object that was used previously. This is largely done to improve the amount of stored information from the simple flash match object in the CAF files. Tested on SBND and ICARUS simulations and shown to fill the correct object in the CAF files. The only changes to icaruscode are to .fcl files related to running the flash matching procedure.