### PR TITLE
PMT decoder support for multi-window PMT readout

### DIFF
--- a/icaruscode/Decode/CMakeLists.txt
+++ b/icaruscode/Decode/CMakeLists.txt
@@ -4,6 +4,7 @@ art_make(
           EXCLUDE
                         PMTconfigurationExtraction_module.cc
                         DumpPMTconfiguration_module.cc
+                        DumpArtDAQfragments_module.cc
                         DaqDecoderICARUSPMT_module.cc
           MODULE_LIBRARIES
                         icarus_signal_processing
@@ -62,6 +63,14 @@ simple_plugin(PMTconfigurationExtraction module
 
 simple_plugin(DumpPMTconfiguration module
   sbnobj_Common_PMT_Data
+  ${MF_MESSAGELOGGER}
+  fhiclcpp
+  cetlib_except
+  )
+
+simple_plugin(DumpArtDAQfragments module
+  icaruscode_Decode_DecoderTools_Dumpers
+  artdaq-core_Data
   ${MF_MESSAGELOGGER}
   fhiclcpp
   cetlib_except

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -69,6 +69,7 @@
 
 //------------------------------------------------------------------------------
 using namespace util::quantities::time_literals;
+using detinfo::timescales::electronics_time;
 
 //------------------------------------------------------------------------------
 namespace icarus { class DaqDecoderICARUSPMT; }
@@ -494,8 +495,8 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
   using Parameters = art::EDProducer::Table<Config>;
   
   
-  static constexpr detinfo::timescales::electronics_time NoTimestamp
-    = std::numeric_limits<detinfo::timescales::electronics_time>::min();
+  static constexpr electronics_time NoTimestamp
+    = std::numeric_limits<electronics_time>::min();
   
   
   // --- END ---- FHiCL configuration ------------------------------------------
@@ -582,7 +583,7 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
   nanoseconds const fOpticalTick;
   
   /// Trigger time as reported by `detinfo::DetectorClocks` service.
-  detinfo::timescales::electronics_time const fNominalTriggerTime;
+  electronics_time const fNominalTriggerTime;
   
   // --- END ---- Cached values ------------------------------------------------
   
@@ -721,7 +722,7 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
   TriggerInfo_t fetchTriggerTimestamp(art::Event const& event) const;
   
   /// Returns the timestamp for the waveforms in the specified fragment.
-  detinfo::timescales::electronics_time fragmentWaveformTimestamp(
+  electronics_time fragmentWaveformTimestamp(
     artdaq::Fragment const& artdaqFragment,
     NeededBoardInfo_t const& boardInfo,
     SplitTimestamp_t triggerTime
@@ -734,7 +735,7 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
    * same time as the global trigger.
    * Unsurprisingly, this does not work well with multiple PMT windows.
    */
-  detinfo::timescales::electronics_time fragmentWaveformTimestampOnTrigger(
+  electronics_time fragmentWaveformTimestampOnTrigger(
     artdaq::Fragment const& artdaqFragment,
     NeededBoardInfo_t const& boardInfo,
     SplitTimestamp_t triggerTime
@@ -752,7 +753,7 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
    * 
    * See `TTTresetEverySecond` configuration option.
    */
-  detinfo::timescales::electronics_time fragmentWaveformTimestampFromTTT(
+  electronics_time fragmentWaveformTimestampFromTTT(
     artdaq::Fragment const& artdaqFragment,
     NeededBoardInfo_t const& boardInfo,
     SplitTimestamp_t triggerTime
@@ -837,10 +838,8 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
    * (`extractFragmentInfo()`). The timestamp can be obtained with a call to
    * `fragmentWaveformTimestamp()`.
    */
-  std::vector<raw::OpDetWaveform> createFragmentWaveforms(
-    FragmentInfo_t const& fragInfo,
-    detinfo::timescales::electronics_time const timeStamp
-    ) const;
+  std::vector<raw::OpDetWaveform> createFragmentWaveforms
+    (FragmentInfo_t const& fragInfo, electronics_time const timeStamp) const;
   
   /// Extracts useful information from fragment data.
   FragmentInfo_t extractFragmentInfo
@@ -892,7 +891,7 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
   void fillPMTfragmentTree(
     FragmentInfo_t const& fragInfo,
     TriggerInfo_t const& triggerInfo,
-    detinfo::timescales::electronics_time waveformTimestamp
+    electronics_time waveformTimestamp
     );
   
   
@@ -1301,7 +1300,7 @@ icarus::DaqDecoderICARUSPMT::findWaveformsWithNominalTrigger
 
 //------------------------------------------------------------------------------
 bool icarus::DaqDecoderICARUSPMT::containsGlobalTrigger
-  (detinfo::timescales::electronics_time time, std::size_t nTicks) const
+  (electronics_time time, std::size_t nTicks) const
 {
   return (fNominalTriggerTime >= time)
     && (fNominalTriggerTime < time + nTicks * fOpticalTick);
@@ -1312,10 +1311,8 @@ bool icarus::DaqDecoderICARUSPMT::containsGlobalTrigger
 bool icarus::DaqDecoderICARUSPMT::containsGlobalTrigger
   (raw::OpDetWaveform const& waveform) const
 {
-  return containsGlobalTrigger(
-    detinfo::timescales::electronics_time{ waveform.TimeStamp() },
-    waveform.size()
-    );
+  return containsGlobalTrigger
+    (electronics_time{ waveform.TimeStamp() }, waveform.size());
 } // icarus::DaqDecoderICARUSPMT::containsGlobalTrigger(waveform)
 
 
@@ -1746,7 +1743,7 @@ auto icarus::DaqDecoderICARUSPMT::createFragmentWaveforms(
 void icarus::DaqDecoderICARUSPMT::fillPMTfragmentTree(
   FragmentInfo_t const& fragInfo,
   TriggerInfo_t const& triggerInfo,
-  detinfo::timescales::electronics_time waveformTimestamp
+  electronics_time waveformTimestamp
 ) {
   
   if (!fTreeFragment) return;
@@ -1869,7 +1866,7 @@ auto icarus::DaqDecoderICARUSPMT::fragmentWaveformTimestampOnTrigger(
   artdaq::Fragment const& /* artdaqFragment */,
   NeededBoardInfo_t const& boardInfo,
   SplitTimestamp_t /* triggerTime */
-) const -> detinfo::timescales::electronics_time {
+) const -> electronics_time {
   
   nanoseconds const preTriggerTime = boardInfo.preTriggerTime;
   nanoseconds const PMTtriggerDelay = boardInfo.PMTtriggerDelay;
@@ -1890,7 +1887,7 @@ auto icarus::DaqDecoderICARUSPMT::fragmentWaveformTimestampFromTTT(
   artdaq::Fragment const& artdaqFragment,
   NeededBoardInfo_t const& boardInfo,
   SplitTimestamp_t triggerTime
-) const -> detinfo::timescales::electronics_time {
+) const -> electronics_time {
   
   /*
    * 1. goal is a timestamp in electronics time
@@ -1911,7 +1908,7 @@ auto icarus::DaqDecoderICARUSPMT::fragmentWaveformTimestampFromTTT(
   //
   // 2. global trigger time
   //
-  detinfo::timescales::electronics_time waveformTime = fNominalTriggerTime;
+  electronics_time waveformTime = fNominalTriggerTime;
   
   //
   // 3. PMT readout board trigger relative to global trigger time

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -1803,14 +1803,15 @@ auto icarus::DaqDecoderICARUSPMT::extractFragmentInfo
     
     mf::LogVerbatim{ fLogCategory }
       << "----> PMT Fragment ID: " << std::hex << fragment_id << std::dec
-        << ", nChannelsPerBoard: " << nChannelsPerBoard
-        << ", nSamplesPerChannel: " << nSamplesPerChannel
+        << ", size: " << ev_size_quad_bytes << " (DAQ)"
+        << ", data size: " << data_size_double_bytes << " (samples)"
+      << "\n    "
+        << "  channels/board: " << nChannelsPerBoard
         << ", enabled: " << icarus::ns::util::bin(enabledChannels)
-      << "\n      size: " << ev_size_quad_bytes
-        << ", data size: " << data_size_double_bytes
         << ", samples/channel: " << nSamplesPerChannel
+      << "\n    "
+        << "  event counter: " << eventCounter
         << ", trigger time tag: " << TTT
-        << ", event counter: " << eventCounter
         << ", time stamp: " << (fragmentTimestamp / 1'000'000'000UL)
           << "." << (fragmentTimestamp % 1'000'000'000UL) << " s"
       ;

--- a/icaruscode/Decode/DecoderTools/CMakeLists.txt
+++ b/icaruscode/Decode/DecoderTools/CMakeLists.txt
@@ -24,6 +24,7 @@ art_make( SUBDIRS details
                         icarus_signal_processing_Filters
                         icaruscode_TPC_Utilities_SignalShapingICARUSService_service
                         icaruscode_Decode_DecoderTools
+                        icaruscode_Decode_DecoderTools_Dumpers
                         icaruscode_Utilities
                         larcorealg_Geometry
                         larcore_Geometry_Geometry_service

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -30,6 +30,9 @@
 #include "icaruscode/Decode/DecoderTools/IDecoder.h"
 // #include "sbnobj/Common/Trigger/BeamBits.h" // maybe future location of:
 #include "icaruscode/Decode/BeamBits.h" // sbn::triggerSource
+#include "icaruscode/Decode/DecoderTools/Dumpers/FragmentDumper.h" // dumpFragment()
+#include "icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h"
+#include "icarusalg/Utilities/BinaryDumpUtils.h" // hexdump() DEBUG
 
 #include <cstdlib>
 #include <iostream>
@@ -127,6 +130,8 @@ namespace daq
     static constexpr nanoseconds BNBgateDuration { 1600. };
     static constexpr nanoseconds NuMIgateDuration { 9500. };
     
+    static std::string_view firstLine(std::string const& s, const char* endl = "\0\n\r");
+    
   };
 
 
@@ -191,6 +196,26 @@ namespace daq
       if(abs(cross_check) > 1000)
         std::cout << "Loaded artdaq TS and fragment data TS are > 1 ms different! They are " << cross_check << " nanoseconds different!" << std::endl;
       std::cout << delta_gates_bnb << " " << delta_gates_numi << " " << delta_gates_other << std::endl; // nonsensical print statement to avoid error that I don't use these...until we have an object to store them in...    
+      
+      // note that this parsing is independent from the one used above
+      std::string_view const dataLine = firstLine(data);
+      try {
+        auto const parsedData = icarus::details::KeyedCSVparser{}(dataLine);
+        std::cout << "Parsed data (from " << dataLine.size() << " characters): "
+          << parsedData << std::endl;
+      }
+      catch(icarus::details::KeyedCSVparser::Error const& e) {
+        mf::LogError("TriggerDecoder")
+          << "Error parsing " << dataLine.length()
+          << "-char long trigger string:\n==>|" << dataLine
+          << "|<==\nError message: " << e.what() << std::endl;
+        throw;
+      }
+      
+      if (fDebug) { // this grows tiresome quickly when processing many events
+        std::cout << "Full trigger fragment dump:"
+          << sbndaq::dumpFragment(fragment) << std::endl;
+      }
     }
     
     //
@@ -263,6 +288,13 @@ namespace daq
     return;
   }
 
+  std::string_view TriggerDecoder::firstLine
+    (std::string const& s, const char* endl /* = "\0\n\r" */)
+  {
+    return { s.data(), std::min(s.find_first_of(endl), s.size()) };
+  }
+  
+  
   DEFINE_ART_CLASS_TOOL(TriggerDecoder)
 
 }

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -155,7 +155,7 @@ namespace daq
   {
     fDiagnosticOutput = pset.get<bool>("DiagnosticOutput", false);
     fDebug = pset.get<bool>("Debug", false);
-    fOffset = pset.get<int>("TAIOffset", 2);
+    fOffset = pset.get<int>("TAIOffset", 2'000'000'000);
     return;
   }
   

--- a/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.cxx
+++ b/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.cxx
@@ -1,0 +1,242 @@
+/**
+ * @file icaruscode/Decode/DecoderTools/details/KeyedCSVparser.cxx
+ * @brief  Simple parser for comma-separated text (implementation).
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   May 9, 2021
+ * @see icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h
+ */
+
+// library header
+#include "icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h"
+
+// C++ standard libraries
+#include <ostream>
+#include <cctype> // std::isspace()
+
+
+// -----------------------------------------------------------------------------
+// ---  icarus::details::KeyValuesData
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyValuesData::makeItem(std::string key) -> Item& {
+  
+  if (hasItem(key)) throw DuplicateKey{ std::move(key) };
+  
+  fItems.emplace_back(std::move(key));
+  
+  return fItems.back();
+} // icarus::details::KeyValuesData::makeItem()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyValuesData::findItem
+  (std::string const& key) const noexcept -> Item const*
+{
+  for (auto const& item: fItems) if (key == item.key) return &item;
+  return nullptr;
+} // icarus::details::KeyValuesData::findItem()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyValuesData::getItem(std::string const& key) const
+  -> Item const&
+{
+  if (auto item = findItem(key); item) return *item;
+  throw ItemNotFound(key);
+} // icarus::details::KeyValuesData::getItem()
+
+
+// -----------------------------------------------------------------------------
+bool icarus::details::KeyValuesData::hasItem
+  (std::string const& key) const noexcept
+{
+  return findItem(key);
+} // icarus::details::KeyValuesData::hasItem()
+
+
+// -----------------------------------------------------------------------------
+bool icarus::details::KeyValuesData::empty() const noexcept
+  { return fItems.empty(); }
+
+
+// -----------------------------------------------------------------------------
+std::size_t icarus::details::KeyValuesData::size() const noexcept
+  { return fItems.size(); }
+
+
+// -----------------------------------------------------------------------------
+decltype(auto) icarus::details::KeyValuesData::items() const noexcept
+  { return fItems; }
+
+
+// -----------------------------------------------------------------------------
+std::ostream& icarus::details::operator<<
+  (std::ostream& out, KeyValuesData const& data)
+{
+  out << data.size() << " items";
+  if (!data.empty()) {
+    out << ':';
+    for (auto const& item: data.items()) {
+      out << "\n  '" << item.key << "' (" << item.values.size() << ")";
+      if (item.values.empty()) continue;
+      out << ':';
+      for (auto const& value: item.values) out << " '" << value << '\'';
+    } // for
+  } // if has data
+  return out << "\n";
+} // icarus::details::operator<< (KeyValuesData)
+
+
+// -----------------------------------------------------------------------------
+// ---  icarus::details::KeyedCSVparser
+// -----------------------------------------------------------------------------
+void icarus::details::KeyedCSVparser::parse
+  (std::string_view const& s, ParsedData_t& data) const
+{
+  
+  auto stream = s;
+  
+  ParsedData_t::Item* currentItem = nullptr;
+  
+  while (!stream.empty()) {
+    
+    auto const token = extractToken(stream);
+    
+    std::string tokenStr { cbegin(token), cend(token) };
+    
+    if (isKey(token)) currentItem = &(data.makeItem(std::move(tokenStr)));
+    else {
+      if (!currentItem) {
+        throw InvalidFormat(
+         "values started without a key ('" + tokenStr + "' is not a valid key)."
+         );
+      }
+      currentItem->addValue(std::move(tokenStr));
+    }
+    
+  } // while
+  
+} // icarus::KeyedCSVparser::parse()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyedCSVparser::parse
+  (std::string const& s) const -> ParsedData_t
+  { return parse(std::string_view{ s.data(), s.size() }); }
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyedCSVparser::extractToken
+  (Buffer_t& buffer) const noexcept -> SubBuffer_t
+{
+  
+  auto const start = cbegin(buffer), bend = cend(buffer);
+  auto finish = start;
+  while (finish != bend) {
+    if (*finish == fSep) break;
+    ++finish;
+  } // for
+  
+  // update the start of the buffer
+  std::size_t const tokenLength = std::distance(start, finish);
+  moveBufferHead(buffer, tokenLength + ((finish == bend)? 0: 1));
+  
+  return strip({ start, tokenLength });
+  
+} // icarus::details::KeyedCSVparser::extractToken()
+
+
+// -----------------------------------------------------------------------------
+bool icarus::details::KeyedCSVparser::isKey
+  (SubBuffer_t const& buffer) const noexcept
+{
+  
+  return !buffer.empty() && std::isalpha(buffer.front());
+  
+} // icarus::details::KeyedCSVparser::isKey()
+
+
+// -----------------------------------------------------------------------------
+template <typename String>
+auto icarus::details::KeyedCSVparser::makeBuffer(String const& s) noexcept
+  -> Buffer_t
+  { return { data(s), size(s) }; } // C++20: use begin/end constructor
+
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyedCSVparser::moveBufferHead
+  (Buffer_t& buffer, std::size_t size) noexcept -> Buffer_t&
+{
+  
+  size = std::min(size, buffer.size());
+  return buffer = { buffer.data() + size, buffer.size() - size };
+  
+} // details::KeyedCSVparser::eatBufferHead()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyedCSVparser::strip(SubBuffer_t s) noexcept
+  -> SubBuffer_t
+  { return stripRight(stripLeft(stripRightChars<'\n', '\r', '\0'>(s))); }
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyedCSVparser::stripLeft(SubBuffer_t s) noexcept
+  -> SubBuffer_t
+{
+  
+  while (!s.empty()) {
+    if (!std::isspace(s.front())) break;
+    s.remove_prefix(1);
+  }
+  return s;
+  
+} // icarus::details::KeyedCSVparser::stripLeft()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyedCSVparser::stripRight(SubBuffer_t s) noexcept
+  -> SubBuffer_t
+{
+  
+  while (!s.empty()) {
+    if (!std::isspace(s.back())) break;
+    s.remove_suffix(1);
+  }
+  return s;
+  
+} // icarus::details::KeyedCSVparser::stripRight()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::details::KeyedCSVparser::stripRightChar
+  (SubBuffer_t s, char c) noexcept -> SubBuffer_t
+{
+  
+  while (!s.empty()) {
+    if (s.back() != c) break;
+    s.remove_suffix(1);
+  }
+  return s;
+  
+} // icarus::details::KeyedCSVparser::stripRightChar()
+
+
+// ----------------------------------------------------------------------------
+template <char... Chars>
+auto icarus::details::KeyedCSVparser::stripRightChars
+  (SubBuffer_t s) noexcept -> SubBuffer_t
+{
+  while (true) {
+    auto ns = s;
+    for (char c: { Chars... }) ns = stripRightChar(ns, c);
+    if (ns == s) return ns;
+    s = ns;
+  } // while(true)
+  
+} // icarus::details::KeyedCSVparser::stripRightChars()
+
+
+// -----------------------------------------------------------------------------
+

--- a/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h
+++ b/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h
@@ -1,0 +1,298 @@
+/**
+ * @file   icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h
+ * @brief  Simple parser for comma-separated text.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   May 9, 2021
+ * @see    icaruscode/Decode/DecoderTools/details/KeyedCSVparser.cxx
+ */
+
+#ifndef ICARUSCODE_DECODE_DECODERTOOLS_DETAILS_KEYEDCVSPARSER_H
+#define ICARUSCODE_DECODE_DECODERTOOLS_DETAILS_KEYEDCVSPARSER_H
+
+
+// C++ standard libraries
+#include <iosfwd> // std::ostream
+#include <string_view>
+#include <vector>
+#include <string>
+#include <optional>
+#include <stdexcept> // std::runtime_error
+#include <utility> // std::move()
+#include <charconv> // std::from_chars()
+#include <cstddef> // std::size_t
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::details {
+  class KeyedCSVparser;
+  struct KeyValuesData;
+  
+  std::ostream& operator<< (std::ostream& out, KeyValuesData const& data);
+} // namespace icarus::details
+
+
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyValuesData {
+  
+  struct Error;
+  struct DuplicateKey;
+  struct ConversionFailed;
+  struct ItemNotFound;
+  struct ValueNotAvailable;
+  
+  /// Representation of a single item of data: a key and several values.
+  struct Item {
+    std::string key;
+    std::vector<std::string> values;
+    
+    Item(std::string key): key(std::move(key)) {}
+    
+    Item& addValue(std::string value)
+      { values.push_back(std::move(value)); return *this; }
+    
+    std::size_t nValues() const noexcept { return values.size(); }
+    
+    bool operator< (Item const& other) const noexcept
+      { return key < other.key; }
+    
+    template <typename T>
+    T getNumber(std::size_t index) const;
+    
+    template <typename T>
+    std::optional<T> getOptionalNumber
+      (std::size_t index, bool ignoreFormatErrors = false) const;
+    
+      private:
+    template <typename T>
+    static std::optional<T> convertStringInto(std::string const& valueStr);
+    
+  }; // struct Item
+  
+  Item& makeItem(std::string key);
+  
+  /// Returns the item with specified `key`, `nullptr` if none.
+  Item const* findItem(std::string const& key) const noexcept;
+  
+  /// Returns the item with specified `key`, throws `std::out_of_range` if none.
+  Item const& getItem(std::string const& key) const;
+  
+  /// Returns whether an item with the specified key is present.
+  bool hasItem(std::string const& key) const noexcept;
+  
+  /// Returns whether there is no item in data.
+  bool empty() const noexcept;
+  
+  /// Returns the number of items in the data.
+  std::size_t size() const noexcept;
+  
+  /// Returns a forward-iterable list of references to items.
+  decltype(auto) items() const noexcept;
+  
+    private:
+  
+  std::vector<Item> fItems; ///< Collection of data items.
+  
+}; // struct icarus::details::KeyValuesData
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Parser to fill a `KeyValuesData` structure out of a character buffer.
+ * 
+ * It currently supports only single-line buffer.
+ */
+class icarus::details::KeyedCSVparser {
+  
+    public:
+  
+  using ParsedData_t = icarus::details::KeyValuesData;
+  
+  using Error = KeyValuesData::Error; ///< Base of all errors by KeyedCSVparser.
+  struct ParserError; ///< Generic error: base of all errors by KeyedCSVparser.
+  struct InvalidFormat; ///< Parsing format is not understood.
+  
+  /// Constructor: specifies the separator character.
+  KeyedCSVparser(char sep = ','): fSep(sep) {}
+  
+  //@{
+  /// Parses the buffer `s` and returns a data structure with the content.
+  ParsedData_t parse(std::string_view const& s) const;
+  ParsedData_t parse(std::string const& s) const;
+  template <typename BIter, typename EIter>
+  ParsedData_t parse(BIter b, EIter e) const;
+  
+  ParsedData_t operator() (std::string_view const& s) const { return parse(s); }
+  ParsedData_t operator() (std::string const& s) const { return parse(s); }
+  template <typename BIter, typename EIter>
+  ParsedData_t operator() (BIter b, EIter e) const { return parse(b, e); }
+  //@}
+  
+  //@{
+  /// Parses the buffer `s` and fills `data` with it.
+  void parse(std::string_view const& s, ParsedData_t& data) const;
+  //@}
+  
+    private:
+  using Buffer_t = std::string_view;
+  using SubBuffer_t = std::string_view;
+  
+  char const fSep = ','; ///< Character used as token separator.
+  
+  
+  SubBuffer_t extractToken(Buffer_t& buffer) const noexcept;
+  
+  /// Is content of `buffer` a key (as opposed to a value)?
+  bool isKey(SubBuffer_t const& buffer) const noexcept;
+  
+  
+  template <typename String>
+  static Buffer_t makeBuffer(String const& s) noexcept;
+
+  static Buffer_t& moveBufferHead(Buffer_t& buffer, std::size_t size) noexcept;
+  
+  static SubBuffer_t strip(SubBuffer_t s) noexcept;
+  static SubBuffer_t stripLeft(SubBuffer_t s) noexcept;
+  static SubBuffer_t stripRight(SubBuffer_t s) noexcept;
+  static SubBuffer_t stripRightChar(SubBuffer_t s, char c) noexcept;
+  
+  template <char... Chars>
+  static SubBuffer_t stripRightChars(SubBuffer_t s) noexcept;
+  
+}; // icarus::details::KeyedCSVparser
+
+
+
+// -----------------------------------------------------------------------------
+// ---  Exception class definitions
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyValuesData::Error: public std::runtime_error {
+  
+  Error(std::string msg): std::runtime_error(std::move(msg)) {}
+  
+}; // icarus::details::KeyValuesData::Error()
+
+
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyValuesData::DuplicateKey: public Error {
+  
+  DuplicateKey(std::string const& msg)
+    : Error("KeyValuesData::DuplicateKey: '" + msg + '\'')
+    {}
+  
+}; // icarus::details::KeyValuesData::DuplicateKey()
+
+
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyValuesData::ConversionFailed: public Error {
+  
+  ConversionFailed(std::string const& s, std::string const& tname = "")
+    : Error{
+      "conversion of '" + s + "'"
+       + (tname.empty()? "": (" to type '" + tname + "'")) + " failed"
+      }
+    {}
+  
+  template <typename T>
+  static ConversionFailed makeFor(std::string const& s)
+    { return { s, typeid(T).name() }; }
+  
+}; // icarus::details::KeyValuesData::ConversionFailed()
+
+
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyValuesData::ItemNotFound: public Error {
+  
+  ItemNotFound(std::string const& key): Error("item not found: '" + key + '\'')
+    {}
+  
+}; // icarus::details::KeyValuesData::ItemNotFound()
+
+
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyValuesData::ValueNotAvailable: public Error {
+  
+  ValueNotAvailable(std::size_t index)
+    : Error("item value #" + std::to_string(index) + " not available")
+    {}
+  
+}; // icarus::details::KeyValuesData::ValueNotAvailable()
+
+
+
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyedCSVparser::ParserError: public Error {
+  
+  ParserError(std::string msg): KeyValuesData::Error(std::move(msg)) {}
+  
+}; // icarus::details::KeyedCSVparser::Error()
+
+
+// -----------------------------------------------------------------------------
+struct icarus::details::KeyedCSVparser::InvalidFormat: public ParserError {
+  
+  InvalidFormat(std::string const& msg): ParserError("Format error: " + msg) {}
+  
+}; // icarus::details::KeyedCSVparser::InvalidFormat()
+
+
+// -----------------------------------------------------------------------------
+// --- Inline implementation
+// -----------------------------------------------------------------------------
+inline auto icarus::details::KeyedCSVparser::parse
+  (std::string_view const& s) const -> ParsedData_t
+  { ParsedData_t data; parse(s, data); return data; }
+
+
+// -----------------------------------------------------------------------------
+// --- Template implementation
+// -----------------------------------------------------------------------------
+template <typename T>
+T icarus::details::KeyValuesData::Item::getNumber(std::size_t index) const {
+  
+  if (index >= values.size()) throw ValueNotAvailable(index);
+  
+  auto const& valueStr = values[index];
+  auto const number = convertStringInto<T>(valueStr);
+  return number? number.value(): throw ConversionFailed::makeFor<T>(valueStr);
+  
+} // icarus::details::KeyValuesData::Item::getNumber<>()
+
+
+// -----------------------------------------------------------------------------
+template <typename T>
+std::optional<T> icarus::details::KeyValuesData::Item::getOptionalNumber
+  (std::size_t index, bool ignoreFormatErrors /* = false */) const
+{
+  if (index < values.size()) return std::nullopt;
+
+  auto const& valueStr = values[index];
+  auto const number = convertStringInto<T>(valueStr);
+  return (number || ignoreFormatErrors)
+    ? number: throw ConversionFailed::makeFor<T>(valueStr);
+
+} // icarus::details::KeyValuesData::Item::getOptionalNumber()
+
+
+// -----------------------------------------------------------------------------
+template <typename T>
+std::optional<T> icarus::details::KeyValuesData::Item::convertStringInto
+  (std::string const& valueStr)
+{
+  T number {}; // useless initialization to avoid GCC complains
+  char const *b = valueStr.data(), *e = b + valueStr.length();
+  return (std::from_chars(b, e, number).ptr == e)
+    ? std::make_optional(number): std::nullopt;
+} // icarus::details::KeyValuesData::Item::convertStringInto()
+
+
+// -----------------------------------------------------------------------------
+template <typename BIter, typename EIter>
+auto icarus::details::KeyedCSVparser::parse(BIter b, EIter e) const
+  -> ParsedData_t
+  { return parse(std::string_view{ &*b, std::distance(b, e) }); }
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_DECODE_DECODERTOOLS_DETAILS_KEYEDCVSPARSER_H

--- a/icaruscode/Decode/DumpArtDAQfragments_module.cc
+++ b/icaruscode/Decode/DumpArtDAQfragments_module.cc
@@ -1,0 +1,207 @@
+/**
+ * @file   DumpArtDAQfragments_module.cc
+ * @brief  Dumps on console the content of `artdaq::Fragment` data products.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   June 10, 2021
+ */
+
+// SBN libraries
+#include "icaruscode/Decode/DecoderTools/Dumpers/FragmentDumper.h" // dumpFragment()
+
+// LArSoft libraries
+#include "larcorealg/CoreUtils/zip.h"
+#include "larcorealg/CoreUtils/enumerate.h"
+
+// framework libraries
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "canvas/Persistency/Provenance/ProductToken.h"
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <algorithm> // std::transform()
+#include <vector>
+#include <string>
+
+
+//------------------------------------------------------------------------------
+namespace sbn { class DumpArtDAQfragments; }
+
+/**
+ * @brief Dumps on console the content of `artdaq::Fragment` collections.
+ * 
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * * `std::vector<artdaq::Fragment>`: data to be dumped; the dump is binary,
+ *   and it does not attempt an interpretation of the content of the fragment
+ *   (in future, it could at least attempt unpacking the container fragments).
+ * 
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * A terse description of the parameters is printed by running
+ * `lar --print-description DumpArtDAQfragments`.
+ * 
+ * * `FragmentTags` (list of data product input tags): the tags identifying the
+ *     data products to dump.
+ * * `OutputCategory` (string, default: `DumpArtDAQfragments`): name of the
+ *     message facility output stream to dump the information into
+ * 
+ */
+class sbn::DumpArtDAQfragments: public art::EDAnalyzer {
+  
+    public:
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Sequence<art::InputTag> FragmentTags {
+      Name("FragmentTags"),
+      Comment("tag of fragment collection data products to be dumped")
+      };
+
+    fhicl::Atom<std::string> OutputCategory {
+      Name("OutputCategory"),
+      Comment("name of the category used for the output"),
+      "DumpArtDAQfragments"
+      };
+
+  }; // struct Config
+  
+  using Parameters = art::EDAnalyzer::Table<Config>;
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  // --- BEGIN Constructors ----------------------------------------------------
+  explicit DumpArtDAQfragments(Parameters const& config);
+  
+  // --- END Constructors ------------------------------------------------------
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Does nothing, but it is mandatory.
+  virtual void analyze(art::Event const& event) override;
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  /// Input data tokens.
+  std::vector<art::InputTag> const fInputTags;
+  
+  /// Input data tokens.
+  std::vector<art::ProductToken<artdaq::Fragments>> const fInputTokens;
+  
+  /// Category used for message facility stream.
+  std::string const fOutputCategory;
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+  /// Get art tokens for specified input data products.
+  std::vector<art::ProductToken<artdaq::Fragments>> getFragmentTokens
+    (std::vector<art::InputTag> const& tags);
+  
+  /// Dumps a single fragment collection.
+  void dumpFragments(
+    art::Event const& event,
+    art::InputTag const& inputTag,
+    art::ProductToken<artdaq::Fragments> const& inputToken
+    ) const;
+  
+}; // sbn::DumpArtDAQfragments
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+//--- sbn::DumpArtDAQfragments
+//------------------------------------------------------------------------------
+sbn::DumpArtDAQfragments::DumpArtDAQfragments
+  (Parameters const& config)
+  : art::EDAnalyzer(config)
+  // configuration
+  , fInputTags     (config().FragmentTags())
+  , fInputTokens   (getFragmentTokens(fInputTags))
+  , fOutputCategory(config().OutputCategory())
+{
+  assert(fInputTags.size() == fInputTokens.size());
+} // sbn::DumpArtDAQfragments::DumpArtDAQfragments()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpArtDAQfragments::analyze(art::Event const& event) {
+  
+  mf::LogVerbatim(fOutputCategory) << event.id() << ":";
+  
+  for (auto const& [ tag, token ]: util::zip(fInputTags, fInputTokens))
+    dumpFragments(event, tag, token);
+
+} // sbn::DumpArtDAQfragments::analyze()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpArtDAQfragments::dumpFragments(
+  art::Event const& event,
+  art::InputTag const& inputTag,
+  art::ProductToken<artdaq::Fragments> const& inputToken
+) const {
+  
+  art::Handle<artdaq::Fragments> fragmentHandle;
+  bool found = event.getByToken(inputToken, fragmentHandle);
+  
+  if (!found) {
+    mf::LogVerbatim(fOutputCategory)
+      << "No fragment collection found as '" << inputTag.encode() << "'.";
+    return;
+  }
+  
+  artdaq::Fragments const& fragments = *fragmentHandle;
+  mf::LogVerbatim log { fOutputCategory };
+  log << "Data product '" << inputTag.encode() << "' has " << fragments.size()
+    << " fragments.";
+  for (auto const& [ iFragment, fragment ]: util::enumerate(fragments)) {
+    // TODO special case for artdaq::ContainerFragment?
+    log << "\n[#" << iFragment << "] " << sbndaq::dumpFragment(fragment);
+  } // for
+  
+} // sbn::DumpArtDAQfragments::dumpFragments()
+
+
+//------------------------------------------------------------------------------
+std::vector<art::ProductToken<artdaq::Fragments>>
+sbn::DumpArtDAQfragments::getFragmentTokens
+  (std::vector<art::InputTag> const& tags)
+{
+  auto getToken = [this](art::InputTag const& tag)
+    { return consumes<artdaq::Fragments>(tag); };
+  
+  std::vector<art::ProductToken<artdaq::Fragments>> tokens;
+  std::transform(begin(tags), end(tags), back_inserter(tokens), getToken);
+  return tokens;
+} // sbn::DumpArtDAQfragments::getFragmentTokens()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(sbn::DumpArtDAQfragments)
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/Decode/fcl/decodePMT_icarus_standalone.fcl
+++ b/icaruscode/Decode/fcl/decodePMT_icarus_standalone.fcl
@@ -1,0 +1,69 @@
+#
+# File:    decodePMT_icarus_standalone.fcl
+# Purpose: PMT readout fragment decoding for studies in ICARUS.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    June 10, 2021
+# 
+# This configuration expects only PMT fragments, and not even all of them:
+# as a consequence many timestamp corrections will be skipped.
+# PMT waveform decoding is performed, extensive debugging messages are
+# included in the `debug.log` log file, and ROOT trees are produced for studies.
+# This configuration, as is, is not meant for production.
+# 
+# 
+# Input
+# ------
+# 
+# * artDAQ fragments from PMT readout boards, named
+#   `daq:ContainerCAENV1730` or `daq:CAENV1730` (not both!)
+# 
+# 
+# Output
+# -------
+# 
+# Only new data products are written in the art/ROOT output file, including:
+# 
+# * `daqPMT` (std::vector<raw::OpDetWaveform>): decoded waveforms,
+#   with our best reconstruction for their time stamps in LArSoft reference
+# 
+# 
+# The `Trees-<InputFile>*.root` file (from `TFileService`) includes ROOT tree
+# `PMTfragments`.
+# 
+# 
+# 
+# Service configuration
+# ----------------------
+# 
+# * `DetectorClocksService` is essential to assign a correct waveform timestamp
+#     * `Geometry` service bundle is required by `DetectorClocksService`
+# * `IICARUSChannelMap` to relate PMT fragment IDs to channels
+# * `TFileService` used to write trees (not needed if all trees are disabled)
+# 
+#
+
+
+# ------------------------------------------------------------------------------
+#include "decodePMT_icarus.fcl"
+
+
+# ------------------------------------------------------------------------------
+physics.decoding: [ daqPMT ]
+
+
+# ------------------------------------------------------------------------------
+
+physics.producers.daqPMT.PMTconfigTag: @erase # required
+physics.producers.daqPMT.TriggerTag:   @erase # required
+
+#
+# customization of PMT decoding
+#
+
+physics.producers.daqPMT.SurviveExceptions:  false
+physics.producers.daqPMT.DiagnosticOutput:    true
+physics.producers.daqPMT.PacketDump:          true
+physics.producers.daqPMT.RequireKnownBoards: false
+physics.producers.daqPMT.RequireBoardConfig: false
+
+# ------------------------------------------------------------------------------

--- a/icaruscode/Decode/fcl/dump_artdaqfragments_pmt_icarus.fcl
+++ b/icaruscode/Decode/fcl/dump_artdaqfragments_pmt_icarus.fcl
@@ -1,0 +1,75 @@
+#
+# File:     dump_artdaqfragments_pmt_icarus.fcl
+# Purpose:  Dump on screen ICARUS PMT art fragments from DAQ.
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     June 10, 2021
+# Version:  1.0
+#
+# This module extracts and then dumps the specified PMT data fragments.
+#
+# Input: (data) files with FHiCL configuration of PMT.
+#
+# Service dependencies:
+# - message facility
+# 
+# Changes:
+# 20210610 (petrillo@slac.stanford.edu) [v1.0]
+#   first version
+#
+
+#include "messages_icarus.fcl"
+
+
+# ------------------------------------------------------------------------------
+process_name: DumpPMTcfg
+
+
+# ------------------------------------------------------------------------------
+services: {
+  
+  message: @local::icarus_message_services_interactive
+  
+} # services
+
+
+services.message.destinations.LogStandardOut.categories.DumpArtDAQfragments: { limit: 0 }
+services.message.destinations.DumpLog: {
+  type:      file
+  filename: "DumpArtDAQfragments.log"
+  threshold: INFO
+  categories: {
+    DumpArtDAQfragments: { limit: -1 }
+    default:             { limit: 0 }
+  }
+} # services.message.destinations.DumpLog
+
+
+# ------------------------------------------------------------------------------
+source: {
+  module_type: RootInput
+  maxEvents:  -1            # number of events to read
+} # source
+
+
+# ------------------------------------------------------------------------------
+physics: {
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  analyzers: {
+    dumppmtdata: {
+      module_type: DumpArtDAQfragments
+      
+      FragmentTags: [ "daq:CAENV1730", "daq:ContainerCAENV1730" ]
+      
+      OutputCategory: "DumpArtDAQfragments"
+      
+    } # dumppmtdata
+  } # analyzers
+  
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  dumpers:    [ dumppmtdata ]
+  
+} # physics
+
+
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
This requests contains changes to the trigger and PMT decoding softare.

## Trigger decoding

* bug fix: a default value was wrong (2 ns instead of 2 s)
* added some optional debugging information: dump the whole fragment content

## PMT decoding

The main feature being pursued here is the support for the "overlapping window" readout mode (the name is not official), which has been pioneered in run `6029`. In that mode, waveforms can come in packets shorter than the configured value (e.g. 30 µs) and they may come adjacent.

* major feature: support for waveforms of any size: timestamp is correctly computed including the actual waveform size
* adjacent waveforms (whose end and start match at less than 1 ns) are merged into a longer waveform
* more information in the optional debugging tree
* minor technical changes here and there

## Other features

* an analyzer module has been added to dump on screen the content of _artdaq_ data fragments
