### PR TITLE
c7:prof build cleanup

### DIFF
--- a/icaruscode/Analysis/overburden/OBAnaICARUS_module.cc
+++ b/icaruscode/Analysis/overburden/OBAnaICARUS_module.cc
@@ -58,7 +58,7 @@ public:
 
   // Required functions.
   void analyze(art::Event const& e) override;
-  void beginSubRun(art::SubRun const& sr);
+  void beginSubRun(art::SubRun const& sr) override;
 
   using Point_t = std::array<double, 3>;
 

--- a/icaruscode/CRT/CRTUtils/CMakeLists.txt
+++ b/icaruscode/CRT/CRTUtils/CMakeLists.txt
@@ -1,5 +1,6 @@
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-
+endif()
 art_make(    LIBRARY_NAME icaruscode_CRTUtils
              LIB_LIBRARIES larcorealg_Geometry
                            larcore_Geometry_Geometry_service

--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -64,14 +64,11 @@ namespace sbn {
     /// Returns the name of the specified `bit`. Delegates to `bitName()`.
     template <typename EnumType>
     std::string name(EnumType bit);
-
-    template <typename EnumType>
-    std::vector<std::string> names(mask_t<EnumType> mask);
     
     /// Returns a list of the names of all the bits set in `mask`.
     /// Mask is interpreted as made of only bits of type `EnumType`.
-    template <typename Mask>
-    std::vector<std::string> names(Mask mask);
+    template <typename EnumType>
+    std::vector<std::string> names(mask_t<EnumType> mask);
     
     /// @}
     // --- END ---- Generic bit functions --------------------------------------

--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -64,6 +64,9 @@ namespace sbn {
     /// Returns the name of the specified `bit`. Delegates to `bitName()`.
     template <typename EnumType>
     std::string name(EnumType bit);
+
+    template <typename EnumType>
+    std::vector<std::string> names(mask_t<EnumType> mask);
     
     /// Returns a list of the names of all the bits set in `mask`.
     /// Mask is interpreted as made of only bits of type `EnumType`.

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -1667,6 +1667,20 @@ auto icarus::DaqDecoderICARUSPMT::processBoardFragments(
 } // icarus::DaqDecoderICARUSPMT::processBoardFragments()
 
 
+template <std::size_t NBits, typename T>
+constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
+icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
+
+  std::pair<std::array<std::size_t, NBits>, std::size_t> res;
+  auto& [ indices, nSetBits ] = res;
+  for (std::size_t& index: indices) {
+    index = (value & 1)? nSetBits++: NBits;
+    value >>= 1;
+  } // for
+  return res;
+
+} // icarus::DaqDecoderICARUSPMT::setBitIndices()
+
 //------------------------------------------------------------------------------
 auto icarus::DaqDecoderICARUSPMT::processFragment(
   artdaq::Fragment const& artdaqFragment,
@@ -2229,7 +2243,7 @@ unsigned int icarus::DaqDecoderICARUSPMT::extractTriggerTimeTag
   sbndaq::CAENV1730Fragment const V1730fragment { fragment };
   sbndaq::CAENV1730EventHeader const header = V1730fragment.Event()->Header;
   
-  return { header.triggerTimeTag }; // prevent narrowing
+  return  header.triggerTimeTag ; // prevent narrowing
   
 } // icarus::DaqDecoderICARUSPMT::extractTriggerTimeTag()
 
@@ -2252,7 +2266,7 @@ void icarus::DaqDecoderICARUSPMT::sortWaveforms
 
 
 //------------------------------------------------------------------------------
-template <std::size_t NBits, typename T>
+/*template <std::size_t NBits, typename T>
 constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
 icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
   
@@ -2265,7 +2279,7 @@ icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
   return res;
   
 } // icarus::DaqDecoderICARUSPMT::setBitIndices()
-
+*/
 
 //------------------------------------------------------------------------------
 void icarus::DaqDecoderICARUSPMT::initTrees

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -1018,6 +1018,24 @@ namespace icarus {
 //------------------------------------------------------------------------------
 // --- icarus::DaqDecoderICARUSPMT
 //------------------------------------------------------------------------------
+// --- template implementation
+//------------------------------------------------------------------------------
+template <std::size_t NBits, typename T>
+constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
+icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
+  
+  std::pair<std::array<std::size_t, NBits>, std::size_t> res;
+  auto& [ indices, nSetBits ] = res;
+  for (std::size_t& index: indices) {
+    index = (value & 1)? nSetBits++: NBits;
+    value >>= 1;
+  } // for
+  return res;
+  
+} // icarus::DaqDecoderICARUSPMT::setBitIndices()
+
+
+//------------------------------------------------------------------------------
 icarus::DaqDecoderICARUSPMT::TreeNameList_t const
 icarus::DaqDecoderICARUSPMT::TreeNames
   = icarus::DaqDecoderICARUSPMT::initTreeNames();
@@ -1667,20 +1685,6 @@ auto icarus::DaqDecoderICARUSPMT::processBoardFragments(
 } // icarus::DaqDecoderICARUSPMT::processBoardFragments()
 
 
-template <std::size_t NBits, typename T>
-constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
-icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
-
-  std::pair<std::array<std::size_t, NBits>, std::size_t> res;
-  auto& [ indices, nSetBits ] = res;
-  for (std::size_t& index: indices) {
-    index = (value & 1)? nSetBits++: NBits;
-    value >>= 1;
-  } // for
-  return res;
-
-} // icarus::DaqDecoderICARUSPMT::setBitIndices()
-
 //------------------------------------------------------------------------------
 auto icarus::DaqDecoderICARUSPMT::processFragment(
   artdaq::Fragment const& artdaqFragment,
@@ -2243,7 +2247,8 @@ unsigned int icarus::DaqDecoderICARUSPMT::extractTriggerTimeTag
   sbndaq::CAENV1730Fragment const V1730fragment { fragment };
   sbndaq::CAENV1730EventHeader const header = V1730fragment.Event()->Header;
   
-  return  header.triggerTimeTag ; // prevent narrowing
+  unsigned int TTT { header.triggerTimeTag }; // prevent narrowing
+  return TTT;
   
 } // icarus::DaqDecoderICARUSPMT::extractTriggerTimeTag()
 
@@ -2264,22 +2269,6 @@ void icarus::DaqDecoderICARUSPMT::sortWaveforms
 
 } // icarus::DaqDecoderICARUSPMT::sortWaveforms()
 
