### PR TITLE
Refurbished PMT readout configuration discovery code.

### DIFF
--- a/icaruscode/Decode/DecoderTools/CMakeLists.txt
+++ b/icaruscode/Decode/DecoderTools/CMakeLists.txt
@@ -8,6 +8,7 @@ art_make( SUBDIRS details
           LIB_LIBRARIES
                         icaruscode_Utilities
                         sbnobj_Common_PMT_Data
+                        canvas
                         ${MF_MESSAGELOGGER}
                         ${FHICLCPP}
                         cetlib_except

--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.cxx
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.cxx
@@ -10,15 +10,10 @@
 // ICARUS libraries
 #include "icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h"
 
-// framework libraries
-#include "fhiclcpp/ParameterSet.h"
-#include "messagefacility/MessageLogger/MessageLogger.h"
-
 // C/C++ standard libraries
 #include <algorithm> // std::find_if()
-#include <optional>
 #include <memory> // std::unique_ptr<>
-#include <utility> // std::move()
+
 
 
 // -----------------------------------------------------------------------------
@@ -240,53 +235,9 @@ sbn::PMTconfiguration icarus::extractPMTreadoutConfiguration
   (TFile& srcFile, icarus::PMTconfigurationExtractor extractor)
 {
   
-  /*
-   * The plan is to look in all the FHiCL configuration fragments we can find
-   * in the input file, and find all the useful configuration therein.
-   * Given that there may be multiple input files, there may also be multiple
-   * configurations for the same detector components.
-   * In that case, we will extract parameters from each and every one of the
-   * configurations, and throw an exception if they are not all consistent.
-   * 
-   * Consistency is tested only for the extracted parameters, not for the whole
-   * FHiCL configuration fragment.
-   */
+  return details::extractPMTreadoutConfigurationImpl
+    (util::readConfigurationFromArtFile(srcFile), std::move(extractor));
   
-  auto const& globalConfigColl = util::readConfigurationFromArtFile(srcFile);
-  
-  std::optional<sbn::PMTconfiguration> config;
-  
-  // look in the global configuration for all parameter sets which contain
-  // `configuration_documents` as a (direct) name;
-  for (auto const& [ id, pset ]: globalConfigColl) {
-    if (!extractor.mayHaveConfiguration(pset)) continue;
-    
-    fhicl::ParameterSet const configDocs
-      = extractor.convertConfigurationDocuments
-        (pset, "configuration_documents", { std::regex{ "icaruspmt.*" } })
-      ;
-    
-    sbn::PMTconfiguration candidateConfig = extractor.extract(configDocs);
-    if (config) {
-      if (config.value() == candidateConfig) continue;
-      mf::LogError log("extractPMTreadoutConfiguration");
-      log << "Found two candidate configurations differring:"
-        "\nFirst:\n" << config.value()
-        << "\nSecond:\n" << candidateConfig
-        ;
-      throw cet::exception("extractPMTreadoutConfiguration")
-        << "extractPMTreadoutConfiguration() found inconsistent configurations.\n";
-    } // if incompatible configurations
-    
-    config.emplace(std::move(candidateConfig));
-  } // for all configuration documents
-  
-  if (!config) {
-    throw cet::exception("extractPMTreadoutConfiguration")
-      << "extractPMTreadoutConfiguration() could not find a suitable configuration.\n";
-  }
-  
-  return extractor.finalize(std::move(config.value()));
 } // icarus::extractPMTreadoutConfiguration(TFile)
 
 

--- a/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
+++ b/icaruscode/Decode/DecoderTools/PMTconfigurationExtractor.h
@@ -9,6 +9,9 @@
  * class hierarchy to be used for other components as well, but not getting
  * quite there.
  * 
+ * Extra linking is required for `extractPMTreadoutConfiguration(Principal)`
+ * to pick up the class used as `Principal`.
+ * 
  */
 
 #ifndef ICARUSCODE_DECODE_DECODERTOOLS_PMTCONFIGURATIONEXTRACTOR_H
@@ -17,11 +20,13 @@
 
 // ICARUS libraries
 #include "icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h"
-#include "icaruscode/Utilities/ReadArtConfiguration.h" // util::readConfigurationFromArtFile()
+#include "icaruscode/Utilities/ReadArtConfiguration.h" // util::readConfigurationFromArtPrincipal()
 #include "sbnobj/Common/PMT/Data/PMTconfiguration.h"
 #include "sbnobj/Common/PMT/Data/V1730Configuration.h"
 
 // framework libraries
+#include "art/Framework/Principal/DataViewImpl.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "cetlib_except/exception.h"
 
@@ -31,6 +36,8 @@
 // C/C++ standard libraries
 #include <regex>
 #include <string>
+#include <optional>
+#include <utility> // std::move(), std::pair<>
 #include <initializer_list>
 
 
@@ -45,6 +52,9 @@ namespace icarus {
     (std::string const& srcFileName, icarus::PMTconfigurationExtractor extractor);
   sbn::PMTconfiguration extractPMTreadoutConfiguration
     (TFile& srcFile, icarus::PMTconfigurationExtractor extractor);
+  template <typename Principal>
+  sbn::PMTconfiguration extractPMTreadoutConfiguration
+    (Principal const& data, icarus::PMTconfigurationExtractor extractor);
   
 } // namespace icarus
 
@@ -389,17 +399,84 @@ class icarus::PMTconfigurationExtractor
 }; // icarus::PMTconfigurationExtractor
 
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // --- Inline implementation
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 icarus::PMTconfigurationExtractor::PMTconfigurationExtractor
   (icarusDB::IICARUSChannelMap const& channelMappingService)
   : fChannelMap(&channelMappingService)
   {}
 
 
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // ---  Template implementation
+// -----------------------------------------------------------------------------
+namespace icarus::details {
+  
+  template <typename ConfigMap>
+  sbn::PMTconfiguration extractPMTreadoutConfigurationImpl
+    (ConfigMap const& configMap, icarus::PMTconfigurationExtractor extractor)
+  {
+    
+    /*
+    * Requirements: ConfigMap is a mapping type supporting iteration and whose
+    * elements support structured assignment into a pair, the first element
+    * being an identifier (process name, parameter set ID...) and the second
+    * being a `fhicl::ParameterSet` with the configuration (or something
+    * offering the same interface).
+    * 
+    * The plan is to look in all the FHiCL configuration fragments we can find
+    * in the input config, and find all the useful configuration therein.
+    * Given that there may be multiple input files, there may also be multiple
+    * configurations for the same detector components.
+    * In that case, we will extract parameters from each and every one of the
+    * configurations, and throw an exception if they are not all consistent.
+    * 
+    * Consistency is tested only for the extracted parameters, not for the whole
+    * FHiCL configuration fragment.
+    */
+    
+    using Key_t = std::tuple_element_t<0U, typename ConfigMap::value_type>;
+    
+    std::optional<std::pair<Key_t, sbn::PMTconfiguration>> config;
+    
+    // look in the global configuration for all parameter sets which contain
+    // `configuration_documents` as a (direct) name;
+    for (auto const& [ id, pset ]: configMap) {
+      if (!extractor.mayHaveConfiguration(pset)) continue;
+      
+      fhicl::ParameterSet const configDocs
+        = extractor.convertConfigurationDocuments
+          (pset, "configuration_documents", { std::regex{ "icaruspmt.*" } })
+        ;
+      
+      sbn::PMTconfiguration candidateConfig = extractor.extract(configDocs);
+      if (config) {
+        if (config->second == candidateConfig) continue;
+        mf::LogError log("extractPMTreadoutConfiguration");
+        log << "Found two candidate configurations differring:"
+          "\nFirst [" << config->first << "]:\n" << config->second
+          << "\nSecond [" << id << "]:\n" << candidateConfig
+          ;
+        throw cet::exception("extractPMTreadoutConfiguration")
+          << "extractPMTreadoutConfiguration() found inconsistent configurations.\n";
+      } // if incompatible configurations
+      
+      config.emplace(std::move(id), std::move(candidateConfig));
+    } // for all configuration documents
+    
+    if (!config) {
+      throw cet::exception("extractPMTreadoutConfiguration")
+        << "extractPMTreadoutConfiguration() could not find a suitable configuration.\n";
+    }
+    
+    return extractor.finalize(std::move(config->second));
+  } // extractPMTreadoutConfigurationImpl(ConfigMap)
+  
+  
+} // namespace icarus::details
+
+
 // -----------------------------------------------------------------------------
 template <typename RBegin, typename REnd>
 bool icarus::PMTconfigurationExtractorBase::matchKey
