### PR TITLE
Updates to PMT and trigger decoding

### DIFF
--- a/fcl/detsim/commissioning/triggersim_icarus.fcl
+++ b/fcl/detsim/commissioning/triggersim_icarus.fcl
@@ -168,6 +168,10 @@ services: {
   #                Geometry, detector properties and clocks
   @table::icarus_common_services
 
+  # art resource tracking services may take a lot of memory on the long run
+  MemoryTracker: @erase
+  TimeTracker:   @erase
+
   # currently unused (remove the line if they start mattering):
   LArPropertiesService:      @erase
   DetectorPropertiesService: @erase

--- a/fcl/detsim/commissioning/triggersim_icarus_data.fcl
+++ b/fcl/detsim/commissioning/triggersim_icarus_data.fcl
@@ -17,6 +17,7 @@
 # ----------------
 #
 #  * optical detector readout: `daqPMT`
+#  * PMT configuration: `PMTconfig` (run data product)
 #
 #
 # Changes
@@ -24,6 +25,8 @@
 # 
 # 20210517 (petrillo@slac.stanford.edu) [v1.0]
 # :   original version based on `triggersim_singlemodule_icarus.fcl` v1.0
+# 20210721 (petrillo@slac.stanford.edu) [v1.1]
+# :   rely on `PMTconfig` from decoding (by now it's "standard")
 #
 
 #include "channelmapping_icarus.fcl"
@@ -48,18 +51,11 @@ physics.producers.pmtbaselines.OpticalWaveforms: "daqPMT"
 
 #
 # additional modules:
-#  * PMT configuration from metadata
+#  * PMT configuration from data product
 #  * baseline from PMT configuration
 #  * discrimination from PMT configuration
 #
 services.IICARUSChannelMap: @local::icarus_channelmappinggservice
-
-
-physics.producers.pmtconfig: {
-
-  module_type: PMTconfigurationExtraction
-
-} # physics.producers.pmtconfig
 
 
 physics.producers.pmtconfigbaselines: {
@@ -70,7 +66,7 @@ physics.producers.pmtconfigbaselines: {
   OpticalWaveforms: "daqPMT"
   
   # label of PMT configuration
-  PMTconfigurationTag: "pmtconfig"
+  PMTconfigurationTag: "PMTconfig"
 
   # produce plots on the extracted baseline
   PlotBaselines: true  # default
@@ -95,7 +91,7 @@ physics.producers.pmtthr: {
   Baselines: "pmtconfigbaselines" # from data products
   
   # threshold configuration
-  ThresholdsFromPMTconfig: "pmtconfig"
+  ThresholdsFromPMTconfig: "PMTconfig"
   NChannels:                360 # to be safe...
   
   #
@@ -167,7 +163,7 @@ physics.producers.discrimopdaq: @erase
 physics.producers.pmtbaselines: @erase
 
 physics.triggerOR: [
-  pmtconfig, pmtconfigbaselines, pmtthr,
+  pmtconfigbaselines, pmtthr,
 
   lvdsgatesOR,
   

--- a/fcl/utilities/find_duplicate_events.fcl
+++ b/fcl/utilities/find_duplicate_events.fcl
@@ -1,0 +1,57 @@
+#
+# File:    find_duplicate_events.fcl
+# Purpose: Prints a list of the duplicate events in the input.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    May 5, 2021
+#
+# This configuration requires to read the content of the input files,
+# and it prints a summary of duplicate events into a
+# `DuplicateEventSummary.log` file.
+# Note that if the production file naming convention allows, it may be
+# much faster to detect duplicate files from that naming convention.
+#
+# Example of usage:
+#     
+#     lar -c find_duplicate_events.fcl -S input.list
+#     
+# will report in `DuplicateEventSummary.log` (and on screen)
+# about all the duplicate events in the files listed in `input.list`.
+# 
+
+process_name: CheckDupl
+
+services: {
+  
+  message: {
+    destinations: {
+      console: {
+        type: cout
+        threshold: INFO
+      } # console
+      summary: {
+        type:      file
+        filename: "DuplicateEventSummary.log"
+        categories: {
+          DuplicateEventTracker: { limit: -1 }
+          default:               { limit:  0 }
+        }
+      } # summary
+    } # destinations
+  } # message
+  
+  DuplicateEventTracker: {
+    # just emit a warning on screen instead of throwing an exception
+    WarningOnly: true
+    
+    # do print a summary of the duplicate events at end of job
+    SkipSummary: false  # default
+
+    # in case of duplicate, wait until the end of job to throw an exception
+    ExceptionAtEnd: true
+
+    LogCategory: "DuplicateEventTracker"  # default
+  }
+  
+} # services
+  
+

--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -17,6 +17,7 @@
 // C/C++ standard libraries
 #include <stdexcept> // std::runtime_error
 #include <string>
+#include <vector>
 #include <initializer_list>
 #include <type_traits> // std::underlying_type_t
 
@@ -66,9 +67,8 @@ namespace sbn {
     std::string name(EnumType bit);
     
     /// Returns a list of the names of all the bits set in `mask`.
-    /// Mask is interpreted as made of only bits of type `EnumType`.
-    template <typename Mask>
-    std::vector<std::string> names(Mask mask);
+    template <typename EnumType>
+    std::vector<std::string> names(mask_t<EnumType> mask);
     
     /// @}
     // --- END ---- Generic bit functions --------------------------------------

--- a/icaruscode/Decode/CMakeLists.txt
+++ b/icaruscode/Decode/CMakeLists.txt
@@ -39,6 +39,7 @@ art_make(
 simple_plugin(DaqDecoderICARUSPMT module
   sbnobj_Common_PMT_Data
   icaruscode_Decode_DecoderTools_Dumpers
+  icaruscode_Decode_DataProducts # should become sbnobj_Common_Trigger
   icaruscode_Decode_DecoderTools
   sbndaq-artdaq-core_Overlays_Common
   sbndaq-artdaq-core_Overlays
@@ -83,5 +84,6 @@ install_source()
 # Add our tools directory
 add_subdirectory(DecoderTools)
 add_subdirectory(ChannelMapping)
+add_subdirectory(DataProducts)
 add_subdirectory(fcl)
 

--- a/icaruscode/Decode/DataProducts/CMakeLists.txt
+++ b/icaruscode/Decode/DataProducts/CMakeLists.txt
@@ -1,0 +1,8 @@
+cet_make( 
+  NO_DICTIONARY
+  )
+
+art_dictionary(DICTIONARY_LIBRARIES icaruscode_Decode_DataProducts)
+
+install_headers()
+install_source()

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
@@ -1,0 +1,123 @@
+/**
+ * @file sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+ * @brief Data product holding additional trigger information.
+ * @authors Gianluca Petrillo (petrillo@slac.stanford.edu),
+ *          Jacob Zettlemoyer (jzettle@fnal.gov>)
+ * @date June 18, 2021
+ * @see sbnobj/Common/Trigger/ExtraTriggerInfo.h
+ */
+
+// #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h" // future location of:
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
+
+// C/C++ standard library
+#include <ostream>
+#include <iomanip> // std::setfill(), std::setw()
+
+
+// -----------------------------------------------------------------------------
+namespace {
+  
+  // ---------------------------------------------------------------------------
+  struct TimestampDumper { std::uint64_t timestamp; };
+  
+  TimestampDumper dumpTimestamp(std::uint64_t timestamp)
+    { return { timestamp }; }
+  
+  std::ostream& operator<< (std::ostream& out, TimestampDumper wrapper) {
+    std::uint64_t const timestamp = wrapper.timestamp;
+    if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
+      out << (timestamp / 1'000'000'000) << "."
+        << std::setfill('0') << std::setw(9) << (timestamp % 1'000'000'000)
+        << " s";
+    }
+    else out << "<n/a>";
+    return out;
+  } // operator<< (TimestampDumper)
+  
+  
+  // ---------------------------------------------------------------------------
+  struct TriggerIDdumper { unsigned int ID; };
+  
+  TriggerIDdumper dumpTriggerID(unsigned int ID) { return { ID }; }
+  
+  std::ostream& operator<< (std::ostream& out, TriggerIDdumper wrapper) {
+    unsigned int const ID = wrapper.ID;
+    if (sbn::ExtraTriggerInfo::isValidID(ID)) out << ID;
+    else                                      out << "<n/a>";
+    return out;
+  } // operator<< (TriggerIDdumper)
+  
+  
+  // ---------------------------------------------------------------------------
+  struct TriggerCountDumper { unsigned int count; };
+  
+  TriggerCountDumper dumpTriggerCount(unsigned int count) { return { count }; }
+  
+  std::ostream& operator<< (std::ostream& out, TriggerCountDumper wrapper) {
+    unsigned int const count = wrapper.count;
+    if (sbn::ExtraTriggerInfo::isValidCount(count)) out << count;
+    else                                            out << "<n/a>";
+    return out;
+  } // operator<< (TriggerCountDumper)
+  
+  
+  // ---------------------------------------------------------------------------
+  long long int timestampDiff(std::uint64_t timestamp, std::uint64_t ref) {
+    return static_cast<long long int>
+      ((timestamp > ref)? (timestamp - ref): (ref - timestamp));
+  }
+  
+  
+  // ---------------------------------------------------------------------------
+  
+} // local namespace
+
+
+// -----------------------------------------------------------------------------
+std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
+{
+  if (!info.isValid()) {
+    out << "<invalid>";
+    return out;
+  }
+  
+  // quite a load:
+  out
+    <<   "trigger ID=" << dumpTriggerID(info.triggerID) << " from source "
+      << name(info.sourceType)
+      << " at " << dumpTimestamp(info.triggerTimestamp)
+      << " on beam gate ID=" << dumpTriggerID(info.gateID)
+      << " at " << dumpTimestamp(info.beamGateTimestamp)
+      << " (diff: "
+      << timestampDiff(info.beamGateTimestamp, info.triggerTimestamp) << " ns)"
+    << "\n"
+      << "counts from this source: trigger="
+        << dumpTriggerCount(info.triggerCount)
+      << " beam=" << dumpTriggerCount(info.gateCount)
+    << "\n"
+      << "previous trigger from this source at "
+      << dumpTimestamp(info.previousTriggerTimestamp)
+      << ", triggers since: "
+      << dumpTriggerCount(info.anyTriggerCountFromPreviousTrigger)
+      << ", gates since: "
+      << dumpTriggerCount(info.anyGateCountFromPreviousTrigger)
+      << " ("
+      << dumpTriggerCount(info.gateCountFromPreviousTrigger)
+      << " from this same source)"
+    << "\n"
+      << "most recent trigger was from source "
+      << name(info.anyPreviousTriggerSourceType) << " at "
+      << dumpTimestamp(info.anyPreviousTriggerTimestamp)
+      << " ("
+      << dumpTimestamp(info.triggerTimestamp - info.anyPreviousTriggerTimestamp)
+      << " earlier), and "
+      << dumpTriggerCount(info.anyGateCountFromAnyPreviousTrigger)
+      << " gates from any source have opened since"
+    ;
+  
+  return out;
+} // sbn::operator<< (ExtraTriggerInfo)
+
+
+// -----------------------------------------------------------------------------

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
@@ -109,9 +109,17 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << "most recent trigger was from source "
       << name(info.anyPreviousTriggerSourceType) << " at "
       << dumpTimestamp(info.anyPreviousTriggerTimestamp)
+    ;
+  if (sbn::ExtraTriggerInfo::isValidTimestamp(info.anyPreviousTriggerTimestamp)
+    && sbn::ExtraTriggerInfo::isValidTimestamp(info.triggerTimestamp))
+  {
+    out
       << " ("
       << dumpTimestamp(info.triggerTimestamp - info.anyPreviousTriggerTimestamp)
-      << " earlier), and "
+      << " earlier)";
+  }
+  out
+      << ", and "
       << dumpTriggerCount(info.anyGateCountFromAnyPreviousTrigger)
       << " gates from any source have opened since"
     ;

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
@@ -1,0 +1,165 @@
+/**
+ * @file sbnobj/Common/Trigger/ExtraTriggerInfo.h
+ * @brief Data product holding additional trigger information.
+ * @authors Gianluca Petrillo (petrillo@slac.stanford.edu),
+ *          Jacob Zettlemoyer (jzettle@fnal.gov>)
+ * @date June 18, 2021
+ * @see sbnobj/Common/Trigger/ExtraTriggerInfo.cxx
+ */
+
+#ifndef SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H
+#define SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H
+
+
+// SBN libraries
+#include "icaruscode/Decode/BeamBits.h"
+
+// C/C++ standard libraries
+#include <iosfwd> // std::ostream
+#include <limits> // std::numeric_limits<>
+#include <cstdint> // std::uint64_t
+
+
+// -----------------------------------------------------------------------------
+namespace sbn { struct ExtraTriggerInfo; }
+/**
+ * @brief Additional information on trigger.
+ * 
+ * This data structure holds information from the trigger that has no place in
+ * the standard LArSoft data products (`raw::Trigger` and
+ * `raw::ExternalTrigger`).
+ * 
+ * Absolute times are counted since The Epoch and are in UTC time.
+ * 
+ * Some "historical" information is available:
+ * *  count of gates and triggers from the start of the run;
+ * *  count of gates and triggers from the previous trigger;
+ * *  timestamps of previous gates and triggers.
+ * 
+ * Some historical information is available for different gate selections:
+ * * including only triggers and gates the same source as this trigger source;
+ * * including triggers and gates from any source (tagged as "any").
+ * 
+ */
+struct sbn::ExtraTriggerInfo {
+  
+  /// Special ID value indicating the absence of an ID.
+  static constexpr unsigned int NoID = std::numeric_limits<unsigned int>::max();
+  
+  /// Special timestamp value indicating the absence of timestamp.
+  static constexpr std::uint64_t NoTimestamp
+    = std::numeric_limits<std::uint64_t>::max();
+  
+  
+  /// Type of this gate (`sbn::triggerSource::NBits` marks this object invalid).
+  sbn::triggerSource sourceType { sbn::triggerSource::NBits };
+  
+  
+  // --- BEGIN -- Since the beginning of the run -------------------------------
+  /// @name Counters and times since the beginning of the run.
+  /// @{
+  
+  /// Absolute timestamp of this trigger [ns]
+  std::uint64_t triggerTimestamp { NoTimestamp };
+  
+  /// Absolute timestamp of the opening of this beam gate [ns]
+  std::uint64_t beamGateTimestamp { NoTimestamp };
+  
+  /// The identifier of this trigger (usually matching the event number).
+  unsigned int triggerID { NoID };
+  
+  /// Incremental counter of gates from any source opened from start of the run.
+  unsigned int gateID { 0 };
+  
+  /// Incremental counter of triggers from this source from start of the run.
+  unsigned int triggerCount { 0 };
+  
+  /// Incremental counter of gates from this source opened from start of the run.
+  unsigned int gateCount { 0 };
+  
+  /// @}
+  // --- END ---- Since the beginning of the run -------------------------------
+  
+  
+  
+  // --- BEGIN -- Since the previous trigger from this same source -------------
+  /// @name Counters since the previous trigger from this same source
+  /// @{
+  
+  /// Gates from this source since the previous trigger also of this source
+  /// (minimum is `1`: the current gate).
+  unsigned int gateCountFromPreviousTrigger { 0 };
+  
+  /// Triggers from any source since the previous trigger also of this source
+  /// (minimum is `1`: the current trigger).
+  unsigned int anyTriggerCountFromPreviousTrigger { 0 };
+  
+  /// Gates from any source since the previous trigger also of this source
+  /// (minimum is `1`: the current trigger).
+  unsigned int anyGateCountFromPreviousTrigger { 0 };
+  
+  /// @}
+  // --- END ---- Since the previous trigger from this same source -------------
+  
+  
+  // --- BEGIN -- Since the previous trigger from any source -------------------
+  /// @name Counters since the previous trigger from any source
+  /// @{
+  
+  /// Type of the previous trigger.
+  sbn::triggerSource anyPreviousTriggerSourceType
+    { sbn::triggerSource::Unknown };
+  
+  /// Gates from any source since the previous trigger also from any source
+  /// (minimum is `1`: the current gate).
+  unsigned int anyGateCountFromAnyPreviousTrigger { 0 };
+  
+  /// @}
+  // --- END ---- Since the previous trigger from any source -------------------
+  
+  
+  // --- BEGIN -- Additional timestamps ----------------------------------------
+  /// @name Additional timestamps
+  /// @{
+  
+  // we do not have timestamps of gates not associated to triggers
+  
+  /// Absolute timestamp of the previous trigger from this same source [ns]
+  std::uint64_t previousTriggerTimestamp { NoTimestamp };
+  
+  /// Absolute timestamp of the previous trigger from any source [ns]
+  std::uint64_t anyPreviousTriggerTimestamp { NoTimestamp };
+  
+  /// @}
+  // --- END ---- Additional timestamps ----------------------------------------
+  
+  
+  /// Returns whether this object contains any valid information.
+  constexpr bool isValid() const noexcept
+    { return sourceType != sbn::triggerSource::NBits; }
+  
+  
+  /// Returns whether the specified `ID` is valid (i.e. is not `NoID`).
+  static constexpr bool isValidID(unsigned int ID) noexcept
+    { return ID != NoID; }
+  
+  /// Returns whether the timestamp `ts` is valid (i.e. is not `NoTimestamp`).
+  static constexpr bool isValidTimestamp(std::uint64_t ts) noexcept
+    { return ts != NoTimestamp; }
+  
+  /// Returns whether the `count` is valid (i.e. is not `0`).
+  static constexpr bool isValidCount(unsigned int count) noexcept
+    { return count != 0U; }
+  
+  
+}; // sbn::ExtraTriggerInfo
+
+
+namespace sbn {
+  std::ostream& operator<< (std::ostream& out, ExtraTriggerInfo const& info);
+}
+
+// -----------------------------------------------------------------------------
+
+
+#endif // SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H

--- a/icaruscode/Decode/DataProducts/classes.h
+++ b/icaruscode/Decode/DataProducts/classes.h
@@ -1,0 +1,26 @@
+/**
+ * @file   sbnobj/Common/Trigger/classes.h
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 10, 2019
+ * 
+ * Enables dictionary definitions for:
+ * 
+ * * `sbn::ExtraTriggerInfo`
+ * 
+ * See also `sbnobj/Common/Trigger/classes_def.xml`.
+ */
+
+// SBN libraries
+// #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
+
+// framework libraries
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/Wrapper.h"
+
+
+namespace {
+  
+  sbn::ExtraTriggerInfo tinfo;
+  
+} // local namespace

--- a/icaruscode/Decode/DataProducts/classes_def.xml
+++ b/icaruscode/Decode/DataProducts/classes_def.xml
@@ -1,0 +1,66 @@
+<!--
+  
+  ROOT dictionary generation for:
+  
+  * `sbn::ExtraTriggerInfo`
+  
+  
+  Reminder:
+  
+  * include `art::Wrapper` lines for objects that we would like to put into the event
+  * include the non-wrapper lines for all objects on the `art::Wrapper` lines
+    and for all objects that are data members of those objects.
+  
+  -->
+
+
+<lcgdict>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!-- sbn::ExtraTriggerInfo -->
+
+  <!--   class -->
+  <class name="sbn::ExtraTriggerInfo" ClassVersion="10" >
+   <version ClassVersion="10" checksum="2751074963"/>
+  </class>
+  
+    <!-- dependencies -->
+    <enum name="sbn::bits::triggerSource" ClassVersion="10" />
+
+    <!-- art pointers and wrappers -->
+    <class name="art::Ptr<sbn::ExtraTriggerInfo>"/>
+    <class name="art::Wrapper<sbn::ExtraTriggerInfo>"/>
+
+
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!-- copy&paste templates for: -->
+  <!-- PROD -->
+
+    <!-- class -->
+  <!--
+  <class name="PROD"/>
+  -->
+
+    <!-- schema evolution rules -->
+      <!-- version 11 -->
+    
+    <!-- dependencies -->
+    <!-- art pointers and wrappers -->
+      <!-- data product collection (PROD) -->
+  <!--
+  <class name="art::Ptr<PROD>"/>
+  <class name="std::vector<PROD>"/>
+  <class name="art::Wrapper<std::vector<PROD>>"/>
+    -->
+
+    <!-- associations and wrappers (PROD <==> OTHER) -->
+  <!--
+  <class name="art::Assns<PROD, OTHER, void>"/>
+  <class name="art::Assns<OTHER, PROD, void>"/>
+  <class name="std::pair<art::Ptr<PROD>, art::Ptr<OTHER>>"/>
+  <class name="art::Wrapper<art::Assns<OTHER, PROD, void>>"/>
+  <class name="std::pair<art::Ptr<OTHER>, art::Ptr<PROD>>"/>
+  <class name="art::Wrapper<art::Assns<OTHER, PROD, void>>"/>
+    -->
+
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+</lcgdict>

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -319,7 +319,15 @@ namespace daq
     auto const parsedData = icarus::details::KeyedCSVparser{}(firstLine(data));
     unsigned int beamgate_count { std::numeric_limits<unsigned int>::max() };
     std::uint64_t beamgate_ts { wr_ts }; // we cheat
-    if (auto pBeamGateInfo = parsedData.findItem("Beam_TS"); pBeamGateInfo) {
+    /* [20210717, petrillo@slac.stanford.edu] `(pBeamGateInfo->nValues() == 3)`:
+     * this is an attempt to "support" a few Run0 runs (6017 to roughly 6043)
+     * which have the beam gate information truncated; this workaround should
+     * be removed when there is enough ICARUS data that these runs become
+     * uninteresting.
+     */
+    if (auto pBeamGateInfo = parsedData.findItem("Beam_TS");
+      pBeamGateInfo && (pBeamGateInfo->nValues() == 3)
+    ) {
       // if gate information is found, it must be complete
       beamgate_count = pBeamGateInfo->getNumber<unsigned int>(0U);
       // use the same linear correction for the beam gate timestamp as it was

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -27,6 +27,8 @@
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh"
 
+// #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h" // maybe future location of:
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
 #include "icaruscode/Decode/DecoderTools/IDecoder.h"
 // #include "sbnobj/Common/Trigger/BeamBits.h" // maybe future location of:
 #include "icaruscode/Decode/BeamBits.h" // sbn::triggerSource
@@ -38,8 +40,32 @@
 #include <iostream>
 #include <memory>
 
+
+using namespace std::string_literals;
+
 namespace daq 
 {
+  
+  // --- BEGIN -- TEMPORARY ----------------------------------------------------
+  // remove when SBNSoftware/sbndaq-artdaq-core pull request #31 is in:
+  // https://github.com/SBNSoftware/sbndaq-artdaq-core/pull/31
+  std::uint64_t getNanoseconds_since_UTC_epoch_fix
+    (icarus::ICARUSTriggerInfo const& info)
+  {
+    
+    if(info.wr_seconds == -2 || info.wr_nanoseconds == -3)
+      return 0;
+    int correction = 0;
+    if(info.wr_seconds >= 1483228800)
+      correction = 37;
+    uint64_t const corrected_ts
+      { (info.wr_seconds-correction)*1'000'000'000ULL + info.wr_nanoseconds };
+    return corrected_ts;
+
+  } // getNanoseconds_since_UTC_epoch_fix()
+  // --- END ---- TEMPORARY ----------------------------------------------------
+  
+  
   /**
    * @brief Tool decoding the trigger information from DAQ.
    * 
@@ -72,6 +98,31 @@ namespace daq
    *     * `Width()`: duration of the gate, in nanoseconds; currently set to a
    *         nominal value.
    *     * `BeamType()`: the type of the beam gate being described (BNB, NuMI).
+   * * `sbn::ExtraTriggerInfo`: the most complete collection of information,
+   *     duplicating also some from the other data products. Some of the
+   *     information is not available yet: if a count is not available, its
+   *     value is set to `0` (which is an invalid value because their valid
+   *     range starts with `1` since they include the current event), and if a
+   *     timestamp is not available it is set to
+   *     `sbn::ExtraTriggerInfo::NoTimestamp`; these two conditions can be
+   *     checked with static methods 
+   *     `sbn::ExtraTriggerInfo::isValidTimestamp()` and 
+   *     `sbn::ExtraTriggerInfo::isValidCount()` respectively.
+   *     Note that differently from the usual, this is a _single object_, not
+   *     a collection; also, this data product has no instance name.
+   *     The information already available includes:
+   *     * `sourceType`: the type of beam or trigger source, a value from
+   *         `sbn::triggerSource` (equivalent to `raw::Trigger::TriggerBits()`,
+   *         but in the form of an enumerator rather than a bit mask).
+   *     * `triggerTimestamp`: same as `raw::ExternalTrigger::GetTrigTime()`
+   *         (nanoseconds from the Epoch, Coordinated Universal Time).
+   *     * `beamGateTimestamp`: absolute time of the beam gate opening as
+   *         reported by the trigger hardware, directly comparable with
+   *         `triggerTimestamp` (same scale and unit).
+   *     * `triggerID`: same as `raw::ExternalTrigger::GetTrigID()`. Should
+   *         match the event number.
+   *     * `gateID`: the count of gates since the beginning of the run, as
+   *         reported by the trigger hardware.
    * 
    * Besides the main data product (empty instance name) an additional
    * `std::vector<raw::ExternalTrigger>` data product with instance name
@@ -100,9 +151,11 @@ namespace daq
     using RelativeTriggerCollection = std::vector<raw::Trigger>;
     using BeamGateInfoCollection = std::vector<sim::BeamGateInfo>;
     using BeamGateInfoPtr = std::unique_ptr<BeamGateInfoCollection>;
+    using ExtraInfoPtr = std::unique_ptr<sbn::ExtraTriggerInfo>;
     TriggerPtr fTrigger;
     TriggerPtr fPrevTrigger;
     std::unique_ptr<RelativeTriggerCollection> fRelTrigger;
+    ExtraInfoPtr fTriggerExtra;
     BeamGateInfoPtr fBeamGateInfo; 
     bool fDiagnosticOutput; //< Produces large number of diagnostic messages, use with caution!
     bool fDebug; //< Use this for debugging this tool
@@ -130,7 +183,15 @@ namespace daq
     static constexpr nanoseconds BNBgateDuration { 1600. };
     static constexpr nanoseconds NuMIgateDuration { 9500. };
     
-    static std::string_view firstLine(std::string const& s, const char* endl = "\0\n\r");
+    static std::string_view firstLine
+      (std::string const& s, std::string const& endl = "\0\n\r"s);
+    
+    /// Combines second and nanosecond counts into a 64-bit timestamp.
+    static std::uint64_t makeTimestamp(unsigned int s, unsigned int ns)
+      { return s * 1'000'000'000ULL + ns; }
+    /// Returns the difference `a - b`.
+    static long long int timestampDiff(std::uint64_t a, std::uint64_t b)
+      { return static_cast<long long int>(a) - static_cast<long long int>(b); }
     
   };
 
@@ -153,6 +214,7 @@ namespace daq
     collector.produces<TriggerCollection>(PreviousTriggerInstanceName);
     collector.produces<RelativeTriggerCollection>(CurrentTriggerInstanceName);
     collector.produces<BeamGateInfoCollection>(CurrentTriggerInstanceName);
+    collector.produces<sbn::ExtraTriggerInfo>(CurrentTriggerInstanceName);
   }
     
 
@@ -160,7 +222,7 @@ namespace daq
   {
     fDiagnosticOutput = pset.get<bool>("DiagnosticOutput", false);
     fDebug = pset.get<bool>("Debug", false);
-    fOffset = pset.get<int>("TAIOffset", 2'000'000'000);
+    fOffset = pset.get<long long int>("TAIOffset", 2'000'000'000);
     return;
   }
   
@@ -172,6 +234,7 @@ namespace daq
     fPrevTrigger = std::make_unique<TriggerCollection>();
     fRelTrigger = std::make_unique<RelativeTriggerCollection>();
     fBeamGateInfo = BeamGateInfoPtr(new BeamGateInfoCollection);
+    fTriggerExtra = std::make_unique<sbn::ExtraTriggerInfo>();
     return;
   }
 
@@ -181,13 +244,44 @@ namespace daq
     icarus::ICARUSTriggerUDPFragment frag(fragment);
     std::string data = frag.GetDataString();
     char *buffer = const_cast<char*>(data.c_str());
+    // --- BEGIN -- TEMPORARY --------------------------------------------------
+    // restore OLD CODE when SBNSoftware/sbndaq-artdaq-core pull request #31 is in:
+    // https://github.com/SBNSoftware/sbndaq-artdaq-core/pull/31
     icarus::ICARUSTriggerInfo datastream_info = icarus::parse_ICARUSTriggerString(buffer);
-    uint64_t wr_ts = datastream_info.getNanoseconds_since_UTC_epoch() + fOffset;
+    uint64_t wr_ts = getNanoseconds_since_UTC_epoch_fix(datastream_info) + fOffset;
+    // OLD CODE:
+//     uint64_t wr_ts = datastream_info.getNanoseconds_since_UTC_epoch() + fOffset;
+    // --- END ---- TEMPORARY --------------------------------------------------
     int gate_type = datastream_info.gate_type;
-    long delta_gates_bnb = frag.getDeltaGatesBNB();
-    long delta_gates_numi = frag.getDeltaGatesOther(); //this is actually NuMI due to abrupt changes in trigger board logic
-    long delta_gates_other = frag.getDeltaGatesNuMI();
+    long delta_gates_bnb [[maybe_unused]] = frag.getDeltaGatesBNB();
+    long delta_gates_numi [[maybe_unused]] = frag.getDeltaGatesOther(); //this is actually NuMI due to abrupt changes in trigger board logic
+    long delta_gates_other [[maybe_unused]] = frag.getDeltaGatesNuMI();
     uint64_t lastTrigger = 0;
+    
+    // --- BEGIN -- TEMPORARY --------------------------------------------------
+    // remove this part when the beam gate timestamp is available via fragment
+    // or via the parser; the beam gate (`beamgate_ts`) is supposed to undergo
+    // the same correction as the trigger time (`wr_ts`)
+    auto const parsedData = icarus::details::KeyedCSVparser{}(firstLine(data));
+    unsigned int beamgate_count { std::numeric_limits<unsigned int>::max() };
+    std::uint64_t beamgate_ts { wr_ts }; // we cheat
+    if (auto pBeamGateInfo = parsedData.findItem("Beam_TS"); pBeamGateInfo) {
+      // if gate information is found, it must be complete
+      beamgate_count = pBeamGateInfo->getNumber<unsigned int>(0U);
+      // use the same linear correction for the beam gate timestamp as it was
+      // used for the trigger one; here we assume that wr_ts
+      // (current value of beamgate_ts) is corrected, while
+      // `getWRSeconds()` and `getWRNanoSeconds()` are as corrected as `Beam_TS`
+      // (i.e. both not corrected)
+      beamgate_ts += makeTimestamp(
+        pBeamGateInfo->getNumber<unsigned int>(1U),
+        pBeamGateInfo->getNumber<unsigned int>(2U)
+        )
+        - makeTimestamp(frag.getWRSeconds(), frag.getWRNanoSeconds())
+        ;
+    } // if has gate information
+    // --- END ---- TEMPORARY --------------------------------------------------
+    
     if(fDiagnosticOutput || fDebug)
     {
       std::cout << "Full Timestamp = " << wr_ts << std::endl;
@@ -195,7 +289,10 @@ namespace daq
         - static_cast<signed long long int>(artdaq_ts);
       if(abs(cross_check) > 1000)
         std::cout << "Loaded artdaq TS and fragment data TS are > 1 ms different! They are " << cross_check << " nanoseconds different!" << std::endl;
-      std::cout << delta_gates_bnb << " " << delta_gates_numi << " " << delta_gates_other << std::endl; // nonsensical print statement to avoid error that I don't use these...until we have an object to store them in...    
+      std::cout << "Beam gate " << beamgate_count << " at "
+        << (beamgate_ts/1'000'000'000) << "." << (beamgate_ts%1'000'000'000)
+        << " s (" << timestampDiff(beamgate_ts, wr_ts)
+        << " ns relative to trigger)" << std::endl;
       
       // note that this parsing is independent from the one used above
       std::string_view const dataLine = firstLine(data);
@@ -213,52 +310,15 @@ namespace daq
       }
       
       if (fDebug) { // this grows tiresome quickly when processing many events
-        std::cout << "Full trigger fragment dump:"
+        std::cout << "Trigger packet content:\n" << dataLine
+          << "\nFull trigger fragment dump:"
+        
           << sbndaq::dumpFragment(fragment) << std::endl;
       }
     }
     
     //
-    // absolute time trigger (raw::ExternalTrigger)
-    //
-    fTrigger->emplace_back(datastream_info.wr_event_no, wr_ts);
-    
-    //
-    // previous absolute time trigger (raw::ExternalTrigger)
-    //
-    if(datastream_info.wr_event_no == 1)
-    {
-      fLastEvent = 0;
-    }
-    else 
-    {
-      fLastEvent = datastream_info.wr_event_no - 1;
-      lastTrigger = frag.getLastTimestampBNB();
-      fPrevTrigger->emplace_back(fLastEvent, lastTrigger);
-    }
-    
-    //
-    // beam gate
-    //
-    // TODO UnknownBeamTime: beam gate time is not available yet, here assuming it's same as trigger
-    nanoseconds gateStartFromTrigger { 0 }; // beam gate - trigger: hope it's negative...
-    auto const gateStart
-      = fDetTimings.toSimulationTime(fDetTimings.TriggerTime() + gateStartFromTrigger);
-    switch (gate_type) {
-      case TriggerGateTypes::BNB:
-        fBeamGateInfo->emplace_back
-          (gateStart.value(), BNBgateDuration.value(), sim::kBNB);
-        break;
-      case TriggerGateTypes::NuMI:
-        fBeamGateInfo->emplace_back
-          (gateStart.value(), NuMIgateDuration.value(), sim::kNuMI);
-        break;
-      default:
-        mf::LogWarning("TriggerDecoder") << "Unsupported gate type #" << gate_type;
-    } // switch gate_type
-    
-    //
-    // relative time trigger (raw::Trigger)
+    // extra trigger info
     //
     sbn::triggerSource beamGateBit;
     switch (gate_type) {
@@ -267,10 +327,74 @@ namespace daq
       default:                     beamGateBit = sbn::triggerSource::Unknown;
     } // switch gate_type
     
+    fTriggerExtra->sourceType = beamGateBit;
+    fTriggerExtra->triggerTimestamp = wr_ts;
+    fTriggerExtra->beamGateTimestamp = beamgate_ts;
+    fTriggerExtra->triggerID = datastream_info.wr_event_no;
+    fTriggerExtra->gateID = datastream_info.gate_id;
+    /* TODO:
+    fTriggerExtra->triggerCount
+    fTriggerExtra->gateCount
+    fTriggerExtra->gateCountFromPreviousTrigger
+    fTriggerExtra->anyTriggerCountFromPreviousTrigger
+    fTriggerExtra->anyGateCountFromPreviousTrigger
+    fTriggerExtra->anyPreviousTriggerSourceType
+    fTriggerExtra->anyGateCountFromAnyPreviousTrigger
+    fTriggerExtra->previousTriggerTimestamp
+    fTriggerExtra->anyPreviousTriggerTimestamp
+    */
+    
+    //
+    // absolute time trigger (raw::ExternalTrigger)
+    //
+    fTrigger->emplace_back
+      (fTriggerExtra->triggerID, fTriggerExtra->triggerTimestamp);
+    
+    //
+    // previous absolute time trigger (raw::ExternalTrigger)
+    //
+    if(fTriggerExtra->triggerID == 1)
+    {
+      fLastEvent = 0;
+    }
+    else 
+    {
+      fLastEvent = fTriggerExtra->triggerID - 1;
+      lastTrigger = frag.getLastTimestampBNB();
+      fPrevTrigger->emplace_back(fLastEvent, lastTrigger);
+    }
+    
+    //
+    // beam gate
+    //
+    // beam gate - trigger: hope it's negative...
+    nanoseconds const gateStartFromTrigger{
+      static_cast<double>(timestampDiff
+        (fTriggerExtra->beamGateTimestamp, fTriggerExtra->triggerTimestamp)
+        )
+      }; // narrowing!!
+    auto const elecGateStart = fDetTimings.TriggerTime() + gateStartFromTrigger;
+    auto const simGateStart = fDetTimings.toSimulationTime(elecGateStart);
+    switch (gate_type) {
+      case TriggerGateTypes::BNB:
+        fBeamGateInfo->emplace_back
+          (simGateStart.value(), BNBgateDuration.value(), sim::kBNB);
+        break;
+      case TriggerGateTypes::NuMI:
+        fBeamGateInfo->emplace_back
+          (simGateStart.value(), NuMIgateDuration.value(), sim::kNuMI);
+        break;
+      default:
+        mf::LogWarning("TriggerDecoder") << "Unsupported gate type #" << gate_type;
+    } // switch gate_type
+    
+    //
+    // relative time trigger (raw::Trigger)
+    //
     fRelTrigger->emplace_back(
       static_cast<unsigned int>(datastream_info.wr_event_no), // counter
       fDetTimings.TriggerTime().value(),                      // trigger_time
-      UnknownBeamTime,                                        // beamgate_time TODO
+      elecGateStart.value(),                                  // beamgate_time
       mask(beamGateBit)                                       // bits
       );
     
@@ -285,11 +409,12 @@ namespace daq
     event.put(std::move(fRelTrigger), CurrentTriggerInstanceName);
     event.put(std::move(fPrevTrigger), PreviousTriggerInstanceName);
     event.put(std::move(fBeamGateInfo), CurrentTriggerInstanceName);
+    event.put(std::move(fTriggerExtra));
     return;
   }
 
   std::string_view TriggerDecoder::firstLine
-    (std::string const& s, const char* endl /* = "\0\n\r" */)
+    (std::string const& s, std::string const& endl /* = "\0\n\r" */)
   {
     return { s.data(), std::min(s.find_first_of(endl), s.size()) };
   }

--- a/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h
+++ b/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h
@@ -55,9 +55,12 @@ struct icarus::details::KeyValuesData {
     bool operator< (Item const& other) const noexcept
       { return key < other.key; }
     
+    /// Converts the value to `T`, throws on failure.
     template <typename T>
     T getNumber(std::size_t index) const;
     
+    /// Converts the value to `T`, throws on conversion failures
+    /// unless `ignoreFormatErrors` is `true`.
     template <typename T>
     std::optional<T> getOptionalNumber
       (std::size_t index, bool ignoreFormatErrors = false) const;

--- a/icaruscode/Decode/fcl/CAEN_V1730_setup_icarus.fcl
+++ b/icaruscode/Decode/fcl/CAEN_V1730_setup_icarus.fcl
@@ -13,15 +13,22 @@
 
 BEGIN_PROLOG
 
-icarus_V1730_West_setup: [
-  #
-  # delays have been measured by Andrea Scarpelli, Animesh Chatterjee and Nick Suarez
-  #   (see e.g. SBN DocDB 20283); the figure "43 ns" here is a rough guess from
-  #   some of the measurements -- more precise ones may be available;
-  #   the offset measured against a (supposedly) common reference via the
-  #   Trigger Time Tag counter of the readout board settles to 48 ns
-  #   (the counter tick is worth 16 ns).
-  #
+################################################################################
+###  Run0
+################################################################################
+#
+# "Run 0": configuration good for commissioning and Run 0 runs.
+# 
+# This configuration is FROZEN: do not change it.
+#
+# Delays have been measured by Andrea Scarpelli, Animesh Chatterjee and Nick Suarez
+#   (see e.g. SBN DocDB 20283); the figure "43 ns" here is a rough guess from
+#   some of the measurements -- more precise ones may be available;
+#   the offset measured against a (supposedly) common reference via the
+#   Trigger Time Tag counter of the readout board settles to 48 ns
+#   (the counter tick is worth 16 ns).
+#
+icarus_V1730_West_setup_Run0: [
 
   ### --------------------------------------------------------------------------
   ###  WW
@@ -55,9 +62,10 @@ icarus_V1730_West_setup: [
   { Name: "icaruspmtwebot03"  TriggerDelay: "86 ns" }
   ### --------------------------------------------------------------------------
 
-] # icarus_V1730_West_setup
+] # icarus_V1730_West_setup_Run0
 
-icarus_V1730_East_setup: [
+
+icarus_V1730_East_setup_Run0: [
   ### --------------------------------------------------------------------------
   ### EW
   ### --------------------------------------------------------------------------
@@ -90,81 +98,23 @@ icarus_V1730_East_setup: [
   { Name: "icaruspmteebot03"  TriggerDelay: "86 ns" }
   ### --------------------------------------------------------------------------
   
-] # icarus_V1730_East_setup
+] # icarus_V1730_East_setup_Run0
 
-icarus_V1730_setup: [
-  #
-  # delays have been measured by Andrea Scarpelli, Animesh Chatterjee and Nick Suarez
-  #   (see e.g. SBN DocDB 20283); the figure "43 ns" here is a rough guess from
-  #   some of the measurements -- more precise ones may be available;
-  #   the offset measured against a (supposedly) common reference via the
-  #   Trigger Time Tag counter of the readout board settles to 48 ns
-  #   (the counter tick is worth 16 ns).
-  #
 
-  ### --------------------------------------------------------------------------
-  ###  WW
-  ### --------------------------------------------------------------------------
-  #
-  # top
-  #
-  { Name: "icaruspmtwwtop01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmtwwtop02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmtwwtop03"  TriggerDelay: "86 ns" },
-  #
-  # bottom
-  #
-  { Name: "icaruspmtwwbot01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmtwwbot02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmtwwbot03"  TriggerDelay: "86 ns" },
-  ### --------------------------------------------------------------------------
-  ### WE
-  ### --------------------------------------------------------------------------
-  #
-  # top
-  #
-  { Name: "icaruspmtwetop01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmtwetop02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmtwetop03"  TriggerDelay: "86 ns" },
-  #
-  # bottom
-  #
-  { Name: "icaruspmtwebot01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmtwebot02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmtwebot03"  TriggerDelay: "86 ns" },
-  ### --------------------------------------------------------------------------
-  ### EW
-  ### --------------------------------------------------------------------------
-  #
-  # top
-  #
-  { Name: "icaruspmtewtop01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmtewtop02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmtewtop03"  TriggerDelay: "86 ns" },
-  #
-  # bottom
-  #
-  { Name: "icaruspmtewbot01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmtewbot02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmtewbot03"  TriggerDelay: "86 ns" },
-  ### --------------------------------------------------------------------------
-  ### EE
-  ### --------------------------------------------------------------------------
-  #
-  # top
-  #
-  { Name: "icaruspmteetop01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmteetop02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmteetop03"  TriggerDelay: "86 ns" },
-  #
-  # bottom
-  #
-  { Name: "icaruspmteebot01"  TriggerDelay: " 0 ns" },
-  { Name: "icaruspmteebot02"  TriggerDelay: "43 ns" },
-  { Name: "icaruspmteebot03"  TriggerDelay: "86 ns" }
-  ### --------------------------------------------------------------------------
+icarus_V1730_setup_Run0: [
   
-] # icarus_V1730_setup
+  @sequence::icarus_V1730_West_setup_Run0,
+  @sequence::icarus_V1730_East_setup_Run0
+  
+] # icarus_V1730_setup_Run0
 
+
+################################################################################
+###  current default
+################################################################################
+icarus_V1730_setup: @local::icarus_V1730_setup_Run0
+
+
+################################################################################
 
 END_PROLOG

--- a/icaruscode/Decode/fcl/decodePMTdefs_icarus.fcl
+++ b/icaruscode/Decode/fcl/decodePMTdefs_icarus.fcl
@@ -1,0 +1,178 @@
+#
+# File:    decodePMTdefs_icarus.fcl
+# Purpose: Presets for decoding of ICARUS runs
+# Date:    July 15, 2021
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# 
+# This file contains several configurations targetting the decoding of PMT data
+# from ICARUS commissioning and Run 0 runs.
+# 
+# The runs have been selected based on SBN DocDB 22700 (v1).
+# 
+# 
+# Assumptions on the job configuration
+# -------------------------------------
+#
+# The definitions in this configuration files cover the configuration of the PMT
+# decoder and possibly others. The names used for the various modules are the
+# "standard" ones from `stage0_icarus_defs.fcl` (which is, however, _not_
+# included):
+# * `PMTconfig`: PMT configuration extractor
+# * `daqPMT`: PMT decoder
+# * `daqTrigger`: trigger decoder
+#
+#
+# Example of usage
+# -----------------
+# 
+# To run a `decodingjob.fcl` with the standard module names on run 5510
+# (or similar), the `decoder_PMT_trigger_minbias_run5510_icarus` configuration
+# may be used. For example:
+#     
+#     #include "decodePMTdefs_icarus.fcl"
+#     #include "decoding_job.fcl"
+#     
+#     physics.producers: {
+#       @table::physics.producers
+#       @table::decoder_PMT_trigger_minbias_run5510_icarus
+#     }
+#     
+# 
+#
+#
+
+#include "decoderdefs_icarus.fcl"
+
+BEGIN_PROLOG
+
+dummyModule: { module_type: DummyProducer }
+
+# we use this as a common starting point
+# (note that this is not based on an official definition from elsewhere):
+decodePMT_base_icarus: {
+  module_type:        DaqDecoderICARUSPMT
+  FragmentsLabels:  [ "daq:CAENV1730", "daq:ContainerCAENV1730" ]
+  PMTconfigTag:       PMTconfig
+  TriggerTag:         daqTrigger
+  BoardSetup:         @local::icarus_V1730_setup
+} # decodePMT_base_icarus
+
+decodePMT_base_icarus_Run0: {
+  @table::decodePMT_base_icarus
+  BoardSetup:         @local::icarus_V1730_setup_Run0
+} # decodePMT_base_icarus_Run0
+
+
+decoder_PMT_trigger_base_icarus: {
+  daqPMT:     @local::decodePMT_base_icarus_Run0
+  # daqTrigger: trigger decoding not explicitly set (but expected)
+} # decoder_PMT_trigger_base_icarus
+
+
+################################################################################
+###  Minimum bias runs
+################################################################################
+
+#
+# base configuration: standard
+#
+# runs tested: 5984, 6002, 6030, 6036, 6069, 6101-6104
+#
+decoder_PMT_trigger_minbias_icarus: @local::decoder_PMT_trigger_base_icarus
+
+
+#
+# no PMT readout board time counter (TTT) reset every second
+#
+decoder_PMT_trigger_minbias_noPPSTTT_icarus: @local::decoder_PMT_trigger_minbias_icarus
+decoder_PMT_trigger_minbias_noPPSTTT_icarus.daqPMT.TTTresetEverySecond: false
+
+
+#
+# no trigger decoding
+#
+decoder_PMT_trigger_minbias_skiptrigger_icarus: {
+  @table::decoder_PMT_trigger_minbias_icarus
+
+  daqTrigger: @local::dummyModule
+
+} # decoder_PMT_trigger_minbias_skiptrigger_icarus
+decoder_PMT_trigger_minbias_skiptrigger_icarus.daqPMT.TriggerTag: @erase
+
+
+#
+# west cryostat only
+#
+decoder_PMT_trigger_minbias_west_icarus: @local::decoder_PMT_trigger_minbias_icarus
+decoder_PMT_trigger_minbias_west_icarus.daqPMT.BoardSetup:  @local::icarus_V1730_West_setup_Run0
+
+
+#
+# west cryostat only, no trigger decoding
+#
+decoder_PMT_trigger_minbias_skiptrigger_west_icarus: @local::decoder_PMT_trigger_minbias_skiptrigger_icarus
+decoder_PMT_trigger_minbias_skiptrigger_west_icarus.daqPMT.BoardSetup:  @local::icarus_V1730_West_setup_Run0
+
+#
+# trigger data payload has wrong string terminator, which is not recognised:
+#   custom trigger parsing is possible
+# Runs known to be affected:
+#  * 5510, 5679: uses `decoder_PMT_trigger_minbias_skiptrigger_icarus`
+#  * 5252 (West only): uses `decoder_PMT_trigger_minbias_skiptrigger_west_icarus`
+#
+decoder_PMT_trigger_minbias_run5252_icarus: @local::decoder_PMT_trigger_minbias_skiptrigger_west_icarus
+decoder_PMT_trigger_minbias_run5510_icarus: @local::decoder_PMT_trigger_minbias_skiptrigger_icarus
+decoder_PMT_trigger_minbias_run5679_icarus: @local::decoder_PMT_trigger_minbias_skiptrigger_icarus
+decoder_PMT_trigger_minbias_run5795_icarus: @local::decoder_PMT_trigger_minbias_skiptrigger_icarus
+
+
+
+################################################################################
+###  Trigger runs
+################################################################################
+
+#
+# base configuration: trigger information used in decoding;
+# supports multi-window PMT acquisition
+# via periodic readout board time count (TTT) reset
+# 
+# runs tested: 5986-7, 5992-3, 6001, 6003-5, 6007-9, 6011-16, 6042-3, 6070,
+#              6079, 6080, 6082-3, 6085, 6093, 6095, 6097-6100,
+# 
+#
+decoder_PMT_trigger_majority_icarus: @local::decoder_PMT_trigger_base_icarus
+
+
+#
+# only east cryostat
+#
+decoder_PMT_trigger_majority_east_icarus: @local::decoder_PMT_trigger_majority_icarus
+decoder_PMT_trigger_majority_east_icarus.daqPMT.BoardSetup:  @local::icarus_V1730_East_setup_Run0
+
+
+#
+# no PMT readout board time counter (TTT) reset every second
+#
+decoder_PMT_trigger_majority_noPPSTTT_icarus: @local::decoder_PMT_trigger_majority_icarus
+decoder_PMT_trigger_majority_noPPSTTT_icarus.daqPMT.TTTresetEverySecond: false
+
+
+#
+# no PMT readout board time counter (TTT) reset every second, east cryostat only
+#
+decoder_PMT_trigger_majority_noPPSTTT_east_icarus: @local::decoder_PMT_trigger_majority_noPPSTTT_icarus
+decoder_PMT_trigger_majority_noPPSTTT_east_icarus.daqPMT.BoardSetup:  @local::icarus_V1730_East_setup_Run0
+
+
+#
+# majority trigger runs without TTT reset (single window PMT acquisition):
+# Runs known to be affected:
+# * 5873: uses `decoder_PMT_trigger_majority_noPPSTTT_east_icarus`
+#
+decoder_PMT_trigger_majority_run5873_icarus: @local::decoder_PMT_trigger_majority_noPPSTTT_east_icarus
+
+
+
+################################################################################
+
+END_PROLOG

--- a/icaruscode/PMT/Trigger/Algorithms/SlidingWindowPatternAlg.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/SlidingWindowPatternAlg.cxx
@@ -13,6 +13,7 @@
 
 // ICARUS libraries
 #include "icaruscode/PMT/Trigger/Utilities/TriggerGateOperations.h"
+#include "icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h"
 
 // LArSoft libraries
 #include "larcorealg/CoreUtils/enumerate.h"
@@ -250,14 +251,15 @@ auto icarus::trigger::SlidingWindowPatternAlg::applyWindowPattern(
   TriggerGateData_t trigPrimitive
     = mainPlusOpposite? *mainPlusOpposite: gates[windowInfo.index];
     
-  mfLogTrace() << "  base: " << trigPrimitive;
+  mfLogTrace() << "  base: " << compactdump(trigPrimitive);
   
   // main window
   if (pattern.minInMainWindow > 0U) {
     trigPrimitive.Mul
       (discriminate(gates[windowInfo.index], pattern.minInMainWindow));
     mfLogTrace()
-      << "  main >= " << pattern.minInMainWindow << ": " << trigPrimitive;
+      << "  main >= " << pattern.minInMainWindow << ": "
+      << compactdump(trigPrimitive);
   } // if
   
   // add opposite window requirement (if any)
@@ -265,7 +267,8 @@ auto icarus::trigger::SlidingWindowPatternAlg::applyWindowPattern(
     trigPrimitive.Mul
       (discriminate(gates[windowInfo.opposite], pattern.minInOppositeWindow));
     mfLogTrace() << "  opposite [#" << windowInfo.opposite << "]: "
-      << gates[windowInfo.opposite] << "\n  => " << trigPrimitive;
+      << compactdump(gates[windowInfo.opposite])
+      << "\n  => " << compactdump(trigPrimitive);
   } // if
   
   // add main plus opposite window requirement (if any)
@@ -274,7 +277,8 @@ auto icarus::trigger::SlidingWindowPatternAlg::applyWindowPattern(
     trigPrimitive.Mul
       (discriminate(*mainPlusOpposite, pattern.minSumInOppositeWindows));
     mfLogTrace() << "  sum [+ #" << windowInfo.opposite << "]: "
-      << *mainPlusOpposite << "\n  => " << trigPrimitive;
+      << compactdump(*mainPlusOpposite)
+      << "\n  => " << compactdump(trigPrimitive);
     
   } // if
   
@@ -292,7 +296,7 @@ auto icarus::trigger::SlidingWindowPatternAlg::applyWindowPattern(
       );
   } // if
   
-  mfLogTrace() << "  final: " << trigPrimitive;
+  mfLogTrace() << "  final: " << compactdump(trigPrimitive);
   
   //
   // 4. find the trigger time, fill the trigger information accordingly

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -3,6 +3,7 @@ cet_add_compiler_flags(CXX -Wno-maybe-uninitialized)
 
 add_subdirectory(Algorithms)
 add_subdirectory(Utilities)
+add_subdirectory(scripts)
 
 art_make(
   EXCLUDE

--- a/icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h
+++ b/icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h
@@ -1,0 +1,113 @@
+/**
+ * @file   icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h
+ * @brief  Utilities for `TriggerGateData` printout.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 13, 2021
+ */
+
+#ifndef ICARUSCODE_PMT_TRIGGER_UTILITIES_TRIGGERGATEDATAFORMATTING_H
+#define ICARUSCODE_PMT_TRIGGER_UTILITIES_TRIGGERGATEDATAFORMATTING_H
+
+
+// ICARUS libraries
+#include "icarusalg/Utilities/IntegerRanges.h" // icarus::makeIntegerRanges()
+#include "sbnobj/ICARUS/PMT/Trigger/Data/ReadoutTriggerGate.h"
+
+// C/C++ standard libraries
+#include <ostream>
+
+
+namespace icarus::trigger {
+  
+  namespace details {
+    
+    /// Container of a single gate (base class).
+    template <typename Gate>
+    struct GateWrapper {
+      Gate const& gate;
+    };
+    
+    /// Wrapper to format a gate as "compact".
+    template <typename Gate>
+    struct CompactFormatter: GateWrapper<Gate> {};
+    
+    /// Implementation of `compactdump()` printout of a gate.
+    /// @see `compactdump()`
+    template <typename Gate>
+    std::ostream& operator<<
+      (std::ostream& out, CompactFormatter<Gate> const& wrap);
+    
+  } // namespace details
+  
+  
+  /**
+   * @brief Manipulator-like function for compact format of trigger gates.
+   * @tparam Tick template type `Tick` for `ReadoutTriggerGate`
+   * @tparam TickInterval template type `TickInterval` for `ReadoutTriggerGate`
+   * @tparam ChannelIDType template type `ChannelIDType` for `ReadoutTriggerGate`
+   * @param gate the gate to be formatted
+   * @return a wrapper with the parameters to format the gate
+   * 
+   * This helper function is always used in the context of the insertion of a
+   * trigger gate data object into an output stream:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * #include "icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h"
+   * #include "sbnobj/ICARUS/PMT/Trigger/Data/OpticalTriggerGate.h"
+   * #include "larcorealg/CoreUtils/enumerate.h"
+   * #include <iostream>
+   * 
+   * // ...
+   * 
+   * std::vector<icarus::trigger::OpticalTriggerGate> LVDSgates;
+   * 
+   * // ...
+   * 
+   * for (auto const& [ iGate, gate ]: util::enumerate(LVDSgates))
+   *   std::cout << "[" << iGate << "] " << compactdump(gate) << std::endl;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * The loop will print all the `LVDSgates` in "compact" mode, one per line,
+   * prepended by their position in the collection.
+   * 
+   * Technical note: `compactdump()` in the example is found by the compiler via
+   * Koenig lookup.
+   * 
+   */
+  template <typename Tick, typename TickInterval, typename ChannelIDType>
+  auto compactdump
+    (ReadoutTriggerGate<Tick, TickInterval, ChannelIDType> const& gate)
+    -> details::CompactFormatter<ReadoutTriggerGate<Tick, TickInterval, ChannelIDType>>
+    { return { gate }; }
+  
+  
+} // namespace icarus::trigger
+
+
+// -----------------------------------------------------------------------------
+// --  template implementation
+// -----------------------------------------------------------------------------
+
+template <typename Gate>
+std::ostream& icarus::trigger::details::operator<<
+  (std::ostream& out, CompactFormatter<Gate> const& wrap)
+{
+  auto const& gate { wrap.gate };
+  
+  out << "[";
+  if (gate.hasChannel()) {
+    out << "channel: " << gate.channel();
+  }
+  else if (gate.hasChannels()) {
+    out << gate.nChannels() << " channels: "
+      << icarus::makeIntegerRanges(gate.channels());
+  }
+  else out << "no channel";
+  out << "] " << gate.gateLevels();
+  
+  return out;
+} // icarus::trigger::operator<< (GateWrapper)
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_PMT_TRIGGER_UTILITIES_TRIGGERGATEDATAFORMATTING_H

--- a/icaruscode/PMT/Trigger/scripts/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/scripts/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_scripts()

--- a/icaruscode/PMT/Trigger/scripts/triggeredEventList.py
+++ b/icaruscode/PMT/Trigger/scripts/triggeredEventList.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+
+import time
+
+__doc__ = """Prints the list of events passing the specified trigger."""
+__author__ = "Gianluca Petrillo (petrillo@slac.stanford.edu)"
+__date__ = time.strptime("July 11, 2021", "%B %d, %Y")
+__version__ = "1.0"
+
+import sys
+import galleryUtils
+import ROOT
+import logging
+
+DefaultTriggerModuleLabel = "trigger" # may be overridden by command line
+
+TriggerDataProductClass = 'std::vector<raw::Trigger>'
+
+# ------------------------------------------------------------------------------
+class EventTagCache:
+  def __init__(self,
+               run=False, subRun=False, event=True, sourceFile=False,
+               human=False, short=False,
+               ):
+    self.eventTag = None
+    self.run = run
+    self.subrun = subRun
+    self.event = event
+    self.sourceFile = sourceFile
+    self.human = human
+    self.short = short
+  # __init__()
+  
+  def prepareFor(self, event):
+    self.eventObj = event
+    self.eventTag = None
+  
+  def __call__(self, event = None):
+    if self.eventTag is None or event is not self.eventObj:
+      self.eventTag = self._makeTag(event)
+    return self.eventTag
+  # __call__()
+  
+  def _makeTag(self, event=None):
+    if event is not None: self.eventObj = event
+    assert self.eventObj, "Needs to prepareFor(event) this object first!"
+    eventAux = self.eventObj.eventAuxiliary()
+    eventID = []
+    if self.run:
+      run = eventAux.run()
+      if self.human: eventID.append(f"run {run}")
+      elif self.short: eventID.append(f"R:{run}")
+      else: eventID.append(str(run))
+    # if print run
+    if self.subrun:
+      subrun = eventAux.subRun()
+      if self.human: eventID.append(f"subrun {subrun}")
+      elif self.short: eventID.append(f"S:{subrun}")
+      else: eventID.append(str(subrun))
+    # if print subrun
+    if self.event:
+      evt = eventAux.event()
+      if self.human: eventID.append(f"event {evt}")
+      elif self.short: eventID.append(f"E:{evt}")
+      else: eventID.append(str(evt))
+    # if print event
+    if self.sourceFile:
+      sourceFile = self.eventObj.getTFile()
+      fileName = sourceFile.GetName() if sourceFile else "<unknown>"
+      eventInFile = self.eventObj.eventEntry()
+      if self.human: eventID.append(f"from file {fileName} entry {eventInFile}")
+      elif self.short: eventID.append(f"F:{fileName!r}@{eventInFile}")
+      else:
+        eventID.append(repr(fileName))
+        eventID.append(str(eventInFile))
+    # if print event
+    return " ".join(eventID)
+  # _makeTag()
+  
+# class EventTagCache
+
+
+# ------------------------------------------------------------------------------
+def findTriggeredEvents(sampleEvents, triggers, args):
+  
+  # digest the trigger info options
+  trigSpecs = triggers.copy()
+  for trigSpec in trigSpecs:
+    tag = trigSpec['spec']
+    if not isinstance(tag, ROOT.art.InputTag):
+      if ':' not in tag: tag = DefaultTriggerModuleLabel + ':' + tag
+      tag = ROOT.art.InputTag(tag)
+    # if
+    trigSpec.update({
+      'tag': tag,
+      'dest': (open(trigSpec['destList'], 'w')
+        if trigSpec['destList'] else sys.stdout),
+      'count': 0,
+      })
+  # for
+  
+  try: # using a context manager here is more complicate...
+    
+    getTrigger \
+     = galleryUtils.make_getValidHandle(TriggerDataProductClass, sampleEvents)
+    
+    eventTag = EventTagCache(
+      run=args.run,
+      subRun=args.subrun,
+      event=args.event,
+      sourceFile=args.sourcefile,
+      human=args.human,
+      short=args.short,
+      )
+    
+    for iEvent, event in enumerate(galleryUtils.forEach(sampleEvents)):
+      
+      if args.maxEvents and iEvent >= args.maxEvents:
+        logging.warning(f"Limit of {iEvent} events reached: stopping now.")
+        break
+      
+      eventTag.prepareFor(event)
+      
+      for trigSpec in trigSpecs:
+        triggers = getTrigger(trigSpec['tag']).product()
+        if len(triggers) == 0: continue
+        print(eventTag(), file=trigSpec['dest'])
+        trigSpec['count'] += 1
+      # for
+    
+    # for all events
+    else: iEvent += 1
+    
+  finally:
+    for trigSpec in trigSpecs:
+      if trigSpec['dest'] is not sys.stdout: trigSpec['dest'].close()
+    # for
+  # try ... finally
+  
+  for trigSpec in trigSpecs:
+    print(
+      f"{trigSpec['tag'].encode()}:"
+      f" {trigSpec['count']}/{iEvent} events triggered"
+      f" ({trigSpec['count']/iEvent*100:g}%)",
+      end="",
+      )
+    if (trigSpec['dest'] is not sys.stdout):
+      print(f" (->'{trigSpec['dest'].name}')", end="")
+    print()
+  # for
+  
+  return 0
+# findTriggeredEvents()
+
+
+def getAllTriggerTags(sampleEvents):
+  
+  return sorted(
+    sampleEvents.getInputTags[TriggerDataProductClass](),
+    key=ROOT.art.InputTag.encode
+    )
+  
+# getAllTriggerTags()
+
+
+def listTriggerDataProducts(sampleEvents):
+  # sorted() also converts a returned `std::vector` into a Python list
+  inputTags = getAllTriggerTags(sampleEvents)
+  nProducts = len(inputTags)
+  print(f"{nProducts} '{TriggerDataProductClass}' data products found:")
+  PadLength=len(str(nProducts))
+  for iProduct, inputTag in enumerate(inputTags):
+    print(f"[#{iProduct+1:0>{PadLength}}] {inputTag.encode()}")
+  # for
+  return 0
+# listTriggerDataProducts()
+
+
+def buildDefaultOutputFile(spec):
+  if isinstance(spec, ROOT.art.InputTag): spec = spec.encode()
+  return f"triggeredEvents_{spec.replace(':', '_')}.log"
+# buildDefaultOutputFile()
+
+
+if __name__ == "__main__":
+  
+  # --- BEGIN -- argument parsing  ---------------------------------------------
+  import argparse
+  
+  parser = argparse.ArgumentParser(description=__doc__)
+  
+  # positional
+  parser.add_argument("InputFile", help="art/ROOT input file or file list")
+  parser.add_argument("TriggerSpec", nargs="*",
+    help=f"trigger to check: data product name (`{DefaultTriggerModuleLabel}:inst`)"
+     f" or just instance name (`M5S10`, becoming `{DefaultTriggerModuleLabel}:M5S10`)"
+     )
+  
+  # options
+  inputGroup = parser.add_argument_group("Input options")
+  inputGroup.add_argument("--maxEvents", "-n", type=int,
+    help="do not process more that this number of events")
+  inputGroup.add_argument("--deflabel", type=str, default=DefaultTriggerModuleLabel,
+    help="trigger module label used in TriggerSpec by default [%(default)s]")
+  inputGroup.add_argument("--all", action="store_true",
+    help="processes all available trigger data products")
+  inputGroup.add_argument("--all-to-files", dest="allToFiles",
+    action="store_true",
+    help="like `--all`, redirecting each trigger into its default-named file"
+    )
+  
+  outputFormatGroup = parser.add_argument_group("Output format")
+  outputFormatGroup.add_argument("--run", "-r", action="store_true",
+    help="print the run number for triggering events [%(default)s]")
+  outputFormatGroup.add_argument("--subrun", "-a", action="store_true",
+    help="print the subrun number for triggering events [%(default)s]")
+  outputFormatGroup.add_argument("--event", "-e", action="store_false",
+    help="print the event number for triggering events [%(default)s]")
+  outputFormatGroup.add_argument("--sourcefile", "--file", "-f",
+    action="store_true",
+    help="print the file where triggering events are stored [%(default)s]"
+    )
+  outputFormatGroup.add_argument("--human", "--hr", "-H", action="store_true",
+    help="print the event ID with extended labels [%(default)s]")
+  outputFormatGroup.add_argument("--short", "-S", action="store_true",
+    help="print the event ID with short labels [%(default)s]")
+
+  generalOptGroup = parser.add_argument_group("General options")
+  generalOptGroup.add_argument("--list", "-l", dest="doList", action="store_true",
+    help="prints the available trigger data product tags, and exits")
+  generalOptGroup.add_argument("--debug", action="store_true",
+    help="enable additional diagnostic output")
+  generalOptGroup.add_argument("--version", "-V", action="version",
+    version=f"%(prog)s v{__version__} ({time.asctime(__date__)})",
+    help="prints the version number"
+    )
+  
+  args = parser.parse_args()
+  
+  logging.basicConfig(level=(logging.DEBUG if args.debug else logging.INFO))
+  
+  DefaultTriggerModuleLabel = args.deflabel
+  # --- END ---- argument parsing  ---------------------------------------------
+  
+  sampleEvents = galleryUtils.makeEvent(args.InputFile)
+  
+  if args.doList: sys.exit(listTriggerDataProducts(sampleEvents))
+  
+  # process trigger specifications
+  triggerSpecs = []
+  if args.all or args.allToFiles:
+    for tag in getAllTriggerTags(sampleEvents):
+      triggerSpecs.append({
+        'spec': tag,
+        'destList': (buildDefaultOutputFile(tag) if args.allToFiles else None),
+        })
+    # for
+  else:
+    for spec in args.TriggerSpec:
+      spec, sep, destList = spec.partition('->')
+      if sep and not destList: destList = buildDefaultOutputFile(spec)
+      triggerSpecs.append({ 'spec': spec, 'destList': destList, })
+    # for
+  # if all ... else
+  
+  sys.exit(findTriggeredEvents(sampleEvents, triggerSpecs, args))
+  
+# main

--- a/icaruscode/Utilities/CMakeLists.txt
+++ b/icaruscode/Utilities/CMakeLists.txt
@@ -2,6 +2,8 @@
 art_make(
   EXCLUDE
     "SaveConfigurationIntoTFile_module.cc"
+    "DummyFilter_module.cc"
+    "DummyProducer_module.cc"
     "DuplicateEventTracker_service.cc"
   LIB_LIBRARIES
     ${ART_ROOT_IO_ROOTDB}
@@ -35,6 +37,9 @@ simple_plugin(DuplicateEventTracker "service"
               ${ART_FRAMEWORK_PRINCIPAL}
               ${MF_MESSAGELOGGER}
 )
+
+simple_plugin(DummyFilter "module")
+simple_plugin(DummyProducer "module")
 
 
 install_headers()

--- a/icaruscode/Utilities/DummyFilter_module.cc
+++ b/icaruscode/Utilities/DummyFilter_module.cc
@@ -1,0 +1,52 @@
+/**
+ * @file   DummyFilter_module.cc
+ * @brief  An _art_ filter which does nothing.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 15, 2021
+ *
+ */
+
+// framework libraries
+#include "art/Framework/Core/SharedFilter.h"
+#include "art/Framework/Core/ModuleMacros.h"
+
+
+//------------------------------------------------------------------------------
+/**
+ * @brief Filter module which passes everything.
+ * @see DummyProducer
+ *
+ * This module accepts any FHiCL configuration (which it ignores), acts like a
+ * filter that passes everything, does not consume anything and does not produce
+ * anything.
+ * 
+ * It is a "good" way to remove a filter module from a job without having to
+ * mess with much configuration: just target it with a:
+ *     
+ *     physics.producers.redundantmod.module_type: DummyFilter
+ *     
+ *
+ * Configuration parameters
+ * =========================
+ *
+ * Anything.
+ *
+ */
+class DummyFilter: public art::SharedFilter {
+  
+    public:
+
+  DummyFilter(fhicl::ParameterSet const& params, const art::ProcessingFrame&)
+    : art::SharedFilter{ params }
+    { async<art::InEvent>(); }
+  
+  virtual bool filter(art::Event&, const art::ProcessingFrame&) override
+    { return true; }
+  
+}; // class DummyFilter
+
+
+DEFINE_ART_MODULE(DummyFilter)
+
+//------------------------------------------------------------------------------
+

--- a/icaruscode/Utilities/DummyProducer_module.cc
+++ b/icaruscode/Utilities/DummyProducer_module.cc
@@ -1,0 +1,50 @@
+/**
+ * @file   DummyProducer_module.cc
+ * @brief  An _art_ producer which does nothing.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 15, 2021
+ *
+ */
+
+// framework libraries
+#include "art/Framework/Core/SharedProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+
+
+//------------------------------------------------------------------------------
+/**
+ * @brief Module which does nothing.
+ * @see DummyFilter
+ *
+ * This module accepts any FHiCL configuration (which it ignores), acts like a
+ * producer that does not consume anything and does not produce anything.
+ * 
+ * It is a "good" way to remove a producer module from a job without having to
+ * mess with much configuration: just target it with a:
+ *     
+ *     physics.producers.redundantfilter.module_type: DummyProducer
+ *     
+ *
+ * Configuration parameters
+ * =========================
+ *
+ * Anything.
+ *
+ */
+class DummyProducer: public art::SharedProducer {
+  
+    public:
+
+  DummyProducer(fhicl::ParameterSet const& params, const art::ProcessingFrame&)
+    : art::SharedProducer{ params }
+    { async<art::InEvent>(); }
+  
+  virtual void produce(art::Event&, const art::ProcessingFrame&) override {}
+  
+}; // class DummyProducer
+
+
+DEFINE_ART_MODULE(DummyProducer)
+
+//------------------------------------------------------------------------------
+

--- a/scripts/manageDataRunDefinitions.py
+++ b/scripts/manageDataRunDefinitions.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python
+
+import logging
+import time
+
+__doc__ = """Manages SAM definitions for ICARUS data run."""
+__author__ = "Gianluca Petrillo (petrillo@slac.stanford.edu)"
+__date__ = time.strptime("July 7, 2021", "%B %d, %Y")
+__version__ = "1.0"
+
+from samweb_client.client import SAMWebClient
+import samweb_client.exceptions as samexcpt
+
+logging.basicConfig()
+
+ExperimentName = "ICARUS"
+DefaultStages = [ 'raw', 'stage0', 'stage1', ]
+
+StageDimensions = {
+  'raw':    "data_tier raw",
+  'stage0': "icarus_project.stage stage0",
+  'stage1': "icarus_project.stage stage1",
+} # StageDimensions
+
+# this is a modal flag that is dangerous enough to be not user-controlled:
+# if `True`, queries without specifying a run number will be allowed.
+AllowAllRuns = False
+
+
+# ------------------------------------------------------------------------------
+class SampleInfo:
+  def __init__(self, run=None, stage=None, stream=None, projectVersion=None, ):
+    self.run = SampleInfo._copyList(run)
+    self.stage = SampleInfo._copyList(stage)
+    self.stream = SampleInfo._copyList(stream)
+    self.projectVersion = SampleInfo._copyList(projectVersion)
+  # __init__()
+  
+  def isRunDefined(self) -> "returns if run is collapsed to a value":
+    return not SampleInfo.hasOptions(self.run) \
+      and (AllowAllRuns or self.run is not None)
+  # isRunDefined()
+  
+  def isStageComplete(self) -> "returns if stage is collapsed to a value":
+    return not SampleInfo.hasOptions(self.stage)
+  
+  def isStreamComplete(self) -> "returns if stream is collapsed to a value":
+    return not SampleInfo.hasOptions(self.stream)
+  
+  def isProjectVersionComplete(self) -> "returns if project version is collapsed to a value":
+    return not SampleInfo.hasOptions(self.projectVersion)
+  
+  def isComplete(self) -> "returns if there are no ambiguities left in the info":
+    return self.isRunDefined() and self.isStageComplete() \
+      and self.isStreamComplete() and self.isProjectVersionComplete()
+  # isComplete()
+  
+  def defName(self):
+    components = [ ExperimentName, 'data' ]
+    if self.isRunDefined() and self.run is not None:
+      components.append(f"run{self.run}")
+    if self.isStageComplete() and self.stage is not None:
+      components.append(self.stage)
+    if self.isStreamComplete() and self.stream is not None:
+      components.append(self.stream)
+    if self.isProjectVersionComplete() and self.projectVersion is not None:
+      components.append(self.projectVersion)
+    return "_".join(filter(None, components))
+  # defName()
+  
+  def copy(self, **kwargs):
+    kwargs.setdefault('run', self.run)
+    kwargs.setdefault('stage', self.stage),
+    kwargs.setdefault('stream', self.stream),
+    kwargs.setdefault('projectVersion', self.projectVersion),
+    return SampleInfo(**kwargs)
+  # copy()
+  
+  def __str__(self):
+    s = f"run {self.run if self.run else 'unspecified'}"
+    if self.stage: s += f", stage {self.stage}"
+    if self.stream: s += f", stream {self.stream}"
+    if self.projectVersion: s += f", project version {self.projectVersion}"
+    return s
+  # __str__()
+  
+  @staticmethod
+  def makeOptionList(value):
+    return value if SampleInfo.hasOptions(value) else [ value ]
+  
+  @staticmethod
+  def hasOptions(value):
+    return SampleInfo._isIterable(value) and not isinstance(value, str)
+  
+  @staticmethod
+  def _isIterable(value): return hasattr(value, "__iter__")
+  
+  @staticmethod
+  def _copyList(value):
+    return value[:] if SampleInfo._isIterable(value) else value
+  
+# class SampleInfo
+
+
+# ------------------------------------------------------------------------------
+class DimensionQueryMaker:
+  """Callable object making a SAM query out of a `SampleInfo` object."""
+  
+  def __call__(self,
+   info: "SampleInfo object with all the information for the query",
+   minimum: "throws an exception if fewer than these elements are included" = 0,
+   ) -> "a SAM dimensions query string":
+    
+    dims = [
+      DimensionQueryMaker.simpleItem('run_number', info.run),
+      DimensionQueryMaker.multiItem(StageDimensions, info.stage, 'stage'),
+      DimensionQueryMaker.simpleItem('data_stream', info.stream),
+      DimensionQueryMaker.simpleItem('icarus_project.version', info.projectVersion),
+      ]
+    query = " and ".join(filter(None, dims))
+    if len(dims) < minimum:
+      raise RuntimeError(f"Query resulted in only {len(dims)} constraints: '{query}'")
+    return query
+  # __call__()
+  
+  @staticmethod
+  def addParentheses(s): return "( " + s + " )" if s else ""
+
+  @staticmethod
+  def simpleItem(key, value, typeName=None):
+    # if typeName is None: typeName = key
+    if SampleInfo.hasOptions(value):
+      return f"{key} in ( { ' '.join(map(str, value)) } )"
+    elif value is not None: return f"{key} {value}"
+    else: return ""
+  # simpleItem()
+
+
+  @staticmethod
+  def multiItem(queries, values, typeName):
+    values = SampleInfo.makeOptionList(values)
+    if not values or None in values: return ""
+    dims = []
+    for value in values:
+      try:
+        dims.append(queries[value])
+      except KeyError:
+        raise RuntimeError(f"{typeName} '{value}' not supported.")
+    # for
+    if len(dims) > 1: dims = list(map(DimensionQueryMaker.addParentheses, dims))
+    query = " or ".join(dims) if dims else ""
+    if len(dims) > 1: query = DimensionQueryMaker.addParentheses(query)
+    return query
+  # multiItem()
+
+# class DimensionQueryMaker
+
+
+# ------------------------------------------------------------------------------
+class SampleBrowser:
+  
+  def __init__(self, samweb):
+    self.samweb = samweb if samweb else SAMWebClient()
+  
+  
+  def iterateProjectVersions(self, info: "SampleInfo object defining iteration ranges"):
+    assert self.samweb, "SAM web client not initialized. We do not go anywhere."
+    
+    # expand the project versions: each version will be treated separately
+    if info.projectVersion is None:
+      if info.stage != 'raw':
+        versionQuery = DimensionQueryMaker()(info, minimum=2)
+        projectVersions = self._discoverProjectVersions(versionQuery)
+      else: projectVersions = [ None ] # no version constraint is ok for raw files
+    else:
+      projectVersions = SampleInfo.makeOptionList(info.projectVersion)
+    # if ... else
+    
+    for prjVer in projectVersions:
+      prjInfo = info.copy(projectVersion=prjVer)
+      yield prjInfo
+    # for
+  # iterateProjectVersions()
+
+
+  def iterateStreams(self, info: "SampleInfo object defining iteration ranges"):
+    assert info.isStageComplete(), "Stage must be set."
+    for stream in SampleInfo.makeOptionList(info.stream):
+      streamInfo = info.copy(stream=stream)
+      yield from self.iterateProjectVersions(streamInfo)
+    # for streams
+  # iterateStreams()
+
+
+  def iterateStages(self, info: "SampleInfo object defining iteration ranges"):
+    assert info.stage is not None, "Stages needs to be explicitly specified."
+    for stage in SampleInfo.makeOptionList(info.stage):
+      assert stage, "Stage must be specified."
+      stageInfo = info.copy(stage=stage)
+      logging.debug(f"Processing {stageInfo}")
+      yield from self.iterateStreams(stageInfo)
+    # for
+  # iterateStages()
+
+  
+  def iterate(self, info: "SampleInfo object defining iteration ranges"):
+    """Iterates through all elements in `info`."""
+    for run in SampleInfo.makeOptionList(info.run):
+      runInfo = info.copy(run=run)
+      yield from self.iterateStages(runInfo)
+    # for
+  # iterate()
+  def __call__(self, info): return self.iterate(info)
+  
+  
+  def _discoverProjectVersions(self, dims):
+    """Returns the project versions from the all files matching `dims`."""
+    logging.debug("Discovering project versions for %s", dims)
+    
+    try:
+      files = self.samweb.listFiles(dims, fileinfo=True)
+    except samexcpt.Error:
+      logging.error(f"SAM exception while translating query: '{dims}'")
+      raise
+    
+    logging.debug(f"  => querying metadata for {len(files)} files")
+    
+    versions = set(
+      meta['icarus_project.version']
+      for meta in self.samweb.getMetadataIterator(fInfo.file_id for fInfo in files)
+      )
+    logging.debug(f"  => extracted {len(versions)} versions: %s", versions)
+    return list(versions)
+  # _discoverProjectVersions()
+
+# class SampleBrowser
+
+
+# ------------------------------------------------------------------------------
+class SampleProcessClass:
+  
+  def __init__(self, samweb, create=False, query=False, printDefs=False,
+   describe=False, check=False, delete=False,
+   fake=False, force=False, prependUser=True,
+   ):
+    # action collection
+    self.actions = []
+    if check: self.actions.append("check")
+    if create: self.actions.append("create")
+    if query: self.actions.append("query")
+    if printDefs: self.actions.append("printDefs")
+    if describe: self.actions.append("describe")
+    if delete: self.actions.append("delete")
+    if not self.actions:
+      raise RuntimeError("At least one action needs to be enabled.")
+    self.fake = fake
+    self.force = force
+    self.prependUser = prependUser
+    
+    self.samweb = samweb if samweb else SAMWebClient()
+    self.buildQuery = DimensionQueryMaker()
+    
+    try: self.SAMuser = samweb.get_user()
+    except samexcpt.Error as e:
+      if self.prependUser:
+        logging.error("Could not find out your name! %s", e)
+        raise
+      self.SAMuser = None
+    #
+    
+  # __init__()
+  
+  
+  def __call__(self, info):
+    assert self.samweb, "SAM web client not initialized. We do not go anywhere."
+    
+    if not info.isComplete():
+      raise RuntimeError(f"Can't process incomplete specification: {info}")
+    
+    dim = self.buildQuery(info)
+    
+    logging.debug("Info: %s => dim='%s'", info, dim)
+    defName = self.buildDefName(info)
+    
+    for action in self.actions:
+    
+      if action == "printDefs":
+        print(defName)
+      
+      elif action == "check":
+        self.doCheck(defName)
+      
+      elif action == "describe":
+        self.doDescribe(defName)
+      
+      elif action == "query":
+        self.doQuery(info=info, defName=defName, dim=dim)
+    
+      elif action == "create":
+        self.doCreateDef(info, defName=defName, dim=dim)
+      
+      elif action == "delete":
+        self.doDeleteDef(info, defName=defName, dim=dim)
+      
+      else:
+        raise RuntimeError(f"LOGIC ERROR: action {action} not implemented.")
+      
+    # for
+    
+    return defName
+  # __call__()
+  
+  
+  def doDescribe(self, defName):
+    if self.fake:
+      print(f"DRYRUN> descDefinition({defName!r})")
+      return
+    try:
+      print(self.samweb.descDefinition(defName))
+    except samexcpt.DefinitionNotFound:
+      print(f"Definition Name: {defName}  => NOT FOUND")
+  # doDescribe()
+  
+  def doQuery(self, info, defName, dim):
+    if self.fake:
+      print(f"DRYRUN> {dim}")
+      return None
+    try:
+      summary = self.getSummary(info=info, defName=defName, dims=dim)
+    except samexcpt.Error as e:
+      logging.error(f"Query of definition {defName} (query: '{dim}') failed: %s", e)
+      summary = None
+    else:
+      print(f"{info}: {(summary['total_event_count'] if summary['total_event_count'] else 'unknown')} events"
+            f" in {summary['file_count']} files"
+            f" ({summary['total_file_size']/(1 << 30):g} GiB)"
+            )
+      e = None
+    # try ... else
+    return summary if summary else e
+  # doQuery()
+  
+  def doCheck(self, defName):
+    assert defName
+    if self.fake:
+      print(f"DRYRUN> countFiles(defname={defName!r})")
+      return True
+    count = self.defNameCount(defName)
+    if count is None:
+      print(f"{defName} not available")
+      return False
+    else:
+      print(f"{defName} available ({count} files)")
+      return True
+  # doCheck()
+  
+  def doCreateDef(self, info, defName=None, dim=None):
+    assert info
+    if not defName: defName = self.buildDefName(info)
+    if not dim: dim = self.buildQuery(info)
+    descr = self.describeSample(info)
+    
+    count = self.defNameCount(defName)
+    if count is not None:
+      logging.error(f"Definition {defName!r} already exists (and matches {count} files).")
+      return None
+    
+    try:
+      count = self.samweb.countFiles(dimensions=dim)
+    except samexcpt.Error as e:
+      logging.error(f"Attempt to count matches with {dim!r} failed: %s", e)
+      return None
+    if count == 0:
+      print(f"Definition {defName} NOT created as it would match no file (query: {dim!r})")
+      return None
+    logging.debug(f"Creating {defName!r}, now matching {count} files")
+    if self.fake:
+      print(f"DRYRUN> createDefinition(defname={defName!r}, dims={dim!r}, description={descr!r})")
+    else:
+      try:
+        self.samweb.createDefinition(defname=defName, dims=dim, description=descr)
+        print(f"{defName} created ({count} files)")
+      except samexcpt.Error as e:
+        logging.error \
+          (f"Failed to create definition {defName} from query='{dim}': %s", e)
+        return None
+    # if
+    return defName
+  # doCreateDef()
+  
+  def doDeleteDef(self, info, defName=None, dim=None):
+    assert self.samweb
+    assert info
+    if not defName: defName = self.buildDefName(info)
+    if not dim: dim = self.buildQuery(info)
+    descr = self.describeSample(info)
+    
+    try:
+      defInfo = self.samweb.descDefinitionDict(defName)
+    except samexcpt.DefinitionNotFound:
+      print(f"Definition Name: {defName}  => NOT FOUND") # we are ok... I guess
+      return None
+    
+    # we perform many checks to make sure this deletion is proper
+    ForcedMsg = { True: "forced to delete it anyway", False: "won't delete unless forced to", }
+    checksOk = True
+    
+    if not self.SAMuser:
+      try: self.SAMuser = self.samweb.get_user()
+      except samexcpt.Error as e:
+        logging.error("Could not find out your name! %s", e)
+    # if not cached already
+    try: SAMgroup = self.samweb.get_group()
+    except samexcpt.Error as e:
+      logging.error("Could not find out the name of your group! %s", e)
+    logging.debug(f"You appear to be {SAMuser!r} of group {SAMgroup!r}")
+    
+    if defInfo['username'] != SAMuser:
+      logging.warning(
+        f"Definition {defName!r} was created on {defInfo['create_time']}"
+        f" by {defInfo['username']}/{defInfo['group']}, not by you ({SAMuser})"
+        f": won't delete."
+        )
+      checksOk = False
+    # if
+    
+    if defInfo['group'] != SAMgroup:
+      logging.warning(
+        f"Definition {defName!r} was created on {defInfo['create_time']}"
+        f" by {defInfo['username']}/{defInfo['group']}, not by your group ({SAMgroup})"
+        f": won't delete."
+        )
+      checksOk = False
+    # if
+    
+    if defInfo['dimensions'] != dim:
+      logging.warning(f"Definition {defName!r} has unexpected query:"
+        f" ({defInfo['dimensions']!r}, expected: {dim!r}); {ForcedMsg[self.force]}."
+        )
+      if not self.force: checksOk = False
+    #
+    
+    if defInfo['description'] != descr:
+      logging.warning(
+        f"Definition {defName!r} appears not to be created with this program:"
+        f" description mismatch"
+        f" ({defInfo['description']!r}, expected: {descr!r}); {ForcedMsg[self.force]}."
+        )
+      if not self.force: checksOk = False
+    # if
+    
+    if not checksOk:
+      logging.error(f"Definition {defName!r} will NOT be deleted.")
+      return None
+    
+    if self.fake:
+      print(f"DRYRUN> deleteDefinition({defName!r})")
+      return defName
+    try:
+      self.samweb.deleteDefinition(defName)
+    except samexcpt.DefinitionNotFound:
+      logging.error(f"Definition {defName} NOT FOUND (can't be deleted)")
+    # except samexcpt.DefinitionNotFound: # which exception to match?
+    #   logging.error(f"Definition {defName!r} has already been used and can't be deleted.")
+    except samexcpt.NoAuthorizationCredentials as e:
+      logging.error(f"Failed to delete definition {defName!r} for lack of credentials: %s", e)
+    except samexcpt.Error as e:
+      logging.error(f"Failed to delete definition {defName!r}: %s", e)
+    
+    count = self.defNameCount(defName)
+    if count is not None:
+      logging.error(f"Deletion of definition {defName!r} silently FAILED"
+                    f" (still there with its own {count} files).")
+      return None
+    # if still there
+    print(f"Definition {defName} successfully deleted.")
+    return defName
+  # doDeleteDef()
+  
+  
+  def buildDefName(self, info):
+    if self.prependUser: return self.SAMuser + "_" + info.defName()
+    else: return info.defName()
+  # buildDefName()
+  
+  def getSummary(self, info=None, defName=None, dims=None):
+    assert info or defName or dims
+    e = RuntimeError("Insufficient parameters to get summary") # should not happen
+    
+    if not defName and info: defName = self.buildDefName(info)
+    if defName:
+      try: return self.samweb.listFilesSummary(defname=defName)
+      except samexcpt.DefinitionNotFound as e: queryError = e
+    
+    if not dims and info: dims = self.buildQuery(info)
+    if dims:
+      try: return self.samweb.listFilesSummary(dims)
+      except samexcpt.Error as e: queryError = e
+    
+    raise e
+  # getSummary()
+  
+  
+  def defNameCount(self, defName: "SAM definition name"):
+    """Returns the count of files of `defName`, `None` if not found.
+    
+    Throws exception in all other error situations.
+    """
+    try: return self.samweb.countFiles(defname=defName)
+    except samexcpt.DefinitionNotFound: return None
+  # defNameCount()
+  
+  def describeSample(self, info): return "ICARUS data " + str(info)
+  
+# class SampleProcessClass
+
+
+# ------------------------------------------------------------------------------
+def collapseList(l):
+  try:
+    if not isinstance(l, str) and len(l) == 1: return next(iter(l))
+  except TypeError: pass
+  return l
+# collapseList()
+
+
+if __name__ == "__main__":
+  import sys
+  import argparse
+  
+  parser = argparse.ArgumentParser(description=__doc__)
+  
+  SampleGroup = parser.add_argument_group(title="Sample selection")
+  SampleGroup.add_argument("runs", nargs="*", type=int, help="runs to process")
+  SampleGroup.add_argument("--stage", "-s", action="append",
+    help="stages to include {DefaultStages}")
+  SampleGroup.add_argument("--prjversion", "-p", action="append",
+    help="project versions to include [autodetect (resource-intensive!)]")
+  SampleGroup.add_argument("--stream", "-f", action="append",
+    help="data streams to include (use 'any' for... any) [any]")
+  SampleGroup.add_argument("--global", "-g", dest='globalDef',
+    action="store_true", help="do not prepend SAM user name to definitions")
+  
+  ActionGroup = parser.add_argument_group(title="Actions")
+  ActionGroup.add_argument("--check", action="store_true",
+    help="prints whether the definition for the sample is available")
+  ActionGroup.add_argument("--describe", action="store_true",
+    help="describes an existing definition for the sample")
+  ActionGroup.add_argument("--query", action="store_true",
+    help="queries the definitions related to the samples")
+  ActionGroup.add_argument("--defname", action="store_true",
+    help="prints the name of the definitions related to the samples")
+  ActionGroup.add_argument("--create", action="store_true",
+    help="creates one definition per sample (use --defname to see their names)")
+  ActionGroup.add_argument("--delete", action="store_true",
+    help="attempts to remove one definition per sample")
+  
+  GeneralOptGroup = parser.add_argument_group(title="General options")
+  GeneralOptGroup.add_argument("--test", action="store_true",
+    help="tests the connection to SAM and exits")
+  GeneralOptGroup.add_argument("--force", "-F", action="store_true",
+    help="skips safety checks of some operations")
+  GeneralOptGroup.add_argument("--fake", "--dryrun", "-n", action="store_true",
+    help="does not perform actual creation and query actions")
+  GeneralOptGroup.add_argument("--debug", action="store_true",
+    help="enable verbose debugging output")
+  GeneralOptGroup.add_argument("--version", "-V", action="version",
+    version=f"%(prog)s v{__version__} ({time.asctime(__date__)})",
+    help="prints the version number")
+  
+  args = parser.parse_args()
+  
+  logging.getLogger().setLevel(logging.DEBUG if args.debug else logging.INFO)
+  if args.stage is None: args.stage = DefaultStages
+  if args.stream:
+    args.stream = [ None if s == "any" else s for s in args.stream ]
+  
+  try: samweb = SAMWebClient()
+  except samexcpt.Error as e:
+    if args.test:
+      print("Failed to connect to SAM.");
+    else:
+      logging.error("Failed to connect to SAM: %s", e)
+    sys.exit(1)
+  # try ... except
+  if args.test:
+    try: print(samweb.serverInfo())
+    except samexcpt.Error as e:
+      logging.error("Test connection to SAM failed: %s", e)
+      sys.exit(1)
+    print("\nConnection test succeeded.")
+    sys.exit(0)
+  # if test
+  
+  if not AllowAllRuns and not args.runs:
+    logging.error("At least one run MUST be specified.")
+    sys.exit(1)
+  #
+
+  iterateSamples = SampleBrowser(samweb)
+  processInfo = SampleProcessClass(samweb,
+    create=args.create, query=args.query, printDefs=args.defname,
+    describe=args.describe, check=args.check, delete=args.delete,
+    fake=args.fake, force=args.force, prependUser=not args.globalDef
+    )
+  
+  baseSampleInfo = SampleInfo(
+    run=collapseList(args.runs if args.runs else None),
+    stage=collapseList(args.stage),
+    stream=collapseList(args.stream), # None means any
+    projectVersion=collapseList(args.prjversion), # None for autodetect
+    )
+  
+  for sampleInfo in iterateSamples(baseSampleInfo):
+    processInfo(sampleInfo)
+  
+  sys.exit(0)
+# main

--- a/scripts/sortDataLoggerFiles.py
+++ b/scripts/sortDataLoggerFiles.py
@@ -351,7 +351,6 @@ if __name__ == "__main__":
     firstLogger = detectFirstLogger(firstPassFiles)
   else: firstLogger = args.firstlogger if args.firstlogger is not None else 4
   
-  print(f"{firstLogger=}")
   FileInfoClass.setFirstDataLogger(firstLogger)
   
   fileInfo.sort() # uses internal FileInfoClass ordering


### PR DESCRIPTION
This is a _large_ pull request containing several additions to PMT and trigger decoding, plus some utility modules, scripts and job configurations here and there.

The highlights:
* introduced a new data product `sbn::ExtraTriggerInfo` (still not fully finalised) that is expected to contain all the information from ICARUS trigger hardware and first processing, including absolute beam gate time
* the trigger decoder fills part of the new data product, _including the beam gate time_ (there is not enough information yet to fill the rest, with a couple of exceptions possible); PMT decoder utilises that data product as trigger information source
* the trigger decoder is now forgiving if the format of the raw trigger packet is corrupted, allowing the processing of some runs (`6017`-`6043`) that have such issue
* additional configurations are provided for older runs (`5252`, `5510`, `5679, `5795` and `5873`) that have format similar issues in the raw trigger data; in these cases, trigger decoding is skipped (which is possible because it is not needed for PMT decoding)

The new configurations for the old runs are provided only as plugins, since I could not figure out how to make the `stage0` configuration work for them. The configurations are defined in `decodePMTdefs_icarus.fcl` and they could be used in a way like:
~~~~
#include "decodePMTdefs_icarus.fcl"
#include "stage0_standard_icarus.fcl"

physics.producers: {
  @table::physics.producers
  @table::decoder_PMT_trigger_majority_run5873_icarus
}
~~~~
provided that the base job configuration file (`stage0_standard_icarus.fcl` in the example) worked on run `5873` with the previous versions of `icaruscode`. I could not test this because I did not find a working job configuration without split streams.

## Testing

My test consisted of running configurations like the one above with
1. `decodePMT_icarus.fcl` on 2 (or sometimes 10) events, confirming the completion of the job and verifying by eye that the PMT timestamps looked correct and that the beam gate time was as expected;
2. `stage0_multitpc_splitstreams_icarus.fcl` on 1 event, confirming the completion of the job.

The first test was executed on runs `5252` (`decoder_PMT_trigger_minbias_run5252_icarus`), `5510`, `5679` and `5795` (`decoder_PMT_trigger_minbias_skiptrigger_icarus`), `5873` (`decoder_PMT_trigger_majority_run5873_icarus`), and `5984`, `5986`, `5987`, `5992`, `5993`, `6001`, `6002`, `6003`, `6004`, `6005`, `6007`, `6008`, `6009`, `6011`, `6012`, `6013`, `6014`, `6015`, `6016`, `6017`, `6018`, `6019`, `6025`, `6026`, `6027`, `6028`, `6030`, `6036`, `6037`, `6038`, `6039`, `6040`, `6041`, `6042`, `6043`, `6069`, `6070`, `6079`, `6080`, `6082`, `6083`, `6085`, `6093`, `6095`, `6097`, `6098`, `6099`, `6100`, `6101`, `6102`, `6103` and `6104` (standard configuration).
The second test ~is still running~ _is also successfully completed_ and is scheduled for all those same runs except for the first 5, i.e. only for the runs that are expected to be processed with the "standard" configuration.

Special thanks to @ascarpel for too many things to be listed here. Part of these commits includes also design contributions by @jzettle.