### PR TITLE
Change memory and cpu ranges for ci tests

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -336,7 +336,7 @@ NEVENTS=2
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on Jenkins on 20210610: +200", +700 MB
 cpu_usage_range=400:600
-mem_usage_range=1000000:1500000
+mem_usage_range=3000000:3800000
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)ssingle_%(STAGE_NAME)s_quick_test_icaruscode.fcl
@@ -565,7 +565,7 @@ STAGE_NAME=gen
 NEVENTS=5
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607: +500 MB
-cpu_usage_range=200:603
+cpu_usage_range=200:653
 mem_usage_range=800000:1500003
 
 script=%(EXPSCRIPT_ICARUSCODE)s


### PR DESCRIPTION
Change scaled cpu range for nucosmics_gen_quick_test_icaruscode from 200:603 to 200:653
Change memory range for single_reco_quick_test_icaruscode from 1000000:1500000 to 3000000:3800000