### PR TITLE
Fix the simulated PMT readout window position in time

### DIFF
--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -155,7 +155,7 @@ icarus_pmtsimulationalg_noise: {
   ThresholdADC:              18             # ADC counts
 
   PulsePolarity:             -1             #Pulse polarity (1 = positive, -1 = negative)
-  TriggerOffsetPMT:          "-1.15 ms"     #Time relative to trigger when readout begins
+  TriggerOffsetPMT:          "-1.0 ms"      #Time relative to trigger when readout begins
   ReadoutEnablePeriod:       "2.0 ms"       #Time for which pmt readout is enabled
   CreateBeamGateTriggers:    true           #Option to create unbiased readout around beam spill
   BeamGateTriggerRepPeriod:  "2.0 us"       #Repetition Period for BeamGateTriggers


### PR DESCRIPTION
When I changed the PMT readout window duration from 2.55 to 2.0 ms (commit e8effda), I did not change the _starting_ time of that window, that I should have.

The TPC readout window is 1.6 ms (4096×400 ns), covering from -340 µs before the trigger/beam to 1238 µs after it (see e.g. [SBN DocDB 18620, page 3](https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=18620)).
The old settings with a window 2.55 ms long starting -1.15 ms before the trigger would cover from -1.15 to 1.4 ms.
The current settings with a window 2.0 ms long starting at -1.15 ms cover from -1.15 to 0.85 ms.
The proposed settings in this pull request are the ones _currently in use_ in the actual readout: with a window 2.0 ms long starting at -1.0 ms cover from -1.0 to 1.0 ms.

ASCII art time:
~~~
Trigger time scale ("starts" 1.5 ms before the trigger):

-1.5      -1.0      -0.5        0        0.5       1.0       1.5 ms
  | - - - - | - - - - | - - - - | - - - - | - - - - | - - - ->

                        -0.34                           1.24
                         |<-----+---------+---------+--->|      ICARUS TPC readout
                                |<--------+------->|            TPC drift time window
                                0                 0.94
                                :                  :
  -1.4                          :                  :        1.4
    |<------+---------+---------==========+=========+------->|  PMT readout: SBN DocDB 18620
                                :                  :
       -1.15                    :                  :        1.4
         |<-+---------+---------==========+=========+------->|  PMT readout: icaruscode < v09_24_01
                                :                  :
       -1.15                    :              0.85:
         |<-+---------+---------==========+====>|  :            PMT readout: icaruscode v09_24_01_01
                                :                  :
          -1.0                  :                  : 1.0
            |<--------+---------==========+========>|           PMT readout: hardware, and this pull request
~~~
If the latter is not appropriate for physics, such message should be propagated to ICARUS PMT and trigger groups.

