### PR TITLE
Model featuring correlated ionization and scintillation set as default

### DIFF
--- a/fcl/services/simulationservices_icarus.fcl
+++ b/fcl/services/simulationservices_icarus.fcl
@@ -67,7 +67,11 @@ icarus_largeantparameters: {
     LarqlChi0D: 0.000129379
     LarqlAlpha: 0.0372
     LarqlBeta: 0.0124
-    # IonAndScintCalculator: "NEST"
+    # adopt the "correlated" model for ionization and scintillation (SBN DocDB 17964)
+    IonAndScintCalculator: "Correlated"
+    # this enables some improvements on top of the correlated model
+    # (LArQL, using the parameters above; see SBN DocDB 21270)
+    # UseModLarqlRecomb: true
 
     # The following parameters specify details of wireplanes or similar
     #  areas with optically parameterized transmissions (Ben J 2013)


### PR DESCRIPTION
This is the change needed to utilise the correlated ionisation/scintillation simulation by @wforeman ([SBN DocDB 17964](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=17964)) as standard for GEANT4 simulation.

The configuration is centralised enough that a change in a single place was needed.

This pull request will be a **draft** until a "all clear" message is sent by the collaboration.
