### PR TITLE
Don't keep shower daughters

### DIFF
--- a/fcl/services/simulationservices_icarus.fcl
+++ b/fcl/services/simulationservices_icarus.fcl
@@ -21,7 +21,7 @@ icarus_largeantparameters: {
     VisualizeNeutrals:        false   #depricated
     ModifyProtonCut:          false   #Whether to modify the default proton cut
     NewProtonCut:             0.0     #new ProtonCut value, ModifyProtonCut must be set to set new value
-    KeepEMShowerDaughters:    true    #save secondary, tertiary, etc particles in EM showers
+    KeepEMShowerDaughters:    false    #Don't save secondary, tertiary, etc particles in EM showers
     LongitudinalDiffusion:    4.0e-9  #in cm^2/ns
     TransverseDiffusion:      8.8e-9  #in cm^2/ns
     ElectronClusterSize:      20.0    #number of ionization electrons to drift in a unit


### PR DESCRIPTION
Change to Drop EM Shower daughters for the ICARUS G4 configuration.