### PR TITLE
Updates FHiCLs for CAF to read weights from SBNEventWeight moduls in sbncode

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -11,7 +11,8 @@
 #include "calorimetry_icarus.fcl"
 #include "particleid_icarus.fcl"
 
-#include "eventweight_genie3_sbn_A.fcl"
+#include "eventweight_genie_sbn.fcl"
+#include "eventweight_flux_sbn.fcl"
 #include "mcreco.fcl"
 #include "mcsproducer.fcl"
 #include "rangeproducer.fcl"

--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -70,7 +70,8 @@ recoana_caf_ana_producers: {
 
   crtconvhit: @local::crthitconverter_icarus
   rns: { module_type: "RandomNumberSaver" }
-  genieweight: @local::sbn_genie_eventweight
+  genieweight: @local::sbn_eventweight_genie
+  fluxweight: @local::sbn_eventweight_flux
 }
 
 # Overwrite labels
@@ -80,6 +81,7 @@ recoana_caf_ana_producers.pandoraTrackRangeCryoE.TrackLabel: pandoraTrackGausCry
 recoana_caf_ana_producers.pandoraTrackRangeCryoW.TrackLabel: pandoraTrackGausCryoW
 
 recoana_caf_ana_producers.genieweight.weight_functions: @local::recoana_caf_ana_producers.genieweight.weight_functions_genie
+recoana_caf_ana_producers.fluxweight.weight_functions: @local::recoana_caf_ana_producers.fluxweight.weight_functions_flux
 
 # Setup CaloAlg for VertexCharge
 recoana_caf_ana_producers.vertexChargeCryoE.CaloAlg: @local::icarus_calorimetryalgmc 
@@ -191,7 +193,7 @@ caf_ana_sequence: [ mcreco,
     # TODO: rns??
     ]
 
-caf_ana_evtw_sequence: [@sequence::caf_ana_sequence, rns, genieweight]
+caf_ana_evtw_sequence: [@sequence::caf_ana_sequence, rns, genieweight, fluxweight]
 
 caf_ana_sce_sequence: [ mcreco,
   # Run the SCE correction
@@ -213,7 +215,7 @@ caf_ana_sce_sequence: [ mcreco,
   # TODO: rns??
 ]
 
-caf_ana_sce_evtw_sequence: [@sequence::caf_ana_sce_sequence, rns, genieweight]
+caf_ana_sce_evtw_sequence: [@sequence::caf_ana_sce_sequence, rns, genieweight, fluxweight]
 
 # CAFMaker config
 cafmaker: @local::standard_cafmaker
@@ -244,7 +246,7 @@ cafmaker.CRTHitLabel: "crthit"
 cafmaker.CRTTrackLabel: "crttrack"
 cafmaker.FlashTrigLabel: "" # unavailable
 cafmaker.SimChannelLabel: "largeant"
-cafmaker.SystWeightLabels: ["genieweight"]
+cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]
 
 # Add CAFMaker to the list of producers
 caf_ana_producers.cafmaker: @local::cafmaker

--- a/fcl/caf/cafmakerjob_icarus_sce_evtw.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_evtw.fcl
@@ -1,5 +1,0 @@
-#include "cafmakerjob_icarus_sce.fcl"
-
-services.RandomNumberGenerator: {}
-
-physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, cafmaker]

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -1,5 +1,7 @@
 #include "cafmakerjob_icarus_sce.fcl"
 
+services.RandomNumberGenerator: {}
+
 physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, genieweight, fluxweight, cafmaker ]
 
 physics.producers.cafmaker.SystWeightLabels: ["genieweight","fluxweight"]

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -1,5 +1,5 @@
 #include "cafmakerjob_icarus_sce.fcl"
 
-physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, cafmaker, genieweight, fluxweight]
+physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, genieweight, fluxweight, cafmaker ]
 
 physics.producers.cafmaker.SystWeightLabels: ["genieweight","fluxweight"]

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -2,4 +2,4 @@
 
 physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, cafmaker, genieweight, fluxweight]
 
-hysics.producers.mycafmaker.SystWeightLabels: ["genieweight","fluxweight"]
+hysics.producers.cafmaker.SystWeightLabels: ["genieweight","fluxweight"]

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -2,4 +2,4 @@
 
 physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, cafmaker, genieweight, fluxweight]
 
-hysics.producers.cafmaker.SystWeightLabels: ["genieweight","fluxweight"]
+physics.producers.cafmaker.SystWeightLabels: ["genieweight","fluxweight"]

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -1,0 +1,5 @@
+#include "cafmakerjob_icarus_sce.fcl"
+
+physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, cafmaker, genieweight, fluxweight]
+
+hysics.producers.mycafmaker.SystWeightLabels: ["genieweight","fluxweight"]


### PR DESCRIPTION
Update `cafmaker_defs.fcl`: 

Change "eventweight_genie3_sbn_A.fcl" to "eventweight_genie_sbn.fcl";
Add "eventweight_flux_sbn.fcl"