### PR TITLE
Suggestions for pull request #203

### DIFF
--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -64,14 +64,11 @@ namespace sbn {
     /// Returns the name of the specified `bit`. Delegates to `bitName()`.
     template <typename EnumType>
     std::string name(EnumType bit);
-
-    template <typename EnumType>
-    std::vector<std::string> names(mask_t<EnumType> mask);
     
     /// Returns a list of the names of all the bits set in `mask`.
     /// Mask is interpreted as made of only bits of type `EnumType`.
-    template <typename Mask>
-    std::vector<std::string> names(Mask mask);
+    template <typename EnumType>
+    std::vector<std::string> names(mask_t<EnumType> mask);
     
     /// @}
     // --- END ---- Generic bit functions --------------------------------------

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -1018,6 +1018,24 @@ namespace icarus {
 //------------------------------------------------------------------------------
 // --- icarus::DaqDecoderICARUSPMT
 //------------------------------------------------------------------------------
+// --- template implementation
+//------------------------------------------------------------------------------
+template <std::size_t NBits, typename T>
+constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
+icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
+  
+  std::pair<std::array<std::size_t, NBits>, std::size_t> res;
+  auto& [ indices, nSetBits ] = res;
+  for (std::size_t& index: indices) {
+    index = (value & 1)? nSetBits++: NBits;
+    value >>= 1;
+  } // for
+  return res;
+  
+} // icarus::DaqDecoderICARUSPMT::setBitIndices()
+
+
+//------------------------------------------------------------------------------
 icarus::DaqDecoderICARUSPMT::TreeNameList_t const
 icarus::DaqDecoderICARUSPMT::TreeNames
   = icarus::DaqDecoderICARUSPMT::initTreeNames();
@@ -1667,20 +1685,6 @@ auto icarus::DaqDecoderICARUSPMT::processBoardFragments(
 } // icarus::DaqDecoderICARUSPMT::processBoardFragments()
 
 
-template <std::size_t NBits, typename T>
-constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
-icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
-
-  std::pair<std::array<std::size_t, NBits>, std::size_t> res;
-  auto& [ indices, nSetBits ] = res;
-  for (std::size_t& index: indices) {
-    index = (value & 1)? nSetBits++: NBits;
-    value >>= 1;
-  } // for
-  return res;
-
-} // icarus::DaqDecoderICARUSPMT::setBitIndices()
-
 //------------------------------------------------------------------------------
 auto icarus::DaqDecoderICARUSPMT::processFragment(
   artdaq::Fragment const& artdaqFragment,
@@ -2243,7 +2247,8 @@ unsigned int icarus::DaqDecoderICARUSPMT::extractTriggerTimeTag
   sbndaq::CAENV1730Fragment const V1730fragment { fragment };
   sbndaq::CAENV1730EventHeader const header = V1730fragment.Event()->Header;
   
-  return  header.triggerTimeTag ; // prevent narrowing
+  unsigned int TTT { header.triggerTimeTag }; // prevent narrowing
+  return TTT;
   
 } // icarus::DaqDecoderICARUSPMT::extractTriggerTimeTag()
 
@@ -2264,22 +2269,6 @@ void icarus::DaqDecoderICARUSPMT::sortWaveforms
 
 } // icarus::DaqDecoderICARUSPMT::sortWaveforms()
 
-
-//------------------------------------------------------------------------------
-/*template <std::size_t NBits, typename T>
-constexpr std::pair<std::array<std::size_t, NBits>, std::size_t>
-icarus::DaqDecoderICARUSPMT::setBitIndices(T value) noexcept {
-  
-  std::pair<std::array<std::size_t, NBits>, std::size_t> res;
-  auto& [ indices, nSetBits ] = res;
-  for (std::size_t& index: indices) {
-    index = (value & 1)? nSetBits++: NBits;
-    value >>= 1;
-  } // for
-  return res;
-  
-} // icarus::DaqDecoderICARUSPMT::setBitIndices()
-*/
 
 //------------------------------------------------------------------------------
 void icarus::DaqDecoderICARUSPMT::initTrees

