### PR TITLE
Feature/jlarkin evtw fcl

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -190,7 +190,7 @@ caf_ana_sequence: [ mcreco,
     # TODO: rns??
     ]
 
-caf_ana_evtw_sequence: [@sequence::caf_ana_sequence, genieweight]
+caf_ana_evtw_sequence: [@sequence::caf_ana_sequence, rns, genieweight]
 
 caf_ana_sce_sequence: [ mcreco,
   # Run the SCE correction
@@ -211,6 +211,8 @@ caf_ana_sce_sequence: [ mcreco,
   fmatchSCECryoE, fmatchSCECryoW
   # TODO: rns??
 ]
+
+caf_ana_sce_evtw_sequence: [@sequence::caf_ana_sce_sequence, rns, genieweight]
 
 # CAFMaker config
 cafmaker: @local::standard_cafmaker

--- a/fcl/caf/cafmakerjob_icarus_evtw.fcl
+++ b/fcl/caf/cafmakerjob_icarus_evtw.fcl
@@ -1,3 +1,5 @@
 #include "cafmakerjob_icarus.fcl"
 
+services.RandomNumberGenerator: {}
+
 physics.runprod: [@sequence::caf_ana_evtw_sequence, cafmaker]

--- a/fcl/caf/cafmakerjob_icarus_sce_evtw.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_evtw.fcl
@@ -1,0 +1,5 @@
+#include "cafmakerjob_icarus_sce.fcl"
+
+services.RandomNumberGenerator: {}
+
+physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, cafmaker]


### PR DESCRIPTION
Adds new cafmakerjob_icarus_sce_evtw.fcl to run genie weights with sce. Fixes cafmakerjob_icarus_evtw.fcl to run without error. This was tested on the nu+cosmics BNB sample in the August 2021 production.

I added rns to caf_ana_evtw_sequence and the new caf_ana_sce_evtw_sequence based on the cafmakerjob_sbnd_geniewgt fcls in sbncode, but I see the comments in cafmaker_defs.fcl in caf_ana_sequence and caf_ana_sce_sequence. I'm not sure if rns should be added there or stay in the evtw sequences.

I also added the RandomNumberGenerator service only to the evtw fcls, but this could also be added to the services in cafmakerjob_icarus.fcl to be propagated to all other cafmakerjob fcls.

I kept the evtw naming convention, but this is different from the sbnd naming which uses geniewgt in the name of the fcl. Not sure if that is an issue, or if we just want to use a different naming convention than sbnd.