### PR TITLE
Updates to enable running of 2D deconvolution

### DIFF
--- a/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
@@ -154,10 +154,13 @@ icarus_stage0_trigger_Unknown:     [ daqTrigger,
                                    ]
 
 icarus_stage0_multiTPC_TPC:        [ decon1droi,
-#                                     decon2droiEE,
-#                                     decon2droiEW,
-#                                     decon2droiWE,
-#                                     decon2droiWW,
+                                     roifinder
+                                   ]
+
+icarus_stage0_multiTPC_2d_TPC:     [ decon2droiEE,
+                                     decon2droiEW,
+                                     decon2droiWE,
+                                     decon2droiWW,
                                      roifinder
                                    ]
 
@@ -196,6 +199,12 @@ icarus_stage0_multiTPC:            [ @sequence::icarus_stage0_multiTPC_TPC,
                                      @sequence::icarus_purity_monitor
                                    ]
 
+icarus_stage0_2d_multiTPC:         [ @sequence::icarus_stage0_multiTPC_2d_TPC,
+                                     @sequence::icarus_stage0_EastHits_TPC,
+                                     @sequence::icarus_stage0_WestHits_TPC,
+                                     @sequence::icarus_purity_monitor
+                                   ]
+
 icarus_stage0_crt:                 [
                                      daqCRT
                                    ]
@@ -204,6 +213,13 @@ icarus_stage0_data:                [
                                      @sequence::icarus_stage0_PMT, 
                                      daqTPCROI, 
                                      @sequence::icarus_stage0_multiTPC,
+                                     @sequence::icarus_stage0_crt
+                                   ]
+
+icarus_stage0_2d_data:             [
+                                     @sequence::icarus_stage0_PMT, 
+                                     daqTPCROI, 
+                                     @sequence::icarus_stage0_2d_multiTPC,
                                      @sequence::icarus_stage0_crt
                                    ]
 
@@ -228,25 +244,25 @@ icarus_stage0_producers.decon2droi.wcls_main.params.signal_output_form:         
 
 icarus_stage0_producers.decon2droiEE.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc0"]
 icarus_stage0_producers.decon2droiEE.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver0"]
-icarus_stage0_producers.decon2droiEE.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCEE"
+icarus_stage0_producers.decon2droiEE.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCEE"
 icarus_stage0_producers.decon2droiEE.wcls_main.params.tpc_volume_label:                        0
 icarus_stage0_producers.decon2droiEE.wcls_main.params.signal_output_form:                      "dense"
 
 icarus_stage0_producers.decon2droiEW.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc1"]
 icarus_stage0_producers.decon2droiEW.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver1"]
-icarus_stage0_producers.decon2droiEW.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCEW"
+icarus_stage0_producers.decon2droiEW.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCEW"
 icarus_stage0_producers.decon2droiEW.wcls_main.params.tpc_volume_label:                        1
 icarus_stage0_producers.decon2droiEW.wcls_main.params.signal_output_form:                      "dense"
 
 icarus_stage0_producers.decon2droiWE.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc2"]
 icarus_stage0_producers.decon2droiWE.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver2"]
-icarus_stage0_producers.decon2droiWE.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCWE"
+icarus_stage0_producers.decon2droiWE.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCWE"
 icarus_stage0_producers.decon2droiWE.wcls_main.params.tpc_volume_label:                        2
 icarus_stage0_producers.decon2droiWE.wcls_main.params.signal_output_form:                      "dense"
 
 icarus_stage0_producers.decon2droiWW.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc3"]
 icarus_stage0_producers.decon2droiWW.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver3"]
-icarus_stage0_producers.decon2droiWW.wcls_main.params.raw_input_label:                         "daqTPC:PHYSCRATEDATATPCWW"
+icarus_stage0_producers.decon2droiWW.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCWW"
 icarus_stage0_producers.decon2droiWW.wcls_main.params.tpc_volume_label:                        3
 icarus_stage0_producers.decon2droiWW.wcls_main.params.signal_output_form:                      "dense"
 

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
@@ -110,7 +110,7 @@ local wcls_output = {
       // frame_tags: ['gauss', 'wiener', 'looseLf'],
       // frame_scale: [0.1, 0.1, 0.1],
       frame_tags: ['looseLf'],
-      frame_scale: [0.1],
+      frame_scale: [0.009],
       // nticks: params.daq.nticks,
       chanmaskmaps: [],
       nticks: -1,

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
@@ -166,11 +166,11 @@ ROIFinder::ROIFinder(fhicl::ParameterSet const& pset) : EDProducer{pset}
 {
     this->reconfigure(pset);
 
-    for(const auto& wireLabel : fWireModuleLabelVec)
+    for(const auto& wireLabel : fOutInstanceLabelVec)
     {
-        produces< std::vector<recob::Wire>>(wireLabel.instance());
+        produces< std::vector<recob::Wire>>(wireLabel);
 
-        if (fOutputMorphed) produces<std::vector<recob::Wire>>(wireLabel.instance() + "M");
+        if (fOutputMorphed) produces<std::vector<recob::Wire>>(wireLabel+ "M");
     }
 }
 


### PR DESCRIPTION
The ROI finder needed one more bug fix in order to work correctly, after that the scale factor needed an adjustment so that the "standard" parameters in the ROI finder and gauss hit finder would not result in too many hits. Finally adjust the definitions in the fcl files so allow switching to 2D deconvolution if desired. 