### PR TITLE
Updates for coherent noise simulation

### DIFF
--- a/icaruscode/Decode/DecoderTools/INoiseFilter.h
+++ b/icaruscode/Decode/DecoderTools/INoiseFilter.h
@@ -50,10 +50,11 @@ public:
      *  @param ChannelVec           list of channels associated to input data array
      *  @param ArrayFloat           array by channel of the waveforms
      */
-    using ChannelVec = std::vector<unsigned int>;
+    using ChannelPlanePair = std::pair<unsigned int,unsigned int>;
+    using ChannelPlaneVec  = std::vector<ChannelPlanePair>;
 
     virtual void process_fragment(detinfo::DetectorClocksData const&,
-                                  const daq::INoiseFilter::ChannelVec&,
+                                  const daq::INoiseFilter::ChannelPlaneVec&,
                                   const icarus_signal_processing::ArrayFloat&) = 0;
 
     /**

--- a/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
@@ -68,7 +68,7 @@ public:
      *  @param fragment            The artdaq fragment to process
      */
     virtual void process_fragment(detinfo::DetectorClocksData const&,
-                                  const daq::INoiseFilter::ChannelVec&,
+                                  const daq::INoiseFilter::ChannelPlaneVec&,
                                   const icarus_signal_processing::ArrayFloat&) override;
 
     /**
@@ -243,8 +243,8 @@ void TPCNoiseFilter1DMC::configure(fhicl::ParameterSet const &pset)
 }
 
 void TPCNoiseFilter1DMC::process_fragment(detinfo::DetectorClocksData const&,
-                                               const daq::INoiseFilter::ChannelVec&        channelVec,
-                                               const icarus_signal_processing::ArrayFloat& dataArray)
+                                          const daq::INoiseFilter::ChannelPlaneVec&   channelPlaneVec,
+                                          const icarus_signal_processing::ArrayFloat& dataArray)
 {
     cet::cpu_timer theClockTotal;
 
@@ -283,13 +283,13 @@ void TPCNoiseFilter1DMC::process_fragment(detinfo::DetectorClocksData const&,
         icarus_signal_processing::VectorFloat& pedCorDataVec = fPedCorWaveforms[idx];
 
         // Keep track of the channel
-        fChannelIDVec[idx] = channelVec[idx];
+        fChannelIDVec[idx] = channelPlaneVec[idx].first;
 
         // We need to recover info on which plane we have
         std::vector<geo::WireID> widVec = fGeometry->ChannelToWire(fChannelIDVec[idx]);
 
         // Handle the filter function to use for this channel
-        unsigned int plane = widVec[0].Plane;
+        unsigned int plane = channelPlaneVec[idx].second;
 
         // Set the threshold which toggles between planes
         fThresholdVec[idx / fCoherentNoiseGrouping] = fThreshold[plane];

--- a/icaruscode/Decode/DecoderTools/TPCNoiseFilterCanny_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCNoiseFilterCanny_tool.cc
@@ -73,7 +73,7 @@ public:
      *  @param fragment            The artdaq fragment to process
      */
     virtual void process_fragment(detinfo::DetectorClocksData const&,
-                                  const daq::INoiseFilter::ChannelVec&,
+                                  const daq::INoiseFilter::ChannelPlaneVec&,
                                   const icarus_signal_processing::ArrayFloat&) override;
 
     /**
@@ -330,7 +330,7 @@ void TPCNoiseFilterCannyMC::configure(fhicl::ParameterSet const &pset)
 }
 
 void TPCNoiseFilterCannyMC::process_fragment(detinfo::DetectorClocksData const&,
-                                               const daq::INoiseFilter::ChannelVec&  channelVec,
+                                               const daq::INoiseFilter::ChannelPlaneVec&  channelPlaneVec,
                                                const icarus_signal_processing::ArrayFloat& dataArray)
 {
     cet::cpu_timer theClockTotal;
@@ -372,7 +372,7 @@ void TPCNoiseFilterCannyMC::process_fragment(detinfo::DetectorClocksData const&,
         icarus_signal_processing::VectorFloat& pedCorDataVec = fPedCorWaveforms[idx];
 
         // Keep track of the channel
-        fChannelIDVec[idx] = channelVec[idx];
+        fChannelIDVec[idx] = channelPlaneVec[idx].first;
 
         // We need to recover info on which plane we have
         std::vector<geo::WireID> widVec = fGeometry->ChannelToWire(fChannelIDVec[idx]);

--- a/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
@@ -85,7 +85,7 @@ public:
     using PlaneIdxToChannelPair = std::pair<unsigned int,ChannelVec>;
     using PlaneIdxToChannelMap  = std::map<unsigned int,ChannelVec>;
 
-    using ChannelArrayPair      = std::pair<ChannelVec,icarus_signal_processing::ArrayFloat>;
+    using ChannelArrayPair      = std::pair<daq::INoiseFilter::ChannelPlaneVec,icarus_signal_processing::ArrayFloat>;
     using ChannelArrayPairVec   = std::vector<ChannelArrayPair>;
 
     // Function to do the work
@@ -513,7 +513,7 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&          event,
             for(size_t tick = 0; tick < dataSize; tick++) dataVec[tick] = rawDataVec[tick];
 
             // Keep track of the channel
-            channelArrayPairVec[planeIndex].first[wire] = channel;
+            channelArrayPairVec[planeIndex].first[wire] = daq::INoiseFilter::ChannelPlanePair(channel,planeID.Plane);
         }
     }
 
@@ -538,7 +538,7 @@ void MCDecoderICARUSTPCwROI::processSingleImage(size_t                          
     const ChannelArrayPair& channelArrayPair = channelArrayPairVec[idx];
 
     // Let's go through and fill the output vector
-    const ChannelVec&                           channelVec = channelArrayPair.first;
+    const daq::INoiseFilter::ChannelPlaneVec&   channelVec = channelArrayPair.first;
     const icarus_signal_processing::ArrayFloat& dataArray  = channelArrayPair.second;
 
     unsigned int numChannels = dataArray.size();
@@ -555,10 +555,12 @@ void MCDecoderICARUSTPCwROI::processSingleImage(size_t                          
     // Now set up for output, we need to convert back from float to short int so use this
     raw::RawDigit::ADCvector_t wvfm(numTicks);
 
+    std::cout << "--> storing output after processing" << std::endl;
+
     // Loop over the channels to recover the RawDigits after filtering
     for(size_t chanIdx = 0; chanIdx < numChannels; chanIdx++)
     {
-        raw::ChannelID_t channel = channelVec[chanIdx];
+        raw::ChannelID_t channel = channelVec[chanIdx].first;
 
         if (fOutputRawWaveform)
         {
@@ -597,7 +599,7 @@ void MCDecoderICARUSTPCwROI::processSingleImage(size_t                          
 
         // And, finally, the ROIs 
         const icarus_signal_processing::VectorBool& chanROIs = decoderTool->getROIVals()[chanIdx];
-        recob::Wire::RegionsOfInterest_t           ROIVec;
+        recob::Wire::RegionsOfInterest_t            ROIVec;
 
         // Go through candidate ROIs and create Wire ROIs
         size_t roiIdx = 0;
@@ -620,7 +622,7 @@ void MCDecoderICARUSTPCwROI::processSingleImage(size_t                          
 
 //        std::cout << "    ROIVec size: " << ROIVec.size() << std::endl;
 
-        concurrentROIs.push_back(recob::WireCreator(std::move(ROIVec),channel,fGeometry->View(channelVec[chanIdx])).move());
+        concurrentROIs.push_back(recob::WireCreator(std::move(ROIVec),channel,fGeometry->View(channel)).move());
     }//loop over channel indices
 
     return;

--- a/icaruscode/TPC/Simulation/DetSim/SimWireICARUS_module.cc
+++ b/icaruscode/TPC/Simulation/DetSim/SimWireICARUS_module.cc
@@ -378,10 +378,10 @@ void SimWireICARUS::produce(art::Event& evt)
             noisetmp.resize(fNTimeSamples, 0.);     //just in case
             
             //use channel number to set some useful numbers
-            std::vector<geo::WireID> widVec = fGeometry.ChannelToWire(channel);
-            size_t                   plane  = widVec[0].Plane;
-            size_t                   wire   = widVec[0].Wire;
-            size_t                   board  = wire / 32;
+            std::vector<geo::WireID> widVec  = fGeometry.ChannelToWire(channel);
+            size_t                   plane   = widVec[0].Plane;
+            size_t                   wire    = widVec[0].Wire;
+            size_t                   board   = wire / 32;
             
             //Get pedestal with random gaussian variation
             float ped_mean = pedestalRetrievalAlg.PedMean(channel);
@@ -395,7 +395,7 @@ void SimWireICARUS::produce(art::Event& evt)
             //Generate Noise
             double noise_factor(0.);
             auto   tempNoiseVec = fSignalShapingService->GetNoiseFactVec();
-            double shapingTime  = fSignalShapingService->GetShapingTime(channel);
+            double shapingTime  = fSignalShapingService->GetShapingTime(plane);
             double gain         = fSignalShapingService->GetASICGain(channel) * sampling_rate(clockData) * 1.e-3; // Gain returned is electrons/us, this converts to electrons/tick
             int    timeOffset   = fSignalShapingService->ResponseTOffset(channel);
             
@@ -422,7 +422,7 @@ void SimWireICARUS::produce(art::Event& evt)
                                                 noisetmp,
                                                 detProp,
                                                 noise_factor,
-                                                channel,
+                                                widVec[0],
                                                 board);
             
             // Recover the SimChannel (if one) for this channel

--- a/icaruscode/TPC/Simulation/DetSim/tools/CorrelatedNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/CorrelatedNoise_tool.cc
@@ -53,11 +53,11 @@ public:
                        icarusutil::TimeVec& noise,
                        detinfo::DetectorPropertiesData const&,
                        double noise_factor,
-                       unsigned int wire,
-                       unsigned int board) override;
+                       const geo::PlaneID&,
+                       unsigned int) override;
     
 private:
-    void GenerateUncorrelatedNoise(CLHEP::HepRandomEngine&, icarusutil::TimeVec&, double, unsigned int);
+    void GenerateUncorrelatedNoise(CLHEP::HepRandomEngine&, icarusutil::TimeVec&, double);
     void GenerateCorrelatedNoise(CLHEP::HepRandomEngine&, icarusutil::TimeVec&, double, unsigned int);
     void GenNoise(std::function<void (double[])>&, const icarusutil::TimeVec&, icarusutil::TimeVec&, double);
     void ExtractCorrelatedAmplitude(float&, int) const;
@@ -232,7 +232,7 @@ void CorrelatedNoise::generateNoise(CLHEP::HepRandomEngine& engine_unc,
                                     icarusutil::TimeVec&    noise,
                                     detinfo::DetectorPropertiesData const&,
                                     double                  noise_factor,
-                                    unsigned int            channel,
+                                    const geo::PlaneID&     planeID,
                                     unsigned int            board)
 {
     // Define a couple of vectors to hold intermediate work
@@ -243,7 +243,7 @@ void CorrelatedNoise::generateNoise(CLHEP::HepRandomEngine& engine_unc,
     if (fNoiseFrequencyVec.size() != noise.size()) fNoiseFrequencyVec.resize(noise.size(),std::complex<float>(0.,0.));
     
     // If applying incoherent noise call the generator
-    if (fIncoherentNoiseFrac > 0.) GenerateUncorrelatedNoise(engine_unc,noise_unc,noise_factor,channel);
+    if (fIncoherentNoiseFrac > 0.) GenerateUncorrelatedNoise(engine_unc,noise_unc,noise_factor);
     
 //    int board=channel/32;
 
@@ -256,7 +256,7 @@ void CorrelatedNoise::generateNoise(CLHEP::HepRandomEngine& engine_unc,
     return;
 }
     
-void CorrelatedNoise::GenerateUncorrelatedNoise(CLHEP::HepRandomEngine& engine, icarusutil::TimeVec& noise, double noise_factor, unsigned int channel)
+void CorrelatedNoise::GenerateUncorrelatedNoise(CLHEP::HepRandomEngine& engine, icarusutil::TimeVec& noise, double noise_factor)
 {
     // Here we aim to produce a waveform consisting of incoherent noise
     // Note that this is expected to be the dominate noise contribution

--- a/icaruscode/TPC/Simulation/DetSim/tools/IGenNoise.h
+++ b/icaruscode/TPC/Simulation/DetSim/tools/IGenNoise.h
@@ -17,7 +17,11 @@
 #include "icaruscode/TPC/Utilities/tools/SignalProcessingDefs.h"
 
 namespace detinfo {
-  class DetectorPropertiesData;
+    class DetectorPropertiesData;
+}
+
+namespace geo {
+    class PlaneID;
 }
 
 class TComplex;
@@ -38,7 +42,7 @@ namespace icarus_tool
                                    icarusutil::TimeVec&,
                                    detinfo::DetectorPropertiesData const& detProp,
                                    double, 
-                                   unsigned int = 0,           // channel
+                                   const geo::PlaneID&,        // Gives Cryostat, TPC and Plane
                                    unsigned int = 0) = 0;      // board ID
     };
 }

--- a/icaruscode/TPC/Simulation/DetSim/tools/NoNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/NoNoise_tool.cc
@@ -27,7 +27,9 @@ public:
                        CLHEP::HepRandomEngine&,
                        icarusutil::TimeVec&,
                        detinfo::DetectorPropertiesData const&,
-                       double, unsigned int, unsigned int) override;
+                       double, 
+                       const geo::PlaneID&, 
+                       unsigned int) override;
     
 private:
 
@@ -55,8 +57,8 @@ void NoNoise::generateNoise(CLHEP::HepRandomEngine&,
                             icarusutil::TimeVec& noise,
                             detinfo::DetectorPropertiesData const&,
                             double noise_factor,
-                            unsigned int channel,
-                            unsigned int board)
+                            const geo::PlaneID&,
+                            unsigned int)
 {
     // Set all values to 0
     std::fill(noise.begin(), noise.end(), 0.);

--- a/icaruscode/TPC/Simulation/DetSim/tools/NoiseFromHist_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/NoiseFromHist_tool.cc
@@ -48,7 +48,9 @@ public:
                        CLHEP::HepRandomEngine&,
                        icarusutil::TimeVec&,
                        detinfo::DetectorPropertiesData const&,
-                       double, unsigned int, unsigned int) override;
+                       double,
+                       const geo::PlaneID&, 
+                       unsigned int) override;
     
 private:
     // Member variables from the fhicl file
@@ -120,7 +122,7 @@ void NoiseFromHist::generateNoise(CLHEP::HepRandomEngine& engine,
                                   icarusutil::TimeVec& noise,
                                   detinfo::DetectorPropertiesData const& detProp,
                                   double noise_factor,
-                                  unsigned int channel,
+                                  const geo::PlaneID& planeID,
                                   unsigned int board)
 {    
     CLHEP::RandFlat flat(engine,-1,1);

--- a/icaruscode/TPC/Simulation/DetSim/tools/RandomNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/RandomNoise_tool.cc
@@ -37,7 +37,7 @@ public:
                        icarusutil::TimeVec&,
                        detinfo::DetectorPropertiesData const&,
                        double,
-                       unsigned int,
+                       const geo::PlaneID&,
                        unsigned int) override;
     
 private:
@@ -72,7 +72,7 @@ void RandomNoise::generateNoise(CLHEP::HepRandomEngine& engine,
                                 icarusutil::TimeVec& noise,
                                 detinfo::DetectorPropertiesData const&,
                                 double noise_factor,
-                                unsigned int,
+                                const geo::PlaneID&,
                                 unsigned int)
 {
     CLHEP::RandGaussQ                              rGauss(engine, 0.0, noise_factor);

--- a/icaruscode/TPC/Simulation/DetSim/tools/SBNNoise_tool.cc
+++ b/icaruscode/TPC/Simulation/DetSim/tools/SBNNoise_tool.cc
@@ -53,12 +53,12 @@ public:
                        icarusutil::TimeVec& noise,
                        detinfo::DetectorPropertiesData const&,
                        double noise_factor,
-                       unsigned int wire,
+                       const geo::PlaneID&,
                        unsigned int board) override;
     
 private:
     void GenerateCorrelatedNoise(CLHEP::HepRandomEngine&, icarusutil::TimeVec&, double, unsigned int);
-    void GenerateUncorrelatedNoise(CLHEP::HepRandomEngine&, icarusutil::TimeVec&, double, unsigned int);
+    void GenerateUncorrelatedNoise(CLHEP::HepRandomEngine&, icarusutil::TimeVec&, double);
     void GenNoise(std::function<void (double[])>&, const icarusutil::TimeVec&, icarusutil::TimeVec&, float);
     void ComputeRMSs();
     void makeHistograms();
@@ -241,7 +241,7 @@ void SBNNoise::generateNoise(CLHEP::HepRandomEngine& engine_unc,
                                     icarusutil::TimeVec&     noise,
                              detinfo::DetectorPropertiesData const&,
                                     double                  noise_factor,
-                                    unsigned int            channel,
+                                    const geo::PlaneID&     planeID,
                                     unsigned int            board)
 {
 noise_factor=totalRMS;
@@ -254,7 +254,7 @@ noise_factor=totalRMS;
     if (fNoiseFrequencyVec.size() != noise.size()) fNoiseFrequencyVec.resize(noise.size(),std::complex<float>(0.,0.));
     //std::cout <<  " generating uncorrelated noise " << std::endl;
     // If applying incoherent noise call the generator
-    if (fIncoherentNoiseFrac > 0.) GenerateUncorrelatedNoise(engine_unc,noise_unc,noise_factor,channel);
+    if (fIncoherentNoiseFrac > 0.) GenerateUncorrelatedNoise(engine_unc,noise_unc,noise_factor);
     
 //    int board=channel/64;
 //std::cout <<  " generating correlated noise " << std::endl;
@@ -267,7 +267,7 @@ noise_factor=totalRMS;
     return;
 }
     
-void SBNNoise::GenerateUncorrelatedNoise(CLHEP::HepRandomEngine& engine, icarusutil::TimeVec &noise, double noise_factor, unsigned int channel)
+void SBNNoise::GenerateUncorrelatedNoise(CLHEP::HepRandomEngine& engine, icarusutil::TimeVec &noise, double noise_factor)
 {
     // Here we aim to produce a waveform consisting of incoherent noise
     // Note that this is expected to be the dominate noise contribution

--- a/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.cc
+++ b/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.cc
@@ -174,22 +174,21 @@ void SignalShapingICARUSService::SetDecon(double const samplingRate,
 }
 
 //-----Give Gain Settings to SimWire-----
-double SignalShapingICARUSService::GetASICGain(unsigned int  channel) const
+double SignalShapingICARUSService::GetASICGain(unsigned int channel) const
 {
     static const double fcToElectrons(6241.50975);
-    
+
     art::ServiceHandle<geo::Geometry> geom;
     size_t planeIdx = geom->ChannelToWire(channel)[0].Plane;
-    double gain     = fPlaneToResponseMap.at(planeIdx).front()->getElectronicsResponse()->getFCperADCMicroS() * fcToElectrons;
+    
+    double gain = fPlaneToResponseMap.at(planeIdx).front()->getElectronicsResponse()->getFCperADCMicroS() * fcToElectrons;
     
     return gain;
 }
 
 //-----Give Shaping time to SimWire-----
-double SignalShapingICARUSService::GetShapingTime(unsigned int  channel) const
+double SignalShapingICARUSService::GetShapingTime(unsigned int planeIdx) const
 {
-    art::ServiceHandle<geo::Geometry> geom;
-    size_t planeIdx     = geom->ChannelToWire(channel)[0].Plane;
     double shaping_time = fPlaneToResponseMap.at(planeIdx).front()->getElectronicsResponse()->getASICShapingTime();
 
     return shaping_time;
@@ -199,7 +198,7 @@ double SignalShapingICARUSService::GetRawNoise(unsigned int const channel) const
 {
     art::ServiceHandle<geo::Geometry> geom;
     size_t planeIdx = geom->ChannelToWire(channel)[0].Plane;
-    
+
     double gain         = fPlaneToResponseMap.at(planeIdx).front()->getElectronicsResponse()->getFCperADCMicroS();
     double shaping_time = fPlaneToResponseMap.at(planeIdx).front()->getElectronicsResponse()->getASICShapingTime();
     int    temp;

--- a/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.h
+++ b/icaruscode/TPC/Utilities/SignalShapingICARUSService_service.h
@@ -108,7 +108,7 @@ public:
     DoubleVec2                    GetNoiseFactVec() { return fNoiseFactVec; }
     
     double                        GetASICGain(unsigned int const channel)            const;
-    double                        GetShapingTime(unsigned int const channel)         const;
+    double                        GetShapingTime(unsigned int const planeIdx)        const;
     
     double                        GetRawNoise(unsigned int const channel)            const;
     double                        GetDeconNoise(unsigned int const channel)          const;


### PR DESCRIPTION
Changes enabling the TPC detector simulation to output "all" channels associated to "boards" to enable the coherent noise simulation across 64 channels. 