### PR TITLE
Updated PMT readout window

### DIFF
--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -27,7 +27,8 @@
 #   added explicit noise configuration, and made standard an alias of it
 # 20210212 (petrillo@slac.stanford.edu)
 #   updated baseline to reflect the one in data
-#
+# 20210615 (petrillo@slac.stanford.edu)
+#  updated PMT readout enable window to 2 ms
 #
 
 #include "opticalproperties_icarus.fcl"
@@ -155,7 +156,7 @@ icarus_pmtsimulationalg_noise: {
 
   PulsePolarity:             -1             #Pulse polarity (1 = positive, -1 = negative)
   TriggerOffsetPMT:          "-1.15 ms"     #Time relative to trigger when readout begins
-  ReadoutEnablePeriod:       "2.55 ms"      #Time for which pmt readout is enabled
+  ReadoutEnablePeriod:       "2.0 ms"       #Time for which pmt readout is enabled
   CreateBeamGateTriggers:    true           #Option to create unbiased readout around beam spill
   BeamGateTriggerRepPeriod:  "2.0 us"       #Repetition Period for BeamGateTriggers
   BeamGateTriggerNReps:      10             #Number of beamgate trigger reps to produce


### PR DESCRIPTION
ICARUS PMT readout window has been settled to 2 milliseconds in data, and this value is not being questioned.
So we can save some space and honour that choice.