### PR TITLE
Adding ICARUS NuMI Oscillation Fcls

### DIFF
--- a/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_fullosc_volDetEnclosure_tpc.fcl
+++ b/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_fullosc_volDetEnclosure_tpc.fcl
@@ -1,3 +1,13 @@
+# Author: Joseph Zennamo (jaz8600@fnal.gov)
+#
+# This configuration takes the flux and swaps all the electron (anti)neutrinos for muon (anti)neutrinos and 
+# all the muon (anti)neutrinos for electron (anti)neutrinos. This replaces a complete (or full) oscillation 
+# of one flavor to the other 
+#
+# Future improvement: Currently this also generates NC interactions, this can likely be reduced to only CC events
+#
+
+
 #include "prodcorsika_genie_protononly_icarus_numi_volDetEnclosure_tpc.fcl"
 
 # output file names

--- a/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_fullosc_volDetEnclosure_tpc.fcl
+++ b/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_fullosc_volDetEnclosure_tpc.fcl
@@ -1,0 +1,12 @@
+#include "prodcorsika_genie_protononly_icarus_numi_volDetEnclosure_tpc.fcl"
+
+# output file names
+services.TFileService.fileName: "Supplemental-prodcorsika_genie_protononly_icarus_numi_fullosc_%tc-%p.root"
+outputs.rootoutput.fileName:    "prodcorsika_genie_protononly_icarus_numi_fullosc_%tc-%p.root"
+
+#
+# Swap the PDG codes for the neutrinos coming from the beam simulation
+#
+
+physics.producers.generator.MixerConfig: "map 14:12 -14:-12 12:14 -12:-14"
+

--- a/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_nue_volDetEnclosure_tpc.fcl
+++ b/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_nue_volDetEnclosure_tpc.fcl
@@ -1,0 +1,11 @@
+#include "prodcorsika_genie_protononly_icarus_numi_volDetEnclosure_tpc.fcl"
+
+# output file names
+services.TFileService.fileName: "Supplemental-prodcorsika_genie_protononly_icarus_numi_nue_%tc-%p.root"
+outputs.rootoutput.fileName:    "prodcorsika_genie_protononly_icarus_numi_nue_%tc-%p.root"
+
+#
+# only generate electron neutrinos
+#
+
+physics.producers.generator.GenFlavors: [ 12, -12 ]

--- a/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_nue_volDetEnclosure_tpc.fcl
+++ b/fcl/gen/numi/prodcorsika_genie_protononly_icarus_numi_nue_volDetEnclosure_tpc.fcl
@@ -1,3 +1,10 @@
+# Author: Joseph Zennamo (jaz8600@fnal.gov)
+#
+# This generates only electron neutrinos from the NuMI beamline in ICARUS
+#
+# Future improvement: Currently this also generates NC interactions, this can likely be reduced to only CC events
+#
+
 #include "prodcorsika_genie_protononly_icarus_numi_volDetEnclosure_tpc.fcl"
 
 # output file names


### PR DESCRIPTION
These fcls should enable the generation of a full osc and intrinsic nue-only samples for NuMI in the ICARUS detector. 

This should address https://github.com/SBNSoftware/icaruscode/issues/235