### PR TITLE
Feature/howard nov21 freeze

### DIFF
--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_numi_sce_on.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_numi_sce_on.fcl
@@ -1,0 +1,3 @@
+#include "prodcorsika_proton_intime_icarus_numi.fcl"
+
+#include "enable_spacecharge_icarus.fcl"

--- a/icaruscode/Decode/fcl/stage0_multiTPC_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_icarus.fcl
@@ -16,11 +16,11 @@ physics.reco: [daqTPCROI, @sequence::icarus_stage0_multiTPC]
 
 ## boiler plate...
 physics.trigger_paths: [ reco ]
-outputs.out1.fileName: "%ifb_%tc-%p.root"
-outputs.out1.dataTier: "reconstructed"
+outputs.outBNB.fileName: "%ifb_%tc-%p.root"
+outputs.outBNB.dataTier: "reconstructed"
 
 # Drop the artdaq format files on output
-outputs.out1.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outBNB.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.daqTPCROI.FragmentsLabelVec:  ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_icarus.fcl
@@ -24,5 +24,5 @@ outputs.outBNB.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.daqTPCROI.FragmentsLabelVec:  ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
-physics.producers.decon1droi.RawDigitLabelVec:  ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:  ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.roifinder.WireModuleLabelVec: ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE","decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_east_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_east_icarus.fcl
@@ -31,5 +31,5 @@ physics.producers.daqPMT.DecoderTool.RequireBoardConfig: false
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.daqTPCROI.FragmentsLabelVec:           ["daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
-physics.producers.decon1droi.RawDigitLabelVec:           ["daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:           ["daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.roifinder.WireModuleLabelVec:          ["decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_icarus.fcl
@@ -37,12 +37,12 @@ physics.producers.daqPMT.RequireBoardConfig:     false
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.daqTPCROI.FragmentsLabelVec:   ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
-physics.producers.decon1droi.RawDigitLabelVec:   ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:   ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.roifinder.WireModuleLabelVec:  ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE","decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]
 
 ## Need overrides for the purity monitor
-physics.producers.purityana0.RawModuleLabel:  ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
-physics.producers.purityana1.RawModuleLabel:  ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.purityana0.RawModuleLabel:  ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.purityana1.RawModuleLabel:  ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
 
 ## Modify the event selection for the purity analyzers
 physics.analyzers.purityinfoana0.SelectEvents:    [ pathBNB, pathNUMI, pathUnknown ]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_nofilter_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_nofilter_icarus.fcl
@@ -37,12 +37,12 @@ outputs.outUnknown.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_d
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.daqTPCROI.FragmentsLabelVec:   ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
-physics.producers.decon1droi.RawDigitLabelVec:   ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:   ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.roifinder.WireModuleLabelVec:  ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE","decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]
 
 ## Need overrides for the purity monitor
-physics.producers.purityana0.RawModuleLabel:  ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
-physics.producers.purityana1.RawModuleLabel:  ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE","daqTPC:PHYSCRATEDATATPCEW","daqTPC:PHYSCRATEDATATPCEE"]
+physics.producers.purityana0.RawModuleLabel:  ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.purityana1.RawModuleLabel:  ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
 
 ## Modify the event selection for the purity analyzers
 physics.analyzers.purityinfoana0.SelectEvents:    [ pathBNB, pathNUMI, pathUnknown ]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_west_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_west_icarus.fcl
@@ -31,5 +31,5 @@ physics.producers.daqPMT.DecoderTool.RequireBoardConfig: false
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.daqTPCROI.FragmentsLabelVec:           ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE"]
-physics.producers.decon1droi.RawDigitLabelVec:           ["daqTPC:PHYSCRATEDATATPCWW","daqTPC:PHYSCRATEDATATPCWE"]
+physics.producers.decon1droi.RawDigitLabelVec:           ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE"]
 physics.producers.roifinder.WireModuleLabelVec:          ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE"]

--- a/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss_numi.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss_numi.fcl
@@ -1,0 +1,4 @@
+#include "stage1_multiTPC_icarus_gauss.fcl"
+
+physics.producers.pandoraGausCryoE.ConfigFile:   "PandoraSettings_Master_ICARUS_NuMI.xml"
+physics.producers.pandoraGausCryoW.ConfigFile:   "PandoraSettings_Master_ICARUS_NuMI.xml"

--- a/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss_numi_MC.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss_numi_MC.fcl
@@ -1,0 +1,4 @@
+#include "stage1_multiTPC_icarus_gauss_MC.fcl"
+
+physics.producers.pandoraGausCryoE.ConfigFile:   "PandoraSettings_Master_ICARUS_NuMI.xml"
+physics.producers.pandoraGausCryoW.ConfigFile:   "PandoraSettings_Master_ICARUS_NuMI.xml"

--- a/icaruscode/Decode/fcl/stage1_multiTPC_nofilter_icarus_gauss_numi.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_nofilter_icarus_gauss_numi.fcl
@@ -1,0 +1,4 @@
+#include "stage1_multiTPC_nofilter_icarus_gauss.fcl"
+
+physics.producers.pandoraGausCryoE.ConfigFile:   "PandoraSettings_Master_ICARUS_NuMI.xml"
+physics.producers.pandoraGausCryoW.ConfigFile:   "PandoraSettings_Master_ICARUS_NuMI.xml"

--- a/icaruscode/TPC/Tracking/ICARUSPandora/pandoramodules_icarus.fcl
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/pandoramodules_icarus.fcl
@@ -9,6 +9,7 @@ icarus_basicpandora:
     EnableProduction:                            true
     EnableLineGaps:                              true
     UseGlobalCoordinates:                        true
+    UseActiveBoundingBox:                        true
     UseHitWidths:                                false
     ShouldRunAllHitsCosmicReco:                  false
     ShouldRunStitching:                          false

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
@@ -49,14 +49,6 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArTrackParticleBuilding">
-        <PfoListName>RecreatedPfos</PfoListName>
-        <VertexListName>RecreatedVertices</VertexListName>
-    </algorithm>
-    <algorithm type = "LArPcaShowerParticleBuilding">
-        <PfoListName>RecreatedPfos</PfoListName>
-        <VertexListName>RecreatedVertices</VertexListName>
-    </algorithm>
     <algorithm type = "LArVisualMonitoring">
         <ShowCurrentPfos>true</ShowCurrentPfos>
         <ShowDetector>true</ShowDetector>

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
@@ -1,0 +1,59 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <LArTransformationPlugin>
+        <MaxAngularDiscrepancyW>1000.</MaxAngularDiscrepancyW>
+    </LArTransformationPlugin>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArPreProcessing">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+    <algorithm type = "LArVisualMonitoring">
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</CaloHitListNames>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+
+    <algorithm type = "LArMaster">
+        <CRSettingsFile>PandoraSettings_Cosmic_Standard.xml</CRSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_ICARUS.xml</NuSettingsFile>
+        <SlicingSettingsFile>PandoraSettings_Slicing_Standard.xml</SlicingSettingsFile>
+        <StitchingTools>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>false</ThreeDStitchingMode></tool>
+        </StitchingTools>
+        <CosmicRayTaggingTools>
+            <tool type = "LArCosmicRayTagging">
+                <InTimeMaxX0>2.0</InTimeMaxX0>
+            </tool>
+        </CosmicRayTaggingTools>
+        <SliceIdTools>
+	    <tool type = "LArBdtNeutrinoId">
+                <MvaFileName>PandoraBdt_v08_33_00_SBND.xml</MvaFileName>
+		<MvaName>NeutrinoId</MvaName>
+		<MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
+		<MaximumNeutrinos>999</MaximumNeutrinos>
+	    </tool>
+        </SliceIdTools>
+        <InputHitListName>Input</InputHitListName>
+        <InputMCParticleListName>Input</InputMCParticleListName>
+        <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
+        <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
+        <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
+        <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
+        <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
+        <InTimeMaxX0>2.0</InTimeMaxX0>
+    </algorithm>
+
+    <algorithm type = "LArVisualMonitoring">
+        <ShowCurrentPfos>true</ShowCurrentPfos>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+</pandora>

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_RawICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_RawICARUS.xml
@@ -47,14 +47,6 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArTrackParticleBuilding">
-        <PfoListName>RecreatedPfos</PfoListName>
-        <VertexListName>RecreatedVertices</VertexListName>
-    </algorithm>
-    <algorithm type = "LArPcaShowerParticleBuilding">
-        <PfoListName>RecreatedPfos</PfoListName>
-        <VertexListName>RecreatedVertices</VertexListName>
-    </algorithm>
     <algorithm type = "LArVisualMonitoring">
         <ShowCurrentPfos>true</ShowCurrentPfos>
         <ShowDetector>true</ShowDetector>


### PR DESCRIPTION
This has several changes, I'll give a short list and if I think there is something important to note about the status I'll put it here too:

* Added a fcl meant to be analogous to the BNB in-time sce on fcl but for NuMI. As it uses pre-existing fcls and just is a 2-line fhicl combining them via include (as in the BNB case) and the dump of fcl configuration seemed okay, I think this is _probably_ okay. HOWEVER, it would be good to check the output objects in some way. **Such a validation is still a work in progress!!**

* Pandora behavior changes: (A) I have switched Pandora to the "ActiveBoundingBox" mode (fhicl switch) and (B) removed a few algorithms.

A. In thinking further about some things, I wonder if the volume should be made to include the wires. I probably need to think more about this, and I also reached out to the Pandora folks for comment. In any case, even if this isn't the final configuration, I contend this configuration should be better around the cathode than the default.

B. I removed a few unnecessary algs (`LArTrackParticleBuilding`/`LArPcaShowerParticleBuilding`) from the "Master Settings" that seemed to be at play in one of the tracks-getting-called-showers pathologies found before.

* NuMI-specific configurations: Added NuMI-version of the "Master Settings" XML that sets the MaxX0 parameter to 2.0 (default 1.0 is not big enough for the NuMI beam window). Correspondingly, there is a set of 3 stage1 fcls that inherit the "non-NuMI" parent and then change the Pandora configuration to use this XML. The `nofilter` and `_MC` ones were tested on a simulated particle gun event to see that this had the desired effect; the third wasn't tested but is essentially the same. (If someone has an idea for an event to test let me know!) NOTE: I did _not_ make a "RawICARUS" version of this. If we want to make some files using the Raw Hits chain, one could be added.

I tag @jzennamo as a reviewer on this PR especially since the overall workflow/requests are involved in this part of the PR, though of course I welcome any comments from anyone on any point.

* Some changes to the stage0 fcls. The more recent changes were only present in the latest release I think (the `daqTPCROI`). I fixed up where I believe the fixes are necessary, but it's possible I missed something. I did run a few of them after the change (I think it was the `multitpc_icarus` and `splitstream_nofilter`) but didn't test every fcl.

Probably @SFBayLaser is best poised to know if I missed something here.