### PR TITLE
Second (more hesistant) PR relating to Reco/ICARUS Pandora updates

### DIFF
--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
@@ -81,7 +81,6 @@
   <!-- VertexAlgorithms -->
   <algorithm type = "LArCutClusterCharacterisation">
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
-    <ZeroMode>true</ZeroMode>
   </algorithm>
   <algorithm type = "LArCandidateVertexCreation">
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>


### PR DESCRIPTION
This PR is a one line commit, but I made it separate since I'm more hesitant about this one. More info below.

@SFBayLaser  - I wasn't sure who the reviewer(s) should be. Can you assign folks that you think would be good to chime in?

**Info:**

This is probably really considered a bug-fix. My understanding (thanks to Ed for giving me the run-down on the change and to Henry for looking into this for SBND originally) is that since the Vertex BDT has features that use the initial characterization, this "ZeroMode" at the beginning of the vertexing algorithms is not desired (since it removes the initial characterization).

However, this is has only been looked at a little bit in ICARUS, and so I think the effects of it (positive/negative) are not very well understood at this point. Hence the hesitant nature/separate request.

We could turn it on and if we find that vertexing seemed better before look at reverting it for the following production? Others' opinions would be valuable!