### PR TITLE
Split the reco test

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -352,6 +352,49 @@ parse_art_output=True
 output1=%(TFILENAME)s
 
 
+[test single_reco0_quick_test_icaruscode]
+STAGE_NAME=reco0
+INPUT_STAGE_NAME=detsim
+NEVENTS=2
+# calibrated with [e20] on icarusbuild02.fnal.gov
+cpu_usage_range=1650:2250
+mem_usage_range=4000000:5000000
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)ssingle_%(STAGE_NAME)s_quick_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=single_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=single_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(SINGLE_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=%(XROOTD_INPUTFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(INPUT_STAGE_NAME)s/%(INPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+#outBNB is added to specify the output and might need to be removed later
+OUTPUT_STREAM=outBNB:%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root 
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
+[test single_reco1_quick_test_icaruscode]
+STAGE_NAME=reco1
+INPUT_STAGE_NAME=reco0
+NEVENTS=2
+# calibrated with [e20] on icarusbuild02.fnal.gov
+cpu_usage_range=450:650
+mem_usage_range=3000000:4200000
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)ssingle_%(STAGE_NAME)s_quick_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=single_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=single_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(SINGLE_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=%(XROOTD_INPUTFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(INPUT_STAGE_NAME)s/%(INPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
 [test single_anatree_quick_test_icaruscode]
 # no reference art ROOT output for this one, but we have analysis tree reference (the "--extra-function" option)
 # (we use the reference file from sequence explicitly here)
@@ -359,7 +402,7 @@ output1=%(TFILENAME)s
 # TODO comparisons with references should happen in a different way, with the "C.I. validation tests" (ask the C.I. crew!)
 # 
 STAGE_NAME=anatree
-INPUT_STAGE_NAME=reco
+INPUT_STAGE_NAME=reco1
 NEVENTS=2
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=10:100
@@ -384,7 +427,7 @@ output1=%(TFILENAME)s
 [suite single_quick_test_icaruscode]
 # TODO analysis trees not included at this time
 # testlist=single_gen_quick_test_icaruscode single_g4_quick_test_icaruscode single_detsim_quick_test_icaruscode single_reco_quick_test_icaruscode single_anatree_quick_test_icaruscode
-testlist=single_gen_quick_test_icaruscode single_g4_quick_test_icaruscode single_detsim_quick_test_icaruscode single_reco_quick_test_icaruscode
+testlist=single_gen_quick_test_icaruscode single_g4_quick_test_icaruscode single_detsim_quick_test_icaruscode single_reco0_quick_test_icaruscode single_reco1_quick_test_icaruscode
 
 
 
@@ -502,6 +545,53 @@ args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(RE
 parse_art_output=True
 output1=%(TFILENAME)s
 
+[test single_reco0_seq_test_icaruscode]
+STAGE_NAME=reco0
+INPUT_STAGE_NAME=detsim
+NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
+# calibrated with [e20] on icarusbuild02.fnal.gov
+cpu_usage_range=100:402
+mem_usage_range=700000:1200002
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+requires=single_%(INPUT_STAGE_NAME)s_seq_test_icaruscode
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)ssingle_%(STAGE_NAME)s_seq_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=single_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=single_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(SINGLE_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=../%(requires)s/%(INPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+#outBNB is added to specify the output and might need to be removed later
+OUTPUT_STREAM=outBNB:%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root 
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
+[test single_reco1_seq_test_icaruscode]
+STAGE_NAME=reco1
+INPUT_STAGE_NAME=reco0
+NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
+# calibrated on icarusbuild01.fnal.gov on 20180325 (same as quick test because detsim has reduced number of events)
+# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
+# calibrated with [e20] on icarusbuild02.fnal.gov on 20210607: 800 MB -> 3.8 GB!!!
+cpu_usage_range=100:402
+mem_usage_range=700000:1200002
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+requires=single_%(INPUT_STAGE_NAME)s_seq_test_icaruscode
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)ssingle_%(STAGE_NAME)s_seq_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=single_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=single_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(SINGLE_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=../%(requires)s/%(INPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
 
 [test single_anatree_seq_test_icaruscode]
 # no reference art ROOT output for this one, but we have analysis tree reference (the "--extra-function" option)
@@ -509,7 +599,7 @@ output1=%(TFILENAME)s
 # See the comment on the quick test for the validation.
 # 
 STAGE_NAME=anatree
-INPUT_STAGE_NAME=reco
+INPUT_STAGE_NAME=reco1
 NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=10:102
@@ -533,10 +623,10 @@ output1=%(TFILENAME)s
 [suite single_seq_test_icaruscode]
 # TODO analysis trees not included at this time
 # testlist=single_gen_seq_test_icaruscode single_g4_seq_test_icaruscode single_detsim_seq_test_icaruscode single_reco_seq_test_icaruscode single_anatree_seq_test_icaruscode
-testlist=single_gen_seq_test_icaruscode single_g4_seq_test_icaruscode single_detsim_seq_test_icaruscode single_reco_seq_test_icaruscode
+testlist=single_gen_seq_test_icaruscode single_g4_seq_test_icaruscode single_detsim_seq_test_icaruscode single_reco0_seq_test_icaruscode single_reco1_seq_test_icaruscode
 
 [suite generate_reference_single_test_icaruscode]
-testlist=single_gen_seq_test_icaruscode single_g4_seq_test_icaruscode single_detsim_seq_test_icaruscode single_reco_seq_test_icaruscode
+testlist=single_gen_seq_test_icaruscode single_g4_seq_test_icaruscode single_detsim_seq_test_icaruscode single_reco0_seq_test_icaruscode single_reco1_seq_test_icaruscode
 
 
 
@@ -649,6 +739,49 @@ args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(RE
 parse_art_output=True
 output1=%(TFILENAME)s
 
+[test nucosmics_reco0_quick_test_icaruscode]
+STAGE_NAME=reco0
+INPUT_STAGE_NAME=detsim
+NEVENTS=2
+# calibrated with [e19] on icarusbuild02.fnal.gov
+cpu_usage_range=900:2403
+mem_usage_range=4500000:7500003
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_quick_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=nucosmics_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=nucosmics_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(NUCOSMICS_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=%(XROOTD_INPUTFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(INPUT_STAGE_NAME)s/%(INPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+#outBNB is added to specify the output and might need to be removed later
+OUTPUT_STREAM=outBNB:%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
+[test nucosmics_reco1_quick_test_icaruscode]
+STAGE_NAME=reco1
+INPUT_STAGE_NAME=reco0
+NEVENTS=2
+# calibrated with [e19] on icarusbuild02.fnal.gov
+cpu_usage_range=900:2403
+mem_usage_range=4500000:7700003
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_quick_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=nucosmics_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=nucosmics_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(NUCOSMICS_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=%(XROOTD_INPUTFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(INPUT_STAGE_NAME)s/%(INPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
 
 [test nucosmics_anatree_quick_test_icaruscode]
 # no reference art ROOT output for this one, but we have analysis tree reference (the "--extra-function" option)
@@ -657,7 +790,7 @@ output1=%(TFILENAME)s
 # TODO comparisons with references should happen in a different way, with the "C.I. validation tests" (ask the C.I. crew!)
 # 
 STAGE_NAME=anatree
-INPUT_STAGE_NAME=reco
+INPUT_STAGE_NAME=reco1
 NEVENTS=2
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=100:403
@@ -682,7 +815,7 @@ output1=%(TFILENAME)s
 [suite nucosmics_quick_test_icaruscode]
 # TODO analysis trees not included at this time
 # testlist=nucosmics_gen_quick_test_icaruscode nucosmics_g4_quick_test_icaruscode nucosmics_detsim_quick_test_icaruscode nucosmics_reco_quick_test_icaruscode nucosmics_anatree_quick_test_icaruscode
-testlist=nucosmics_gen_quick_test_icaruscode nucosmics_g4_quick_test_icaruscode nucosmics_detsim_quick_test_icaruscode nucosmics_reco_quick_test_icaruscode
+testlist=nucosmics_gen_quick_test_icaruscode nucosmics_g4_quick_test_icaruscode nucosmics_detsim_quick_test_icaruscode nucosmics_reco0_quick_test_icaruscode nucosmics_reco1_quick_test_icaruscode
 
 
 
@@ -795,6 +928,55 @@ args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(RE
 parse_art_output=True
 output1=%(TFILENAME)s
 
+[test nucosmics_reco0_seq_test_icaruscode]
+STAGE_NAME=reco0
+INPUT_STAGE_NAME=detsim
+NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
+
+# calibrated with [e19] on icarusbuild02.fnal.gov
+
+cpu_usage_range=3000:6504
+mem_usage_range=5000000:8000004
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_icaruscode
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_seq_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=nucosmics_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=nucosmics_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(NUCOSMICS_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=../%(requires)s/%(INPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+#outBNB is added to specify the output and might need to be removed later
+OUTPUT_STREAM=outBNB:%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root  
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
+[test nucosmics_reco1_seq_test_icaruscode]
+STAGE_NAME=reco1
+INPUT_STAGE_NAME=reco0
+NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
+
+# calibrated with [e19] on icarusbuild02.fnal.gov
+
+cpu_usage_range=3000:6504
+mem_usage_range=5000000:8000004
+
+script=%(EXPSCRIPT_ICARUSCODE)s
+requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_icaruscode
+FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_seq_test_icaruscode.fcl
+INPUT_BASE_FILE_NAME=nucosmics_%(INPUT_STAGE_NAME)s_test_icaruscode
+OUTPUT_BASE_FILE_NAME=nucosmics_%(STAGE_NAME)s_test_icaruscode
+EXTRA_DIR=%(NUCOSMICS_INPUT_DIRNAME_ICARUSCODE)s
+INPUT_STREAM=../%(requires)s/%(INPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_ICARUSCODE)s.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_ICARUSCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_ICARUSCODE)s.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_ICARUSCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
 
 [test nucosmics_anatree_seq_test_icaruscode]
 # no reference art ROOT output for this one, but we have analysis tree reference (the "--extra-function" option)
@@ -802,7 +984,7 @@ output1=%(TFILENAME)s
 # See the comment on the quick test for the validation.
 # 
 STAGE_NAME=anatree
-INPUT_STAGE_NAME=reco
+INPUT_STAGE_NAME=reco1
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=250:504
@@ -826,10 +1008,10 @@ output1=%(TFILENAME)s
 [suite nucosmics_seq_test_icaruscode]
 # TODO analysis trees not included at this time
 # testlist=nucosmics_gen_seq_test_icaruscode nucosmics_g4_seq_test_icaruscode nucosmics_detsim_seq_test_icaruscode nucosmics_reco_seq_test_icaruscode nucosmics_anatree_seq_test_icaruscode
-testlist=nucosmics_gen_seq_test_icaruscode nucosmics_g4_seq_test_icaruscode nucosmics_detsim_seq_test_icaruscode nucosmics_reco_seq_test_icaruscode
+testlist=nucosmics_gen_seq_test_icaruscode nucosmics_g4_seq_test_icaruscode nucosmics_detsim_seq_test_icaruscode nucosmics_reco0_seq_test_icaruscode nucosmics_reco1_seq_test_icaruscode
 
 [suite generate_reference_nucosmics_test_icaruscode]
-testlist=nucosmics_gen_seq_test_icaruscode nucosmics_g4_seq_test_icaruscode nucosmics_detsim_seq_test_icaruscode nucosmics_reco_seq_test_icaruscode
+testlist=nucosmics_gen_seq_test_icaruscode nucosmics_g4_seq_test_icaruscode nucosmics_detsim_seq_test_icaruscode nucosmics_reco0_seq_test_icaruscode nucosmics_reco1_seq_test_icaruscode
 
 
 

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -261,8 +261,6 @@ CUR_ICARUSCODE=Current%(IDENTIFIER_ICARUSCODE)s
 [test single_gen_quick_test_icaruscode]
 STAGE_NAME=gen
 NEVENTS=5
-# calibrated with [c2] on icarusbuild01.fnal.gov on 20191123
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607
 cpu_usage_range=5:50
 mem_usage_range=100000:400000
@@ -284,8 +282,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=2
-# calibrated with [c2] on icarusbuild01.fnal.gov on 20191123
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=700:1000
 mem_usage_range=1800000:2600000
@@ -308,8 +304,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=2
-# calibrated with [c2] on icarusbuild01.fnal.gov on 20191123
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=450:900
 mem_usage_range=2100000:2900000
@@ -332,8 +326,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco
 INPUT_STAGE_NAME=detsim
 NEVENTS=2
-# calibrated on icarusbuild01.fnal.gov on 20180325
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=450:650
 mem_usage_range=3000000:3800000
@@ -356,8 +348,8 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco0
 INPUT_STAGE_NAME=detsim
 NEVENTS=2
-# calibrated with [e20] on icarusbuild02.fnal.gov
-cpu_usage_range=1650:2250
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
+cpu_usage_range=2650:4250
 mem_usage_range=4000000:5000000
 
 script=%(EXPSCRIPT_ICARUSCODE)s
@@ -378,8 +370,8 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco1
 INPUT_STAGE_NAME=reco0
 NEVENTS=2
-# calibrated with [e20] on icarusbuild02.fnal.gov
-cpu_usage_range=450:650
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
+cpu_usage_range=450:850
 mem_usage_range=3000000:4200000
 
 script=%(EXPSCRIPT_ICARUSCODE)s
@@ -450,8 +442,6 @@ testlist=single_gen_quick_test_icaruscode single_g4_quick_test_icaruscode single
 [test single_gen_seq_test_icaruscode]
 STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
-# calibrated from [c2] on icarusbuild01.fnal.gov on 20191121
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607
 cpu_usage_range=5:52
 mem_usage_range=100000:400002
@@ -474,8 +464,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
-# calibrated with [c2:prof] on icarusbuild01.fnal.gov on 20191121;
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607: +500 MB memory requirement!
 # 2 GB is tight, but we want to be aware when that threshold is passed
 cpu_usage_range=330:602
@@ -500,8 +488,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
-# calibrated with [c2:prof] on icarusbuild01.fnal.gov on 20191121;
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607: +200 MB memory requirement!
 cpu_usage_range=80:302
 mem_usage_range=200000:1000002
@@ -525,8 +511,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco
 INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
-# calibrated on icarusbuild01.fnal.gov on 20180325 (same as quick test because detsim has reduced number of events)
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607: 800 MB -> 3.8 GB!!!
 cpu_usage_range=100:402
 mem_usage_range=700000:1200002
@@ -549,9 +533,9 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco0
 INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
-# calibrated with [e20] on icarusbuild02.fnal.gov
-cpu_usage_range=100:402
-mem_usage_range=700000:1200002
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
+cpu_usage_range=100:405
+mem_usage_range=700000:1200005
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_icaruscode
@@ -572,11 +556,9 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco1
 INPUT_STAGE_NAME=reco0
 NEVENTS=%(NEVENTS_SEQ_SINGLE_ICARUSCODE)s
-# calibrated on icarusbuild01.fnal.gov on 20180325 (same as quick test because detsim has reduced number of events)
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
-# calibrated with [e20] on icarusbuild02.fnal.gov on 20210607: 800 MB -> 3.8 GB!!!
-cpu_usage_range=100:402
-mem_usage_range=700000:1200002
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
+cpu_usage_range=100:405
+mem_usage_range=700000:1200005
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_icaruscode
@@ -653,7 +635,6 @@ testlist=single_gen_seq_test_icaruscode single_g4_seq_test_icaruscode single_det
 [test nucosmics_gen_quick_test_icaruscode]
 STAGE_NAME=gen
 NEVENTS=5
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607: +500 MB
 cpu_usage_range=200:653
 mem_usage_range=800000:1500003
@@ -675,7 +656,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=2
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=3000:5003
 mem_usage_range=5000000:9000003
@@ -698,7 +678,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=2
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=1000:1803
 mem_usage_range=6000000:12000003
@@ -721,7 +700,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco
 INPUT_STAGE_NAME=detsim
 NEVENTS=2
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on Jenkins on 20210810
 cpu_usage_range=900:2403
 mem_usage_range=4500000:7500003
@@ -743,9 +721,9 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco0
 INPUT_STAGE_NAME=detsim
 NEVENTS=2
-# calibrated with [e19] on icarusbuild02.fnal.gov
-cpu_usage_range=900:2403
-mem_usage_range=4500000:7500003
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
+cpu_usage_range=1900:4403
+mem_usage_range=4500000:7650003
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_quick_test_icaruscode.fcl
@@ -765,9 +743,9 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco1
 INPUT_STAGE_NAME=reco0
 NEVENTS=2
-# calibrated with [e19] on icarusbuild02.fnal.gov
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
 cpu_usage_range=900:2403
-mem_usage_range=4500000:7700003
+mem_usage_range=4500000:8000003
 
 script=%(EXPSCRIPT_ICARUSCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_ICARUSCODE)snucosmics_%(STAGE_NAME)s_quick_test_icaruscode.fcl
@@ -838,7 +816,6 @@ testlist=nucosmics_gen_quick_test_icaruscode nucosmics_g4_quick_test_icaruscode 
 [test nucosmics_gen_seq_test_icaruscode]
 STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607
 cpu_usage_range=200:504
 mem_usage_range=500000:1500004
@@ -860,7 +837,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210607
 cpu_usage_range=3000:5004
 mem_usage_range=6000000:10000004
@@ -908,7 +884,6 @@ output1=%(TFILENAME)s
 STAGE_NAME=reco
 INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
-# calibrated with [e19] on icarusbuild02.fnal.gov on 20200921
 # calibrated with [e20] on icarusbuild02.fnal.gov on 20210610: -1000"
 # again: 8 GB limit us tight, but it's an important threshold for grid jobs
 cpu_usage_range=3000:6504
@@ -933,7 +908,7 @@ STAGE_NAME=reco0
 INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
 
-# calibrated with [e19] on icarusbuild02.fnal.gov
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
 
 cpu_usage_range=3000:6504
 mem_usage_range=5000000:8000004
@@ -958,7 +933,7 @@ STAGE_NAME=reco1
 INPUT_STAGE_NAME=reco0
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_ICARUSCODE)s
 
-# calibrated with [e19] on icarusbuild02.fnal.gov
+# calibrated with [e20] on icarusbuild02.fnal.gov 20210818
 
 cpu_usage_range=3000:6504
 mem_usage_range=5000000:8000004

--- a/test/ci/icarus_ci_nucosmics_reco0_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_nucosmics_reco0_quick_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "stage0_multiTPC_icarus_MC.fcl"

--- a/test/ci/icarus_ci_nucosmics_reco0_seq_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_nucosmics_reco0_seq_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "icarus_ci_nucosmics_reco0_quick_test_icaruscode.fcl"

--- a/test/ci/icarus_ci_nucosmics_reco1_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_nucosmics_reco1_quick_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "stage1_multiTPC_icarus_gauss_MC.fcl"

--- a/test/ci/icarus_ci_nucosmics_reco1_seq_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_nucosmics_reco1_seq_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "icarus_ci_nucosmics_reco1_quick_test_icaruscode.fcl"

--- a/test/ci/icarus_ci_single_reco0_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_single_reco0_quick_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "stage0_multiTPC_icarus_MC.fcl"

--- a/test/ci/icarus_ci_single_reco0_seq_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_single_reco0_seq_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "icarus_ci_single_reco0_quick_test_icaruscode.fcl"

--- a/test/ci/icarus_ci_single_reco1_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_single_reco1_quick_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "stage1_multiTPC_icarus_gauss_MC.fcl"

--- a/test/ci/icarus_ci_single_reco1_seq_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_single_reco1_seq_test_icaruscode.fcl
@@ -1,0 +1,1 @@
+#include "icarus_ci_single_reco1_quick_test_icaruscode.fcl"


### PR DESCRIPTION
The reco test is split into two tests.
reco0 is run with detsim input via stage0_multiTPC_icarus_MC.fcl
reco1 is run with reco0 input via stage1_multiTPC_icarus_gauss_MC.fcl

preliminary reference files are generated but need to be updated through Jenkins after merging  

old reco test is preserved, but disabled 