### PR TITLE
Including trigger filter and updated decoder fhicl files

### DIFF
--- a/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
@@ -25,10 +25,6 @@ icarus_stage0_producers:
   daqTrigger:                     @local::decodeTrigger
 
   daqTPC:                         @local::decodeTPC
-  daqTPCWW:                       @local::decodeTPC
-  daqTPCWE:                       @local::decodeTPC
-  daqTPCEW:                       @local::decodeTPC
-  daqTPCEE:                       @local::decodeTPC
 
   daqTPCROI:                      @local::decodeTPCROI
 
@@ -39,30 +35,14 @@ icarus_stage0_producers:
 
   ### calwire producers
   decon1droi:                     @local::icarus_decon1droi
-  decon1DroiTPCWW:                @local::icarus_decon1droi
-  decon1DroiTPCWE:                @local::icarus_decon1droi
-  decon1DroiTPCEW:                @local::icarus_decon1droi
-  decon1DroiTPCEE:                @local::icarus_decon1droi
 
   recowireraw:                    @local::icarus_recowireraw
-  recoWireRawTPC0:                @local::icarus_recowireraw
-  recoWireRawTPC1:                @local::icarus_recowireraw
-  recoWireRawTPC2:                @local::icarus_recowireraw
-  recoWireRawTPC3:                @local::icarus_recowireraw
 
   ### wire-cell decon producers
   decon2droi:                     @local::standard_wirecell_sigproc
-  decon2DroiTPC0:                 @local::standard_wirecell_sigproc
-  decon2DroiTPC1:                 @local::standard_wirecell_sigproc
-  decon2DroiTPC2:                 @local::standard_wirecell_sigproc
-  decon2DroiTPC3:                 @local::standard_wirecell_sigproc
 
   ### ROI finding on complete deconvolved waveforms
   roifinder:                      @local::icarus_roifinder
-  roifinderTPCWW:                 @local::icarus_roifinder
-  roifinderTPCWE:                 @local::icarus_roifinder
-  roifinderTPCEW:                 @local::icarus_roifinder
-  roifinderTPCEE:                 @local::icarus_roifinder
 
   ### hit-finder producers
   gaushit:                        @local::gaus_hitfinder_icarus
@@ -96,7 +76,7 @@ icarus_stage0_producers:
   opflashCryoW:                   @local::ICARUSSimpleFlashDataCryoW
 }
 
