### PR TITLE
new reco1 stage for MC productions with new daq label in RawDigitFilter

### DIFF
--- a/fcl/reco/reco_icarus_driver_reco_multitpc_gauss_sce_July2021.fcl
+++ b/fcl/reco/reco_icarus_driver_reco_multitpc_gauss_sce_July2021.fcl
@@ -1,0 +1,9 @@
+#include "reco_icarus_driver_reco_multitpc_gauss_sce.fcl"
+
+process_name: McRecoGauss
+
+
+physics.producers.rawDigitFilterTPC0.DigitModuleLabel:                                     "daq0:PHYSCRATEDATATPCEE"
+physics.producers.rawDigitFilterTPC1.DigitModuleLabel:                                     "daq1:PHYSCRATEDATATPCEW"
+physics.producers.rawDigitFilterTPC2.DigitModuleLabel:                                     "daq2:PHYSCRATEDATATPCWE"
+physics.producers.rawDigitFilterTPC3.DigitModuleLabel:                                     "daq3:PHYSCRATEDATATPCWW"


### PR DESCRIPTION
I prepare this fhicl in order to run MC productions in a similar way as previously done, I mean with reco1 and reco2 stages, but with the new labels required by the RawDigitFilter 