### PR TITLE
Removed unnecessary compiler warning setting

### DIFF
--- a/icaruscode/CRT/CRTUtils/CMakeLists.txt
+++ b/icaruscode/CRT/CRTUtils/CMakeLists.txt
@@ -1,5 +1,3 @@
-cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-
 art_make(    LIBRARY_NAME icaruscode_CRTUtils
              LIB_LIBRARIES larcorealg_Geometry
                            larcore_Geometry_Geometry_service

--- a/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-
 cet_make(
   SUBDIRS
     "details"

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-
 add_subdirectory(Algorithms)
 add_subdirectory(Utilities)
 


### PR DESCRIPTION
GCC 8.3 (`e19`) wrongly issued a warning that therefore I disabled.
GCC 9.3 (`e20`) appears to have that issue solved.