### PR TITLE
Updates to stage 0 processing for both data and simulation

### DIFF
--- a/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
+++ b/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
@@ -31,7 +31,7 @@ decodeTPC: {
 
 decodeTPCROI: {
                     module_type:        DaqDecoderICARUSTPCwROI
-                    FragmentsLabel:     "daq:PHYSCRATEDATA"
+                    FragmentsLabelVec:  [ "daq:PHYSCRATEDATA" ]
                     OutputRawWaveform:  false
                     OutputCorrection:   false
                     OutputRawWavePath:  "RAW"

--- a/icaruscode/Decode/fcl/decoderdefs_mc_icarus.fcl
+++ b/icaruscode/Decode/fcl/decoderdefs_mc_icarus.fcl
@@ -1,0 +1,15 @@
+
+BEGIN_PROLOG
+
+
+MCDecodeTPCROI: {
+                    module_type:        MCDecoderICARUSTPCwROI
+                    FragmentsLabelVec:  [ "daq:PHYSCRATEDATA" ]
+                    OutputRawWaveform:  false
+                    OutputCorrection:   false
+                    OutputRawWavePath:  "RAW"
+                    OutputCoherentPath: "Cor"
+                    DiagnosticOutput:   false
+}
+
+END_PROLOG

--- a/icaruscode/Decode/fcl/stage0_multiTPC_icarus_MC.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_icarus_MC.fcl
@@ -29,7 +29,7 @@ outputs.outBNB.fileName: "%ifb_%tc-%p.root"
 outputs.outBNB.dataTier: "reconstructed"
 
 # Drop the artdaq format files on output
-#outputs.outBNB.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outBNB.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.MCDecodeTPCROI.FragmentsLabelVec: ["daq3:PHYSCRATEDATATPCWW","daq2:PHYSCRATEDATATPCWE","daq1:PHYSCRATEDATATPCEW","daq0:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_icarus_MC.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_icarus_MC.fcl
@@ -1,0 +1,46 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "decoderdefs_mc_icarus.fcl"
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: MCstage0
+
+## Add the MC module to the list of producers
+physics.producers: {
+					  @table::icarus_stage0_producers
+
+            MCDecodeTPCROI: @local::MCDecodeTPCROI
+}
+
+
+## Use the following to run the full defined stage0 set of modules
+physics.reco: [ MCDecodeTPCROI, 
+                decon1droi,
+                roifinder,
+                @sequence::icarus_stage0_EastHits_TPC,
+                @sequence::icarus_stage0_WestHits_TPC
+              ]
+
+## boiler plate...
+physics.trigger_paths: [ reco ]
+outputs.outBNB.fileName: "%ifb_%tc-%p.root"
+outputs.outBNB.dataTier: "reconstructed"
+
+# Drop the artdaq format files on output
+#outputs.outBNB.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+# Set up for the single module mutliple TPC mode...
+physics.producers.MCDecodeTPCROI.FragmentsLabelVec: ["daq3:PHYSCRATEDATATPCWW","daq2:PHYSCRATEDATATPCWE","daq1:PHYSCRATEDATATPCEW","daq0:PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:      ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+
+physics.producers.roifinder.ROIFinderToolVec.ROIFinderPlane0: @local::decoderroifinder_0
+physics.producers.roifinder.ROIFinderToolVec.ROIFinderPlane1: @local::decoderroifinder_1
+physics.producers.roifinder.ROIFinderToolVec.ROIFinderPlane2: @local::decoderroifinder_2
+
+physics.producers.roifinder.ROIFinderToolVec.ROIFinderPlane0.ROILabelVec: ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.roifinder.ROIFinderToolVec.ROIFinderPlane1.ROILabelVec: ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.roifinder.ROIFinderToolVec.ROIFinderPlane2.ROILabelVec: ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+
+physics.producers.roifinder.WireModuleLabelVec: ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE","decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss_MC.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss_MC.fcl
@@ -1,0 +1,88 @@
+
+#include "mchitmodules.fcl"
+#include "mcreco.fcl"
+#include "mctrutht0matching.fcl"
+#include "stage1_icarus_driver_common.fcl"
+
+process_name: MCstage1
+
+## Add the MC module to the list of producers
+physics.producers: {
+            @table::icarus_stage1_producers
+
+
+            mcophit:                        @local::ICARUSMCOpHit
+            mcopflashTPC0:                  @local::ICARUSMCOpFlashTPC0
+            mcopflashTPC1:                  @local::ICARUSMCOpFlashTPC1
+            mcopflashTPC2:                  @local::ICARUSMCOpFlashTPC2
+            mcopflashTPC3:                  @local::ICARUSMCOpFlashTPC3
+          
+            cheatopflashTPC0:               @local::ICARUSCheatOpFlashTPC0
+            cheatopflashTPC1:               @local::ICARUSCheatOpFlashTPC1
+            cheatopflashTPC2:               @local::ICARUSCheatOpFlashTPC2
+            cheatopflashTPC3:               @local::ICARUSCheatOpFlashTPC3
+
+            ### mc producers
+            mchitfinder:                    @local::standard_mchitfinder
+            mcassociationsGausCryoE:        @local::standard_mcparticlehitmatching
+            mcassociationsGausCryoW:        @local::standard_mcparticlehitmatching
+}
+
+physics.reco: [ 
+                @sequence::icarus_reco_Gauss_CryoE ,
+                @sequence::icarus_reco_Gauss_CryoW ,
+                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
+                mcassociationsGausCryoE,  mcassociationsGausCryoW
+              ]
+
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
+physics.trigger_paths:     [ reco ]
+physics.end_paths:         [ outana, stream1 ]
+outputs.out1.fileName:     "%ifb_%tc-%p.root"
+outputs.out1.dataTier:     "reconstructed"
+outputs.out1.SelectEvents: [ reco ]
+outputs.out1.outputCommands: [
+  "keep *_*_*_*",
+  "drop *_caloskimCalorimetryCryoE_*_*",
+  "drop *_caloskimCalorimetryCryoW_*_*"
+]
+
+# Disabled Space-Charge service for calorimetry
+services.SpaceChargeService: {
+    EnableCalEfieldSCE: false
+    EnableCalSpatialSCE: false
+    EnableCorrSCE: false
+    EnableSimEfieldSCE: false
+    EnableSimSpatialSCE: false
+    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
+    RepresentationType: "Voxelized_TH3"
+    service_provider: "SpaceChargeServiceICARUS"
+}
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "DEBUG"     #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       Cluster3D:
+       {
+         limit: -1
+         reportEvery: 1
+       }
+       PMAlgTracker:
+       {
+         limit: -1
+         reportEvery: 1
+       }
+       default:
+       {
+         limit: 0  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 0
+       }
+     }
+  }
+}
+

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
@@ -322,7 +322,7 @@ void  ROIFinder::processPlane(size_t                      idx,
     icarus_signal_processing::ArrayFloat outputArray(dataArray.size(),icarus_signal_processing::VectorFloat(dataArray[0].size(),0.));
     icarus_signal_processing::ArrayBool  selectedVals(dataArray.size(),icarus_signal_processing::VectorBool(dataArray[0].size(),false));
 
-    fROIToolMap.at(planeID.Plane)->FindROIs(dataArray, mapItr->first, outputArray, selectedVals);
+    fROIToolMap.at(planeID.Plane)->FindROIs(event, dataArray, mapItr->first, outputArray, selectedVals);
 
 //    icarus_signal_processing::ArrayFloat morphedWaveforms(dataArray.size());
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/IROILocator.h
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/IROILocator.h
@@ -15,6 +15,7 @@
 
 #include "fhiclcpp/ParameterSet.h"
 #include "larcore/Geometry/Geometry.h"
+#include "art/Framework/Principal/Event.h" 
 
 namespace icarus_tool
 {
@@ -34,7 +35,7 @@ namespace icarus_tool
         using PlaneIDVec  = std::vector<geo::PlaneID>;
         
         // Find the ROI's
-        virtual void FindROIs(const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) const = 0;
+        virtual void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) const = 0;
     };
 }
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
@@ -35,7 +35,7 @@ public:
     
     void configure(const fhicl::ParameterSet& pset) override;
     
