### PR TITLE
Trigger simulation support using energy deposition summary

### DIFF
--- a/icaruscode/CMakeLists.txt
+++ b/icaruscode/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 set( IFDH_ART_DIR $ENV{IFDH_ART_DIR} )
 
+add_subdirectory(IcarusObj) 
+
 add_subdirectory(Analysis)
 add_subdirectory(CRT)
 add_subdirectory(Decode)

--- a/icaruscode/IcarusObj/CMakeLists.txt
+++ b/icaruscode/IcarusObj/CMakeLists.txt
@@ -1,0 +1,4 @@
+art_dictionary()
+
+install_headers()
+install_source()

--- a/icaruscode/IcarusObj/SimEnergyDepositSummary.h
+++ b/icaruscode/IcarusObj/SimEnergyDepositSummary.h
@@ -1,0 +1,31 @@
+/**
+ * @file   icaruscode/IcarusObj/SimEnergyDepositSummary.h
+ * @brief  Object storing a summary of energy depositions in the detector.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * 
+ */
+
+#ifndef ICARUSCODE_ICARUSOBJ_SIMENERGYDEPOSITSUMMARY_H
+#define ICARUSCODE_ICARUSOBJ_SIMENERGYDEPOSITSUMMARY_H
+
+// -----------------------------------------------------------------------------
+namespace icarus { struct SimEnergyDepositSummary; }
+
+/// Data structure containing summary information about deposited energy.
+struct icarus::SimEnergyDepositSummary {
+  
+  float Total       { 0.0 }; ///< Total deposited energy [GeV]
+  float Spill       { 0.0 }; ///< Energy deposited in spill [GeV]
+  float PreSpill    { 0.0 }; ///< Energy deposited in pre-spill [GeV]
+  float Active      { 0.0 }; ///< Energy deposited in active volume [GeV]
+  /// Energy deposited in active volume in spill [GeV]
+  float SpillActive { 0.0 };
+  /// Energy deposited in active volume in pre-spill window [GeV]
+  float PreSpillActive { 0.0 };
+  
+}; // icarus::SimEnergyDepositSummary
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_ICARUSOBJ_SIMENERGYDEPOSITSUMMARY_H

--- a/icaruscode/IcarusObj/classes.h
+++ b/icaruscode/IcarusObj/classes.h
@@ -1,0 +1,8 @@
+#include "canvas/Persistency/Common/Wrapper.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "icaruscode/IcarusObj/SimEnergyDepositSummary.h"
+#include <vector>
+
+namespace {
+  icarus::SimEnergyDepositSummary EDepSum;
+}

--- a/icaruscode/IcarusObj/classes_def.xml
+++ b/icaruscode/IcarusObj/classes_def.xml
@@ -1,0 +1,8 @@
+<lcgdict>
+
+  <class name="icarus::SimEnergyDepositSummary" ClassVersion="10" >
+   <version ClassVersion="10" checksum="1932250066"/>
+  </class>
+  <class name="art::Wrapper<icarus::SimEnergyDepositSummary>"/>
+
+</lcgdict>

