### PR TITLE
Some fixes to trigger simulation

### DIFF
--- a/icaruscode/PMT/Trigger/Algorithms/details/TriggerInfo_t.h
+++ b/icaruscode/PMT/Trigger/Algorithms/details/TriggerInfo_t.h
@@ -220,11 +220,14 @@ struct icarus::trigger::details::TriggerInfo_t {
  *   if (info) triggerInfo.add(info.value());
  * } // while
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * fills `triggerInfo` with all the openings above level `6U`.
- * Each opening is defined as from when `gate` reaches the specified threshold
- * to when it goes below it, with no dead time afterward.
+ * fills `triggerInfo` with all the openings equal or above level `6U`.
+ * Each opening is defined as from when `gate` reaches a specified threshold
+ * ("opening threshold") to when it reaches or goes below another one ("closing
+ * threshold"), with no dead time afterward.
  * The time of the opening is the time when threshold is passed, but
  * _the reported level is the maximum in the opening range_.
+ * By default, the closing threshold is one less than the opening one (i.e. as
+ * soon as the level goes below the opening threshold, the gate closes).
  * 
  * This algorithm will not work in multi-threading.
  */
@@ -260,7 +263,7 @@ class icarus::trigger::details::GateOpeningInfoExtractor {
       , location(location)
       {}
     
-    Config_t(OpeningCount_t threshold): Config_t(threshold, threshold) {}
+    Config_t(OpeningCount_t threshold): Config_t(threshold, threshold - 1) {}
     
   }; // struct Config_t
   

--- a/icaruscode/PMT/Trigger/Algorithms/details/TriggerInfo_t.h
+++ b/icaruscode/PMT/Trigger/Algorithms/details/TriggerInfo_t.h
@@ -407,15 +407,20 @@ auto icarus::trigger::details::GateOpeningInfoExtractor<Gate>::findNextOpening()
 {
   if (atEnd()) return {};
   
+  using ClockDiff_t = decltype( ClockTick_t{} - ClockTick_t{} );
+  
   ClockTick_t const start = nextStart;
   ClockTick_t closing;
   do {
     std::tie(closing, nextStart) = findNextCloseAndOpen(nextStart);
     if (nextStart == Gate_t::MaxTick) break;
-  } while((closing - start < minWidth()) || (nextStart - closing < minGap()));
+  } while(
+    (closing - start < static_cast<ClockDiff_t>(minWidth()))
+    || (nextStart - closing < static_cast<ClockDiff_t>(minGap()))
+  );
   
   return std::optional<OpeningInfo_t>{ std::in_place,
-    detinfo::DetectorTimings::optical_tick{ start },
+    detinfo::timescales::optical_tick{ start },
     gate.openingCount(gate.findMaxOpen(start, closing)),
     location()
     };

--- a/icaruscode/PMT/Trigger/MajorityTriggerEfficiencyPlots_module.cc
+++ b/icaruscode/PMT/Trigger/MajorityTriggerEfficiencyPlots_module.cc
@@ -749,14 +749,16 @@ void icarus::trigger::MajorityTriggerEfficiencyPlots::plotResponses(
     if (maxPrimitivesInCryo.second > maxPrimitives.second)
       maxPrimitives = maxPrimitivesInCryo;
 
-    mf::LogTrace(helper().logCategory())
-      << "Max primitive count in " << threshold << " for C:" << iCryo << ": "
-      << maxPrimitivesInCryo.second << " at tick "
-      << maxPrimitivesInCryo.first << " ("
-      << detinfo::DetectorTimings(clockData).toElectronicsTime
-        (detinfo::DetectorTimings::optical_tick{ maxPrimitivesInCryo.first })
-      << ")"
-      ;
+    mf::LogTrace log { helper().logCategory() };
+    log << "Max primitive count in " << threshold << " for C:" << iCryo << ": "
+      << maxPrimitivesInCryo.second;
+    if (maxPrimitivesInCryo.second > 0) {
+      log << " at tick " << maxPrimitivesInCryo.first << " ("
+        << detinfo::DetectorTimings(clockData).toElectronicsTime
+          (detinfo::DetectorTimings::optical_tick{ maxPrimitivesInCryo.first })
+        << ")"
+        ;
+    } // if
   } // for
   
   PMTInfo_t const PMTinfo { threshold, channelList };
@@ -906,21 +908,13 @@ auto icarus::trigger::MajorityTriggerEfficiencyPlots::combineTriggerPrimitives(
       << "Simulating trigger response with ADC threshold " << threshold
       << " for " << cryoID << " (" << gates.size() << " primitives)";
 
-    if (gates.empty()) { // this is unexpected...
-      mf::LogWarning(helper().logCategory())
-        << "No trigger primitive found for threshold " << threshold
-        << " in " << cryoID;
-      return {};
-    } // if no gates
-
     cryoCombinedGate.push_back(icarus::trigger::sumGates(gates));
   } // for
 
   //
-  // largest number of trigger primitives at any time for any cryostat
+  // largest number of trigger primitives at any time, per cryostat
   //
   return cryoCombinedGate;
-//   return icarus::trigger::maxGates(cryoCombinedGate);
   
 } // icarus::trigger::MajorityTriggerEfficiencyPlots::combineTriggerPrimitives()
 