--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
@@ -79,8 +79,8 @@ class icarus::PMTconfigurationExtractorBase {
   
   
   /// Finalizes the content of `config` and returns it.
-  ConfigurationData_t finalize(ConfigurationData_t config) const;
-    //{ return std::move(config); }
+  ConfigurationData_t finalize(ConfigurationData_t config) const
+    { return config; }
   
   
   /// @}

--- a/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
+++ b/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
@@ -12,7 +12,6 @@
 
 
 // LArSoft libraries
-#include "lardataalg/Utilities/intervals.h" // FIXME bug in lardataalg/Utilities/quantities/electronics.h
 #include "lardataalg/Utilities/quantities/electronics.h" // counts_f
 
 // C++ standard library

--- a/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt
@@ -1,7 +1,3 @@
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-endif()
-
 cet_make(
   SUBDIRS
     "details"

--- a/icaruscode/PMT/Trigger/Algorithms/ManagedTriggerGateBuilder.tcc
+++ b/icaruscode/PMT/Trigger/Algorithms/ManagedTriggerGateBuilder.tcc
@@ -182,10 +182,33 @@ void icarus::trigger::ManagedTriggerGateBuilder::buildChannelGates(
     // we keep track of whether we have no lower or higher thresholds available
     // to simplify the checks;
     // we name them "pp" because they behave (almost) like pointers to pointers
+    #if defined( __GNUC__ )
+    # pragma GCC diagnostic push
+    # if (__GNUC__ <= 9) // last tested with: GCC 9.3.0
+    #  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    # else
+    #  error "Maintenance required here. See comments in the code"
+    /* [20210715 petrillo@slac.stanford.edu] The comments in the code:
+     * GCC 9.3.0 erroneously thinks that `ppXxxerThreshold` value _might_ be
+     * used before initialization. Due to the logic of the program, that is
+     * not the case (unless I am wrong!), and the only "solution" I have found
+     * is to disable the warning; Clang 7 on the other end does not complain.
+     * When GCC is updated and support for GCC 9 is dropped, this situation
+     * should be revisited by attempting the compilation with the warning
+     * still enabled (by just commenting out the #error directive).
+     * If compilation succeeds, this whole block and the `pop` directive below
+     * have become unnecessary and should be removed. Otherwise, the GCC version
+     * in the check above should be bumped up to cover the last tested GCC
+     * (here I went lazy and stuck to just the major version).
+     * I do not know which newer GCC version, if any, solves this issue so far.
+     */
+    # endif // GCC version
+    #endif // GCC
     using ThresholdIterPtr_t
       = std::optional<std::vector<ADCCounts_t>::const_iterator>;
-    ThresholdIterPtr_t ppLowerThreshold; // start at bottom with no lower threshold
-    ThresholdIterPtr_t ppUpperThreshold;
+    // start at bottom with no lower threshold:
+    ThresholdIterPtr_t ppLowerThreshold = std::nullopt;
+    ThresholdIterPtr_t ppUpperThreshold = std::nullopt;
     if (!channelThresholds().empty())
       ppUpperThreshold = channelThresholds().begin(); // std::optional behavior
     
@@ -281,6 +304,10 @@ void icarus::trigger::ManagedTriggerGateBuilder::buildChannelGates(
       } // if opening gate
       
     } // for threshold
+
+    #if defined( __GNUC__ )
+    # pragma GCC diagnostic pop
+    #endif // __clang__
     
   } // for waveforms
   

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -1,7 +1,3 @@
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
-endif()
-
 add_subdirectory(Algorithms)
 add_subdirectory(Utilities)
 


### PR DESCRIPTION
I am offering a few suggestions/recommendations for pull request #203 pertaining the code I am maintaining:
* `icaruscode/Decode/BeamBits.h`: the type declared for `names()` was wrong and should be replaced (rather than a correct one _added_)
* `icaruscode/Decode/DaqDecoderICARUSPMT_module.cc`:
    * I personally prefer to move the definition of `icarus::DaqDecoderICARUSPMT::setBitIndices()` higher, in a section for templates
    * the functionality of preventing narrowing (compiler will not build the code if narrowing would happen) is restored in `icarus::DaqDecoderICARUSPMT::extractTriggerTimeTag()`
* `icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h`: `finalize()` method of base class is provided a definition (I have been fought on this for a while... not at all a strong opinion here)
* `icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx`: in `ClipWaveform` I prefer to use the same explicit cast for all the four branches
* `icaruscode/PMT/Trigger/Algorithms/ManagedTriggerGateBuilder.tcc`, `icaruscode/PMT/Trigger/Algorithms/CMakeLists.txt`, `icaruscode/PMT/Trigger/CMakeLists.txt`: with these changes, the `maybe-uninitialized` warning/error will not be emitted anywhere and disabling it is not necessary; the exception is a spot in `ManagedTriggerGateBuilder.tcc`: there, I rather disable the warning locally and preserve it globally, so that errors of that kind can still be recognised by the compiler.

In addition, I am sneaking in here a maintenance change in `icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h`.