### PR TITLE
Add bit to ignore the DuplicateEventTracker for the event display (th…

### DIFF
--- a/fcl/evd/evd_icarus.fcl
+++ b/fcl/evd/evd_icarus.fcl
@@ -51,6 +51,9 @@ services.SimulationDrawingOptions.ShowMCTruthTrajectories: true
 services.SimulationDrawingOptions.MinimumEnergyDeposition: 0.0001  # in GeV
 
 services.RecoDrawingOptions.HitModuleLabels:               ["gaushit"]
-services.RecoDrawingOptions.WireModuleLabels:              ["decon1droi"] 
+services.RecoDrawingOptions.WireModuleLabels:              ["decon1droi"]
+
+#Turn off DuplicateEventTracker
+services.DuplicateEventTracker: @erase
 
 

--- a/fcl/evd/evd_icarusraw.fcl
+++ b/fcl/evd/evd_icarusraw.fcl
@@ -53,4 +53,7 @@ services.RecoDrawingOptions.HitModuleLabels:               ["icarushit"]
 services.RecoDrawingOptions.ClusterModuleLabels:               ["linecluster"]
 services.RecoDrawingOptions.WireModuleLabels:              ["recowireraw"]
 
+#Turn off DuplicateEventTracker
+services.DuplicateEventTracker: @erase
+
 

--- a/fcl/evd/evd_multitpc_icarus.fcl
+++ b/fcl/evd/evd_multitpc_icarus.fcl
@@ -99,4 +99,7 @@ services.RecoDrawingOptions.OpHitModuleLabels:     ["ophit"]
 services.RecoDrawingOptions.DrawOpFlashes:         0
 services.RecoDrawingOptions.OpFlashModuleLabels:   ["opflashTPC0", "opflashTPC1", "opflashTPC2", "opflashTPC3"]
 
+#Turn off DuplicateEventTracker
+services.DuplicateEventTracker: @erase
+
 


### PR DESCRIPTION
…anks Gianluca!). Note I am only adding these to the EVD fcls in the main directory and not the overburden directory.

NOTE: I only tested this out on a custom event display fcl using version v09_22_01 with data and not a checked out version of the default ones for simulation, but this seems like a rather minor change. Let me know if more formal testing/etc. is desired before merging.