### PR TITLE
CI calibration/c7 fix

### DIFF
--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/TPCNoiseMC_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/TPCNoiseMC_module.cc
@@ -72,13 +72,12 @@ public:
   //TPCNoiseMC(TPCNoiseMC&&) = delete;
   //TPCNoiseMC& operator=(TPCNoiseMC const&) = delete;
   //TPCNoiseMC& operator=(TPCNoiseMC&&) = delete;
-
   void analyze(const art::Event& e);
   void reconfigure(fhicl::ParameterSet const& pset);
   void beginJob();
-  void beginRun();
+ // void beginRun();
   void endJob();
-  void endRun();
+ // void endRun();
 
 private:
   // Various FHiCL parameters.

--- a/icaruscode/TPC/SignalProcessing/RawDigitFilter/TPCNoise_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RawDigitFilter/TPCNoise_module.cc
@@ -76,9 +76,9 @@ public:
   void analyze(const art::Event& e);
   void reconfigure(fhicl::ParameterSet const& pset);
   void beginJob();
-  void beginRun();
+//  void beginRun();
   void endJob();
-  void endRun();
+ // void endRun();
 
 private:
   // Various FHiCL parameters.

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -286,9 +286,9 @@ INPUT_STAGE_NAME=gen
 NEVENTS=2
 # calibrated with [c2] on icarusbuild01.fnal.gov on 20191123
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
-# calibrated with [e20] on Jenkins on 20210610: +200", +300 MB
-cpu_usage_range=600:900
-mem_usage_range=1800000:2500000
+# calibrated with [e20] on Jenkins on 20210810
+cpu_usage_range=700:1000
+mem_usage_range=1800000:2600000
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)ssingle_%(STAGE_NAME)s_quick_test_icaruscode.fcl
@@ -310,9 +310,9 @@ INPUT_STAGE_NAME=g4
 NEVENTS=2
 # calibrated with [c2] on icarusbuild01.fnal.gov on 20191123
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
-# calibrated with [e20] on Jenkins on 20210610: +500 MB
-cpu_usage_range=50:300
-mem_usage_range=800000:1300000
+# calibrated with [e20] on Jenkins on 20210810
+cpu_usage_range=450:900
+mem_usage_range=2100000:2900000
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)ssingle_%(STAGE_NAME)s_quick_test_icaruscode.fcl
@@ -334,8 +334,8 @@ INPUT_STAGE_NAME=detsim
 NEVENTS=2
 # calibrated on icarusbuild01.fnal.gov on 20180325
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
-# calibrated with [e20] on Jenkins on 20210610: +200", +700 MB
-cpu_usage_range=400:600
+# calibrated with [e20] on Jenkins on 20210810
+cpu_usage_range=450:650
 mem_usage_range=3000000:3800000
 
 script=%(EXPSCRIPT_ICARUSCODE)s
@@ -586,9 +586,9 @@ STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=2
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
-# calibrated with [e20] on Jenkins on 20210610: +1500", -2 GB
+# calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=3000:5003
-mem_usage_range=6000000:10000003
+mem_usage_range=5000000:9000003
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_quick_test_icaruscode.fcl
@@ -609,8 +609,9 @@ STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=2
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
+# calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=1000:1803
-mem_usage_range=8000000:12000003
+mem_usage_range=6000000:12000003
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_quick_test_icaruscode.fcl
@@ -631,9 +632,9 @@ STAGE_NAME=reco
 INPUT_STAGE_NAME=detsim
 NEVENTS=2
 # calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
-# calibrated with [e20] on Jenkins on 20210610: +2000"
-cpu_usage_range=4000:5503
-mem_usage_range=7000000:10000003
+# calibrated with [e20] on Jenkins on 20210810
+cpu_usage_range=900:2403
+mem_usage_range=4500000:7500003
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_quick_test_icaruscode.fcl


### PR DESCRIPTION
1)calibration adjustments for ci tests

2)In TPCNoiseMC_module.cc and TPCNoise_module.cc comment out beginRun() and endRun() (hidden overloaded virtual function) for c7 