@@ -409,6 +486,18 @@ bool icarus::PMTconfigurationExtractorBase::matchKey
     if (std::regex_match(key, *iRegex)) return true;
   return false;
 } // icarus::PMTconfigurationExtractorBase::matchKey()
+
+
+// -----------------------------------------------------------------------------
+template <typename Principal>
+sbn::PMTconfiguration icarus::extractPMTreadoutConfiguration
+  (Principal const& principal, icarus::PMTconfigurationExtractor extractor)
+{
+  
+  return details::extractPMTreadoutConfigurationImpl
+    (util::readConfigurationFromArtPrincipal(principal), std::move(extractor));
+  
+} // icarus::extractPMTreadoutConfiguration(Principal)
 
 
 // ---------------------------------------------------------------------------

--- a/icaruscode/Decode/PMTconfigurationExtraction_module.cc
+++ b/icaruscode/Decode/PMTconfigurationExtraction_module.cc
@@ -11,6 +11,10 @@
 #include "sbnobj/Common/PMT/Data/PMTconfiguration.h"
 
 // framework libraries
+#include "canvas/Persistency/Provenance/ProcessConfiguration.h"
+#include "canvas/Persistency/Provenance/ProcessHistory.h"
+#include "fhiclcpp/ParameterSet.h"
+
 #include "art/Framework/Services/Registry/ServiceHandle.h" 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Core/ModuleMacros.h"