--- a/icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.cxx
@@ -21,7 +21,7 @@
 // -----------------------------------------------------------------------------
 icarus::trigger::details::EventInfoExtractor::EventInfoExtractor(
   std::vector<art::InputTag> truthTags,
-  std::vector<art::InputTag> edepTags,
+  EDepTags_t edepTags,
   TimeSpan_t inSpillTimes,
   TimeSpan_t inPreSpillTimes,
   geo::GeometryCore const& geom,
@@ -232,7 +232,7 @@ auto icarus::trigger::details::EventInfoExtractor::getInteractionTime
 // -----------------------------------------------------------------------------
 icarus::trigger::details::EventInfoExtractorMaker::EventInfoExtractorMaker(
   std::vector<art::InputTag> truthTags,
-  std::vector<art::InputTag> edepTags,
+  EDepTags_t edepTags,
   geo::GeometryCore const& geom,
   std::string logCategory
   )

--- a/icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.cxx
@@ -11,11 +11,86 @@
 #include "icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.h"
 
 // LArSoft libraries
+#include "lardataalg/Utilities/quantities/spacetime.h" // microseconds
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/TPCGeo.h"
 
 // C/C++ standard libraries
 #include <utility> // std::move()
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+namespace {
+  
+  /// Returns in which active TPC volume `point` falls in (`nullptr` if none).
+  geo::TPCGeo const* pointInActiveTPC
+    (geo::GeometryCore const& geom, geo::Point_t const& point)
+    {
+      geo::TPCGeo const* tpc = geom.PositionToTPCptr(point);
+      return (tpc && tpc->ActiveBoundingBox().ContainsPosition(point))
+        ? tpc: nullptr;
+    } // pointInActiveTPC()
+  
+  
+  /// Helper tracking energy depositions.
+  struct EnergyAccumulator {
+    
+    using TimeSpan_t = icarus::trigger::details::EventInfoExtractor::TimeSpan_t;
+    using GeV = util::quantities::gigaelectronvolt;
+    
+    GeV totalEnergy { 0.0 }, inSpillEnergy { 0.0 }, inPreSpillEnergy { 0.0 };
+    GeV activeEnergy { 0.0 }, inSpillActiveEnergy { 0.0 },
+      inPreSpillActiveEnergy { 0.0 };
+    
+    EnergyAccumulator(
+      TimeSpan_t inSpillTimes,
+      TimeSpan_t inPreSpillTimes,
+      geo::GeometryCore const& geom
+      )
+      : fGeom(geom)
+      , fInSpillTimes(inSpillTimes)
+      , fInPreSpillTimes(inPreSpillTimes)
+      {}
+    
+    void add(
+      GeV energy,
+      detinfo::timescales::simulation_time time,
+      geo::Point_t const& location
+      ) {
+        
+        bool const inSpill
+          = (time >= fInSpillTimes.first) && (time <= fInSpillTimes.second);
+        bool const inPreSpill =
+          (time >= fInPreSpillTimes.first) && (time <= fInPreSpillTimes.second);
+        
+        totalEnergy += energy;
+        if (inSpill) inSpillEnergy += energy;
+        if (inPreSpill) inPreSpillEnergy += energy;
+        
+        if (pointInActiveTPC(location)) {
+          activeEnergy += energy;
+          if (inSpill) inSpillActiveEnergy += energy;
+          if (inPreSpill) inPreSpillActiveEnergy += energy;
+        }
+      } // add()
+    
+      private:
+    geo::GeometryCore const& fGeom; ///< Geometry service provider.
+    
+    /// Start and stop time for "in spill" label.
+    TimeSpan_t const fInSpillTimes;
+    
+    /// Start and stop time for "pre-spill" label.
+    TimeSpan_t const fInPreSpillTimes;
+    
+    /// Returns in which active TPC volume `point` falls in (`nullptr` if none).
+    geo::TPCGeo const* pointInActiveTPC(geo::Point_t const& point) const
+      { return ::pointInActiveTPC(fGeom, point); }
+
+  }; // EnergyAccumulator
+  
+} // local namespace
 
 
 // -----------------------------------------------------------------------------
@@ -25,12 +100,16 @@ icarus::trigger::details::EventInfoExtractor::EventInfoExtractor(
   TimeSpan_t inSpillTimes,
   TimeSpan_t inPreSpillTimes,
   geo::GeometryCore const& geom,
+  detinfo::DetectorPropertiesData const* detProps,
+  detinfo::DetectorTimings const* detTimings,
   std::string logCategory
   )
   : fGeneratorTags(std::move(truthTags))
   , fEnergyDepositTags(std::move(edepTags))
   , fLogCategory(std::move(logCategory))
   , fGeom(geom)
+  , fDetProps(detProps)
+  , fDetTimings(detTimings)
   , fInSpillTimes(std::move(inSpillTimes))
   , fInPreSpillTimes(std::move(inPreSpillTimes))
 {
@@ -151,49 +230,95 @@ void icarus::trigger::details::EventInfoExtractor::addEnergyDepositionInfo
   const
 {
   using MeV = util::quantities::megaelectronvolt;
-  using GeV = util::quantities::gigaelectronvolt;
   
-  //
-  // propagation in the detector
-  //
-  GeV totalEnergy { 0.0 }, inSpillEnergy { 0.0 }, inPreSpillEnergy { 0.0 };
-  GeV activeEnergy { 0.0 }, inSpillActiveEnergy { 0.0 },
-    inPreSpillActiveEnergy { 0.0 };
+  auto Eacc = EnergyAccumulator(fInSpillTimes, fInPreSpillTimes, fGeom);
   
   for (sim::SimEnergyDeposit const& edep: energyDeposits) {
     
-    MeV const e { edep.Energy() }; // assuming it's stored in MeV
-    
-    detinfo::timescales::simulation_time const t { edep.Time() };
-    bool const inSpill
-      = (t >= fInSpillTimes.first) && (t <= fInSpillTimes.second);
-    bool const inPreSpill
-      = (t >= fInPreSpillTimes.first) && (t <= fInPreSpillTimes.second);
-    
-    totalEnergy += e;
-    if (inSpill) inSpillEnergy += e;
-    if (inPreSpill) inPreSpillEnergy += e;
-    
-    if (pointInActiveTPC(edep.MidPoint())) {
-      activeEnergy += e;
-      if (inSpill) inSpillActiveEnergy += e;
-      if (inPreSpill) inPreSpillActiveEnergy += e;
-    }
+    Eacc.add(
+        MeV{ edep.Energy() } // assuming it's stored in MeV
+      , detinfo::timescales::simulation_time{ edep.Time() }
+      , edep.MidPoint()
+      );
     
   } // for all energy deposits in the data product
   
   info.SetDepositedEnergy
-    (info.DepositedEnergy() + totalEnergy);
+    (info.DepositedEnergy() + Eacc.totalEnergy);
   info.SetDepositedEnergyInSpill
-    (info.DepositedEnergyInSpill() + inSpillEnergy);
+    (info.DepositedEnergyInSpill() + Eacc.inSpillEnergy);
   info.SetDepositedEnergyInPreSpill
-    (info.DepositedEnergyInPreSpill() + inPreSpillEnergy);
+    (info.DepositedEnergyInPreSpill() + Eacc.inPreSpillEnergy);
   info.SetDepositedEnergyInActiveVolume
-    (info.DepositedEnergyInActiveVolume() + activeEnergy);
+    (info.DepositedEnergyInActiveVolume() + Eacc.activeEnergy);
   info.SetDepositedEnergyInSpillInActiveVolume
-    (info.DepositedEnergyInSpillInActiveVolume() + inSpillActiveEnergy);
-  info.SetDepositedEnergyInPreSpillInActiveVolume
-    (info.DepositedEnergyInPreSpillInActiveVolume() + inPreSpillActiveEnergy);
+    (info.DepositedEnergyInSpillInActiveVolume() + Eacc.inSpillActiveEnergy);
+  info.SetDepositedEnergyInPreSpillInActiveVolume(
+    info.DepositedEnergyInPreSpillInActiveVolume() + Eacc.inPreSpillActiveEnergy
+    );
+  
+} // icarus::trigger::details::EventInfoExtractor::addEnergyDepositionInfo()
+
+
+// -----------------------------------------------------------------------------
+void icarus::trigger::details::EventInfoExtractor::addEnergyDepositionInfo
+  (EventInfo_t& info, std::vector<sim::SimChannel> const& channels) const
+{
+  assert(fDetProps);
+  assert(fDetTimings);
+  
+  using MeV = util::quantities::megaelectronvolt;
+  
+  auto Eacc = EnergyAccumulator(fInSpillTimes, fInPreSpillTimes, fGeom);
+  
+  double const driftVel = fDetProps->DriftVelocity(); // cm/us
+  
+  for (sim::SimChannel const& channel: channels) {
+    
+    // only channels on any of the first induction planes
+    std::vector<geo::WireID> const& wires
+      = fGeom.ChannelToWire(channel.Channel());
+    if (empty(wires)) continue; // ghost channel or something; move on
+    if (wires.front().Plane != 0) continue; // not the first induction plane
+    
+    geo::PlaneGeo const& plane = fGeom.Plane(wires.front());
+    
+    for (auto const& [ tdc, IDEs ]: channel.TDCIDEMap()) {
+      
+      // collection tick: includes also drift time, diffusion and what-not
+      detinfo::timescales::electronics_tick const tick { tdc };
+      detinfo::timescales::simulation_time const time
+         = fDetTimings->toSimulationTime(tick);
+      
+      for (sim::IDE const& IDE: IDEs) {
+        MeV const energy { IDE.energy }; // assuming it's stored in MeV
+        geo::Point_t const location { IDE.x, IDE.y, IDE.z };
+        
+        // tentative estimation of drift length:
+        double const d = plane.DistanceFromPlane(location); // cm
+        util::quantities::intervals::microseconds const driftTime
+          { d / driftVel };
+        
+        Eacc.add(energy, time - driftTime, location);
+      } // all deposits at this time tick
+      
+    } // all time ticks in this channel
+    
+  } // for all channels
+  
+  info.SetDepositedEnergy
+    (info.DepositedEnergy() + Eacc.totalEnergy);
+  info.SetDepositedEnergyInSpill
+    (info.DepositedEnergyInSpill() + Eacc.inSpillEnergy);
+  info.SetDepositedEnergyInPreSpill
+    (info.DepositedEnergyInPreSpill() + Eacc.inPreSpillEnergy);
+  info.SetDepositedEnergyInActiveVolume
+    (info.DepositedEnergyInActiveVolume() + Eacc.activeEnergy);
+  info.SetDepositedEnergyInSpillInActiveVolume
+    (info.DepositedEnergyInSpillInActiveVolume() + Eacc.inSpillActiveEnergy);
+  info.SetDepositedEnergyInPreSpillInActiveVolume(
+    info.DepositedEnergyInPreSpillInActiveVolume() + Eacc.inPreSpillActiveEnergy
+    );
   
 } // icarus::trigger::details::EventInfoExtractor::addEnergyDepositionInfo()
 
@@ -211,9 +336,7 @@ geo::TPCGeo const*
 icarus::trigger::details::EventInfoExtractor::pointInActiveTPC
   (geo::Point_t const& point) const
 {
-  geo::TPCGeo const* tpc = pointInTPC(point);
-  return
-    (tpc && tpc->ActiveBoundingBox().ContainsPosition(point))? tpc: nullptr;
+  return ::pointInActiveTPC(fGeom, point);
 } // icarus::trigger::TriggerEfficiencyPlotsBase::pointInActiveTPC()
 
 
@@ -234,12 +357,16 @@ icarus::trigger::details::EventInfoExtractorMaker::EventInfoExtractorMaker(
   std::vector<art::InputTag> truthTags,
   EDepTags_t edepTags,
   geo::GeometryCore const& geom,
+  detinfo::DetectorPropertiesData const* detProps,
+  detinfo::DetectorTimings const* detTimings,
   std::string logCategory
   )
   : fGeneratorTags(std::move(truthTags))
   , fEnergyDepositTags(std::move(edepTags))
   , fLogCategory(std::move(logCategory))
   , fGeom(geom)
+  , fDetProps(detProps)
+  , fDetTimings(detTimings)
   {}
 
 
@@ -251,7 +378,7 @@ icarus::trigger::details::EventInfoExtractorMaker::make
   return EventInfoExtractor{
     fGeneratorTags, fEnergyDepositTags,
     inSpillTimes, inPreSpillTimes,
-    fGeom, fLogCategory
+    fGeom, fDetProps, fDetTimings, fLogCategory
     };
 } // icarus::trigger::details::EventInfoExtractorMaker::make()
 

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -34,10 +34,10 @@ art_make(
     ${MF_MESSAGELOGGER}
     ${FHICLCPP}
     ${CETLIB_EXCEPT}
-    ${ROOT_GENVECTOR}
-    ${ROOT_HIST}
-    ${ROOT_TREE}
-    ${ROOT_CORE}
+    ROOT::GenVector
+    ROOT::Hist
+    ROOT::Tree
+    ROOT::Core
   MODULE_LIBRARIES
     icaruscode_PMT_Trigger_Algorithms
     sbnobj_ICARUS_PMT_Trigger_Data
@@ -46,8 +46,8 @@ art_make(
     ${ART_FRAMEWORK_SERVICES_REGISTRY}
     ${MF_MESSAGELOGGER}
     ${FHICLCPP}
-    ${ROOT_CORE}
-    ${ROOT_PHYSICS}
+    ROOT::Core
+    ROOT::Physics
   TOOL_LIBRARIES
     icaruscode_PMT_Trigger_Algorithms
     sbnobj_ICARUS_PMT_Trigger_Data
@@ -150,10 +150,10 @@ simple_plugin(TriggerEfficiencyPlots module
   ${MF_MESSAGELOGGER}
   ${FHICLCPP}
   ${CETLIB_EXCEPT}
-  ${ROOT_GENVECTOR}
-  ${ROOT_HIST}
-  ${ROOT_TREE}
-  ${ROOT_CORE}
+  ROOT::GenVector
+  ROOT::Hist
+  ROOT::Tree
+  ROOT::Core
   )
 
 simple_plugin(MakeTriggerSimulationTree module
@@ -173,9 +173,9 @@ simple_plugin(MakeTriggerSimulationTree module
   ${MF_MESSAGELOGGER}
   ${FHICLCPP}
   ${CETLIB_EXCEPT}
-  ${ROOT_GENVECTOR}
-  ${ROOT_TREE}
-  ${ROOT_CORE}
+  ROOT::GenVector
+  ROOT::Tree
+  ROOT::Core
   )
 
 # trigger efficiency plot modules with the same build configuration:
@@ -204,10 +204,10 @@ foreach(TriggerEfficiencyPlotsModule
     ${MF_MESSAGELOGGER}
     ${FHICLCPP}
     ${CETLIB_EXCEPT}
-    ${ROOT_GENVECTOR}
-    ${ROOT_HIST}
-    ${ROOT_TREE}
-    ${ROOT_CORE}
+    ROOT::GenVector
+    ROOT::Hist
+    ROOT::Tree
+    ROOT::Core
     )
 
 endforeach()

--- a/icaruscode/PMT/Trigger/ExtractEnergyDepositionSummary_module.cc
+++ b/icaruscode/PMT/Trigger/ExtractEnergyDepositionSummary_module.cc
@@ -1,0 +1,306 @@
+/**
+ * @file   ExtractEnergyDepositionSummary_module.cc
+ * @brief  Module producing discriminated waveforms.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   December 4, 2019
+ */
+
+// ICARUS libraries
+#include "icaruscode/PMT/Trigger/Algorithms/BeamGateMaker.h"
+#include "icaruscode/PMT/Trigger/Algorithms/BeamGateStruct.h"
+#include "icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.h"
+#include "icaruscode/PMT/Trigger/Algorithms/details/EventInfo_t.h"
+#include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()...
+#include "icarusalg/Utilities/ChangeMonitor.h" // ThreadSafeChangeMonitor
+#include "icaruscode/IcarusObj/SimEnergyDepositSummary.h"
+// #include "icaruscode/Utilities/FHiCLutils.h" // util::fhicl::getOptionalValue()
+
+// LArSoft libraries
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
+#include "lardataalg/Utilities/intervals_fhicl.h" // microseconds from FHiCL
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "lardataobj/Simulation/SimEnergyDeposit.h"
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "canvas/Utilities/InputTag.h"
+/*
+#include "art/Framework/Principal/Handle.h"
+*/
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <vector>
+#include <string>
+#include <cassert>
+/*
+#include <map>
+*/
+
+//------------------------------------------------------------------------------
+namespace icarus::trigger { class ExtractEnergyDepositionSummary; }
+
+/**
+ * @brief Produces energy deposition summary data products.
+ * 
+ * This data product is an alternatice to storing the whole energy deposition,
+ * which can be huge.
+ * 
+ * Thresholds are ultimately chosen by the tool in charge of actually run the
+ * discrimination algorithm. Out of the thresholds that this algorithm produces,
+ * it is possible to choose only a subset of them (`SelectThresholds`).
+ * 
+ * 
+ * Output data products
+ * =====================
+ * 
+ * * a single `icarus::SimEnergyDepositSummary`
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * * `std::vector<sim::SimEnergyDeposits>`: sums of energies in a spill time,
+ *   in a pre-spill time, and total, everywhere and in active volume only.
+ * 
+ * 
+ * Service requirements
+ * ---------------------
+ * 
+ * The following services are _required_:
+ * 
+ * * `Geometry` for the determination of the active volume(s)
+ * * `DetectorClocksService` for the determination of beam gate
+ * * _art_ message facility
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * A terse description of the parameters is printed by running
+ * `lar --print-description ExtractEnergyDepositionSummary`.
+ * 
+ * * `EnergyDepositTags`
+ *     (list of input tags, default: `[ "largeant:TPCActive" ]`): a list of
+ *     data products with energy depositions;
+ * * `BeamGateDuration` (time, _mandatory_): the duration of the beam
+ *     gate; _the time requires the unit to be explicitly specified_: use
+ *     `"1.6 us"` for BNB, `9.5 us` for NuMI (also available as
+ *     `BNB_settings.spill_duration` and `NuMI_settings.spill_duration` in
+ *     `trigger_icarus.fcl`);
+ * * `BeamGateStart` (time, default: 0 &micro;s): open the beam gate this long
+ *      after the nominal beam gate time;
+ * * `PreSpillWindow` (time, default: 10 &micro;s): duration of the pre-spill
+ *      window;
+ * * `PreSpillWindowGap` (time, default: 0 &micro;s): gap from the end of
+ *      pre-spill window to the start of beam gate;
+ * * `OutputCategory` (string, default: `"ExtractEnergyDepositionSummary"`): label
+ *   for the category of messages in the console output; this is the label
+ *   that can be used for filtering messages via MessageFacility service
+ *   configuration.
+ * 
+ */
+class icarus::trigger::ExtractEnergyDepositionSummary: public art::EDProducer {
+  
+    public:
+  
+  using microseconds = util::quantities::intervals::microseconds;
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Sequence<art::InputTag> EnergyDepositTags {
+      Name("EnergyDepositTags"),
+      Comment("label of energy deposition data product(s) in the detector"),
+      std::vector<art::InputTag>{ "largeant:TPCActive" }
+      };
+
+    fhicl::Atom<microseconds> BeamGateDuration {
+      Name("BeamGateDuration"),
+      Comment("length of time interval when optical triggers are accepted")
+      };
+
+    fhicl::Atom<microseconds> BeamGateStart {
+      Name("BeamGateStart"),
+      Comment("open the beam gate this long after the nominal beam gate time"),
+      microseconds{ 0.0 }
+      };
+
+    fhicl::Atom<microseconds> PreSpillWindow {
+      Name("PreSpillWindow"),
+      Comment("duration of the pre-spill window"),
+      microseconds{ 10.0 }
+      };
+
+    fhicl::Atom<microseconds> PreSpillWindowGap {
+      Name("PreSpillWindowGap"),
+      Comment("gap from the end of pre-spill window to the start of beam gate"),
+      microseconds{ 0.0 }
+      };
+
+    fhicl::Atom<std::string> OutputCategory {
+      Name("OutputCategory"),
+      Comment("tag of the module output to console via message facility"),
+      "ExtractEnergyDepositionSummary"
+      };
+    
+  }; // struct Config
+  
+  using Parameters = art::EDProducer::Table<Config>;
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  // --- BEGIN Constructors ----------------------------------------------------
+  explicit ExtractEnergyDepositionSummary(Parameters const& config);
+  
+  // Plugins should not be copied or assigned.
+  ExtractEnergyDepositionSummary(ExtractEnergyDepositionSummary const&) = delete;
+  ExtractEnergyDepositionSummary(ExtractEnergyDepositionSummary&&) = delete;
+  ExtractEnergyDepositionSummary& operator=(ExtractEnergyDepositionSummary const&) = delete;
+  ExtractEnergyDepositionSummary& operator=(ExtractEnergyDepositionSummary&&) = delete;
+  
+  // --- END Constructors ------------------------------------------------------
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Creates the data products.
+  virtual void produce(art::Event& event) override;
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  /// Duration of the gate during with global optical triggers are accepted.
+  microseconds fBeamGateDuration;
+  
+  /// Start of the beam gate with respect to `BeamGate()`.
+  microseconds fBeamGateStart;
+  
+  microseconds fPreSpillWindow; ///< Duration of the pre-spill gate.
+  
+  microseconds fPreSpillStart; ///< Start of the pre-spill gate.
+  
+  std::string const fLogCategory; ///< Category name for the console output stream.
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+  // --- BEGIN Service variables -----------------------------------------------
+  
+  geo::GeometryCore const& fGeom; ///< Access to detector geometry information.
+  
+  // --- END Service variables -------------------------------------------------
+  
+  
+  // --- BEGIN Algorithms ------------------------------------------------------
+  
+  /// Functor returning whether a gate has changed.
+  icarus::ns::util::ThreadSafeChangeMonitor<icarus::trigger::BeamGateStruct>
+    fBeamGateChangeCheck;
+
+  details::EventInfoExtractorMaker const fEventInfoExtractorMaker;
+  
+  // --- END Algorithms --------------------------------------------------------
+  
+  
+  
+}; // icarus::trigger::ExtractEnergyDepositionSummary
+
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+//--- icarus::trigger::ExtractEnergyDepositionSummary
+//------------------------------------------------------------------------------
+icarus::trigger::ExtractEnergyDepositionSummary::ExtractEnergyDepositionSummary
+  (Parameters const& config)
+  : art::EDProducer(config)
+  // configuration
+  , fBeamGateDuration     (config().BeamGateDuration())
+  , fBeamGateStart        (config().BeamGateStart())
+  , fPreSpillWindow       (config().PreSpillWindow())
+  , fPreSpillStart
+      (fBeamGateStart - config().PreSpillWindowGap() - fPreSpillWindow)
+  , fLogCategory(config().OutputCategory())
+  // services
+  , fGeom(*(lar::providerFrom<geo::Geometry>()))
+  // algorithms
+  , fEventInfoExtractorMaker(
+    {},                                    // truthTags: none
+    { config().EnergyDepositTags() },      // edepTags
+    fGeom,                                 // geom
+    fLogCategory,                          // logCategory
+    consumesCollector()                    // consumesCollector
+    )
+{
+  produces<icarus::SimEnergyDepositSummary>();
+} // icarus::trigger::ExtractEnergyDepositionSummary::ExtractEnergyDepositionSummary()
+
+
+//------------------------------------------------------------------------------
+void icarus::trigger::ExtractEnergyDepositionSummary::produce(art::Event& event)
+{
+  
+  //
+  // prepare the information extractor and extract the information
+  //
+  
+  // we need to convert the two relevant gates with the proper parameters
+  auto const detTimings = icarus::ns::util::makeDetTimings(event);
+  
+  auto const beamGate = icarus::trigger::makeBeamGateStruct
+    (detTimings, fBeamGateDuration, fBeamGateStart);
+  
+  if (auto oldGate = fBeamGateChangeCheck(beamGate); oldGate) {
+    mf::LogWarning(fLogCategory)
+      << "Beam gate has changed from " << oldGate->asOptTickRange()
+      << " to " << beamGate.asOptTickRange() << " (optical tick)!";
+  }
+  
+  details::EventInfo_t const info = fEventInfoExtractorMaker(
+    beamGate.asSimulationRange(),
+    icarus::trigger::makeBeamGateStruct
+      (detTimings, fPreSpillStart, fPreSpillStart + fPreSpillWindow)
+      .asSimulationRange()
+    )(event);
+  assert(info.hasDepEnergy());
+  
+  //
+  // move the information into the data product
+  //
+  icarus::SimEnergyDepositSummary summary;
+  summary.Total          = info.DepositedEnergy().value();
+  summary.Spill          = info.DepositedEnergyInSpill().value();
+  summary.PreSpill       = info.DepositedEnergyInPreSpill().value();
+  summary.Active         = info.DepositedEnergyInActiveVolume().value();
+  summary.SpillActive    = info.DepositedEnergyInSpillInActiveVolume().value();
+  summary.PreSpillActive = info.DepositedEnergyInPreSpillInActiveVolume().value();
+
+  //
+  // finish
+  //
+  event.put
+    (std::make_unique<icarus::SimEnergyDepositSummary>(std::move(summary)));
+  
+} // icarus::trigger::ExtractEnergyDepositionSummary::produce()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(icarus::trigger::ExtractEnergyDepositionSummary)
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/MakeTriggerSimulationTree_module.cc
+++ b/icaruscode/PMT/Trigger/MakeTriggerSimulationTree_module.cc
@@ -13,17 +13,17 @@
 #include "icaruscode/PMT/Trigger/Algorithms/details/TreeHolder.h"
 #include "icaruscode/PMT/Trigger/Algorithms/details/EventInfoUtils.h"
 #include "icaruscode/PMT/Trigger/Algorithms/details/EventInfo_t.h"
-#include "sbnobj/ICARUS/PMT/Trigger/Data/OpticalTriggerGate.h"
-#include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()...
-#include "icarusalg/Utilities/ChangeMonitor.h" // ThreadSafeChangeMonitor
 #include "icaruscode/PMT/Trigger/Algorithms/TriggerGateBuilder.h"
 #include "icaruscode/PMT/Trigger/Algorithms/TriggerTypes.h" // ADCCounts_t
 #include "icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h"
-#include "sbnobj/ICARUS/PMT/Trigger/Data/SingleChannelOpticalTriggerGate.h"
-#include "sbnobj/ICARUS/PMT/Trigger/Data/TriggerGateData.h"
-#include "sbnobj/ICARUS/PMT/Data/WaveformBaseline.h"
+#include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()...
 #include "icaruscode/Utilities/DataProductPointerMap.h"
 #include "icarusalg/Utilities/FHiCLutils.h" // util::fhicl::getOptionalValue()
+#include "icarusalg/Utilities/ChangeMonitor.h" // ThreadSafeChangeMonitor
+#include "sbnobj/ICARUS/PMT/Trigger/Data/SingleChannelOpticalTriggerGate.h"
+#include "sbnobj/ICARUS/PMT/Trigger/Data/OpticalTriggerGate.h"
+#include "sbnobj/ICARUS/PMT/Trigger/Data/TriggerGateData.h"
+#include "sbnobj/ICARUS/PMT/Data/WaveformBaseline.h"
 
 // LArSoft libraries
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
@@ -31,12 +31,12 @@
 #include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // simulation_time, ...
 #include "lardataalg/Utilities/intervals_fhicl.h" // microseconds from FHiCL
+#include "lardataalg/Utilities/quantities_fhicl.h" // for ADCCounts_t parameters
 #include "larcorealg/Geometry/geo_vectors_utils.h" // MiddlePointAccumulator
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/CoreUtils/enumerate.h"
-#include "lardataalg/Utilities/quantities_fhicl.h" // for ADCCounts_t parameters
-#include "lardataobj/RawData/OpDetWaveform.h"
 #include "larcorealg/CoreUtils/values.h" // util::const_values()
+#include "lardataobj/RawData/OpDetWaveform.h"
 
 // framework libraries
 #include "art_root_io/TFileService.h"

--- a/icaruscode/PMT/Trigger/MakeTriggerSimulationTree_module.cc
+++ b/icaruscode/PMT/Trigger/MakeTriggerSimulationTree_module.cc
@@ -553,6 +553,8 @@ icarus::trigger::MakeTriggerSimulationTree::MakeTriggerSimulationTree
     makeEdepTag(config().EnergyDepositTags, config().EnergyDepositSummaryTag),
                                            // edepTags
     fGeom,                                 // geom
+    nullptr,                               // detProps
+    nullptr,                               // detTimings
     fLogCategory,                          // logCategory
     consumesCollector()                    // consumesCollector
     )

--- a/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.cxx
+++ b/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.cxx
@@ -14,8 +14,9 @@
 #include "icaruscode/PMT/Trigger/Algorithms/BeamGateMaker.h"
 #include "icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h" // FillTriggerGates()
 #include "icaruscode/PMT/Trigger/Utilities/PlotSandbox.h"
-#include "icarusalg/Utilities/ROOTutils.h" // util::ROOT
 #include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()
+#include "icarusalg/Utilities/ROOTutils.h" // util::ROOT
+#include "icarusalg/Utilities/FHiCLutils.h" // util::fhicl::getOptionalValue()
 
 // LArSoft libraries
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
@@ -507,7 +508,8 @@ icarus::trigger::TriggerEfficiencyPlotsBase::TriggerEfficiencyPlotsBase
   // cached
   , fEventInfoExtractorMaker(
       config.GeneratorTags(),              // truthTags
-      config.EnergyDepositTags(),          // edepTags
+      makeEdepTag(config.EnergyDepositTags, config.EnergyDepositSummaryTag),
+                                           // edepTags
       fGeom,                               // geom
       nullptr,                             // detProps
       nullptr,                             // detTimings
@@ -1171,9 +1173,6 @@ void icarus::trigger::TriggerEfficiencyPlotsBase::fillEfficiencyPlots(
       getTrigEff.Hist("OpeningTicks"s).Fill(double(detTimings.toElectronicsTime(opening.tick))-timeOffset);
     }
   }
-
-
-
   
 } // icarus::trigger::TriggerEfficiencyPlotsBase::fillEfficiencyPlots()
 
@@ -1445,6 +1444,29 @@ auto icarus::trigger::TriggerEfficiencyPlotsBase::makeChannelCryostatMap
   return channelCryostatMap;
   
 } // icarus::trigger::TriggerEfficiencyPlotsBase::makeChannelCryostatMap()
