### PR TITLE
extend decon2droi to full cryostats

### DIFF
--- a/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
@@ -59,6 +59,10 @@ icarus_stage0_producers:
 
   ### wire-cell decon producers
   decon2droi:                     @local::standard_wirecell_sigproc
+  decon2droiEE:                   @local::standard_wirecell_sigproc
+  decon2droiEW:                   @local::standard_wirecell_sigproc
+  decon2droiWE:                   @local::standard_wirecell_sigproc
+  decon2droiWW:                   @local::standard_wirecell_sigproc
 
   ### ROI finding on complete deconvolved waveforms
   roifinder:                      @local::icarus_roifinder
@@ -158,6 +162,10 @@ icarus_stage0_single_TPC:          [ daqTPC,
 
 icarus_stage0_multiTPC_TPC:        [ daqTPC,
                                      decon1droi,
+#                                     decon2droiEE,
+#                                     decon2droiEW,
+#                                     decon2droiWE,
+#                                     decon2droiWW,
                                      roifinder
                                    ]
 
@@ -224,6 +232,31 @@ icarus_stage0_producers.decon2droi.wcls_main.inputers:                          
 icarus_stage0_producers.decon2droi.wcls_main.outputers:                                        ["wclsFrameSaver:spsaver0"]
 icarus_stage0_producers.decon2droi.wcls_main.params.raw_input_label:                           "daqTPC"
 icarus_stage0_producers.decon2droi.wcls_main.params.tpc_volume_label:                          0
+icarus_stage0_producers.decon2droi.wcls_main.params.signal_output_form:                        "dense"
+
+icarus_stage0_producers.decon2droiEE.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc0"]
+icarus_stage0_producers.decon2droiEE.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver0"]
+icarus_stage0_producers.decon2droiEE.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCEE"
+icarus_stage0_producers.decon2droiEE.wcls_main.params.tpc_volume_label:                        0
+icarus_stage0_producers.decon2droiEE.wcls_main.params.signal_output_form:                      "dense"
+
+icarus_stage0_producers.decon2droiEW.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc1"]
+icarus_stage0_producers.decon2droiEW.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver1"]
+icarus_stage0_producers.decon2droiEW.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCEW"
+icarus_stage0_producers.decon2droiEW.wcls_main.params.tpc_volume_label:                        1
+icarus_stage0_producers.decon2droiEW.wcls_main.params.signal_output_form:                      "dense"
+
+icarus_stage0_producers.decon2droiWE.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc2"]
+icarus_stage0_producers.decon2droiWE.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver2"]
+icarus_stage0_producers.decon2droiWE.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCWE"
+icarus_stage0_producers.decon2droiWE.wcls_main.params.tpc_volume_label:                        2
+icarus_stage0_producers.decon2droiWE.wcls_main.params.signal_output_form:                      "dense"
+
+icarus_stage0_producers.decon2droiWW.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc3"]
+icarus_stage0_producers.decon2droiWW.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver3"]
+icarus_stage0_producers.decon2droiWW.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCWW"
+icarus_stage0_producers.decon2droiWW.wcls_main.params.tpc_volume_label:                        3
+icarus_stage0_producers.decon2droiWW.wcls_main.params.signal_output_form:                      "dense"
 
 ### Set up to find ROIs
 icarus_stage0_producers.roifinder.WireModuleLabelVec:                                          ["decon1droi"]

--- a/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
@@ -51,6 +51,7 @@ function(params, tools, override = {}) {
       gauss_tag: 'gauss%d' % anode.data.ident,
 
       use_roi_debug_mode: false,
+      use_roi_refinement: false, // default: true
       tight_lf_tag: 'tight_lf%d' % anode.data.ident,
       loose_lf_tag: 'loose_lf%d' % anode.data.ident,
       cleanup_roi_tag: 'cleanup_roi%d' % anode.data.ident,

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
@@ -107,8 +107,10 @@ local wcls_output = {
       // anode: wc.tn(tools.anode),
       anode: wc.tn(mega_anode),
       digitize: false,  // true means save as RawDigit, else recob::Wire
-      frame_tags: ['gauss', 'wiener', 'looseLf'],
-      frame_scale: [0.1, 0.1, 0.1],
+      // frame_tags: ['gauss', 'wiener', 'looseLf'],
+      // frame_scale: [0.1, 0.1, 0.1],
+      frame_tags: ['looseLf'],
+      frame_scale: [0.1],
       // nticks: params.daq.nticks,
       chanmaskmaps: [],
       nticks: -1,


### PR DESCRIPTION
I also added a configuration parameter `use_roi_refinement`. If it's set to `false`, it skips the ROI refinement in wirecell toolkit and reduces the memory usage. Note, our current plan is to use Tracy's and Dae's ROI, so it's fine for wirecell to skip its own ROI finding and refinement.