-    void FindROIs(const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&)    const override;
+    void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&)    const override;
     
 private:
 
@@ -86,7 +86,7 @@ void ROICannyEdgeDetection::configure(const fhicl::ParameterSet& pset)
     return;
 }
 
-void ROICannyEdgeDetection::FindROIs(const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs) const
+void ROICannyEdgeDetection::FindROIs(const art::Event& event, const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs) const
 {
     unsigned int numChannels = inputImage.size();
     unsigned int numTicks    = inputImage[0].size();

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIFromDecoder_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIFromDecoder_tool.cc
@@ -1,0 +1,162 @@
+////////////////////////////////////////////////////////////////////////
+/// \file   ROIFromDecoder_tool.cc
+/// \author T. Usher
+////////////////////////////////////////////////////////////////////////
+
+#include <cmath>
+#include "icaruscode/TPC/SignalProcessing/RecoWire/ROITools/IROILocator.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "art_root_io/TFileService.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "cetlib_except/exception.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "larcore/Geometry/Geometry.h"
+#include "lardataobj/RecoBase/Wire.h"
+
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+
+#include <fstream>
+
+namespace icarus_tool
+{
+
+class ROIFromDecoder : public IROILocator
+{
+public:
+    explicit ROIFromDecoder(const fhicl::ParameterSet& pset);
+    
+    ~ROIFromDecoder();
+    
+    void configure(const fhicl::ParameterSet& pset) override;
+    
+    void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) const override;
+    
+private:
+    // A magic map because all tools need them
+    using TPCIDToLabelMap = std::map<geo::TPCID,std::string>;
+
+    TPCIDToLabelMap            fTPCIDToLabelMap;      ///< Translate from TPCID to a substring
+
+    // fhicl parameters
+    std::vector<art::InputTag> fROILabelVec;          ///< List of input files to search
+
+    const geo::GeometryCore* fGeometry = lar::providerFrom<geo::Geometry>();
+};
+    
+//----------------------------------------------------------------------
+// Constructor.
+ROIFromDecoder::ROIFromDecoder(const fhicl::ParameterSet& pset)
+{
+    std::cout << "*** In ROIFromDecoder constructor ***" << std::endl;
+    configure(pset);
+}
+    
+ROIFromDecoder::~ROIFromDecoder()
+{
+}
+    
+void ROIFromDecoder::configure(const fhicl::ParameterSet& pset)
+{
+    // Start by recovering the parameters
+    fROILabelVec = pset.get<std::vector<art::InputTag>>("ROILabelVec", {""});
+
+    // Build our map
+    fTPCIDToLabelMap[geo::TPCID(0,0)] = "EE";
+    fTPCIDToLabelMap[geo::TPCID(0,1)] = "EE";
+    fTPCIDToLabelMap[geo::TPCID(0,2)] = "EW";
+    fTPCIDToLabelMap[geo::TPCID(0,3)] = "EW";
+    fTPCIDToLabelMap[geo::TPCID(1,0)] = "WE";
+    fTPCIDToLabelMap[geo::TPCID(1,1)] = "WE";
+    fTPCIDToLabelMap[geo::TPCID(1,2)] = "WW";
+    fTPCIDToLabelMap[geo::TPCID(1,3)] = "WW";
+
+    return;
+}
+
+void ROIFromDecoder::FindROIs(const art::Event& event, const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs) const
+{
+    // First thing is find the correct data product to recover ROIs
+    TPCIDToLabelMap::const_iterator tpcItr = fTPCIDToLabelMap.find(planeID.asTPCID());
+
+    if (tpcItr == fTPCIDToLabelMap.end())
+    {
+        std::cout << "Can't happen? for planeID: " << planeID << std::endl;
+        return;
+    }
+
+    art::InputTag roiLabel("");
+
+    for(const auto& tag : fROILabelVec)
+    {
+        if (tag.instance().find(tpcItr->second) != std::string::npos)
+        {
+            roiLabel = tag;
+            break;
+        }
+    }
+
+    if (roiLabel != "")
+    {
+        // do stuff here
+    
+        // Read in the collection of full length deconvolved waveforms
+        // Note we assume this list is sorted in increasing channel number!
+        art::Handle< std::vector<recob::Wire>> wireVecHandle;
+        
+        event.getByLabel(roiLabel, wireVecHandle);
+
+        // The input data product will contain information for every plane in a physical TPC... unfortunately, we only want a single plane within
+        // a logical TPC... so we need to loop through to find what we want
+        for(const auto& wireData : *wireVecHandle)
+        {
+            std::vector<geo::WireID> wireIDVec = fGeometry->ChannelToWire(wireData.Channel());
+
+            for(const auto& wireID : wireIDVec)
+            {
+                if (wireID.asPlaneID() != planeID) continue;
+
+                if (wireID.Wire > outputROIs.size())
+                {
+                    std::cout << "#################################### Wire out of bounds! Wire: " << wireID.Wire << ", max: " << outputROIs.size() << " #################" << std::endl;
+                    continue;
+                }
+
+                // Recover this wire's output vector
+                VectorBool& channelData = outputROIs[wireID.Wire];
+
+                // What we need to do is find the ROIs in the input wire data and then translate to the output
+                const recob::Wire::RegionsOfInterest_t signalROIs = wireData.SignalROI();
+
+                for(const auto& range : signalROIs.get_ranges())
+                {
+                    size_t startTick = range.begin_index();
+                    size_t roiLen    = range.data().size();
+                    size_t stopTick  = startTick + roiLen;
+
+                    if (startTick > channelData.size())
+                    {
+                        std::cout << "*** ROI decoder has start tick larger than output array, start: " << startTick << ", array size: " << channelData.size() << std::endl;
+                        continue;
+                    }
+
+                    if (stopTick > channelData.size())
+                    {
+                        std::cout << "*** ROI decoder has ROI length larger than output array, start: " << startTick << ", end: " << stopTick << ", array size: " << channelData.size() << std::endl;
+                        continue;
+                    }
+
+                    std::fill(channelData.begin() + startTick, channelData.begin() + stopTick, true);
+                }
+            }
+        }
+
+    }
+
+    return;
+}
+
+DEFINE_ART_CLASS_TOOL(ROIFromDecoder)
+}

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIMorphological2D_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIMorphological2D_tool.cc
@@ -33,7 +33,7 @@ public:
     
     void configure(const fhicl::ParameterSet& pset) override;
     
