### PR TITLE
Data-handling CAFMaker script(s)

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -193,6 +193,18 @@ caf_ana_sequence: [ mcreco,
     # TODO: rns??
     ]
 
+caf_ana_data_sequence: [
+    # Calorimetry
+    pandoraCaloGausCryoE, pandoraCaloGausCryoW,
+    pandoraPidGausCryoE, pandoraPidGausCryoW,
+    # Low Energy Proton Reco
+    vertexChargeCryoE, vertexChargeCryoW, vertexStubCryoE, vertexStubCryoW,
+    # Track Momentum Estimation
+    pandoraTrackMCSCryoE, pandoraTrackMCSCryoW,
+    pandoraTrackRangeCryoE, pandoraTrackRangeCryoW
+    # TODO: rns??
+    ]
+
 caf_ana_evtw_sequence: [@sequence::caf_ana_sequence, rns, genieweight, fluxweight]
 
 caf_ana_sce_sequence: [ mcreco,

--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -197,6 +197,8 @@ caf_preprocess_data_sequence: [
     # Calorimetry
     pandoraCaloGausCryoE, pandoraCaloGausCryoW,
     pandoraPidGausCryoE, pandoraPidGausCryoW,
+    # Low Energy Proton Reco
+    vertexChargeCryoE, vertexChargeCryoW, vertexStubCryoE, vertexStubCryoW,
     # Track Momentum Estimation
     pandoraTrackMCSCryoE, pandoraTrackMCSCryoW,
     pandoraTrackRangeCryoE, pandoraTrackRangeCryoW

--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -193,12 +193,10 @@ caf_ana_sequence: [ mcreco,
     # TODO: rns??
     ]
 
-caf_ana_data_sequence: [
+caf_preprocess_data_sequence: [
     # Calorimetry
     pandoraCaloGausCryoE, pandoraCaloGausCryoW,
     pandoraPidGausCryoE, pandoraPidGausCryoW,
-    # Low Energy Proton Reco
-    vertexChargeCryoE, vertexChargeCryoW, vertexStubCryoE, vertexStubCryoW,
     # Track Momentum Estimation
     pandoraTrackMCSCryoE, pandoraTrackMCSCryoW,
     pandoraTrackRangeCryoE, pandoraTrackRangeCryoW

--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -54,7 +54,7 @@ recoana_calo_producers.pandoraCaloGausCryoW.TrackIsFieldDistortionCorrected: tru
 recoana_calo_producers.pandoraCaloGausCryoW.FieldDistortionEfield: true
 
 # Producers for making analysis level products
-recoana_caf_ana_producers: {
+recoana_caf_preprocess_producers: {
   mcreco: @local::standard_mcreco
 
   pandoraTrackMCSCryoE: @local::mcs_sbn
@@ -75,19 +75,19 @@ recoana_caf_ana_producers: {
 }
 
 # Overwrite labels
-recoana_caf_ana_producers.pandoraTrackMCSCryoE.TrackLabel: pandoraTrackGausCryoE
-recoana_caf_ana_producers.pandoraTrackMCSCryoW.TrackLabel: pandoraTrackGausCryoW
-recoana_caf_ana_producers.pandoraTrackRangeCryoE.TrackLabel: pandoraTrackGausCryoE
-recoana_caf_ana_producers.pandoraTrackRangeCryoW.TrackLabel: pandoraTrackGausCryoW
+recoana_caf_preprocess_producers.pandoraTrackMCSCryoE.TrackLabel: pandoraTrackGausCryoE
+recoana_caf_preprocess_producers.pandoraTrackMCSCryoW.TrackLabel: pandoraTrackGausCryoW
+recoana_caf_preprocess_producers.pandoraTrackRangeCryoE.TrackLabel: pandoraTrackGausCryoE
+recoana_caf_preprocess_producers.pandoraTrackRangeCryoW.TrackLabel: pandoraTrackGausCryoW
 
-recoana_caf_ana_producers.genieweight.weight_functions: @local::recoana_caf_ana_producers.genieweight.weight_functions_genie
-recoana_caf_ana_producers.fluxweight.weight_functions: @local::recoana_caf_ana_producers.fluxweight.weight_functions_flux
+recoana_caf_preprocess_producers.genieweight.weight_functions: @local::recoana_caf_preprocess_producers.genieweight.weight_functions_genie
+recoana_caf_preprocess_producers.fluxweight.weight_functions: @local::recoana_caf_preprocess_producers.fluxweight.weight_functions_flux
 
 # Setup CaloAlg for VertexCharge
-recoana_caf_ana_producers.vertexChargeCryoE.CaloAlg: @local::icarus_calorimetryalgmc 
-recoana_caf_ana_producers.vertexChargeCryoW.CaloAlg: @local::icarus_calorimetryalgmc 
-recoana_caf_ana_producers.vertexStubCryoE.CaloAlg: @local::icarus_calorimetryalgmc 
-recoana_caf_ana_producers.vertexStubCryoW.CaloAlg: @local::icarus_calorimetryalgmc 
+recoana_caf_preprocess_producers.vertexChargeCryoE.CaloAlg: @local::icarus_calorimetryalgmc
+recoana_caf_preprocess_producers.vertexChargeCryoW.CaloAlg: @local::icarus_calorimetryalgmc
+recoana_caf_preprocess_producers.vertexStubCryoE.CaloAlg: @local::icarus_calorimetryalgmc
+recoana_caf_preprocess_producers.vertexStubCryoW.CaloAlg: @local::icarus_calorimetryalgmc
 
 # Producers for making SCE products
 recoana_sce_producers: {
@@ -109,11 +109,11 @@ recoana_sce_producers: {
   fmatchSCECryoE: @local::transfer_flashmatch_sce_icarus_cryoE
   fmatchSCECryoW: @local::transfer_flashmatch_sce_icarus_cryoW
 
-  pandoraTrackSCEMCSCryoE: @local::recoana_caf_ana_producers.pandoraTrackMCSCryoE
-  pandoraTrackSCEMCSCryoW: @local::recoana_caf_ana_producers.pandoraTrackMCSCryoW
+  pandoraTrackSCEMCSCryoE: @local::recoana_caf_preprocess_producers.pandoraTrackMCSCryoE
+  pandoraTrackSCEMCSCryoW: @local::recoana_caf_preprocess_producers.pandoraTrackMCSCryoW
 
-  pandoraTrackSCERangeCryoE: @local::recoana_caf_ana_producers.pandoraTrackRangeCryoE
-  pandoraTrackSCERangeCryoW: @local::recoana_caf_ana_producers.pandoraTrackRangeCryoW
+  pandoraTrackSCERangeCryoE: @local::recoana_caf_preprocess_producers.pandoraTrackRangeCryoE
+  pandoraTrackSCERangeCryoW: @local::recoana_caf_preprocess_producers.pandoraTrackRangeCryoW
 
   vertexChargeCryoE: @local::vertex_charge_icarus_sce_cryoE 
   vertexChargeCryoW: @local::vertex_charge_icarus_sce_cryoW
@@ -169,19 +169,19 @@ recoana_sce_producers.vertexStubCryoE.CaloAlg: @local::icarus_calorimetryalgmc
 recoana_sce_producers.vertexStubCryoW.CaloAlg: @local::icarus_calorimetryalgmc 
 
 # All the producers together
-caf_ana_producers: {
+caf_preprocess_producers: {
   @table::recoana_calo_producers
-  @table::recoana_caf_ana_producers
+  @table::recoana_caf_preprocess_producers
 }
 
-caf_ana_sce_producers: {
+caf_preprocess_sce_producers: {
   @table::recoana_calo_producers
-  @table::recoana_caf_ana_producers
+  @table::recoana_caf_preprocess_producers
   @table::recoana_sce_producers
 }
 
 # Sequences
-caf_ana_sequence: [ mcreco,
+caf_preprocess_sequence: [ mcreco,
     # Calorimetry
     pandoraCaloGausCryoE, pandoraCaloGausCryoW,
     pandoraPidGausCryoE, pandoraPidGausCryoW,
@@ -205,9 +205,9 @@ caf_preprocess_data_sequence: [
     # TODO: rns??
     ]
 
-caf_ana_evtw_sequence: [@sequence::caf_ana_sequence, rns, genieweight, fluxweight]
+caf_preprocess_evtw_sequence: [@sequence::caf_preprocess_sequence, rns, genieweight, fluxweight]
 
-caf_ana_sce_sequence: [ mcreco,
+caf_preprocess_sce_sequence: [ mcreco,
   # Run the SCE correction
   pandoraGausSCECryoE, pandoraGausSCECryoW,
   # Then remake tracks
@@ -227,7 +227,7 @@ caf_ana_sce_sequence: [ mcreco,
   # TODO: rns??
 ]
 
-caf_ana_sce_evtw_sequence: [@sequence::caf_ana_sce_sequence, rns, genieweight, fluxweight]
+caf_preprocess_sce_evtw_sequence: [@sequence::caf_preprocess_sce_sequence, rns, genieweight, fluxweight]
 
 # CAFMaker config
 cafmaker: @local::standard_cafmaker
@@ -261,6 +261,6 @@ cafmaker.SimChannelLabel: "largeant"
 cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]
 
 # Add CAFMaker to the list of producers
-caf_ana_producers.cafmaker: @local::cafmaker
+caf_preprocess_producers.cafmaker: @local::cafmaker
 
 END_PROLOG

--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -41,10 +41,10 @@ physics:
 {
  
   producers: {
-    @table::caf_ana_producers
+    @table::caf_preprocess_producers
   }
 
-  runprod: [ @sequence::caf_ana_sequence, cafmaker]
+  runprod: [ @sequence::caf_preprocess_sequence, cafmaker]
   stream1:       [  ]
   trigger_paths: [ runprod ] 
   end_paths:     [ stream1 ]

--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -34,9 +34,6 @@ outputs:
   }
 }
 
-# Define and configure some modules to do work on each event.
-# First modules are defined; they are scheduled later.
-# Modules are grouped by type.
 physics:
 {
  

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -53,4 +53,4 @@ physics:
 physics.producers.cafmaker.G4Label: ""
 physics.producers.cafmaker.GenLabel: ""
 physics.producers.cafmaker.SimChannelLabel: ""
-physics.producers.cafmaker.SystWeightLabels: [] #["genieweight", "fluxweight"]
+physics.producers.cafmaker.SystWeightLabels: []

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -22,21 +22,6 @@ services:
   NuRandomService: @local::per_event_NuRandomService
 }
 
-
-outputs:
-{
-  outpid:
-  {
-    dataTier: cafana # for grid
-    streamName: out1 # for grid
-    module_type: RootOutput
-    fileName:    "stage2_r%r_s%s.root"
-  }
-}
-
-# Define and configure some modules to do work on each event.
-# First modules are defined; they are scheduled later.
-# Modules are grouped by type.
 physics:
 {
  
@@ -44,13 +29,13 @@ physics:
     @table::caf_ana_producers
   }
 
-  runprod: [ @sequence::caf_ana_data_sequence, cafmaker]
-  stream1:       [  ]
+  runprod: [ @sequence::caf_preprocess_data_sequence, cafmaker]
   trigger_paths: [ runprod ] 
-  end_paths:     [ stream1 ]
 }
 
 physics.producers.cafmaker.G4Label: ""
 physics.producers.cafmaker.GenLabel: ""
 physics.producers.cafmaker.SimChannelLabel: ""
 physics.producers.cafmaker.SystWeightLabels: []
+
+physics.producers.cafmaker.StubLabel: ""

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -26,7 +26,7 @@ physics:
 {
  
   producers: {
-    @table::caf_ana_producers
+    @table::caf_preprocess_producers
   }
 
   runprod: [ @sequence::caf_preprocess_data_sequence, cafmaker]

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -1,0 +1,56 @@
+#include "services_common_icarus.fcl"
+#include "channelmapping_icarus.fcl"
+
+#include "correctionservices_icarus.fcl"
+#include "seedservice.fcl"
+#include "particleinventoryservice.fcl"
+#include "backtrackerservice.fcl"
+#include "photonbacktrackerservice.fcl"
+#include "mccheatermodules.fcl"
+
+#include "cafmaker_defs.fcl"
+
+process_name: CAFmaker
+
+services:
+{
+  ParticleInventoryService:  @local::standard_particleinventoryservice
+  BackTrackerService:        @local::standard_backtrackerservice
+  @table::icarus_wirecalibration_minimum_services
+
+  SpaceChargeService: @local::icarus_spacecharge
+  NuRandomService: @local::per_event_NuRandomService
+}
+
+
+outputs:
+{
+  outpid:
+  {
+    dataTier: cafana # for grid
+    streamName: out1 # for grid
+    module_type: RootOutput
+    fileName:    "stage2_r%r_s%s.root"
+  }
+}
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+ 
+  producers: {
+    @table::caf_ana_producers
+  }
+
+  runprod: [ @sequence::caf_ana_data_sequence, cafmaker]
+  stream1:       [  ]
+  trigger_paths: [ runprod ] 
+  end_paths:     [ stream1 ]
+}
+
+physics.producers.cafmaker.G4Label: ""
+physics.producers.cafmaker.GenLabel: ""
+physics.producers.cafmaker.SimChannelLabel: ""
+physics.producers.cafmaker.SystWeightLabels: [] #["genieweight", "fluxweight"]

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -3,10 +3,6 @@
 
 #include "correctionservices_icarus.fcl"
 #include "seedservice.fcl"
-#include "particleinventoryservice.fcl"
-#include "backtrackerservice.fcl"
-#include "photonbacktrackerservice.fcl"
-#include "mccheatermodules.fcl"
 
 #include "cafmaker_defs.fcl"
 
@@ -14,8 +10,6 @@ process_name: CAFmaker
 
 services:
 {
-  ParticleInventoryService:  @local::standard_particleinventoryservice
-  BackTrackerService:        @local::standard_backtrackerservice
   @table::icarus_wirecalibration_minimum_services
 
   SpaceChargeService: @local::icarus_spacecharge

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -37,5 +37,3 @@ physics.producers.cafmaker.G4Label: ""
 physics.producers.cafmaker.GenLabel: ""
 physics.producers.cafmaker.SimChannelLabel: ""
 physics.producers.cafmaker.SystWeightLabels: []
-
-physics.producers.cafmaker.StubLabel: ""

--- a/fcl/caf/cafmakerjob_icarus_evtw.fcl
+++ b/fcl/caf/cafmakerjob_icarus_evtw.fcl
@@ -2,4 +2,4 @@
 
 services.RandomNumberGenerator: {}
 
-physics.runprod: [@sequence::caf_ana_evtw_sequence, cafmaker]
+physics.runprod: [@sequence::caf_preprocess_evtw_sequence, cafmaker]

--- a/fcl/caf/cafmakerjob_icarus_nocaf.fcl
+++ b/fcl/caf/cafmakerjob_icarus_nocaf.fcl
@@ -1,6 +1,6 @@
 #include "cafmakerjob_icarus.fcl"
 
 # Turn off "CAFMaker"
-physics.runprod: [ @sequence::caf_ana_sequence ]
+physics.runprod: [ @sequence::caf_preprocess_sequence ]
 # Turn on output art ROOT file
 physics.sream1: [ outpid ]

--- a/fcl/caf/cafmakerjob_icarus_sce.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce.fcl
@@ -14,7 +14,7 @@ physics.producers: {
 }
 
 # Different sequence
-physics.runprod: [ @sequence::caf_ana_sce_sequence, cafmaker]
+physics.runprod: [ @sequence::caf_preprocess_sce_sequence, cafmaker]
 
 # change all the labels we need to
 physics.producers.cafmaker.PFParticleLabel:   "pandoraGausSCE"

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -2,6 +2,6 @@
 
 services.RandomNumberGenerator: {}
 
-physics.runprod: [ @sequence::caf_ana_sce_evtw_sequence, genieweight, fluxweight, cafmaker ]
+physics.runprod: [ @sequence::caf_preprocess_sce_evtw_sequence, genieweight, fluxweight, cafmaker ]
 
 physics.producers.cafmaker.SystWeightLabels: ["genieweight","fluxweight"]


### PR DESCRIPTION
Add fhicl that is basically a copy of `cafmakerjob_icarus.fcl` but nullifies a some labels and a list of labels that belong to the simulation:

> physics.producers.cafmaker.G4Label: ""
> physics.producers.cafmaker.GenLabel: ""
> physics.producers.cafmaker.SimChannelLabel: ""
> physics.producers.cafmaker.SystWeightLabels: []

and makes it use a `caf_ana_data_sequence` which is the same as `caf_ana_sequence` removing the `mcreco` instance.

Tested that it ran over a few data events in v09_37 and produced a CAF file with some of the reco branches filled that I'd expect to be filled for data.

I'm tagging Gray and Chris B as reviewers here, and in fact have a question for each:
* Chris B: the resulting CAF file had many (33?) `globalTree` s -- is that expected?
* Gray: are there preliminary data calo constants that we should point this fcl too, or if not should we maybe comment that as a `TODO`?