-icarus_reco_filters:
+icarus_stage0_filters:
 {
    flashfilterBNB: { module_type:         "FilterOpFlash" 
                      OpFlashProducerList: ["opflashCryoE","opflashCryoW"] 
@@ -104,18 +84,36 @@ icarus_reco_filters:
 #                     WindowEndTime:       -1487.6 # -1487.8 + 0.2us safe margin
 #                     WindowStartTime:     -1490.8 # 9.6 us - 1500 us offset - 0.4us safe margin
 #                     WindowEndTime:       -1488.4 # 11.2 -1500 us offset + 0.4us safe margin
-                     WindowStartTime:     -0.2 # 9.6 us - 1500 us offset - 0.4us safe margin
-                     WindowEndTime:        1.8 # 11.2 -1500 us offset + 0.4us safe margin
+                     WindowStartTime:     -0.2 # Gate is now recentered by Gianluca/Andrea
+                     WindowEndTime:        1.8 
                    }
-   flashfilterNUMI: { module_type:         "FilterOpFlash" 
+   flashfilterNuMI: { module_type:         "FilterOpFlash" 
                       OpFlashProducerList: ["opflashCryoE","opflashCryoW"] 
-                      WindowStartTime:     -0.2 # 9.6 us - 1500 us offset - 0.4us safe margin
-                      WindowEndTime:        9.8 # 11.2 -1500 us offset + 0.4us safe margin
+                      WindowStartTime:     -0.2 
+                      WindowEndTime:        9.8 
                     }
+
+   triggerfilterBNB:   {  module_type:        "TriggerTypeFilter"
+                          TriggerDataLabel:   "daqTrigger"
+                          TriggerType:        "BNB"
+                       }
+
+   triggerfilterNuMI:  {  module_type:        "TriggerTypeFilter"
+                          TriggerDataLabel:   "daqTrigger"
+                          TriggerType:        "NuMI"
+                       }
 }
 
 
 ### Below are a list of convenient sequences that can be used for production/typical users. ###
+
+icarus_stage0_trigger_BNB:         [ daqTrigger,
+                                     triggerfilterBNB 
+                                   ]
+
+icarus_stage0_trigger_NuMI:        [ daqTrigger,
+                                     triggerfilterNuMI 
+                                   ]
 
 icarus_stage0_single_TPC:          [ daqTPC,
 #                                     recowireraw,
@@ -124,12 +122,6 @@ icarus_stage0_single_TPC:          [ daqTPC,
 #                                     decon2droi,
                                      roifinder,
                                      gaushit
-                                   ]
-
-icarus_stage0_multiTPC_Sep_TPC:    [ daqTPCWW,        daqTPCWE,        daqTPCEW,        daqTPCEE,
-                                     decon1DroiTPCWW, decon1DroiTPCWE, decon1DroiTPCEW, decon1DroiTPCEE,
-                                     roifinderTPCWW,  roifinderTPCWE,  roifinderTPCEW,  roifinderTPCEE,
-                                     gaushitSTPCWW,   gaushitSTPCWE,   gaushitSTPCEW,   gaushitSTPCEE
                                    ]
 
 icarus_stage0_multiTPC_TPC:        [ daqTPC,
@@ -153,26 +145,20 @@ icarus_stage0_pmt:                 [ daqTrigger,
                                      opflashCryoW
                                    ]
 
+icarus_stage0_pmt_BNB:             [ @sequence::icarus_stage0_pmt,
+                                     flashfilterBNB
+                                   ]
+
+icarus_stage0_pmt_NuMI:            [ @sequence::icarus_stage0_pmt,
+                                     flashfilterNuMI
+                                   ]
+
 icarus_stage0_single:              [ @sequence::icarus_stage0_pmt,
                                      flashfilterBNB,
                                      @sequence::icarus_stage0_single_TPC
                                    ]
 
-icarus_stage0_multiTPC:            [ @sequence::icarus_stage0_pmt,
-                                     flashfilterBNB,
-                                     @sequence::icarus_stage0_multiTPC_TPC,
-                                     @sequence::icarus_stage0_EastHits_TPC,
-                                     @sequence::icarus_stage0_WestHits_TPC
-                                   ]
-
-icarus_stage0_multiTPC_BNB:        [ flashfilterBNB,
-                                     @sequence::icarus_stage0_multiTPC_TPC,
-                                     @sequence::icarus_stage0_EastHits_TPC,
-                                     @sequence::icarus_stage0_WestHits_TPC
-                                   ]
-
-icarus_stage0_multiTPC_NUMI:       [ #flashfilterNUMI,
-                                     @sequence::icarus_stage0_multiTPC_TPC,
+icarus_stage0_multiTPC:            [ @sequence::icarus_stage0_multiTPC_TPC,
                                      @sequence::icarus_stage0_EastHits_TPC,
                                      @sequence::icarus_stage0_WestHits_TPC
                                    ]
@@ -183,25 +169,6 @@ icarus_stage0_multiTPC_NUMI:       [ #flashfilterNUMI,
 icarus_stage0_producers.daqTPC.DiagnosticOutput:                                               false
 icarus_stage0_producers.daqTPC.DecoderTool.UseFFTFilter:                                       false               # If true will run high/low/window filters
 icarus_stage0_producers.daqTPC.DecoderTool.Threshold:                                          [3.00, 3.00, 3.00]  # ROI thresholds for coherent noise subtraction "protection"
-
-### Setup for multiple TPC readout
-icarus_stage0_producers.daqTPCWW.FragmentsLabelVec:                                            ["daq:PHYSCRATEDATATPCWW"]
-icarus_stage0_producers.daqTPCWE.FragmentsLabelVec:                                            ["daq:PHYSCRATEDATATPCWE"]
-icarus_stage0_producers.daqTPCEW.FragmentsLabelVec:                                            ["daq:PHYSCRATEDATATPCEW"]
-icarus_stage0_producers.daqTPCEE.FragmentsLabelVec:                                            ["daq:PHYSCRATEDATATPCEE"]
-
-icarus_stage0_producers.daqTPCWW.DiagnosticOutput:                                             false
-icarus_stage0_producers.daqTPCWW.DecoderTool.UseFFTFilter:                                     false               # If true will run high/low/window filters
-icarus_stage0_producers.daqTPCWW.DecoderTool.Threshold:                                        [3.00, 3.00, 3.00]  # ROI thresholds for coherent noise subtraction "protection"
-icarus_stage0_producers.daqTPCWE.DiagnosticOutput:                                             false
-icarus_stage0_producers.daqTPCWE.DecoderTool.UseFFTFilter:                                     false               # If true will run high/low/window filters
-icarus_stage0_producers.daqTPCWE.DecoderTool.Threshold:                                        [3.00, 3.00, 3.00]  # ROI thresholds for coherent noise subtraction "protection"
-icarus_stage0_producers.daqTPCEW.DiagnosticOutput:                                             false
-icarus_stage0_producers.daqTPCEW.DecoderTool.UseFFTFilter:                                     false               # If true will run high/low/window filters
-icarus_stage0_producers.daqTPCEW.DecoderTool.Threshold:                                        [3.00, 3.00, 3.00]  # ROI thresholds for coherent noise subtraction "protection"
-icarus_stage0_producers.daqTPCEE.DiagnosticOutput:                                             false
-icarus_stage0_producers.daqTPCEE.DecoderTool.UseFFTFilter:                                     false               # If true will run high/low/window filters
-icarus_stage0_producers.daqTPCEE.DecoderTool.Threshold:                                        [3.00, 3.00, 3.00]  # ROI thresholds for coherent noise subtraction "protection"
 
 ### Handle multiple TPC readout with single instances
 icarus_stage0_producers.daqTPC.FragmentsLabelVec:                                              ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
@@ -219,40 +186,9 @@ icarus_stage0_producers.decon2droi.wcls_main.outputers:                         
 icarus_stage0_producers.decon2droi.wcls_main.params.raw_input_label:                           "daqTPC"
 icarus_stage0_producers.decon2droi.wcls_main.params.tpc_volume_label:                          0
 
-### Set up for multiple TPC readout
-icarus_stage0_producers.decon1DroiTPCWW.RawDigitLabelVec:                                      ["daqTPCWW:PHYSCRATEDATATPCWW"]
-icarus_stage0_producers.decon1DroiTPCWE.RawDigitLabelVec:                                      ["daqTPCWE:PHYSCRATEDATATPCWE"]
-icarus_stage0_producers.decon1DroiTPCEW.RawDigitLabelVec:                                      ["daqTPCEW:PHYSCRATEDATATPCEW"]
-icarus_stage0_producers.decon1DroiTPCEE.RawDigitLabelVec:                                      ["daqTPCEE:PHYSCRATEDATATPCEE"]
-
-icarus_stage0_producers.decon1DroiTPCWW.ROIFinderToolVec.ROIFinderToolPlane0:                  @local::icarus_noproifinder_0
-icarus_stage0_producers.decon1DroiTPCWW.ROIFinderToolVec.ROIFinderToolPlane1:                  @local::icarus_noproifinder_1
-icarus_stage0_producers.decon1DroiTPCWW.ROIFinderToolVec.ROIFinderToolPlane2:                  @local::icarus_noproifinder_2
-icarus_stage0_producers.decon1DroiTPCWE.ROIFinderToolVec.ROIFinderToolPlane0:                  @local::icarus_noproifinder_0
-icarus_stage0_producers.decon1DroiTPCWE.ROIFinderToolVec.ROIFinderToolPlane1:                  @local::icarus_noproifinder_1
-icarus_stage0_producers.decon1DroiTPCWE.ROIFinderToolVec.ROIFinderToolPlane2:                  @local::icarus_noproifinder_2
-icarus_stage0_producers.decon1DroiTPCEW.ROIFinderToolVec.ROIFinderToolPlane0:                  @local::icarus_noproifinder_0
-icarus_stage0_producers.decon1DroiTPCEW.ROIFinderToolVec.ROIFinderToolPlane1:                  @local::icarus_noproifinder_1
-icarus_stage0_producers.decon1DroiTPCEW.ROIFinderToolVec.ROIFinderToolPlane2:                  @local::icarus_noproifinder_2
-icarus_stage0_producers.decon1DroiTPCEE.ROIFinderToolVec.ROIFinderToolPlane0:                  @local::icarus_noproifinder_0
-icarus_stage0_producers.decon1DroiTPCEE.ROIFinderToolVec.ROIFinderToolPlane1:                  @local::icarus_noproifinder_1
-icarus_stage0_producers.decon1DroiTPCEE.ROIFinderToolVec.ROIFinderToolPlane2:                  @local::icarus_noproifinder_2
-
 ### Set up to find ROIs
 icarus_stage0_producers.roifinder.WireModuleLabelVec:                                          ["decon1droi"]
 icarus_stage0_producers.roifinder.OutputMorphed:                                               false
-
-### Set up for multiple TPC readout
-icarus_stage0_producers.roifinderTPCWW.WireModuleLabelVec:                                     ["decon1DroiTPCWW:PHYSCRATEDATATPCWW"]
-icarus_stage0_producers.roifinderTPCWE.WireModuleLabelVec:                                     ["decon1DroiTPCWE:PHYSCRATEDATATPCWE"]
-icarus_stage0_producers.roifinderTPCEW.WireModuleLabelVec:                                     ["decon1DroiTPCEW:PHYSCRATEDATATPCEW"]
-icarus_stage0_producers.roifinderTPCEE.WireModuleLabelVec:                                     ["decon1DroiTPCEE:PHYSCRATEDATATPCEE"]
-
-icarus_stage0_producers.roifinderTPCWW.OutputMorphed:                                          false
-icarus_stage0_producers.roifinderTPCWE.OutputMorphed:                                          false
-icarus_stage0_producers.roifinderTPCEW.OutputMorphed:                                          false
-icarus_stage0_producers.roifinderTPCEE.OutputMorphed:                                          false
-
 
 ### Set up for the single hit finding
 icarus_stage0_producers.gaushit.CalDataModuleLabel:                                            "decon1droi"

--- a/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
@@ -33,6 +33,8 @@ icarus_stage0_producers:
   pmtconfig:                      @local::extractPMTconfig
   daqPMT:                         @local::decodePMT
 
+  daqTrigger:                     @local::decodeTrigger
+
   ### calwire producers
   decon1droi:                     @local::icarus_decon1droi
   decon1DroiTPCWW:                @local::icarus_decon1droi
@@ -94,13 +96,20 @@ icarus_stage0_producers:
 
 icarus_reco_filters:
 {
-   flashfilter: { module_type: "FilterOpFlash" 
-                  OpFlashProducerList: ["opflashCryoE","opflashCryoW"] 
-#                  WindowStartTime: -1489.6 # -1489.4 - 0.2us safe margin
-#                  WindowEndTime:   -1487.6 # -1487.8 + 0.2us safe margin
-                  WindowStartTime: -1490.8 # 9.6 us - 1500 us offset - 0.4us safe margin
-                  WindowEndTime:   -1488.4 # 11.2 -1500 us offset + 0.4us safe margin
-                }
+   flashfilterBNB: { module_type:         "FilterOpFlash" 
+                     OpFlashProducerList: ["opflashCryoE","opflashCryoW"] 
+#                     WindowStartTime:     -1489.6 # -1489.4 - 0.2us safe margin
+#                     WindowEndTime:       -1487.6 # -1487.8 + 0.2us safe margin
+#                     WindowStartTime:     -1490.8 # 9.6 us - 1500 us offset - 0.4us safe margin
+#                     WindowEndTime:       -1488.4 # 11.2 -1500 us offset + 0.4us safe margin
+                     WindowStartTime:     -0.2 # 9.6 us - 1500 us offset - 0.4us safe margin
+                     WindowEndTime:        1.8 # 11.2 -1500 us offset + 0.4us safe margin
+                   }
+   flashfilterNUMI: { module_type:         "FilterOpFlash" 
+                      OpFlashProducerList: ["opflashCryoE","opflashCryoW"] 
+                      WindowStartTime:     -0.2 # 9.6 us - 1500 us offset - 0.4us safe margin
+                      WindowEndTime:        9.8 # 11.2 -1500 us offset + 0.4us safe margin
+                    }
 }
 
 
@@ -142,12 +151,24 @@ icarus_stage0_pmt:                 [ pmtconfig,
                                    ]
 
 icarus_stage0_single:              [ @sequence::icarus_stage0_pmt,
-                                     flashfilter,
+                                     flashfilterBNB,
                                      @sequence::icarus_stage0_single_TPC
                                    ]
 
 icarus_stage0_multiTPC:            [ @sequence::icarus_stage0_pmt,
-                                     flashfilter,
+                                     flashfilterBNB,
+                                     @sequence::icarus_stage0_multiTPC_TPC,
+                                     @sequence::icarus_stage0_EastHits_TPC,
+                                     @sequence::icarus_stage0_WestHits_TPC
+                                   ]
+
+icarus_stage0_multiTPC_BNB:        [ flashfilterBNB,
+                                     @sequence::icarus_stage0_multiTPC_TPC,
+                                     @sequence::icarus_stage0_EastHits_TPC,
+                                     @sequence::icarus_stage0_WestHits_TPC
+                                   ]
+
+icarus_stage0_multiTPC_NUMI:       [ #flashfilterNUMI,
                                      @sequence::icarus_stage0_multiTPC_TPC,
                                      @sequence::icarus_stage0_EastHits_TPC,
                                      @sequence::icarus_stage0_WestHits_TPC

--- a/icaruscode/Decode/fcl/stage0_icarus_driver_common.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_driver_common.fcl
@@ -35,13 +35,14 @@ physics:
 
  filters:
  {
-     @table::icarus_reco_filters
+     @table::icarus_stage0_filters
  }
 
  #reco sequence and trigger_paths to be defined elsewhere
 
- stream1:  [ out1 ]
- end_paths:     [stream1]
+ streamBNB:  [ outBNB ]
+ streamNUMI: [ outNUMI ]
+ end_paths:  [streamBNB]
 
 }
 
@@ -50,7 +51,14 @@ physics:
 #entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
 outputs:
 {
- out1:
+ outBNB:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+ }
+ outNUMI:
  {
    module_type: RootOutput
    dataTier: "reconstructed"
@@ -60,7 +68,7 @@ outputs:
 }
 
 # Include this as per directive of Kazu and Andrea (circa March 25, 2021) for introduction of the filter
-services.DetectorClocksService.InheritClockConfig: false
+#services.DetectorClocksService.InheritClockConfig: false
 
 ### Here we try to suppress known and pointless messages
 ### See https://cdcvs.fnal.gov/redmine/projects/messagefacility/wiki for details

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_east_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_east_icarus.fcl
@@ -1,0 +1,35 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the paths we'll execute depending on data
+physics.pathBNB:     [ @sequence::icarus_stage0_trigger_BNB,  @sequence::icarus_stage0_pmt_BNB,  @sequence::icarus_stage0_multiTPC_TPC, @sequence::icarus_stage0_EastHits_TPC ]
+physics.pathNUMI:    [ @sequence::icarus_stage0_trigger_NuMI, @sequence::icarus_stage0_pmt_NuMI, @sequence::icarus_stage0_multiTPC_TPC, @sequence::icarus_stage0_EastHits_TPC ]
+
+## boiler plate...
+physics.trigger_paths: [ pathBNB, pathNUMI ]
+physics.end_paths:     [ streamBNB, streamNUMI ]
+
+outputs.outBNB.fileName: "BNB_%ifb_%tc-%p.root"
+outputs.outBNB.dataTier:  "reconstructed"
+outputs.outBNB.SelectEvents: [ pathBNB ]
+
+outputs.outNUMI.fileName: "NUMI_%ifb_%tc-%p.root"
+outputs.outNUMI.dataTier:  "reconstructed"
+outputs.outNUMI.SelectEvents: [ pathNUMI ]
+
+# Drop the artdaq format files on output
+outputs.outBNB.outputCommands:  ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outNUMI.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+# Temporarily overrie pmt configuration for a single cryostat configuration
+physics.producers.daqPMT.DecoderTool.RequireBoardConfig: false
+
+# Set up for the single module mutliple TPC mode...
+physics.producers.daqTPC.FragmentsLabelVec:              ["daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:           ["daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.roifinder.WireModuleLabelVec:          ["decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_icarus.fcl
@@ -1,0 +1,36 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the paths we'll execute depending on data
+#physics.pathOptical: [ @sequence::icarus_stage0_pmt ]
+physics.pathBNB:     [ @sequence::icarus_stage0_trigger_BNB,  @sequence::icarus_stage0_pmt_BNB,  @sequence::icarus_stage0_multiTPC ]
+physics.pathNUMI:    [ @sequence::icarus_stage0_trigger_NuMI, @sequence::icarus_stage0_pmt_NuMI, @sequence::icarus_stage0_multiTPC ]
+
+## boiler plate...
+physics.trigger_paths: [ pathBNB, pathNUMI ]
+physics.end_paths:     [ streamBNB, streamNUMI ]
+
+outputs.outBNB.fileName: "BNB_%ifb_%tc-%p.root"
+outputs.outBNB.dataTier:  "reconstructed"
+outputs.outBNB.SelectEvents: [ pathBNB ]
+
+outputs.outNUMI.fileName: "NUMI_%ifb_%tc-%p.root"
+outputs.outNUMI.dataTier:  "reconstructed"
+outputs.outNUMI.SelectEvents: [ pathNUMI ]
+
+# Drop the artdaq format files on output
+outputs.outBNB.outputCommands:  ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outNUMI.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+# Temporarily overrie pmt configuration
+#physics.producers.daqPMT.DecoderTool.RequireBoardConfig: false
+
+# Set up for the single module mutliple TPC mode...
+physics.producers.daqTPC.FragmentsLabelVec:              ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:           ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.roifinder.WireModuleLabelVec:          ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE","decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_west_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_west_icarus.fcl
@@ -1,0 +1,35 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the paths we'll execute depending on data
+physics.pathBNB:     [ @sequence::icarus_stage0_trigger_BNB,  @sequence::icarus_stage0_pmt_BNB,  @sequence::icarus_stage0_multiTPC_TPC, @sequence::icarus_stage0_WestHits_TPC ]
+physics.pathNUMI:    [ @sequence::icarus_stage0_trigger_NuMI, @sequence::icarus_stage0_pmt_NuMI, @sequence::icarus_stage0_multiTPC_TPC, @sequence::icarus_stage0_WestHits_TPC ]
+
+## boiler plate...
+physics.trigger_paths: [ pathBNB, pathNUMI ]
+physics.end_paths:     [ streamBNB, streamNUMI ]
+
+outputs.outBNB.fileName: "BNB_%ifb_%tc-%p.root"
+outputs.outBNB.dataTier:  "reconstructed"
+outputs.outBNB.SelectEvents: [ pathBNB ]
+
+outputs.outNUMI.fileName: "NUMI_%ifb_%tc-%p.root"
+outputs.outNUMI.dataTier:  "reconstructed"
+outputs.outNUMI.SelectEvents: [ pathNUMI ]
+
+# Drop the artdaq format files on output
+outputs.outBNB.outputCommands:  ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outNUMI.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+# Temporarily overrie pmt configuration
+physics.producers.daqPMT.DecoderTool.RequireBoardConfig: false
+
+# Set up for the single module mutliple TPC mode...
+physics.producers.daqTPC.FragmentsLabelVec:              ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE"]
+physics.producers.decon1droi.RawDigitLabelVec:           ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE"]
+physics.producers.roifinder.WireModuleLabelVec:          ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE"]

--- a/icaruscode/Filters/TriggerTypeFilter_module.cc
+++ b/icaruscode/Filters/TriggerTypeFilter_module.cc
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////
+//
+// TriggerTypeFilter class
+//
+////////////////////////////////////////////////////////////////////////
+#include <fstream>
+
+/// Framework includes
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Principal/Event.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "lardataobj/RawData/TriggerData.h" // raw::Trigger
+#include "icaruscode/Decode/BeamBits.h"
+
+///filters for events, etc
+namespace filter
+{
+
+    class TriggerTypeFilter : public art::EDFilter
+    {
+
+    public:
+        explicit TriggerTypeFilter(fhicl::ParameterSet const &);
+
+        bool filter(art::Event &evt) override;
+
+    private:
+        art::InputTag fTriggerDataLabel;
+        std::string   fTriggerType;
+        unsigned int  fTriggerBits;
+
+    }; //class TriggerTypeFilter
+}
+
+///////////////////////////////////////////////////////
+
+filter::TriggerTypeFilter::TriggerTypeFilter(fhicl::ParameterSet const &pset)
+    : EDFilter{pset}
+{
+    fTriggerDataLabel = pset.get<art::InputTag>("TriggerDataLabel", "daqTrigger");
+    fTriggerType      = pset.get<std::string  >("TriggerType",             "BNB");
+
+    std::cout << "****> Initializing trigger type " << fTriggerType << std::endl;
+
+    if (fTriggerType == "BNB")  fTriggerBits = value(sbn::triggerSource::BNB);
+    if (fTriggerType == "NuMI") fTriggerBits = value(sbn::triggerSource::NuMI);
+
+    return;
+}
+
+bool filter::TriggerTypeFilter::filter(art::Event &event)
+{
+    bool filterPass = false;
+
+    auto const& triggerVec = event.getByLabel<std::vector<raw::Trigger>>(fTriggerDataLabel);
+
+    if (!triggerVec.empty())
+    {
+        const raw::Trigger& trigger = triggerVec.front();
+
+        if (trigger.Triggered(fTriggerBits))
+        {
+            std::cout << "***> Trigger type matched, type is " << fTriggerType << ", " << fTriggerBits << std::endl;
+            filterPass = true;
+        }
+    }
+
+    return filterPass;
+}
+
+namespace filter
+{
+
+    DEFINE_ART_MODULE(TriggerTypeFilter)
+
+} //namespace filt


### PR DESCRIPTION
Include a filter function which can select between BNB and NuMI from the trigger data. Update the decoder stage0 fhicl files to use this filter in a "split stream" configuration (separate BNB and NuMI output streams) as well include two versions for single module running. 