-
-//------------------------------------------------------------------------------
-/*template <std::size_t NBits, typename T>
-constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
-icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
-  
-  std::pair<std::array<std::size_t, NBits>, std::size_t> res;
-  auto& [ indices, nSetBits ] = res;
-  for (std::size_t& index: indices) {
-    index = (value & 1)? nSetBits++: NBits;
-    value >>= 1;
-  } // for
-  return res;
-  
-} // icarus::DaqDecoderICARUSPMT::setBitIndices()
-*/
 
 //------------------------------------------------------------------------------
 void icarus::DaqDecoderICARUSPMT::initTrees

--- a/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
@@ -199,7 +199,7 @@ private:
     unsigned int                                                fCoherentNoiseGrouping;      ///< Number of consecutive channels in coherent noise subtraction
     unsigned int                                                fCoherentNoiseOffset;        ///< Offset for the midplane...
     unsigned int                                                fMorphologicalWindow;        ///< Window size for filter
-    bool                                                        fOutputStats;                ///< Output of timiing statistics?
+//    bool                                                        fOutputStats;                ///< Output of timiing statistics?
     float                                                       fCoherentThresholdFactor;    ///< Threshold factor for coherent noise removal
 
     // Parameters for the ROI finding
@@ -593,7 +593,7 @@ void DaqDecoderICARUSTPCwROI::processSingleFragment(size_t                      
 
     std::string boardIDs = "";
 
-    for(const auto& id : boardIDVec) boardIDs += id + " ";
+    for(const auto& id : boardIDVec) boardIDs += id + std::string(" ");
 
     mf::LogDebug(fLogCategory) << "   - # boards: " << boardIDVec.size() << ", boards: " << boardIDs;
 

--- a/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
@@ -593,7 +593,7 @@ void DaqDecoderICARUSTPCwROI::processSingleFragment(size_t                      
 
     std::string boardIDs = "";
 
-    for(const auto& id : boardIDVec) boardIDs += id + std::string(" ");
+    for(const auto& id : boardIDVec) boardIDs += std::to_string(id) + " ";
 
     mf::LogDebug(fLogCategory) << "   - # boards: " << boardIDVec.size() << ", boards: " << boardIDs;
 

--- a/icaruscode/Decode/DecoderTools/PMTDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/PMTDecoder_tool.cc
@@ -406,10 +406,10 @@ public:
     virtual void configure(const fhicl::ParameterSet&) override;
 
     /// Reads the PMT configuration from the run.
-    virtual void setupRun(art::Run const& run);
+    virtual void setupRun(art::Run const& run) override;
 
     /// Will read trigger information one day if needed.
-    virtual void setupEvent(art::Event const& event);
+    virtual void setupEvent(art::Event const& event) override;
     
     /**
      *  @brief Initialize any data products the tool will output
@@ -800,6 +800,21 @@ void daq::PMTDecoder::initializeDataProducts()
     fOpDetWaveformCollection = OpDetWaveformCollectionPtr(new OpDetWaveformCollection);
 }
 
+
+template <std::size_t NBits, typename T>
+constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
+daq::PMTDecoder::setBitIndices(T value) noexcept{
+
+    std::pair<std::array<std::size_t, NBits>, std::size_t> res;
+    auto& [ indices, nSetBits ] = res;
+    for (std::size_t& index: indices) {
+        index = (value & 1)? nSetBits++: NBits;
+        value >>= 1;
+    } // for
+    return res;
+
+} // daq::PMTDecoder::setBitIndices()
+
 void daq::PMTDecoder::process_fragment(const artdaq::Fragment &artdaqFragment)
 {
     size_t const fragment_id = artdaqFragment.fragmentID();
@@ -1134,9 +1149,9 @@ auto daq::PMTDecoder::fetchNeededBoardInfo
 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-template <std::size_t NBits, typename T>
+/*template <std::size_t NBits, typename T>
 constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
-daq::PMTDecoder::setBitIndices(T value) noexcept {
+daq::PMTDecoder::setBitIndices(T value) noexcept{
     
     std::pair<std::array<std::size_t, NBits>, std::size_t> res;
     auto& [ indices, nSetBits ] = res;
@@ -1147,7 +1162,7 @@ daq::PMTDecoder::setBitIndices(T value) noexcept {
     return res;
     
 } // daq::PMTDecoder::setBitIndices()
-
+*/
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 void daq::PMTDecoder::initTrees(std::vector<std::string> const& treeNames) {

--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.cxx
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.cxx
@@ -185,7 +185,7 @@ sbn::PMTconfiguration icarus::PMTconfigurationExtractor::finalize
     
   } // for boards
   
-  return std::move(config);
+  return config;
 } // icarus::PMTconfigurationExtractor::finalize()
 
 

--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
@@ -79,8 +79,8 @@ class icarus::PMTconfigurationExtractorBase {
   
   
   /// Finalizes the content of `config` and returns it.
-  ConfigurationData_t finalize(ConfigurationData_t config) const
-    { return std::move(config); }
+  ConfigurationData_t finalize(ConfigurationData_t config) const;
+    //{ return std::move(config); }
   
   
   /// @}

--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
@@ -79,8 +79,8 @@ class icarus::PMTconfigurationExtractorBase {
   
   
   /// Finalizes the content of `config` and returns it.
-  ConfigurationData_t finalize(ConfigurationData_t config) const;
-    //{ return std::move(config); }
+  ConfigurationData_t finalize(ConfigurationData_t config) const
+    { return config; }
   
   
   /// @}

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -108,7 +108,9 @@ namespace daq
     bool fDebug; //< Use this for debugging this tool
     int fOffset; //< Use this to determine additional correction needed for TAI->UTC conversion from White Rabbit timestamps. Needs to be changed if White Rabbit firmware is changed and the number of leap seconds changes! 
     //Add in trigger data member information once it is selected, current LArSoft object likely not enough as is
-    uint64_t fLastTimeStamp = 0;
+    
+    // uint64_t fLastTimeStamp = 0;
+   
     long fLastEvent = 0;
     
     detinfo::DetectorTimings const fDetTimings; ///< Detector clocks and timings.

--- a/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
@@ -172,7 +172,7 @@ private:
     unsigned int                                                fCoherentNoiseGrouping;      ///< Number of consecutive channels in coherent noise subtraction
     unsigned int                                                fCoherentNoiseOffset;        ///< Offset for the midplane...
     unsigned int                                                fMorphologicalWindow;        ///< Window size for filter
-    bool                                                        fOutputStats;                ///< Output of timiing statistics?
+//    bool                                                        fOutputStats;                ///< Output of timiing statistics?
     float                                                       fCoherentThresholdFactor;    ///< Threshold factor for coherent noise removal
 
     // Parameters for the ROI finding

--- a/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
+++ b/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
@@ -667,18 +667,18 @@ void icarus::opdet::PMTsimulationAlg::ApplySaturation
 void icarus::opdet::PMTsimulationAlg::ClipWaveform
   (Waveform_t& waveform, ADCcount min, ADCcount max)
 {
-  auto const clamper =
+ auto const clamper =
     (min == std::numeric_limits<ADCcount>::min())
       ? ((max == std::numeric_limits<ADCcount>::max())
-        ? std::function{ [](ADCcount s){ return s; } }
-        : std::function{ [max](ADCcount s){ return std::min(s, max); } }
+        ? std::function<ADCcount(ADCcount)>{ [](ADCcount s){ return s; } }
+        : std::function<ADCcount(ADCcount)>{ [max](ADCcount s){ return std::min(s, max); } }
         )
       : ((max == std::numeric_limits<ADCcount>::max())
-        ? std::function{ [min](ADCcount s){ return std::max(s, min); } }
-        : std::function{ [min,max](ADCcount s){ return std::clamp(s, min, max); } }
+        ? std::function<ADCcount(ADCcount)>{ [min](ADCcount s){ return std::max(s, min); } }
+        : std::function<ADCcount(ADCcount)>{ [min,max](ADCcount s){ return std::clamp(s, min, max); } }
         )
       ;
-  
+
   std::for_each(waveform.begin(), waveform.end(),
     [clamper](ADCcount& s){ s = clamper(s); });
   

--- a/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
+++ b/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
@@ -12,7 +12,6 @@
 
 
 // LArSoft libraries
-#include "lardataalg/Utilities/intervals.h" // FIXME bug in lardataalg/Utilities/quantities/electronics.h
 #include "lardataalg/Utilities/quantities/electronics.h" // counts_f
 
 // C++ standard library

--- a/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
@@ -1,5 +1,6 @@
-
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
+endif()
 
 cet_make(
   SUBDIRS

--- a/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
@@ -1,7 +1,3 @@
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-endif()
-
 cet_make(
   SUBDIRS
     "details"

--- a/icaruscode/PMT/Trigger/Algorithms/ManagedTriggerGateBuilder.tcc
+++ b/icaruscode/PMT/Trigger/Algorithms/ManagedTriggerGateBuilder.tcc
@@ -182,10 +182,33 @@ void icarus::trigger::ManagedTriggerGateBuilder::buildChannelGates(
     // we keep track of whether we have no lower or higher thresholds available
     // to simplify the checks;
     // we name them "pp" because they behave (almost) like pointers to pointers
+    #if defined( __GNUC__ )
+    # pragma GCC diagnostic push
+    # if (__GNUC__ <= 9) // last tested with: GCC 9.3.0
+    #  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    # else
+    #  error "Maintenance required here. See comments in the code"
+    /* [20210715 petrillo@slac.stanford.edu] The comments in the code:
+     * GCC 9.3.0 erroneously thinks that `ppXxxerThreshold` value _might_ be
+     * used before initialization. Due to the logic of the program, that is
+     * not the case (unless I am wrong!), and the only "solution" I have found
+     * is to disable the warning; Clang 7 on the other end does not complain.
+     * When GCC is updated and support for GCC 9 is dropped, this situation
+     * should be revisited by attempting the compilation with the warning
+     * still enabled (by just commenting out the #error directive).
+     * If compilation succeeds, this whole block and the `pop` directive below
+     * have become unnecessary and should be removed. Otherwise, the GCC version
+     * in the check above should be bumped up to cover the last tested GCC
+     * (here I went lazy and stuck to just the major version).
+     * I do not know which newer GCC version, if any, solves this issue so far.
+     */
+    # endif // GCC version
+    #endif // GCC
     using ThresholdIterPtr_t
       = std::optional<std::vector<ADCCounts_t>::const_iterator>;
-    ThresholdIterPtr_t ppLowerThreshold; // start at bottom with no lower threshold
-    ThresholdIterPtr_t ppUpperThreshold;
+    // start at bottom with no lower threshold:
+    ThresholdIterPtr_t ppLowerThreshold = std::nullopt;
+    ThresholdIterPtr_t ppUpperThreshold = std::nullopt;
     if (!channelThresholds().empty())
       ppUpperThreshold = channelThresholds().begin(); // std::optional behavior
     
@@ -281,6 +304,10 @@ void icarus::trigger::ManagedTriggerGateBuilder::buildChannelGates(
       } // if opening gate
       
     } // for threshold
+
+    #if defined( __GNUC__ )
+    # pragma GCC diagnostic pop
+    #endif // __clang__
     
   } // for waveforms
   

--- a/icaruscode/PMT/Trigger/Algorithms/SlidingWindowCombinerAlg.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/SlidingWindowCombinerAlg.cxx
@@ -55,7 +55,7 @@ auto icarus::trigger::SlidingWindowCombinerAlg::sortChannels
   (std::vector<raw::Channel_t> channels) -> std::vector<raw::Channel_t>
 {
   std::sort(channels.begin(), channels.end());
-  return channels; // is move() needed?
+  return channels;
 } // icarus::trigger::SlidingWindowCombinerAlg::sortChannels
 
 

--- a/icaruscode/PMT/Trigger/Algorithms/SlidingWindowCombinerAlg.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/SlidingWindowCombinerAlg.cxx
@@ -55,7 +55,7 @@ auto icarus::trigger::SlidingWindowCombinerAlg::sortChannels
   (std::vector<raw::Channel_t> channels) -> std::vector<raw::Channel_t>
 {
   std::sort(channels.begin(), channels.end());
-  return std::move(channels); // is move() needed?
+  return channels; // is move() needed?
 } // icarus::trigger::SlidingWindowCombinerAlg::sortChannels
 
 

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -1,5 +1,6 @@
-
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
+endif()
 
 add_subdirectory(Algorithms)
 add_subdirectory(Utilities)

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -1,7 +1,3 @@
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-endif()
-
 add_subdirectory(Algorithms)
 add_subdirectory(Utilities)
 

--- a/icaruscode/PMT/Trigger/MajorityTriggerEfficiencyPlots_module.cc
+++ b/icaruscode/PMT/Trigger/MajorityTriggerEfficiencyPlots_module.cc
@@ -770,7 +770,9 @@ void icarus::trigger::MajorityTriggerEfficiencyPlots::plotResponses(
    * Note that in this type of plots each event appears in all bins
    * (may be with "fired" or "not fired" on each bin)
    */
-  PrimitiveCount_t lastMinCount { TriggerGateData_t::MinTick, 0 };
+
+  // PrimitiveCount_t lastMinCount { TriggerGateData_t::MinTick, 0 };
+
   bool fired = true; // the final trigger response (changes with requirement)
   
   for (auto [ iReq, minCount ]: util::enumerate(fMinimumPrimitives)) {

--- a/icaruscode/PMT/Trigger/Utilities/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/Utilities/CMakeLists.txt
@@ -1,3 +1,7 @@
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
+endif()
+
 art_make(
   LIB_LIBRARIES
     ${ART_ROOT_IO_TFILE_SUPPORT}

--- a/icaruscode/TPC/SignalProcessing/RecoWire/CMakeLists.txt
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/CMakeLists.txt
@@ -1,5 +1,6 @@
-
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
+endif()
 
 # Add the subfolder containing the deconvolution tools
 add_subdirectory(DeconTools)

--- a/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
@@ -69,9 +69,9 @@ class Decon1DROI : public art::ReplicatedProducer
     // an fft to remove the electronics shaping.     
     explicit Decon1DROI(fhicl::ParameterSet const &, art::ProcessingFrame const&);
     
-    void produce(art::Event& evt, art::ProcessingFrame const&); 
-    void beginJob(); 
-    void endJob();                 
+    void produce(art::Event& evt, art::ProcessingFrame const&) override; 
+ //   void beginJob() override;  
+ //   void endJob() override;                 
     void reconfigure(fhicl::ParameterSet const& p);
     
   private:
@@ -170,6 +170,7 @@ Decon1DROI::Decon1DROI(fhicl::ParameterSet const & pset, art::ProcessingFrame co
         produces< std::vector<recob::Wire> >(rawDigit.instance());
         produces<art::Assns<raw::RawDigit, recob::Wire>>(rawDigit.instance());
     }
+	fEventCount = 0;
 }
 
 //////////////////////////////////////////////////////
@@ -245,7 +246,7 @@ void Decon1DROI::reconfigure(fhicl::ParameterSet const& pset)
 }
 
 //-------------------------------------------------
-void Decon1DROI::beginJob()
+/*void Decon1DROI::beginJob()
 {
     fEventCount = 0;
 } // beginJob
@@ -253,7 +254,7 @@ void Decon1DROI::beginJob()
 //////////////////////////////////////////////////////
 void Decon1DROI::endJob()
 {
-}
+}*/
   
 //////////////////////////////////////////////////////
 void Decon1DROI::produce(art::Event& evt, art::ProcessingFrame const& frame)


### PR DESCRIPTION
1. Change in all `CMakeLists.txt` files is the same. Since `-Wno-maybe-uninitialized` is not supported by clang, it is made exclusive for GNU compiler
2. In `icaruscode/Analysis/overburden/OBAnaICARUS_module.cc` added override to funcion declaration
3. In `icaruscode/Decode/BeamBits.h` put names template in namespace
4. In `icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h` deleted one return statement since it is declared in cxx
file
5. In `icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.cxx` and `icaruscode/PMT/Trigger/Algorithms/SlidingWindowCombinerAlg.cxx` removed std::move as redundand use
6. In `icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx` added template statemens to std::function around lumbda functions to make it work (review?)
7. In `icaruscode/Decode/DaqDecoderICARUSPMT_module.cc` remove brackets around scalar initializer
8. In `icaruscode/PMT/Trigger/MajorityTriggerEfficiencyPlots_module.cc` commented out unused variable
9. In `icaruscode/Decode/DecoderTools/PMTDecoder_tool.cc` mark function as override and moved function setBitIndices defenition prior to its use
10. In `icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc` commented unused privet variable
11. In `icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc` since to add `int` and `" "` changed `" "` to `std::string(" ")` as a solution (please review?)
12. In `icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc` removed `beginJob()` and `endJob()` public functions since they override one's from initial class. The private field `fEvent` declaration is moved from `beginJob()` to constructor (review?)
13. In `icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc` commented out unused variables