### PR TITLE
PMT decoding can autodetect the input type

### DIFF
--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -15,8 +15,10 @@
 
 
 // C/C++ standard libraries
+#include <stdexcept> // std::runtime_error
 #include <string>
 #include <initializer_list>
+#include <type_traits> // std::underlying_type_t
 
 
 // -----------------------------------------------------------------------------
@@ -28,37 +30,89 @@
  */
 namespace sbn {
   
-  /// Type of beam or beam gate or other trigger source.
-  enum class triggerSource: unsigned int {
-    Unknown, ///< Type of beam unknown.
-    BNB,     ///< Type of beam: BNB.
-    NuMI,    ///< Type of beam: NuMI.
-    // ==> add here if more are needed <==
-    NBits    ///< Number of bits currently supported.
-  }; // triggerSource
+  /**
+   * @brief Simple utilities to deal with bit enumerators.
+   * 
+   * A few simple concepts:
+   * * a bit is identified by its position (integral number: `0`, `1`, `2`...)
+   * * representation of a bit is via a enumerator (`enum class`)
+   * * bits may be associated with a name (`name()`)
+   * * to test bits, `mask()`, `value()` and `hasBitSet()` help with the
+   *   conversions between `enum class` and the underlying integral type
+   * 
+   */
+  namespace bits {
+    
+    // --- BEGIN -- Generic bit functions --------------------------------------
+    /// @name Generic bit functions
+    /// @{
+    template <typename EnumType>
+    using mask_t = std::underlying_type_t<EnumType>;
+    
+    /// Returns the value of specified `bit` (conversion like `enum` to `int`).
+    template <typename EnumType>
+    constexpr auto value(EnumType bit);
+    
+    /// Returns a mask with all specified bits set.
+    template <typename EnumType, typename... OtherBits>
+    constexpr mask_t<EnumType> mask(EnumType bit, OtherBits... otherBits);
+    
+    /// Returns whether the specified `bit` is set in `bitMask`.
+    template <typename EnumType>
+    constexpr bool hasBitSet(mask_t<EnumType> bitMask, EnumType bit);
+    
+    /// Returns the name of the specified `bit`. Delegates to `bitName()`.
+    template <typename EnumType>
+    std::string name(EnumType bit);
+    
+    /// Returns a list of the names of all the bits set in `mask`.
+    /// Mask is interpreted as made of only bits of type `EnumType`.
+    template <typename Mask>
+    std::vector<std::string> names(Mask mask);
+    
+    /// @}
+    // --- END ---- Generic bit functions --------------------------------------
+    
+    
+    // --- BEGIN -- Beam bits --------------------------------------------------
+    /// @name Beam bits
+    /// @{
+    
+    /// Type of beam or beam gate or other trigger source.
+    enum class triggerSource: unsigned int {
+      Unknown, ///< Type of beam unknown.
+      BNB,     ///< Type of beam: BNB.
+      NuMI,    ///< Type of beam: NuMI.
+      // ==> add here if more are needed <==
+      NBits    ///< Number of bits currently supported.
+    }; // triggerSource
+    
+    /// Returns a mnemonic short name of the beam type.
+    std::string bitName(triggerSource bit);
+    
+    /// @}
+    // --- END ---- Beam bits --------------------------------------------------
+
+  } // namespace bits
   
-  /// Returns the value of the specified bit.
-  constexpr unsigned int value(triggerSource bit);
-  
-  /// Returns a mask with all specified bits set.
-  template <typename... OtherBits>
-  constexpr unsigned int mask(triggerSource bit, OtherBits... otherBits);
-  //@}
-  
-  /// Returns a mnemonic short name of the beam type.
-  std::string bitName(triggerSource bit);
+  using bits::triggerSource; // import symbol
   
 } // namespace sbn
 
 
 // -----------------------------------------------------------------------------
-inline constexpr unsigned int sbn::value(triggerSource bit)
-  { return static_cast<int>(bit); }
+// ---  inline and template implementation
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+constexpr auto sbn::bits::value(EnumType bit)
+  { return static_cast<std::underlying_type_t<EnumType>>(bit); }
 
 
 // -----------------------------------------------------------------------------