+
+
+//------------------------------------------------------------------------------
+icarus::trigger::details::EventInfoExtractor::EDepTags_t
+icarus::trigger::TriggerEfficiencyPlotsBase::makeEdepTag(
+  fhicl::Sequence<art::InputTag> const& EnergyDepositTags,
+  fhicl::OptionalAtom<art::InputTag> const& EnergyDepositSummaryTag
+) {
+  
+  if (auto summaryTag = util::fhicl::getOptionalValue(EnergyDepositSummaryTag))
+  {
+    return {
+      icarus::trigger::details::EventInfoExtractor::SimEnergyDepositSummaryInputTag
+        { *summaryTag }
+      };
+  }
+  else {
+    
+    return { EnergyDepositTags() };
+    
+  }
+  
+} // icarus::trigger::MakeTriggerSimulationTree::makeEdepTag()
 
 
 //------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.cxx
+++ b/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.cxx
@@ -18,6 +18,7 @@
 #include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()
 
 // LArSoft libraries
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larcore/Geometry/Geometry.h"
 #include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
@@ -508,6 +509,8 @@ icarus::trigger::TriggerEfficiencyPlotsBase::TriggerEfficiencyPlotsBase
       config.GeneratorTags(),              // truthTags
       config.EnergyDepositTags(),          // edepTags
       fGeom,                               // geom