--- a/test/PMT/Trigger/Algorithms/CMakeLists.txt
+++ b/test/PMT/Trigger/Algorithms/CMakeLists.txt
@@ -1,0 +1,5 @@
+cet_test(TriggerInfo_t_test
+  LIBRARIES
+    sbnobj_ICARUS_PMT_Trigger_Data
+  USE_BOOST_UNIT
+  )

--- a/test/PMT/Trigger/Algorithms/TriggerInfo_t_test.cc
+++ b/test/PMT/Trigger/Algorithms/TriggerInfo_t_test.cc
@@ -1,0 +1,211 @@
+/**
+ * @file TriggerInfo_t_test.cc
+ * @brief Unit test for utilities in `TriggerInfo_t.h`
+ * @date July 8, 2021
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see icaruscode/PMT/Trigger/Algorithms/details/TriggerInfo_t.h
+ * 
+ * Largely incomplete.
+ */
+
+// ICARUS libraries
+#include "icaruscode/PMT/Trigger/Algorithms/details/TriggerInfo_t.h"
+#include "sbnobj/ICARUS/PMT/Trigger/Data/TriggerGateData.h"
+
+// LArSoft libraries
+#include "lardataalg/DetectorInfo/DetectorTimingTypes.h"
+
+// Boost libraries
+#define BOOST_TEST_MODULE ( TriggerGateData_test )
+#include <cetlib/quiet_unit_test.hpp> // BOOST_AUTO_TEST_CASE()
+#include <boost/test/test_tools.hpp> // BOOST_CHECK(), BOOST_CHECK_EQUAL()
+
+
+// -----------------------------------------------------------------------------
+// --- implementation detail tests
+// -----------------------------------------------------------------------------
+
+icarus::trigger::TriggerGateData<int, int> TestedInputGate() {
+  
+  // prepare the input:
+  icarus::trigger::TriggerGateData<int, int> gate;
+  
+  BOOST_CHECK(gate.alwaysClosed());
+  
+  /*
+   *   ^                     12                    34
+   * 4 |                       ===   20              ===
+   * 3 |     -4       4    10     ==   === 26
+   * 2 |       ===  2  ===   ==  15 ===      ===         40
+   * 1 |             ==  7===      17   23=== 29==     37  ===
+   * 0-*=======---=|=---,----,----,----,----,----,===-,-===,--===============
+   *    -10  -5    0    5   10        20        30        40        50
+   */
+  
+  gate.openBetween(-4, -1, 2); // -> 2
+  gate.openAt ( 2);    // -> 1
+  gate.openAt ( 4);    // -> 2
+  gate.closeAt( 7);    // -> 1
+  gate.openAt (10);    // -> 2
+  gate.openAt (12, 2); // -> 4
+  gate.closeAt(15);    // -> 3
+  gate.closeAt(17);    // -> 2
+  gate.openAt (20);    // -> 3
+  gate.closeAt(23, 2); // -> 1
+  gate.openAt (26);    // -> 2
+  gate.closeAt(29);    // -> 1
+  gate.closeAt(31);    // -> 0
+  gate.openAt (34, 4); // -> 4
+  gate.closeAt(37, 4); // -> 0
+  gate.openAt (40);    // -> 1
+  gate.closeAt(43);    // -> 0
+  
+  BOOST_CHECK(!gate.alwaysClosed());
+  BOOST_CHECK_EQUAL(gate.openingCount(-9), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(-8), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(-7), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(-6), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(-5), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(-4), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(-3), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(-2), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(-1), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount( 0), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount( 1), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount( 2), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount( 3), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount( 4), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount( 5), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount( 6), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount( 7), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount( 8), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount( 9), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(10), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(11), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(12), 4);
+  BOOST_CHECK_EQUAL(gate.openingCount(13), 4);
+  BOOST_CHECK_EQUAL(gate.openingCount(14), 4);
+  BOOST_CHECK_EQUAL(gate.openingCount(15), 3);
+  BOOST_CHECK_EQUAL(gate.openingCount(16), 3);
+  BOOST_CHECK_EQUAL(gate.openingCount(17), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(18), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(19), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(20), 3);
+  BOOST_CHECK_EQUAL(gate.openingCount(21), 3);
+  BOOST_CHECK_EQUAL(gate.openingCount(22), 3);
+  BOOST_CHECK_EQUAL(gate.openingCount(23), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(24), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(25), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(26), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(27), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(28), 2);
+  BOOST_CHECK_EQUAL(gate.openingCount(29), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(30), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(31), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(32), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(33), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(34), 4);
+  BOOST_CHECK_EQUAL(gate.openingCount(35), 4);
+  BOOST_CHECK_EQUAL(gate.openingCount(36), 4);
+  BOOST_CHECK_EQUAL(gate.openingCount(37), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(38), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(39), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(40), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(41), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(42), 1);
+  BOOST_CHECK_EQUAL(gate.openingCount(43), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(44), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(45), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(46), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(47), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(48), 0);
+  BOOST_CHECK_EQUAL(gate.openingCount(49), 0);
+ 
+  BOOST_CHECK_EQUAL(gate.findMaxOpen(  ), 12);
+  BOOST_CHECK_EQUAL(gate.findMaxOpen(12), 12);
+  BOOST_CHECK_EQUAL(gate.findMaxOpen(13), 13);
+  BOOST_CHECK_EQUAL(gate.findMaxOpen(14), 14);
+  BOOST_CHECK_EQUAL(gate.findMaxOpen(15), 34);
+  
+  auto [ lower2031, upper2031 ] = gate.openingRange(20, 30);
+  BOOST_CHECK_EQUAL(lower2031, 1);
+  BOOST_CHECK_EQUAL(upper2031, 4);
+  
+  return gate;
+} // TestedInputGate()
+
+
+void GateOpeningInfoExtractor_test() {
+  
+  // prepare the input:
+  icarus::trigger::TriggerGateData<int, int> const gate { TestedInputGate() };
+  
+  /*
+   *   ^                     12                    34
+   * 4 |                       ===   20              ===
+   * 3 |     -4       4    10     ==   === 26
+   * 2 |       ===  2  ===   ==  15 ===      ===         40
+   * 1 |             ==  7===      17   23=== 29==     37  ===
+   * 0-*=======---=|=---,----,----,----,----,----,===-,-===,--===============
+   *    -10  -5    0    5   10        20        30        40        50
+   */
+  
+  icarus::trigger::details::GateOpeningInfoExtractor extract { gate, 2U };
+  
+  BOOST_CHECK_EQUAL(extract.openThreshold(),  2U);
+  BOOST_CHECK_EQUAL(extract.closeThreshold(), 1U);
+  BOOST_CHECK_EQUAL(extract.minGap(),         0U);
+  BOOST_CHECK_EQUAL(extract.minWidth(),       1U);
+  
+  BOOST_CHECK(!extract.atEnd());
+  
+  auto opening = extract.findNextOpening();
+  BOOST_CHECK(opening);
+  BOOST_CHECK_EQUAL(opening.value().tick.value(), -4);
+  BOOST_CHECK_EQUAL(opening.value().level,         2);
+  BOOST_CHECK(!extract.atEnd());
+  
+  opening = extract.findNextOpening();
+  BOOST_CHECK(opening);
+  BOOST_CHECK_EQUAL(opening.value().tick.value(),  4);
+  BOOST_CHECK_EQUAL(opening.value().level,         2);
+  BOOST_CHECK(!extract.atEnd());
+  
+  opening = extract.findNextOpening();
+  BOOST_CHECK(opening);
+  BOOST_CHECK_EQUAL(opening.value().tick.value(), 10);
+  BOOST_CHECK_EQUAL(opening.value().level,         4);
+  BOOST_CHECK(!extract.atEnd());
+  
+  opening = extract.findNextOpening();
+  BOOST_CHECK(opening);
+  BOOST_CHECK_EQUAL(opening.value().tick.value(), 26);
+  BOOST_CHECK_EQUAL(opening.value().level,         2);
+  BOOST_CHECK(!extract.atEnd());
+  
+  opening = extract.findNextOpening();
+  BOOST_CHECK(opening);
+  BOOST_CHECK_EQUAL(opening.value().tick.value(), 34);
+  BOOST_CHECK_EQUAL(opening.value().level,         4);
+  BOOST_CHECK(extract.atEnd());
+  
+  opening = extract.findNextOpening();
+  BOOST_CHECK(!opening);
+  BOOST_CHECK(extract.atEnd());
+  
+} // GateOpeningInfoExtractor_test()
+
+
+// -----------------------------------------------------------------------------
+// BEGIN Test cases  -----------------------------------------------------------
+// -----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(GateOpeningInfoExtractor_testcase) {
+  
+  GateOpeningInfoExtractor_test();
+  
+} // BOOST_AUTO_TEST_CASE(GateOpeningInfoExtractor_testcase)
+
+
+// -----------------------------------------------------------------------------
+// END Test cases  -------------------------------------------------------------
+// -----------------------------------------------------------------------------

--- a/test/PMT/Trigger/CMakeLists.txt
+++ b/test/PMT/Trigger/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Data)
+add_subdirectory(Algorithms)


### PR DESCRIPTION
A couple of fixed to trigger simulation.
I don't have a good perception of how one of them would affect the results.
The other affected the module creating plots from the majority trigger simulation (not the sliding window one, and not the majority trigger simulation module which just produces `raw::Trigger` objects), and would claim no trigger if one of the two cryostats had no channels at all. This could happen when channels from an entire cryostat were ignored upstream in the simulation.