### PR TITLE
PMT decoder now throws an exception if PMT channel DB is empty

### DIFF
--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.cxx
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.cxx
@@ -69,7 +69,7 @@ ICARUSChannelMapProvider::ICARUSChannelMapProvider(const fhicl::ParameterSet& ps
     // Do the channel mapping initialization
     if (fChannelMappingTool->BuildFragmentToDigitizerChannelMap(fFragmentToDigitizerMap))
       {
-	throw cet::exception("PMTDecoder") << "Cannot recover the Fragment ID channel map from the database \n";
+	throw cet::exception("ICARUSChannelMapProvider") << "Cannot recover the Fragment ID channel map from the database \n";
       }
     else if (fDiagnosticOutput)
       {
@@ -106,6 +106,12 @@ bool ICARUSChannelMapProvider::hasFragmentID(const unsigned int fragmentID) cons
     return fFragmentToReadoutMap.find(fragmentID) != fFragmentToReadoutMap.end();
 }
 
+
+unsigned int ICARUSChannelMapProvider::nTPCfragmentIDs() const {
+  return fFragmentToReadoutMap.size();
+}
+
+
 const std::string&  ICARUSChannelMapProvider::getCrateName(const unsigned int fragmentID) const
 {
     IChannelMapping::TPCFragmentIDToReadoutIDMap::const_iterator fragToReadoutItr = fFragmentToReadoutMap.find(fragmentID);
@@ -132,6 +138,12 @@ bool ICARUSChannelMapProvider::hasBoardID(const unsigned int boardID)  const
     return fReadoutBoardToChannelMap.find(boardID) != fReadoutBoardToChannelMap.end();
 }
 
+
+unsigned int ICARUSChannelMapProvider::nTPCboardIDs() const {
+  return fReadoutBoardToChannelMap.size();
+}
+
+
 unsigned int ICARUSChannelMapProvider::getBoardSlot(const unsigned int boardID)  const
 {
     IChannelMapping::TPCReadoutBoardToChannelMap::const_iterator readoutBoardItr = fReadoutBoardToChannelMap.find(boardID);
@@ -157,6 +169,12 @@ bool ICARUSChannelMapProvider::hasPMTDigitizerID(const unsigned int fragmentID) 
 {
     return fFragmentToDigitizerMap.find(fragmentID) != fFragmentToDigitizerMap.end();
 }
+
+
+unsigned int ICARUSChannelMapProvider::nPMTfragmentIDs() const {
+  return fFragmentToDigitizerMap.size();
+}
+
 
 const DigitizerChannelChannelIDPairVec& ICARUSChannelMapProvider::getChannelIDPairVec(const unsigned int fragmentID) const
 {

--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.h
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.h
@@ -31,16 +31,22 @@ public:
     
     // Section to access fragment to board mapping
     bool                                    hasFragmentID(const unsigned int)       const override;
+    /// Returns the number of TPC fragment IDs known to the service.
+    unsigned int                            nTPCfragmentIDs() const override;
     const std::string&                      getCrateName(const unsigned int)        const override;
     const ReadoutIDVec&                     getReadoutBoardVec(const unsigned int)  const override;
 
     // Section to access channel information for a given board
     bool                                    hasBoardID(const unsigned int)          const override;
+    /// Returns the number of TPC board IDs known to the service.
+    unsigned int                            nTPCboardIDs() const override;
     unsigned int                            getBoardSlot(const unsigned int)        const override;
     const ChannelPlanePairVec&              getChannelPlanePair(const unsigned int) const override;
 
     // Section for PMT channel mapping
     bool                                    hasPMTDigitizerID(const unsigned int)   const override;
+    /// Returns the number of PMT fragment IDs known to the service.
+    unsigned int                            nPMTfragmentIDs() const override;
     const DigitizerChannelChannelIDPairVec& getChannelIDPairVec(const unsigned int) const override;
 
     // Section for CRT channel mapping    

--- a/icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h
+++ b/icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h
@@ -33,16 +33,22 @@ public:
 
     // Section to access fragment to board mapping
     virtual bool                                    hasFragmentID(const unsigned int)       const = 0;
+    /// Returns the number of TPC fragment IDs known to the service.
+    virtual unsigned int                            nTPCfragmentIDs() const = 0;
     virtual const std::string&                      getCrateName(const unsigned int)        const = 0;
     virtual const ReadoutIDVec&                     getReadoutBoardVec(const unsigned int)  const = 0;
 
     // Section to access channel information for a given board
     virtual bool                                    hasBoardID(const unsigned int)          const = 0;
+    /// Returns the number of TPC board IDs known to the service.
+    virtual unsigned int                            nTPCboardIDs() const = 0;
     virtual unsigned int                            getBoardSlot(const unsigned int)        const = 0;
     virtual const ChannelPlanePairVec&              getChannelPlanePair(const unsigned int) const = 0;
 
     // Section for recovering PMT information
     virtual bool                                    hasPMTDigitizerID(const unsigned int)   const = 0;
+    /// Returns the number of PMT fragment IDs known to the service.
+    virtual unsigned int                            nPMTfragmentIDs() const = 0;
     virtual const DigitizerChannelChannelIDPairVec& getChannelIDPairVec(const unsigned int) const = 0;
 
     virtual unsigned int                            getSimMacAddress(const unsigned int)    const = 0;    

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -1177,6 +1177,17 @@ icarus::DaqDecoderICARUSPMT::DaqDecoderICARUSPMT(Parameters const& params)
       ;
   }
   
+  
+  //
+  // sanity checks
+  //
+  
+  if (fChannelMap.nPMTfragmentIDs() == 0) {
+    throw cet::exception("DaqDecoderICARUSPMT")
+      << "Channel mapping database does not report any PMT fragment ID!\n";
+  } // if no PMT in database
+  
+  
 } // icarus::DaqDecoderICARUSPMT::DaqDecoderICARUSPMT()
 
 


### PR DESCRIPTION
The PMT decoder can't work without the mapping from fragment ID to off-line channel number which `IICARUSChannelMapping` is providing.
It has now changed to throw an exception at begin of the job when no PMT fragment ID is known to the service at all.

Since the service itself was not providing that information, the service (provider) interface and implementation was updated too.