+      nullptr,                             // detProps
+      nullptr,                             // detTimings
       fLogCategory,                        // logCategory
       consumer                             // consumesCollector
     )

--- a/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.h
+++ b/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.h
@@ -658,7 +658,12 @@ struct icarus::trigger::details::PlotInfoTree: public TreeHolder {
  * * `EnergyDepositTags`
  *     (list of input tags, default: `[ "largeant:TPCActive" ]`): a list of
  *     data products with energy depositions; if empty, plots or categories
- *     requiring energy deposition information will be omitted;
+ *     requiring energy deposition information will be omitted; in alternative,
+ *     `EnergyDepositSummaryTag` can be specified with the same purpose;
+ * * `EnergyDepositSummaryTag` (input tags, optional): if specified, overrides
+ *     `EnergyDepositTags` and uses for the energy deposition the information
+ *     from the summary in the specified data product; such summary may be
+ *     created for example by `ExtractEnergyDepositionSummary` module;
  * * `BeamGateDuration` (time, _mandatory_): the duration of the beam
  *     gate; _the time requires the unit to be explicitly specified_: use
  *     `"1.6 us"` for BNB, `9.5 us` for NuMI (also available as
@@ -983,6 +988,11 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
       Name("EnergyDeposits"),
       Comment("label of energy deposition data product(s) in the detector"),
       std::vector<art::InputTag>{ "largeant:TPCActive" }
+      };
+
+    fhicl::OptionalAtom<art::InputTag> EnergyDepositSummaryTag {
+      Name("EnergyDepositSummaryTag"),
+      Comment("label of energy deposition summary data product")
       };
 
     fhicl::Atom<std::string> TriggerGatesTag {
@@ -1534,6 +1544,11 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
     (PlotSandbox const& box, std::string const& category)
     { return thrAndCatName(box.name(), category); }
   
+  /// Creates a `EDepTags_t` out of the module configuration.
+  static icarus::trigger::details::EventInfoExtractor::EDepTags_t makeEdepTag(
+    fhicl::Sequence<art::InputTag> const& EnergyDepositTags,
+    fhicl::OptionalAtom<art::InputTag> const& EnergyDepositSummaryTag
+    );
   
 }; // icarus::trigger::TriggerEfficiencyPlotsBase
 


### PR DESCRIPTION
The trigger simulation modules have been extended to support alternative ways to provide energy deposition information.
The motivation is that the source files might have dropped the information needed for the energy deposition because of data size; at the time of dropping, if a summary is created, the necessary information stays available for the next stages.
Two sources are now supported:
* `sim::SimEnergyDeposits` collections: all energy depositions, one by one;
* `sim::EnergyDepositionSummary`: summary of the information from above.

Summary objects may be produced with the provided module, `ExtractEnergyDepositionSummary`, which supports the concepts of beam gate, pre-spill window and active volume. While the intended source to extract the summary information from is energy depositions, an alternative, lesser way is also provided, from `sim::SimChannel`. The account of the total energy in the active volume may be slightly different here (for example, some charge — and energy — may get lost because of diffusion simulation). The time determination of the energy depositions is, on the other end, at the verge of the useless: the time recorded in `sim::SimChannel` is the time of arrival of the drifting charge, _quantised_ by the sampling period (400 ns), and subject to all physics effects from transportation (non-uniform electric field, diffusion, ...). Only the drift time is "reverted" in this module, and in the end the resolution is on the same order of magnitude as the BNB beam gate.
In short: do not use `sim::SimChannel` as source unless you don't have alternatives, and do not use it if the energy deposition falling into a narrow beam gate is important.