@@ -34,13 +38,12 @@ namespace icarus { class PMTconfigurationExtraction; }
  * @brief Writes PMT configuration from FHiCL into a data product.
  * 
  * This module reads the configuration related to PMT from the FHiCL
- * configuration of the input files and puts it into each run as a data product.
+ * configuration of the input runs and puts it into each run as a data product.
  * 
  * Input
  * ------
  * 
- * This module requires a _art_ ROOT file as input, which contains FHiCL
- * configuration with PMT information.
+ * This module requires any input with _art_ run objects in it.
  * The format expected for that configuration is defined in
  * `icarus::PMTconfigurationExtractor`, which is the utility used for the actual
  * extraction.
@@ -140,14 +143,18 @@ class icarus::PMTconfigurationExtraction: public art::EDProducer {
   PMTconfigurationExtraction(Parameters const& config);
   
   
-  /// Action on new file: configuration is read.
-  virtual void respondToOpenInputFile(art::FileBlock const& fileInfo) override;
-  
   /// Action on new run: configuration is written.
   virtual void beginRun(art::Run& run) override;
   
   /// Mandatory method, unused.
   virtual void produce(art::Event&) override {}
+  
+  
+    private:
+  
+  /// Throws an exception if the `newConfig` is not compatible with the current.
+  bool checkConsistency
+    (sbn::PMTconfiguration const& newConfig, std::string const& srcName) const;
   
   
 }; // icarus::PMTconfigurationExtraction
@@ -174,54 +181,46 @@ icarus::PMTconfigurationExtraction::PMTconfigurationExtraction
 
 
 // -----------------------------------------------------------------------------