-template <typename... OtherBits>
-constexpr unsigned int sbn::mask(triggerSource bit, OtherBits... otherBits) {
+template <typename EnumType, typename... OtherBits>
+constexpr auto sbn::bits::mask(EnumType bit, OtherBits... otherBits)
+  -> mask_t<EnumType>
+{
   unsigned int m { 1U << value(bit) };
   if constexpr(sizeof...(OtherBits) > 0U) m |= mask(otherBits...);
   return m;
@@ -66,8 +120,43 @@ constexpr unsigned int sbn::mask(triggerSource bit, OtherBits... otherBits) {
 
 
 // -----------------------------------------------------------------------------
+template <typename EnumType>
+constexpr bool sbn::bits::hasBitSet(mask_t<EnumType> bitMask, EnumType bit)
+  { return bitMask & mask(bit); }
+
+
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+std::string sbn::bits::name(EnumType bit)
+  { return bitName(bit); }
+  
+  
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+std::vector<std::string> sbn::bits::names(mask_t<EnumType> mask) {
+  static_assert(value(EnumType::NBits) >= 0);
+  
+  using namespace std::string_literals;
+  
+  constexpr std::size_t MaxBits = sizeof(mask) * 8U;
+  constexpr std::size_t NSupportedBits = value(EnumType::NBits);
+  
+  std::vector<std::string> names;
+  for (std::size_t bit = 0U; bit < MaxBits; ++bit) {
+    auto const typedBit = static_cast<EnumType>(bit);
+    if (!hasBitSet(mask, typedBit)) continue;
+    names.push_back((bit > NSupportedBits)
+      ? "<unsupported ["s + std::to_string(bit) + "]>"s: name(typedBit)
+      );
+  } // for
+  return names;
+  
+} // sbn::bits::names()
+
+
+// -----------------------------------------------------------------------------
 /// @todo Move into an implementation file once this header in the final location.
-inline std::string sbn::bitName(triggerSource bit) {
+inline std::string sbn::bits::bitName(triggerSource bit) {
   
   using namespace std::string_literals;
   switch (bit) {
@@ -76,9 +165,9 @@ inline std::string sbn::bitName(triggerSource bit) {
     case triggerSource::NuMI:    return "NuMI"s;
     case triggerSource::NBits:   return "<invalid>"s;
   } // switch
-  
+  throw std::runtime_error("sbn::bits::bitName(triggerSource{ "s
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
-
 
 // -----------------------------------------------------------------------------
 

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -186,7 +186,8 @@ namespace daq
     if(fDiagnosticOutput || fDebug)
     {
       std::cout << "Full Timestamp = " << wr_ts << std::endl;
-      double cross_check = wr_ts - artdaq_ts;
+      auto const cross_check = static_cast<signed long long int>(wr_ts)
+        - static_cast<signed long long int>(artdaq_ts);
       if(abs(cross_check) > 1000)
         std::cout << "Loaded artdaq TS and fragment data TS are > 1 ms different! They are " << cross_check << " nanoseconds different!" << std::endl;
       std::cout << delta_gates_bnb << " " << delta_gates_numi << " " << delta_gates_other << std::endl; // nonsensical print statement to avoid error that I don't use these...until we have an object to store them in...    

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -29,7 +29,7 @@
 
 #include "icaruscode/Decode/DecoderTools/IDecoder.h"
 // #include "sbnobj/Common/Trigger/BeamBits.h" // maybe future location of:
-#include "icaruscode/Decode/BeamBits.h"
+#include "icaruscode/Decode/BeamBits.h" // sbn::triggerSource
 
 #include <cstdlib>
 #include <iostream>

--- a/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
+++ b/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
@@ -41,7 +41,7 @@ decodeTPCROI: {
 
 decodePMT: {
                     module_type:        DaqDecoderICARUSPMT
-                    FragmentsLabel:     "daq:ContainerCAENV1730"
+                    FragmentsLabels:  [ "daq:CAENV1730", "daq:ContainerCAENV1730" ]
                     PMTconfigTag:       @nil # must override
                     TriggerTag:         @nil # must override
                     BoardSetup:         @local::icarus_V1730_setup

--- a/scripts/sortDataLoggerFiles.py
+++ b/scripts/sortDataLoggerFiles.py
@@ -11,6 +11,9 @@
 #   first public version
 # 20210518 (petrillo@slac.fnal.gov) [1.1]
 #   added options for duplicate events
+# 20210602 (petrillo@slac.fnal.gov) [1.2]
+#   added optional stream name to the file name pattern;
+#   fixed a bug where first logger option value would be ignored
 #
 
 import sys, os
@@ -42,7 +45,7 @@ for duplication altogether.
 
 __author__ = 'Gianluca Petrillo (petrillo@slac.stanford.edu)'
 __date__ = 'February 26, 2021'
-__version__ = '1.1'
+__version__ = '1.2'
 
 
 class CycleCompareClass:
@@ -65,7 +68,9 @@ class FileInfoClass:
   POSIXprotocolHead = '/'
   POSIXprotocolDir = 'pnfs'
   
-  Pattern = re.compile(r"data_dl(\d+)_run(\d+)_(\d+)_(.*)\.root")
+  # pattern parameters:   data logger stream stream name run  pass  filler (timestamp)
+  #                              <1>  <2>    <3>         <4>   <5>  <6>
+  Pattern = re.compile(r"data_dl(\d+)(_fstrm([^_]*))?_run(\d+)_(\d+)_(.*)\.root")
   POSIXPattern = re.compile(
     POSIXprotocolHead.replace('.', r'\.')
     + POSIXprotocolDir.replace('.', r'\.')
@@ -94,7 +99,10 @@ class FileInfoClass:
     self.protocolAndDir, self.name = os.path.split(self.path)
     match = FileInfoClass.Pattern.match(self.name)
     self.is_file = match is not None
-    if self.is_file: self.dataLogger, self.run, self.pass_ = map(int, match.group(1, 2, 3))
+    if self.is_file:
+      # see Pattern above:
+      self.dataLogger, self.run, self.pass_ = map(int, match.group(1, 4, 5))
+      self.stream = match.group(3)
   # __init__()
   
   def __lt__(self, other):
@@ -109,8 +117,13 @@ class FileInfoClass:
     if self.pass_ < other.pass_: return True
     if self.pass_ > other.pass_: return False
     
-    return \
-      FileInfoClass._DataLoggerSorter.less(self.dataLogger, other.dataLogger)
+    if self.dataLogger != other.dataLogger:
+      return \
+        FileInfoClass._DataLoggerSorter.less(self.dataLogger, other.dataLogger)
+    
+    assert (self.stream is None) == (other.stream is None)
+    return False if self.stream is None else self.stream < other.stream
+    
   # __lt__()
   
   def pathToXRootD(self) -> "stored file path in XRootD format":
@@ -158,11 +171,12 @@ class MinimumAccumulator:
 # class MinimumAccumulator
 
 
-def findFirstCycle(files):
+def findFirstCycle(files, stream):
   firstLogger = None
   firstPassFiles = []
   wrapped = False
-  for info in fileInfo:
+  for info in files:
+    if info.stream != stream: continue
     if firstLogger == info.dataLogger: break # cycle completed
     if wrapped and info.dataLogger > firstLogger: break # cycle completed
     
@@ -191,7 +205,10 @@ def extractFirstEvent(filePath):
     raise RuntimeError \
       ("Failed to open '%s' for event number extraction." % filePath)
   #
-  firstEvent = next(iter(srcFile.Events)) # go PyROOT
+  try: firstEvent = next(iter(srcFile.Events)) # go PyROOT
+  except StopIteration:
+    logging.debug("File '%s' appears to contain no events.", filePath)
+    return None
   firstEventNumber = firstEvent.EventAuxiliary.event() # keep going PyROOT
   
   logging.debug("First event from '%s': %d", filePath, firstEventNumber)
@@ -200,11 +217,22 @@ def extractFirstEvent(filePath):
 
 
 def detectFirstLogger(fileInfo):
+  # in the end, we don't need a stream-aware algorithm to determine which
+  # data logger received the first event, as long as we have all relevant
+  # streams represented
   lowestEvent = MinimumAccumulator()
-  for info in fileInfo:
-    firstEvent = extractFirstEvent(info.pathToXRootD())
-    lowestEvent.add(info, key=firstEvent)
-  firstLogger = lowestEvent.min().dataLogger
+  for stream, files in fileInfo.items():
+    if not len(files): continue
+    for info in files:
+      firstEvent = extractFirstEvent(info.pathToXRootD())
+      if firstEvent is not None: lowestEvent.add(info, key=firstEvent)
+    # for files
+  # for 
+  try: firstLogger = lowestEvent.min().dataLogger
+  except AttributeError:
+    # this is in general a problem because it implies that we are failing to
+    # correctly parse the list of input files
+    raise RuntimeError("No data found for the first data logger pass.")
   logging.debug("Detected first logger: %d", firstLogger)
   return firstLogger
 # detectFirstLogger()
@@ -214,7 +242,7 @@ def buildFileIndex(
   fileInfo: "list with information from all files",
   ) -> "a dictionary: { key -> list of files }":
   
-  fileKey = lambda info: ( info.run, info.pass_, info.dataLogger )
+  fileKey = lambda info: ( info.run, info.pass_, info.dataLogger, info.stream, )
   index = {}
   for info in fileInfo:
     index.setdefault(fileKey(info), []).append(info)
@@ -308,14 +336,22 @@ if __name__ == "__main__":
     # for line in file
   # for input files
   
+  Streams = list(set( info.stream for info in fileInfo ))
+  logging.debug("%d data files in %d streams: %s",
+    len(fileInfo), len(Streams),
+    ", ".join(stream if stream else "<none>" for stream in Streams)
+    )
+  
   if fileInfo and (args.firstlogger is None):
     # uses internal FileInfoClass ordering (firstLogger not set: any will do)
     fileInfo.sort()
-    firstPassFiles = findFirstCycle(fileInfo)
+    firstPassFiles = dict( ( stream, findFirstCycle(fileInfo, stream) )
+      for stream in Streams )
     assert firstPassFiles
     firstLogger = detectFirstLogger(firstPassFiles)
-  else: firstLogger = args.firstlogger if args.firstlogger is None else 4
+  else: firstLogger = args.firstlogger if args.firstlogger is not None else 4
   
+  print(f"{firstLogger=}")
   FileInfoClass.setFirstDataLogger(firstLogger)
   
   fileInfo.sort() # uses internal FileInfoClass ordering
@@ -337,7 +373,9 @@ if __name__ == "__main__":
         if duplicateFiles is not None: duplicateFiles.extend(fileList[1:])
         if printDuplicates:
           firstSource = mainInfo.source[0]
-          msg = f"Run {mainInfo.run} cycle {mainInfo.pass_} data logger {mainInfo.dataLogger} with {len(fileList) - 1} duplicates of"
+          msg = f"Run {mainInfo.run} cycle {mainInfo.pass_} data logger {mainInfo.dataLogger}"
+          if mainInfo.stream: msg += f" stream {mainInfo.stream}"
+          msg += f" with {len(fileList) - 1} duplicates of"
           
           if len(sources) > 1: msg += f" {sources[mainInfo.source[0]]}"
           if mainInfo.source[1] is not None: msg += f" line {mainInfo.source[1]}"

--- a/scripts/sortDataLoggerFiles.py
+++ b/scripts/sortDataLoggerFiles.py
@@ -184,8 +184,8 @@ def findFirstCycle(files, stream):
     elif not wrapped and info.dataLogger < firstLogger: wrapped = True
     
     firstPassFiles.append(info)
-    logging.debug("Added cycle %d logger %d to first cycle list",
-      info.pass_, info.dataLogger)
+    logging.debug("Added cycle %d logger %d stream %s to first cycle list",
+      info.pass_, info.dataLogger, info.stream)
   # for
   return firstPassFiles
 # findFirstCycle()


### PR DESCRIPTION
The new decoder chooses the input data product from a list of possible candidates that is provided in the configuration.
If only one of them qualifies, then that one is chosen; otherwise an exception is thrown.

Currently for a input to "qualify", it needs to have data in it (empty fragment lists are not good enough, although a list of empty container fragments is ok).

Breaking change
------------------------

The input tag configuration parameter was changed from `FragmentsLabel` (a string) into `FragmentsLabels` (a list of strings).
Configurations will need to be updated (the standard ones have already).