-    void FindROIs(const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&)    const override;
+    void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&)    const override;
     
 private:
     // This is for the baseline...
@@ -64,7 +64,7 @@ void ROIMorphological2D::configure(const fhicl::ParameterSet& pset)
     return;
 }
 
-void ROIMorphological2D::FindROIs(const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs) const
+void ROIMorphological2D::FindROIs(const art::Event& event, const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs) const
 {
     icarus_signal_processing::ArrayFloat morphedWaveforms(inputImage.size(),icarus_signal_processing::VectorFloat(inputImage[0].size(),0.));
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/roiTools_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/roiTools_icarus.fcl
@@ -43,4 +43,18 @@ cannyedgedetector_2.Plane:  2
 cannyedgedetector_2.LowThreshold:   15.0
 cannyedgedetector_2.HighThreshold:  30.0
 
+icarus_decoderroifinder:
+{
+    tool_type:           ROIFromDecoder
+    Plane:               0
+    ROILabelVec:         ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
+}
+
+decoderroifinder_0:       @local::icarus_decoderroifinder
+decoderroifinder_1:       @local::icarus_decoderroifinder
+decoderroifinder_2:       @local::icarus_decoderroifinder
+
+decoderroifinder_1.Plane: 1
+decoderroifinder_2.Plane: 2
+
 END_PROLOG

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -93,9 +93,6 @@ icarus_roifinder:
         ROIFinderPlane0: @local::morphologicalfinder_0
         ROIFinderPlane1: @local::morphologicalfinder_1
         ROIFinderPlane2: @local::morphologicalfinder_2
-#        ROIFinderPlane0: @local::cannyedgedetector_0
-#        ROIFinderPlane1: @local::cannyedgedetector_1
-#        ROIFinderPlane2: @local::cannyedgedetector_2
     }
 }
 


### PR DESCRIPTION
Updates in the pull request will allow for processing of TPC detector simulation output through the same processing chain as the data with the caveat that it will take as the "raw" input the RawDigits from the detector simulation (so skips the actual "decoding" of the data but otherwise performs all the same steps with the same code). 

In addition, the decoder step now outputs the ROIs determined from the raw images during the noise processing in the form of "wire" data. This is then picked up by a new "ROI Finding" tool which runs after the deconvolution  to form ROIs for the deconvolved waveforms too. 