-void icarus::PMTconfigurationExtraction::respondToOpenInputFile
-  (art::FileBlock const& fileInfo)
-{
-
-  icarus::PMTconfigurationExtractor extractor { *fChannelMap };
+void icarus::PMTconfigurationExtraction::beginRun(art::Run& run) {
   
-  sbn::PMTconfiguration config
-    = extractPMTreadoutConfiguration(fileInfo.fileName(), extractor);
-
-  mf::LogDebug(fLogCategory) << "Input file '"
-    << fileInfo.fileName() << "' contains PMT readout configuration: "
-    << config
-    ;
+  sbn::PMTconfiguration config = extractPMTreadoutConfiguration
+    (run, icarus::PMTconfigurationExtractor{ *fChannelMap });
   
-  if (fPMTconfig.has_value() && (fPMTconfig != config)) {
-    // see debug information for more details
-    if (fRequireConsistency) {
-      throw cet::exception("PMTconfigurationExtraction")
-        << "Configuration from input file '" << fileInfo.fileName()
-        << "' is incompatible with the previously found configuration.\n"
-        ;
-    }
-    else {
-      mf::LogWarning(fLogCategory)
-        << "Configuration from input file '" << fileInfo.fileName()
-        << "' is incompatible with the previously found configuration.\n"
-        ;
-      if (fVerbose) mf::LogVerbatim(fLogCategory) << "PMT readout:" << config;
-    }
-  }
-  
+  checkConsistency(config, "run " + std::to_string(run.run()));
   if (!fPMTconfig.has_value() && fVerbose)
     mf::LogInfo(fLogCategory) << "PMT readout:" << config;
   
   fPMTconfig = std::move(config);
   
-} // icarus::PMTconfigurationExtraction::respondToOpenInputFile()
-
-
-// -----------------------------------------------------------------------------
-void icarus::PMTconfigurationExtraction::beginRun(art::Run& run) {
-  
-  assert(fPMTconfig);
-  
   // put a copy of the current configuration
   run.put(std::make_unique<sbn::PMTconfiguration>(fPMTconfig.value()));
   
 } // icarus::PMTconfigurationExtraction::beginRun()
+
+
+// -----------------------------------------------------------------------------
+bool icarus::PMTconfigurationExtraction::checkConsistency
+  (sbn::PMTconfiguration const& config, std::string const& srcName) const
+{
+  if (!fPMTconfig.has_value() || (*fPMTconfig == config)) return true;
+  
+  // see debug information for more details
+  if (fRequireConsistency) {
+    throw cet::exception("PMTconfigurationExtraction")
+      << "Configuration from " << srcName
+      << " is incompatible with the previously found configuration.\n"
+      ;
+  } // if consistency is required
+  
+  mf::LogWarning(fLogCategory)
+    << "Configuration from " << srcName
+    << " is incompatible with the previously found configuration.\n"
+    ;
+  if (fVerbose) mf::LogVerbatim(fLogCategory) << "PMT readout:" << config;
+  return false;
+  
+  
+} // icarus::PMTconfigurationExtraction::checkConsistency()
 
 
 // -----------------------------------------------------------------------------

--- a/icaruscode/Utilities/ReadArtConfiguration.h
+++ b/icaruscode/Utilities/ReadArtConfiguration.h
@@ -12,6 +12,8 @@
 
 
 // framework libraries
+#include "canvas/Persistency/Provenance/ProcessConfiguration.h"
+#include "canvas/Persistency/Provenance/ProcessHistory.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "fhiclcpp/ParameterSetID.h"
 #include "fhiclcpp/ParameterSetRegistry.h" // also defines ParameterSetID hash
@@ -33,6 +35,7 @@ namespace util {
    * @param file ROOT file where the configuration is stored
    * @return the full configuration
    * @throw cet::exception (category: `"readConfigurationFromArtFile"`) on error
+   * @see `readConfigurationFromArtPrincipal()`
    * 
    * The configuration is expected to be stored by _art_ in the way it does
    * for _art_ ROOT files.
@@ -45,8 +48,75 @@ namespace util {
   
   
   // ---------------------------------------------------------------------------
+  /**
+   * @brief Reads and returns the complete _art_ configuration in the principal.
+   * @tparam Principal type of framework principal class (e.g. `art::Event`)
+   * @param principal the "principal" _art_ object to read the information from
+   * @return the full configuration, as map: process name -> FHiCL parameter set
+   * @throw cet::exception (category: `"readConfigurationFromArtPrincipal"`)
+   *        on error
+   * @see `readConfigurationFromArtFile()`
+   * 
+   * Compared to `readConfigurationFromArtFile()`, this function relays the same
+   * information after it has been conveniently extracted by the framework.
+   * A "principal" is framework jargon for `art::Event`, `art::SubRun` or
+   * `art::Run` (all derived from `art::DataViewImpl`).
+   * Therefore, this function can be called e.g. in `beginRun()` hook of a
+   * module using its `art::Run` argument, or in a `analyze()` hook using
+   * its `art::Event` argument.
+   * 
+   * This function is supposed to be more solid than
+   * `readConfigurationFromArtFile()` because it relies less on internals of
+   * how the framework works. , this function relays the same
+   * information after it has been conveniently extracted by the framework.
+   * Also, this function should also be compatible with `gallery::Event` too
+   * (which is the reason why it is implemented as template instead of taking
+   * a `art::DataViewImpl`, which is _art_-specific), making the name of this
+   * function a misnomer.
+   * 
+   * The configuration is returned as a map of process names to parameter sets
+   * (note that the key is different from the one returned by
+   * `readConfigurationFromArtFile()`).
+   */
+  template <typename Principal>
+  std::map<std::string, fhicl::ParameterSet>
+  readConfigurationFromArtPrincipal(Principal const& principal);
+  
+  
+  // ---------------------------------------------------------------------------
   
 } // namespace util
+
+
+
+// -----------------------------------------------------------------------------
+// --- template implementation
+// -----------------------------------------------------------------------------
+template <typename Principal>
+std::map<std::string, fhicl::ParameterSet>
+util::readConfigurationFromArtPrincipal(Principal const& principal) {
+  
+  std::map<std::string, fhicl::ParameterSet> configMap;
+  
+  for (art::ProcessConfiguration const& procConfig: principal.processHistory())
+  {
+    
+    fhicl::ParameterSet config;
+    if (!fhicl::ParameterSetRegistry::get(procConfig.parameterSetID(), config))
+    {
+      // this would be, as far as I understand, a logic error
+      throw cet::exception("readConfigurationFromArtPrincipal")
+        << "Configuration of process '" << procConfig.processName()
+        << "' can't be found!\n";
+    }
+    
+    configMap[procConfig.processName()] = std::move(config);
+  } // for
+  
+  return configMap;
+  
+} // util::readConfigurationFromArtPrincipal()
+
 
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
It should be more resilient to art changes, and might also work in the online monitor.

In particular, I have added a utility to extract the configuration from `art::Run` (or `art::Event`, or `canvas::Event`) instead of directly from the _art_/ROOT input file, and the module uses this new utility.

The issue with the online monitor was that it gets its data from a stream so it does not have a input file; this new approach _might_ work since the input stream does have _art_ runs (whether they hold configuration or not is a different question).