### PR TITLE
Fixed bug on PMT readout configuration extraction

### DIFF
--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.cxx
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.cxx
@@ -44,7 +44,7 @@ icarus::PMTconfigurationExtractorBase::convertConfigurationDocuments(
     
     fhicl::ParameterSet pset;
     try {
-      auto pset = fhicl::ParameterSet::make(psetStr);
+      pset = fhicl::ParameterSet::make(psetStr);
     }
     catch (cet::exception& e) {
       throw cet::exception{ "convertConfigurationDocuments", "", e }


### PR DESCRIPTION
This bug was introduced with the update to art 3.9 (commit 5eb6a4c2d).
It manifests in the decoder not finding configuration for the PMT readout, usually throwing an exception. If the error is bypassed, some time corrections are not used in the decoding, affecting the quality of the result (which way, has to be proven).
