### PR TITLE
Updates to decoder for 2d simulation and introduction of purity monitor module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
-project(icaruscode VERSION 09.42.01 LANGUAGES CXX)
+project(icaruscode VERSION 09.42.02 LANGUAGES CXX)
 
 message(STATUS
   "\n-- ============================================================================="

--- a/icaruscode/Analysis/TPCPurityInfoAna_module.cc
+++ b/icaruscode/Analysis/TPCPurityInfoAna_module.cc
@@ -58,7 +58,7 @@ private:
 ana::TPCPurityInfoAna::TPCPurityInfoAna(fhicl::ParameterSet const& p)
   : EDAnalyzer{p}  // ,
   , fPurityInfoLabel(p.get<art::InputTag>("PurityInfoLabel"))
-  , fPrintInfo(p.get<bool>("PrintInfo",true))
+  , fPrintInfo(p.get<bool>("PrintInfo",false))
 {
   consumes< std::vector<anab::TPCPurityInfo> >(fPurityInfoLabel);
 }

--- a/icaruscode/Analysis/TPCPurityMonitor_module.cc
+++ b/icaruscode/Analysis/TPCPurityMonitor_module.cc
@@ -456,8 +456,10 @@ void TPCPurityMonitor::produce(art::Event& event)
 
                 for(const auto& hitPair : hitStatusChargePairVec)
                 {
+                    double charge = fUseHitIntegral ? hitPair.first->Integral() : hitPair.first->SummedADC();
+
                     fTickVec.emplace_back(hitPair.first->PeakTime());
-                    fChargeVec.emplace_back(hitPair.first->Integral());
+                    fChargeVec.emplace_back(charge);
                     fGoodHitVec.emplace_back(hitPair.second.first);
                 }
 
@@ -641,8 +643,10 @@ void TPCPurityMonitor::RejectOutliers(HitStatusChargePairVec& hitPairVector, con
         // We are only interested in the "good" hits here
         if (hitPair.second.first)
         {
+            double charge = fUseHitIntegral ? hitPair.first->Integral() : hitPair.first->SummedADC();
+
             double predLogCharge  = (fSamplingRate * (hitPair.first->PeakTime() - firstHitTime) - avePos[0]) * slope + avePos[1];
-            double deltaLogCharge = std::log(hitPair.first->Integral()) - predLogCharge;
+            double deltaLogCharge = std::log(charge) - predLogCharge;
 
             hitPair.second.second = deltaLogCharge;
         }

--- a/icaruscode/Analysis/TPCPurityMonitor_module.cc
+++ b/icaruscode/Analysis/TPCPurityMonitor_module.cc
@@ -1,0 +1,653 @@
+// TPCPurityMonitor_module.cc
+// A basic "skeleton" to read in art::Event records from a file,
+// access their information, and do something with them.
+
+// See
+// <https://cdcvs.fnal.gov/redmine/projects/larsoftsvn/wiki/Using_the_Framework>
+// for a description of the ART classes used here.
+
+// Almost everything you see in the code below may have to be changed
+// by you to suit your task. The example task is to make histograms
+// and n-tuples related to dE/dx of particle tracks in the detector.
+
+// As you try to understand why things are done a certain way in this
+// example ("What's all this stuff about 'auto const&'?"), it will help
+// to read ADDITIONAL_NOTES.txt in the same directory as this file.
+
+#ifndef TPCPurityMonitor_module
+#define TPCPurityMonitor_module
+
+// Framework includes
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+#include "art_root_io/TFileDirectory.h"
+#include "art/Utilities/make_tool.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "lardata/Utilities/AssociationUtil.h"
+#include "cetlib/cpu_timer.h"
+
+// LArSoft includes
+#include "larcore/Geometry/Geometry.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
+#include "lardata/DetectorInfoServices/LArPropertiesService.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
+
+#include "lardataobj/RawData/raw.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/Cluster.h"
+#include "lardataobj/RecoBase/PFParticle.h"
+#include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/RecoBase/TrackHitMeta.h"
+#include "lardataobj/RecoBase/Vertex.h"
+#include "lardataobj/RecoBase/SpacePoint.h"
+
+// One really does not like root but one has to use it
+#include "TTree.h"
+
+//purity info class
+#include "sbnobj/Common/Analysis/TPCPurityInfo.hh"
+
+// Eigen includes
+#include "Eigen/Core"
+#include "Eigen/Dense"
+#include "Eigen/Eigenvalues"
+#include "Eigen/Geometry"
+#include "Eigen/Jacobi"
+
+// C++ Includes
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <functional>
+
+namespace TPCPurityMonitor
+{
+//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
+// class definition
+
+class TPCPurityMonitor : public art::EDProducer
+{
+public:
+
+    // Standard constructor and destructor for an ART module.
+    explicit TPCPurityMonitor(fhicl::ParameterSet const& pset);
+    virtual ~TPCPurityMonitor();
+
+    // This method is called once, at the start of the job. In this
+    // example, it will define the histograms and n-tuples we'll write.
+    void beginJob();
+    void endJob();
+
+    // This method is called once, at the start of each run. It's a
+    // good place to read databases or files that may have
+    // run-dependent information.
+    void beginRun(const art::Run& run);
+
+    // The analysis routine, called once per event.
+    void produce(art::Event& evt);
+
+private:
+    // Definie the basic data structure we will use
+    using StatusChargePair    = std::pair<bool,double>;
+    using HitLogChargePair    = std::pair<const recob::Hit*,StatusChargePair>;
+    using HitLogChargePairVec = std::vector<HitLogChargePair>;
+
+    // We also need to define a container for the output of the PCA Analysis
+    class PrincipalComponents
+    {
+    public:
+
+        using EigenValues  = Eigen::Vector2d;
+        using EigenVectors = Eigen::Matrix2d;
+
+        PrincipalComponents() :
+            fSVD_OK(false), fNumHitsUsed(0), fEigenValues(EigenValues::Zero()), fEigenVectors(EigenVectors::Zero()), fAvePosition(Eigen::Vector2d::Zero()) {}
+
+    private:
+
+        bool            fSVD_OK;             ///< SVD Decomposition was successful
+        int             fNumHitsUsed;        ///< Number of hits in the decomposition
+        EigenValues     fEigenValues;        ///< Eigen values from SVD decomposition
+        EigenVectors    fEigenVectors;       ///< The three principle axes
+        Eigen::Vector2d fAvePosition;        ///< Average position of hits fed to PCA
+
+    public:
+
+        PrincipalComponents(bool ok, int nHits, const EigenValues& eigenValues, const EigenVectors& eigenVecs, const Eigen::Vector2d& avePos) :
+            fSVD_OK(ok), fNumHitsUsed(nHits), fEigenValues(eigenValues), fEigenVectors(eigenVecs), fAvePosition(avePos) {}
+
+        bool                   getSvdOK()                 const {return fSVD_OK;}
+        int                    getNumHitsUsed()           const {return fNumHitsUsed;}
+        const EigenValues&     getEigenValues()           const {return fEigenValues;}
+        const EigenVectors&    getEigenVectors()          const {return fEigenVectors;}
+        const Eigen::Vector2d& getAvePosition()           const {return fAvePosition;}
+
+        void                   flipAxis(size_t axis)            { fEigenVectors.row(axis) = -fEigenVectors.row(axis);}
+    };
+
+    // This method reads in any parameters from the .fcl files. This
+    // method is called 'reconfigure' because it might be called in the
+    // middle of a job; e.g., if the user changes parameter values in an
+    // interactive event display.
+    void reconfigure(fhicl::ParameterSet const& pset);
+
+    // Compute the principle axes
+    void GetPrincipalComponents(const HitLogChargePairVec& hitPairVector, PrincipalComponents& pca) const;
+
+    // Reject outliers
+    void RejectOutliers(HitLogChargePairVec& hitPairVector, const PrincipalComponents& pca) const;
+
+    // The following typedefs will, obviously, be useful
+    double length(const recob::Track* track);
+
+    double projectedLength(const recob::Track* track);
+
+    // The parameters we'll read from the .fcl file.
+    std::vector<art::InputTag> fTrackLabelVec;      ///< labels for source of tracks
+    unsigned                   fSelectedPlane;      ///< Select hits from this plane
+    unsigned                   fMinNumHits;         ///< Minimum number of hits
+    float                      fMinTickRange;       ///< Require track to span some number of ticks
+    float                      fAssumedELifetime;   ///< Lifetime assumed for calculation
+    float                      fMinRejectFraction;  ///< Reject this fraction of "low Q" hits
+    float                      fMaxRejectFraction;  ///< Reject this fraction of "high Q" hits
+    float                      fOutlierRejectFrac;  ///< Fraction of outliers to reject
+    bool                       fUseHitIntegral;     ///< Setting to false swaps to "SummedADC"
+    bool                       fWeightByChiSq;      ///< Weight the PCA by the hit chisquare
+    bool                       fDiagnosticTuple;    ///< Output the diagnostic tuple
+
+    float                      fSamplingRate;       ///< Recover the sampling rate from the clock data
+
+    // Output tuple variables
+    int                        fRunNumber;          ///< run number this event
+    int                        fSubRunNumber;       ///< sub run number this event
+    int                        fEventNumber;        ///< event number this event
+    int                        fCryostat;           ///< Cryostat for given track
+    int                        fTPC;                ///< TPC for given track
+    int                        fTrackIdx;           ///< index of track
+    int                        fWireRange;          ///< Last - first wire number
+    int                        fWires;              ///< Number wires spanned
+    int                        fTicks;              ///< Number ticks spanned
+    double                     fAttenuation;        ///< Attenuation from calc
+    double                     fError;              ///< Error from calc
+    std::vector<double>        fPCAAxes;            ///< Axes for PCA
+    std::vector<double>        fEigenValues;        ///< Eigen values 
+    std::vector<double>        fMeanPosition;       ///< Mean position used for PCA
+    std::vector<double>        fTickVec;            ///< vector of ticks
+    std::vector<double>        fChargeVec;          ///< vector of hit charges
+
+    TTree*                     fDiagnosticTree;     ///< Pointer to our tree
+
+    int fNumEvents;
+
+    // Other variables that will be shared between different methods.
+    const geo::GeometryCore*                   fGeometry;       // pointer to Geometry service
+}; // class TPCPurityMonitor
+
+// This macro has to be defined for this module to be invoked from a
+// .fcl file; see TPCPurityMonitor.fcl for more information.
+DEFINE_ART_MODULE(TPCPurityMonitor)
+
+//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
+// class implementation
+
+//-----------------------------------------------------------------------
+// Constructor
+TPCPurityMonitor::TPCPurityMonitor(fhicl::ParameterSet const& parameterSet)
+    : EDProducer{parameterSet},
+      fDiagnosticTree(nullptr),
+      fNumEvents(0)
+
+{
+    fGeometry = lar::providerFrom<geo::Geometry>();
+
+    // We're going to output purity objects
+    produces<std::vector<anab::TPCPurityInfo>>("",art::Persistable::Yes);
+
+    // Read in the parameters from the .fcl file.
+    this->reconfigure(parameterSet);
+}
+
+//-----------------------------------------------------------------------
+// Destructor
+TPCPurityMonitor::~TPCPurityMonitor()
+{}
+
+//-----------------------------------------------------------------------
+void TPCPurityMonitor::beginJob()
+{
+    // Get the detector length, to determine the maximum bin edge of one
+    // of the histograms.
+    //double detectorLength = fGeometry->DetLength();
+
+    // Access ART's TFileService, which will handle creating and writing
+    // histograms and n-tuples for us.
+    if (fDiagnosticTuple)
+    {
+        art::ServiceHandle<art::TFileService> tfs;
+    
+        fDiagnosticTree = tfs->make<TTree>("PurityMonitor","");
+
+        fDiagnosticTree->Branch("run",         &fRunNumber,     "run/I");
+        fDiagnosticTree->Branch("subrun",      &fSubRunNumber,  "subrun/I");
+        fDiagnosticTree->Branch("event",       &fEventNumber,   "event/I");
+        fDiagnosticTree->Branch("cryostat",    &fCryostat,      "cryostat/I");
+        fDiagnosticTree->Branch("tpc",         &fTPC,           "tpc/I");
+        fDiagnosticTree->Branch("trackidx",    &fTrackIdx,      "trackidx/I");
+        fDiagnosticTree->Branch("wirerange",   &fWireRange,     "wirerange/I");
+        fDiagnosticTree->Branch("nwires",      &fWires,         "nwires/I");
+        fDiagnosticTree->Branch("nticks",      &fTicks,         "nticks/I");
+        fDiagnosticTree->Branch("attenuation", &fAttenuation,   "attenuation/D");
+        fDiagnosticTree->Branch("error",       &fError,         "error/D");
+
+        fDiagnosticTree->Branch("pcavec",    "std::vector<double>", &fPCAAxes);
+        fDiagnosticTree->Branch("eigenvec",  "std::vector<double>", &fEigenValues);
+        fDiagnosticTree->Branch("meanpos",   "std::vector<double>", &fMeanPosition);
+        fDiagnosticTree->Branch("tickvec",   "std::vector<double>", &fTickVec);
+        fDiagnosticTree->Branch("chargevec", "std::vector<double>", &fChargeVec);
+    }
+
+
+    // zero out the event counter
+    fNumEvents = 0;
+}
+
+//-----------------------------------------------------------------------
+void TPCPurityMonitor::beginRun(const art::Run& /*run*/)
+{
+    // How to convert from number of electrons to GeV.  The ultimate
+    // source of this conversion factor is
+    // ${LARSIM_DIR}/include/SimpleTypesAndConstants/PhysicalConstants.h.
+//    art::ServiceHandle<sim::LArG4Parameters> larParameters;
+//    fElectronsToGeV = 1./larParameters->GeVToElectrons();
+}
+
+//-----------------------------------------------------------------------
+void TPCPurityMonitor::reconfigure(fhicl::ParameterSet const& p)
+{
+    // Read parameters from the .fcl file. The names in the arguments
+    // to p.get<TYPE> must match names in the .fcl file.
+    fTrackLabelVec      = p.get< std::vector<art::InputTag> >("TrackLabel",    std::vector<art::InputTag>() = {""});
+    fSelectedPlane      = p.get< unsigned                   >("SelectedPlane",                                   2);
+    fMinNumHits         = p.get< unsigned                   >("MinNumHits",                                    100);
+    fMinTickRange       = p.get< float                      >("MinTickRange",                                 150.);
+    fAssumedELifetime   = p.get< float                      >("AssumedELifetime",                          600000.);
+    fMinRejectFraction  = p.get< float                      >("MinRejectFraction",                            0.00);
+    fMaxRejectFraction  = p.get< float                      >("MaxRejectFraction",                            1.00);
+    fOutlierRejectFrac  = p.get< float                      >("OutlierRejectFrac",                            0.70);
+    fUseHitIntegral     = p.get< bool                       >("UseHitIntegral",                               true);
+    fWeightByChiSq      = p.get< bool                       >("WeightByChiSq",                                true);
+    fDiagnosticTuple    = p.get< bool                       >("DiagnosticTuple",                              true);
+
+    return;
+}
+
+//-----------------------------------------------------------------------
+void TPCPurityMonitor::produce(art::Event& event)
+{
+    //setup output vector#include "lardataobj/RecoBase/TrackHitMeta.h"
+    std::unique_ptr< std::vector<anab::TPCPurityInfo> > outputPtrVector(new std::vector<anab::TPCPurityInfo>());
+
+    fNumEvents++;
+    
+    // Recover the detector properties.
+    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+
+    fSamplingRate = 1.e-3 * sampling_rate(clockData); // Note sampling rate is in ns, convert to us
+    
+    for(const auto& trackLabel : fTrackLabelVec)
+    {
+        // Make a pass through all hits to make contrasting plots
+        art::Handle< std::vector<recob::Track>> trackHandle;
+        event.getByLabel(trackLabel, trackHandle);
+        
+        if (!trackHandle.isValid()) continue;
+
+        // Recover the collection of associations between tracks and hits
+        art::FindManyP<recob::Hit,recob::TrackHitMeta> trackHitAssns(trackHandle, event, trackLabel);
+
+        // Loop over tracks and recover hits
+        for(size_t trackIdx = 0; trackIdx < trackHandle->size(); trackIdx++)
+        {
+            art::Ptr<recob::Track> track(trackHandle,trackIdx);
+
+            const std::vector<art::Ptr<recob::Hit>>&      trackHitsVec(trackHitAssns.at(track.key()));
+//            const std::vector<const recob::TrackHitMeta*> metaHitsVec = trackHitAssns.data(track.key());
+
+            // Focus on selected hits:
+            // 1) Pick out hits on a single plane given by fhicl parameter
+            // 2) multiplicity == 1 which should give us clean gaussian shaped pulses
+            std::vector<art::Ptr<recob::Hit>> selectedTrackHitsVec;
+
+            for(auto& hit : trackHitsVec)
+            {
+                if (hit->WireID().Plane == fSelectedPlane && hit->Multiplicity() == 1) selectedTrackHitsVec.emplace_back(hit);
+            }
+
+            // Need a minimum number of hits
+            if (selectedTrackHitsVec.size() < fMinNumHits) continue;
+
+//            std::cout << "--> trackMeta index: " << metaHitsVec.front()->Index() << ", Dx: " << metaHitsVec.front()->Dx() << ", meta size: " << metaHitsVec.size() << ", track:" << trackHitsVec.size() << std::endl;
+
+            // Sort hits by increasing time 
+            std::sort(selectedTrackHitsVec.begin(),selectedTrackHitsVec.end(),[](const auto& left, const auto& right){return left->PeakTime() < right->PeakTime();});
+
+            // Require track to have a minimum range in ticks
+            if (selectedTrackHitsVec.back()->PeakTime() - selectedTrackHitsVec.front()->PeakTime() < fMinTickRange) continue;
+
+            // At this point we should have a vector of art::Ptrs to hits on the selected plane
+            // So we should be able to now transition to computing the attenuation
+            // Start by forming a vector of pairs of the time (in ticks) and the ln of charge derated by an assumed lifetime
+            HitLogChargePairVec hitLogChargePairVec;
+
+            float firstHitTime(selectedTrackHitsVec.front()->PeakTime());
+
+            for(const auto& hit : selectedTrackHitsVec)
+            {
+                float charge    = fUseHitIntegral ? hit->Integral() : hit->SummedADC(); 
+                float logCharge = charge * exp(fSamplingRate * (hit->PeakTime() - firstHitTime) / fAssumedELifetime);
+
+                hitLogChargePairVec.emplace_back(hit.get(),StatusChargePair(true,logCharge));
+            }
+
+            // Drop the smallest and largest charges
+//            std::sort(hitLogChargePairVec.begin(),hitLogChargePairVec.end(),[](const auto& left, const auto& right){return left.second.second < right.second.second;});
+
+            size_t numOrig   = hitLogChargePairVec.size();
+            size_t lowCutIdx = fMinRejectFraction * numOrig;
+            size_t hiCutIdx  = fMaxRejectFraction * numOrig;
+
+            // Will require a minimum number of hits left over to proceed
+            if (lowCutIdx + 10 >= hiCutIdx)
+            {
+                std::cout << "*****>>>> lowCutIdx >= hiCutIdx: " << lowCutIdx << ", " << hiCutIdx << std::endl;
+                continue;
+            }
+
+            HitLogChargePairVec(hitLogChargePairVec.begin() + lowCutIdx, hitLogChargePairVec.begin() + hiCutIdx).swap(hitLogChargePairVec);
+
+            // Put back in time order
+            std::sort(hitLogChargePairVec.begin(),hitLogChargePairVec.end(),[](const auto& left, const auto& right){return left.first->PeakTime() < right.first->PeakTime();});
+
+            PrincipalComponents pca;
+
+            GetPrincipalComponents(hitLogChargePairVec, pca);
+
+            // Reject the outliers
+            RejectOutliers(hitLogChargePairVec, pca);
+
+            // Recompute the pca
+            GetPrincipalComponents(hitLogChargePairVec, pca);
+
+            const PrincipalComponents::EigenVectors& eigenVectors = pca.getEigenVectors();
+
+            double attenuation = eigenVectors.row(1)[1] / eigenVectors.row(1)[0];
+
+            // Want to find the wire range (or should it be the number of wires?)
+            unsigned maxWire(0);
+            unsigned minWire(100000);
+
+            std::set<unsigned> usedWiresSet;
+
+            for(const auto& hitPair : hitLogChargePairVec)
+            {
+                unsigned wire = hitPair.first->WireID().Wire;
+
+                usedWiresSet.insert(wire);
+
+                if (wire > maxWire) maxWire = wire;
+                if (wire < minWire) minWire = wire;
+            }
+
+            geo::WireID wireID  = hitLogChargePairVec.front().first->WireID();
+			  
+			anab::TPCPurityInfo purityInfo;
+
+			purityInfo.Run         = event.run();
+			purityInfo.Subrun      = event.subRun();
+			purityInfo.Event       = event.event();
+            purityInfo.Cryostat    = wireID.Cryostat;
+			purityInfo.TPC         = wireID.TPC;
+			purityInfo.Wires       = usedWiresSet.size(); //maxWire - minWire;
+            purityInfo.Ticks       = hitLogChargePairVec.back().first->PeakTime() - firstHitTime;
+            purityInfo.Attenuation = -attenuation;
+			purityInfo.FracError   = std::sqrt(pca.getEigenValues()[0] / pca.getEigenValues()[1]);
+
+            outputPtrVector->emplace_back(purityInfo);
+
+            if (fDiagnosticTuple)
+            {
+                fRunNumber    = event.run();
+                fSubRunNumber = event.subRun();
+                fEventNumber  = event.event();
+                fCryostat     = wireID.Cryostat;
+                fTPC          = wireID.TPC;
+                fTrackIdx     = trackIdx; 
+                fWireRange    = maxWire - minWire;
+                fWires        = usedWiresSet.size();
+                fTicks        = hitLogChargePairVec.back().first->PeakTime() - firstHitTime;
+                fAttenuation  = -attenuation;
+                fError        = std::sqrt(pca.getEigenValues()[0] / pca.getEigenValues()[1]);
+
+                for(size_t rowIdx = 0; rowIdx < 2; rowIdx++)
+                {
+                    for(size_t colIdx = 0; colIdx < 2; colIdx++) fPCAAxes.emplace_back(eigenVectors.row(rowIdx)[colIdx]);
+                }
+
+                fEigenValues.emplace_back(pca.getEigenValues()[0]); 
+                fEigenValues.emplace_back(pca.getEigenValues()[1]); 
+
+                fMeanPosition.emplace_back(pca.getAvePosition()[0]);
+                fMeanPosition.emplace_back(pca.getAvePosition()[1]);
+
+                for(const auto& hitPair : hitLogChargePairVec)
+                {
+                    fTickVec.emplace_back(hitPair.first->PeakTime());
+                    fChargeVec.emplace_back(hitPair.first->Integral());
+                }
+
+                fDiagnosticTree->Fill();
+
+                fPCAAxes.clear(); 
+                fEigenValues.clear(); 
+                fMeanPosition.clear();
+                fTickVec.clear(); 
+                fChargeVec.clear(); 
+            }
+        }
+    }
+    
+    //put info onto the event
+    event.put(std::move(outputPtrVector));
+
+    return;
+}
+
+void TPCPurityMonitor::endJob()
+{
+    return;
+}
+
+// Length of reconstructed track.
+//----------------------------------------------------------------------------
+double TPCPurityMonitor::length(const recob::Track* track)
+{
+    double   result(0.);
+/*
+    TVector3 disp(track->LocationAtPoint(0));
+    TVector3 lastPoint(track->LocationAtPoint(0));
+    TVector3 lastDir(0.,0.,0.);
+    int      n(track->NumberTrajectoryPoints());
+
+    for(int i = 1; i < n; ++i)
+    {
+        const TVector3& pos = track->LocationAtPoint(i);
+
+        TVector3 trajDir = pos - lastPoint;
+
+        if (trajDir.Mag2()) trajDir.SetMag(1.);
+
+//        if (lastDir.Dot(trajDir) >= 0.)
+//        {
+            disp   -= pos;
+            result += disp.Mag();
+            disp    = pos;
+//        }
+
+        lastPoint = pos;
+        lastDir   = trajDir;
+    }
+*/
+    return result;
+}
+
+// Length of reconstructed track.
+//----------------------------------------------------------------------------
+double TPCPurityMonitor::projectedLength(const recob::Track* track)
+{
+    double   result(0.);
+/*
+    TVector3 lastPoint(track->LocationAtPoint(0));
+    TVector3 lastDir(track->DirectionAtPoint(0));
+    int      n(track->NumberTrajectoryPoints());
+
+    for(int i = 1; i < n; ++i)
+    {
+        const TVector3& newPoint = track->LocationAtPoint(i);
+
+        TVector3 lastToNewPoint = newPoint - lastPoint;
+        double   arcLenToDoca   = lastDir.Dot(lastToNewPoint);
+
+        result    += arcLenToDoca;
+        lastPoint  = lastPoint + arcLenToDoca * lastDir;
+        lastDir    = track->DirectionAtPoint(i);
+    }
+*/
+    return result;
+}
+
+
+
+void TPCPurityMonitor::GetPrincipalComponents(const HitLogChargePairVec& hitPairVector, PrincipalComponents& pca) const
+{
+    // Run through the HitPairList and get the mean position of all the hits
+    Eigen::Vector2d meanPos(Eigen::Vector2d::Zero());
+    double          meanWeightSum(0.);
+    int             numPairsInt(0);
+
+    float startTime = hitPairVector.front().first->PeakTime();
+
+    for (const auto& hitPair : hitPairVector) 
+    {
+        if (!hitPair.second.first) continue;
+
+        const recob::Hit* hit = hitPair.first;
+
+        // Weight the hit by the peak time difference significance
+        double weight = fWeightByChiSq ? 1./hit->GoodnessOfFit() : 1.; 
+        double charge = fUseHitIntegral ? hit->Integral() : hit->SummedADC();
+
+        meanPos(0) += fSamplingRate * (hit->PeakTime() - startTime) * weight;
+        meanPos(1) += std::log(charge) * weight;
+        numPairsInt++;
+
+        meanWeightSum += weight;
+    }
+
+    meanPos /= meanWeightSum;
+
+    // Define elements of our covariance matrix
+    double xi2(0.);
+    double xiyi(0.);
+    double yi2(0.0);
+    double weightSum(0.);
+
+    // Back through the hits to build the matrix
+    for (const auto& hitPair : hitPairVector) 
+    {
+        if (!hitPair.second.first) continue;
+
+        const recob::Hit* hit = hitPair.first;
+
+        double weight = fWeightByChiSq ? 1./hit->GoodnessOfFit() : 1.;
+        double charge = fUseHitIntegral ? hit->Integral() : hit->SummedADC();
+
+        double x = (fSamplingRate * (hit->PeakTime() - startTime) - meanPos(0)) * weight;
+        double y = (std::log(charge) - meanPos(1)) * weight;
+
+        weightSum += weight * weight;
+
+        xi2  += x * x;
+        xiyi += x * y;
+        yi2  += y * y;
+    }
+
+    // Using Eigen package
+    Eigen::Matrix2d sig;
+
+    sig << xi2, xiyi, xiyi, yi2;
+
+    sig *= 1. / weightSum;
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix2d> eigenMat(sig);
+
+    if (eigenMat.info() == Eigen::ComputationInfo::Success) 
+    {
+        // Now copy output
+        // The returned eigen values and vectors will be returned in an xyz system where x is the smallest spread,
+        // y is the next smallest and z is the largest. Adopt that convention going forward
+        PrincipalComponents::EigenValues  eigenVals = eigenMat.eigenvalues();
+        PrincipalComponents::EigenVectors eigenVecs = eigenMat.eigenvectors().transpose();
+
+        // Store away
+        // NOTE: the major axis will be the second entry, the minor axis will be the first
+        pca = PrincipalComponents(true, numPairsInt, eigenVals, eigenVecs, meanPos);
+    }
+    else 
+    {
+        mf::LogDebug("Cluster3D") << "PCA decompose failure, numPairs = " << numPairsInt << std::endl;
+        pca = PrincipalComponents();
+    }
+
+    return;
+}
+
+void TPCPurityMonitor::RejectOutliers(HitLogChargePairVec& hitPairVector, const PrincipalComponents& pca) const
+{
+    double                 slope  = pca.getEigenVectors().row(1)[1] / pca.getEigenVectors().row(1)[0];
+    const Eigen::Vector2d& avePos = pca.getAvePosition(); 
+
+    // We assume the input vector has been time ordered
+    double firstHitTime = hitPairVector.front().first->PeakTime();
+
+    for(auto& hitPair : hitPairVector)
+    {
+        double predLogCharge  = (fSamplingRate* (hitPair.first->PeakTime() - firstHitTime) - avePos[0]) * slope + avePos[1];
+        double deltaLogCharge = std::log(hitPair.first->Integral()) - predLogCharge;
+
+        hitPair.second.second = deltaLogCharge;
+    }
+
+    std::sort(hitPairVector.begin(),hitPairVector.end(),[](const auto& left, const auto& right){return abs(left.second.second) < abs(right.second.second);});
+
+    size_t rejectIdx = fOutlierRejectFrac * hitPairVector.size();
+
+    for(size_t idx = rejectIdx; idx < hitPairVector.size(); idx++) hitPairVector[idx].second.first = false;
+
+    std::sort(hitPairVector.begin(), hitPairVector.end(), [](const auto& left, const auto& right){return left.first->PeakTime() < right.first->PeakTime();});
+
+    return;
+}
+
+
+} // namespace TPCPurityMonitor
+
+#endif // TPCPurityMonitor_module

--- a/icaruscode/Analysis/TPCPurityMonitor_module.cc
+++ b/icaruscode/Analysis/TPCPurityMonitor_module.cc
@@ -89,7 +89,7 @@ public:
     // This method is called once, at the start of each run. It's a
     // good place to read databases or files that may have
     // run-dependent information.
-    void beginRun(const art::Run& run);
+   // void beginRun(const art::Run& run);
 
     // The analysis routine, called once per event.
     void produce(art::Event& evt);
@@ -275,14 +275,14 @@ void TPCPurityMonitor::beginJob()
 }
 
 //-----------------------------------------------------------------------
-void TPCPurityMonitor::beginRun(const art::Run& /*run*/)
-{
+//void TPCPurityMonitor::beginRun(const art::Run& /*run*/)
+//{
     // How to convert from number of electrons to GeV.  The ultimate
     // source of this conversion factor is
     // ${LARSIM_DIR}/include/SimpleTypesAndConstants/PhysicalConstants.h.
 //    art::ServiceHandle<sim::LArG4Parameters> larParameters;
 //    fElectronsToGeV = 1./larParameters->GeVToElectrons();
-}
+//}
 
 //-----------------------------------------------------------------------
 void TPCPurityMonitor::reconfigure(fhicl::ParameterSet const& p)

--- a/icaruscode/Analysis/TPCPurityMonitor_module.cc
+++ b/icaruscode/Analysis/TPCPurityMonitor_module.cc
@@ -277,17 +277,17 @@ void TPCPurityMonitor::reconfigure(fhicl::ParameterSet const& p)
 {
     // Read parameters from the .fcl file. The names in the arguments
     // to p.get<TYPE> must match names in the .fcl file.
-    fTrackLabelVec      = p.get< std::vector<art::InputTag> >("TrackLabel",    std::vector<art::InputTag>() = {""});
-    fSelectedPlane      = p.get< unsigned                   >("SelectedPlane",                                   2);
-    fMinNumHits         = p.get< unsigned                   >("MinNumHits",                                    100);
-    fMinTickRange       = p.get< float                      >("MinTickRange",                                 150.);
-    fAssumedELifetime   = p.get< float                      >("AssumedELifetime",                          600000.);
-    fMinRejectFraction  = p.get< float                      >("MinRejectFraction",                            0.05);
-    fMaxRejectFraction  = p.get< float                      >("MaxRejectFraction",                            0.95);
-    fOutlierRejectFrac  = p.get< float                      >("OutlierRejectFrac",                            0.70);
-    fUseHitIntegral     = p.get< bool                       >("UseHitIntegral",                               true);
-    fWeightByChiSq      = p.get< bool                       >("WeightByChiSq",                               false);
-    fDiagnosticTuple    = p.get< bool                       >("DiagnosticTuple",                              true);
+    fTrackLabelVec      = p.get< std::vector<art::InputTag> >("TrackLabel",             {""});
+    fSelectedPlane      = p.get< unsigned                   >("SelectedPlane",             2);
+    fMinNumHits         = p.get< unsigned                   >("MinNumHits",              100);
+    fMinTickRange       = p.get< float                      >("MinTickRange",           150.);
+    fAssumedELifetime   = p.get< float                      >("AssumedELifetime",    600000.);
+    fMinRejectFraction  = p.get< float                      >("MinRejectFraction",      0.05);
+    fMaxRejectFraction  = p.get< float                      >("MaxRejectFraction",      0.95);
+    fOutlierRejectFrac  = p.get< float                      >("OutlierRejectFrac",      0.70);
+    fUseHitIntegral     = p.get< bool                       >("UseHitIntegral",         true);
+    fWeightByChiSq      = p.get< bool                       >("WeightByChiSq",         false);
+    fDiagnosticTuple    = p.get< bool                       >("DiagnosticTuple",        true);
 
     return;
 }

--- a/icaruscode/Analysis/analysis_icarus.fcl
+++ b/icaruscode/Analysis/analysis_icarus.fcl
@@ -36,10 +36,18 @@ icarus_HitEfficiencyAnalysis:
 icarus_TPCPurityMonitor:
 {
   module_type:          TPCPurityMonitor
-#  TrackLabel:           ["pandoraKalmanTrackGausCryoW","pandoraKalmanTrackGausCryoE"]
-  TrackLabel:           ["pandoraTrackGausCryoW","pandoraTrackGausCryoE"]
+#  TrackLabel:           ["pandoraKalmanTrackGausCryoW:"pandoraKalmanTrackGausCryoE"]
+  TrackLabel:           ["pandoraTrackGausCryoW:"pandoraTrackGausCryoE"]
   SelectedPlane:        2
+  MinNumHits:           100
   MinTickRange:         150.
+  AssumedELifetime:     600000.
+  MinRejectFraction:    0.05
+  MaxRejectFraction:    0.95
+  OutlierRejectFrac:    0.70
+  UseHitIntegral:       true
+  WeightByChiSq:        false
+  DiagnosticTuple:      true
 }
 
 END_PROLOG

--- a/icaruscode/Analysis/analysis_icarus.fcl
+++ b/icaruscode/Analysis/analysis_icarus.fcl
@@ -36,8 +36,8 @@ icarus_HitEfficiencyAnalysis:
 icarus_TPCPurityMonitor:
 {
   module_type:          TPCPurityMonitor
-#  TrackLabel:           ["pandoraKalmanTrackGausCryoW:"pandoraKalmanTrackGausCryoE"]
-  TrackLabel:           ["pandoraTrackGausCryoW:"pandoraTrackGausCryoE"]
+#  TrackLabel:           ["pandoraKalmanTrackGausCryoW","pandoraKalmanTrackGausCryoE"]
+  TrackLabel:           ["pandoraTrackGausCryoW","pandoraTrackGausCryoE"]
   SelectedPlane:        2
   MinNumHits:           100
   MinTickRange:         150.

--- a/icaruscode/Analysis/analysis_icarus.fcl
+++ b/icaruscode/Analysis/analysis_icarus.fcl
@@ -33,5 +33,14 @@ icarus_HitEfficiencyAnalysis:
   HitEfficiencyHistogramToolList: [ @local::TrackHitEfficiencyAnalysisTool ]
 }
 
+icarus_TPCPurityMonitor:
+{
+  module_type:          TPCPurityMonitor
+#  TrackLabel:           ["pandoraKalmanTrackGausCryoW","pandoraKalmanTrackGausCryoE"]
+  TrackLabel:           ["pandoraTrackGausCryoW","pandoraTrackGausCryoE"]
+  SelectedPlane:        2
+  MinTickRange:         150.
+}
+
 END_PROLOG
 

--- a/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
@@ -159,6 +159,7 @@ private:
     std::string                                                 fOutputCoherentPath;         ///< Path to assign to the output if asked for
     bool                                                        fDiagnosticOutput;           ///< Set this to get lots of messages
     float                                                       fSigmaForTruncation;         ///< Cut for truncated rms calc
+    size_t                                                      fCoherentNoiseGrouping;      ///< Grouping for removing coherent noise
 
     const std::string                                           fLogCategory;                ///< Output category when logging messages
 
@@ -293,13 +294,14 @@ DaqDecoderICARUSTPCwROI::~DaqDecoderICARUSTPCwROI()
 ///
 void DaqDecoderICARUSTPCwROI::configure(fhicl::ParameterSet const & pset)
 {
-    fFragmentsLabelVec   = pset.get<std::vector<art::InputTag>>("FragmentsLabelVec",  std::vector<art::InputTag>()={"daq:PHYSCRATEDATA"});
-    fOutputRawWaveform   = pset.get<bool                      >("OutputRawWaveform",                                               false);
-    fOutputCorrection    = pset.get<bool                      >("OutputCorrection",                                                false);
-    fOutputRawWavePath   = pset.get<std::string               >("OutputRawWavePath",                                               "raw");
-    fOutputCoherentPath  = pset.get<std::string               >("OutputCoherentPath",                                              "Cor");
-    fDiagnosticOutput    = pset.get<bool                      >("DiagnosticOutput",                                                false);
-    fSigmaForTruncation  = pset.get<float                     >("NSigmaForTrucation",                                                3.5);
+    fFragmentsLabelVec     = pset.get<std::vector<art::InputTag>>("FragmentsLabelVec",  std::vector<art::InputTag>()={"daq:PHYSCRATEDATA"});
+    fOutputRawWaveform     = pset.get<bool                      >("OutputRawWaveform",                                               false);
+    fOutputCorrection      = pset.get<bool                      >("OutputCorrection",                                                false);
+    fOutputRawWavePath     = pset.get<std::string               >("OutputRawWavePath",                                               "raw");
+    fOutputCoherentPath    = pset.get<std::string               >("OutputCoherentPath",                                              "Cor");
+    fDiagnosticOutput      = pset.get<bool                      >("DiagnosticOutput",                                                false);
+    fSigmaForTruncation    = pset.get<float                     >("NSigmaForTrucation",                                                3.5);
+    fCoherentNoiseGrouping = pset.get<size_t                    >("CoherentGrouping",                                                   64);
 }
 
 //----------------------------------------------------------------------------
@@ -573,7 +575,7 @@ void DaqDecoderICARUSTPCwROI::processSingleFragment(size_t                      
         }
 
         //process_fragment(event, rawfrag, product_collection, header_collection);
-        decoderTool->process_fragment(clockData, channelArrayPair.first, channelArrayPair.second);
+        decoderTool->process_fragment(clockData, channelArrayPair.first, channelArrayPair.second, fCoherentNoiseGrouping);
 
         // We need to recalculate pedestals for the noise corrected waveforms
         icarus_signal_processing::WaveformTools<float> waveformTools;

--- a/icaruscode/Decode/DecoderTools/INoiseFilter.h
+++ b/icaruscode/Decode/DecoderTools/INoiseFilter.h
@@ -55,7 +55,8 @@ public:
 
     virtual void process_fragment(detinfo::DetectorClocksData const&,
                                   const daq::INoiseFilter::ChannelPlaneVec&,
-                                  const icarus_signal_processing::ArrayFloat&) = 0;
+                                  const icarus_signal_processing::ArrayFloat&,
+                                  const size_t&) = 0;
 
     /**
      *  @brief Recover the channels for the processed fragment

--- a/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
+++ b/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
@@ -87,7 +87,6 @@ TPCNoiseFilter1DTool: {
     tool_type:          TPCNoiseFilter1D
     fragment_id_offset: 0
     NSigmaForTrucation: 3.5
-    CoherentGrouping:   64
     StructuringElement: 16
     FilterWindow:       10
     Threshold:          [12.0, 12.0, 12.0] #[8., 7.0 , 8.0] #[2.75, 2.75, 2.75] # changing threshold scheme from dynamic to static

--- a/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
@@ -583,6 +583,17 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
 //                channelArrayPairVec[planeIndex].first[wire] = daq::INoiseFilter::ChannelPlanePair(channel,planeID.Plane);
             }
         }
+
+        // Some detector simulations don't output channels that don't have any possibility of signal (ghost channels)
+        // Do a cleanup phase here to find these
+        for(auto& boardInfo : boardToChannelArrayPairMap)
+        {
+            if (boardWireCountMap[boardInfo.first] == 32)
+            {
+                std::cout << "****> caught a 32 channel remnant" << std::endl;
+            }
+        }
+
     }
 
     theClockProcess.stop();

--- a/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
@@ -92,6 +92,7 @@ public:
     // Function to do the work
     void processSingleImage(const detinfo::DetectorClocksData&,
                             const ChannelArrayPair&,
+                            size_t,
                             ConcurrentRawDigitCol&,
                             ConcurrentRawDigitCol&,
                             ConcurrentRawDigitCol&,
@@ -104,6 +105,7 @@ private:
                             const art::InputTag&, 
                             detinfo::DetectorClocksData const&,
                             ChannelArrayPairVec const&,
+                            size_t const&,
                             ConcurrentRawDigitCol&,
                             ConcurrentRawDigitCol&,
                             ConcurrentRawDigitCol&,
@@ -115,6 +117,7 @@ private:
         multiThreadImageProcessing(MCDecoderICARUSTPCwROI      const& parent,
                                    detinfo::DetectorClocksData const& clockData,
                                    ChannelArrayPairVec         const& channelArrayPairVec,
+                                   size_t                      const& coherentNoiseGrouping,
                                    ConcurrentRawDigitCol&             concurrentRawDigits,
                                    ConcurrentRawDigitCol&             concurrentRawRawDigits,
                                    ConcurrentRawDigitCol&             coherentRawDigits,
@@ -122,6 +125,7 @@ private:
             : fMCDecoderICARUSTPCwROI(parent),
               fClockData{clockData},
               fChannelArrayPairVec(channelArrayPairVec),
+              fCoherentNoiseGrouping(coherentNoiseGrouping),
               fConcurrentRawDigits(concurrentRawDigits),
               fConcurrentRawRawDigits(concurrentRawRawDigits),
               fCoherentRawDigits(coherentRawDigits),
@@ -134,13 +138,14 @@ private:
             {
                 const ChannelArrayPair& channelArrayPair = fChannelArrayPairVec[idx];
 
-                fMCDecoderICARUSTPCwROI.processSingleImage(fClockData, channelArrayPair, fConcurrentRawDigits, fConcurrentRawRawDigits, fCoherentRawDigits, fConcurrentROIs);
+                fMCDecoderICARUSTPCwROI.processSingleImage(fClockData, channelArrayPair, fCoherentNoiseGrouping, fConcurrentRawDigits, fConcurrentRawRawDigits, fCoherentRawDigits, fConcurrentROIs);
             }
         }
     private:
         const MCDecoderICARUSTPCwROI&      fMCDecoderICARUSTPCwROI;
         const detinfo::DetectorClocksData& fClockData;
         const ChannelArrayPairVec&         fChannelArrayPairVec;
+        size_t                             fCoherentNoiseGrouping;
         ConcurrentRawDigitCol&             fConcurrentRawDigits;
         ConcurrentRawDigitCol&             fConcurrentRawRawDigits;
         ConcurrentRawDigitCol&             fCoherentRawDigits;
@@ -162,6 +167,7 @@ private:
     std::string                                                 fOutputRawWavePath;          ///< Path to assign to the output if asked for
     std::string                                                 fOutputCoherentPath;         ///< Path to assign to the output if asked for
     bool                                                        fDiagnosticOutput;           ///< Set this to get lots of messages
+    size_t                                                      fCoherentNoiseGrouping;      ///< # channels in common for coherent noise
 
     const std::string                                           fLogCategory;                ///< Output category when logging messages
 
@@ -329,6 +335,7 @@ void MCDecoderICARUSTPCwROI::configure(fhicl::ParameterSet const & pset)
     fOutputRawWavePath          = pset.get<std::string               >("OutputRawWavePath",                   "raw");
     fOutputCoherentPath         = pset.get<std::string               >("OutputCoherentPath",                  "Cor");
     fDiagnosticOutput           = pset.get<bool                      >("DiagnosticOutput",                    false);
+    fCoherentNoiseGrouping      = pset.get<size_t                    >("CoherentGrouping",                       64);
 
 }
 
@@ -400,9 +407,9 @@ void MCDecoderICARUSTPCwROI::produce(art::Event & event, art::ProcessingFrame co
         auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService>()->DataFor(event);
     
         // ... repackage the input MC data to format suitable for noise processing
-        processSingleLabel(event, rawDigitLabel, clockData, channelArrayPairVec, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
+        processSingleLabel(event, rawDigitLabel, clockData, channelArrayPairVec, fCoherentNoiseGrouping, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
 
-//        multiThreadImageProcessing imageProcessing(*this, clockData, channelArrayPairVec, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
+//        multiThreadImageProcessing imageProcessing(*this, clockData, channelArrayPairVec, fCoherentNoiseGrouping, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
 //
 //        tbb::parallel_for(tbb::blocked_range<size_t>(0, fNumROPs), imageProcessing);
     
@@ -473,6 +480,7 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
                                                 const art::InputTag&               inputLabel,
                                                 detinfo::DetectorClocksData const& clockData,
                                                 ChannelArrayPairVec         const& channelArrayPairVec,
+                                                size_t                      const& coherentNoiseGrouping,
                                                 ConcurrentRawDigitCol&             concurrentRawDigits,
                                                 ConcurrentRawDigitCol&             concurrentRawRawDigits,
                                                 ConcurrentRawDigitCol&             coherentRawDigits,
@@ -533,7 +541,7 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
             if (boardMapItr == boardToChannelArrayPairMap.end())
             {
                 const auto [mapItr, success] = 
-                    boardToChannelArrayPairMap.insert({readoutBoardID,{daq::INoiseFilter::ChannelPlaneVec(MAXCHANNELS),icarus_signal_processing::ArrayFloat(MAXCHANNELS,icarus_signal_processing::VectorFloat(dataSize))}});
+                    boardToChannelArrayPairMap.insert({readoutBoardID,{daq::INoiseFilter::ChannelPlaneVec(MAXCHANNELS,{0,3}),icarus_signal_processing::ArrayFloat(MAXCHANNELS,icarus_signal_processing::VectorFloat(dataSize))}});
 
                 if (!success) 
                 {
@@ -557,7 +565,7 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
 
             if (++boardWireCountMap[readoutBoardID] == MAXCHANNELS)
             {
-                processSingleImage(clockData, boardMapItr->second, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
+                processSingleImage(clockData, boardMapItr->second, coherentNoiseGrouping, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
 
                 boardToChannelArrayPairMap.erase(boardMapItr);
 
@@ -586,11 +594,17 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
 
         // Some detector simulations don't output channels that don't have any possibility of signal (ghost channels)
         // Do a cleanup phase here to find these
+        std::cout << "Size of board map: " << boardToChannelArrayPairMap.size() << std::endl;
         for(auto& boardInfo : boardToChannelArrayPairMap)
         {
-            if (boardWireCountMap[boardInfo.first] == 32)
+            if (boardWireCountMap[boardInfo.first] < 64)
             {
-                std::cout << "****> caught a 32 channel remnant" << std::endl;
+                std::cout << "****> caught less than 64 channel remnant: " << boardWireCountMap[boardInfo.first] << std::endl;
+                std::cout << "  channels: ";
+                for(const auto& pair : boardInfo.second.first) std::cout << pair.first << " ";
+                std::cout << std::endl;
+
+                processSingleImage(clockData, boardInfo.second, boardWireCountMap[boardInfo.first], concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
             }
         }
 
@@ -607,6 +621,7 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
 
 void MCDecoderICARUSTPCwROI::processSingleImage(const detinfo::DetectorClocksData& clockData,
                                                 const ChannelArrayPair&            channelArrayPair,
+                                                size_t                             coherentNoiseGrouping,
                                                 ConcurrentRawDigitCol&             concurrentRawDigitCol,
                                                 ConcurrentRawDigitCol&             concurrentRawRawDigitCol,
                                                 ConcurrentRawDigitCol&             coherentRawDigitCol,
@@ -623,7 +638,7 @@ void MCDecoderICARUSTPCwROI::processSingleImage(const detinfo::DetectorClocksDat
     INoiseFilter* decoderTool = fDecoderToolVec[tbb::this_task_arena::current_thread_index()].get();
 
     //process_fragment(event, rawfrag, product_collection, header_collection);
-    decoderTool->process_fragment(clockData, channelVec, dataArray);
+    decoderTool->process_fragment(clockData, channelVec, dataArray, coherentNoiseGrouping);
 
     // Now set up for output, we need to convert back from float to short int so use this
     raw::RawDigit::ADCvector_t wvfm(numTicks);
@@ -631,6 +646,9 @@ void MCDecoderICARUSTPCwROI::processSingleImage(const detinfo::DetectorClocksDat
     // Loop over the channels to recover the RawDigits after filtering
     for(size_t chanIdx = 0; chanIdx < numChannels; chanIdx++)
     {
+        // Skip if no channel data (plane is wrong)
+        if (channelVec[chanIdx].second > 2) continue;
+        
         raw::ChannelID_t channel = channelVec[chanIdx].first;
 
         if (fOutputRawWaveform)

--- a/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
+++ b/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
@@ -37,6 +37,7 @@ decodeTPCROI: {
                     OutputRawWavePath:  "RAW"
                     OutputCoherentPath: "Cor"
                     DiagnosticOutput:   false
+                    CoherentGrouping:   64
                     DecoderTool:        @local::TPCNoiseFilter1DTool
 }
 

--- a/icaruscode/Decode/fcl/stage0_icarus_mc_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_mc_defs.fcl
@@ -21,6 +21,7 @@ icarus_stage0_mc_producers:
                            OutputRawWavePath:   "RAW"
                            OutputCoherentPath:  "Cor"
                            DiagnosticOutput:    false
+                           CoherentGrouping:    64
                            DecoderTool:         @local::TPCNoiseFilter1DTool
                        }
   

--- a/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
@@ -33,10 +33,10 @@ base {
         // sides are enumerated by "s", while "n" counts the physical anodes.
         // NOTE: the actual physical volumes in ICARUS are only 4
 
-        local xanode = [-369.33*wc.cm, -71.1*wc.cm, 71.1*wc.cm, 369.33*wc.cm],
+        local xanode = [-359.33*wc.cm, -61.1*wc.cm, 61.1*wc.cm, 359.33*wc.cm],
         local offset_response = [if a%2==0 then +10*wc.cm else -10*wc.cm for a in std.range(0,3)],
         local xresponse = [xanode[a] + offset_response[a] for a in std.range(0,3)],
-        local xcathode = [-220.29*wc.cm, -220.29*wc.cm, 220.29*wc.cm, 220.29*wc.cm],
+        local xcathode = [-210.29*wc.cm, -210.29*wc.cm, 210.29*wc.cm, 210.29*wc.cm],
         volumes : [
             {
                 local world = 100,  // identify this geometry

--- a/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
@@ -33,10 +33,10 @@ base {
         // sides are enumerated by "s", while "n" counts the physical anodes.
         // NOTE: the actual physical volumes in ICARUS are only 4
 
-        local xanode = [-359.33*wc.cm, -61.1*wc.cm, 61.1*wc.cm, 359.33*wc.cm],
+        local xanode = [-369.33*wc.cm, -71.1*wc.cm, 71.1*wc.cm, 369.33*wc.cm],
         local offset_response = [if a%2==0 then +10*wc.cm else -10*wc.cm for a in std.range(0,3)],
         local xresponse = [xanode[a] + offset_response[a] for a in std.range(0,3)],
-        local xcathode = [-210.29*wc.cm, -210.29*wc.cm, 210.29*wc.cm, 210.29*wc.cm],
+        local xcathode = [-220.29*wc.cm, -220.29*wc.cm, 220.29*wc.cm, 220.29*wc.cm],
         volumes : [
             {
                 local world = 100,  // identify this geometry
@@ -125,7 +125,7 @@ base {
     files: {
         wires: "icarus-wires-dualanode-v5.json.bz2",
 
-        fields: ["garfield-icarus-fnal-commissioning.json.bz2"],
+        fields: ["garfield-icarus-fnal-rev1.json.bz2"],
 
 	noise: ["icarus_noise_model_int_TPCEE.json.bz2","icarus_noise_model_int_TPCEW.json.bz2","icarus_noise_model_int_TPCWE.json.bz2","icarus_noise_model_int_TPCWW.json.bz2"],
         coherent_noise: ["icarus_noise_model_coh_TPCEE.json.bz2","icarus_noise_model_coh_TPCEW.json.bz2","icarus_noise_model_coh_TPCWE.json.bz2","icarus_noise_model_coh_TPCWW.json.bz2"],

--- a/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/Decon1DROI_module.cc
@@ -436,9 +436,7 @@ void  Decon1DROI::processChannel(size_t                                  idx,
     // The following test is meant to be temporary until the "correct" solution is implemented
     if (!fChannelFilter->IsPresent(channel)) return;
 
-    // Testing an idea about rejecting channels
-    if (digitVec->GetPedestal() < 0.) return;
-
+    // The waveforms should have been set to a 0. pedestal...
     float pedestal = 0.;
         
     // Recover the plane info
@@ -476,7 +474,8 @@ void  Decon1DROI::processChannel(size_t                                  idx,
     std::transform(rawadc.begin(),rawadc.end(),rawAdcLessPedVec.begin(),std::bind(std::minus<short>(),std::placeholders::_1,pedestal));
     
     // It seems there are deviations from the pedestal when using wirecell for noise filtering
-    float raw_noise = fixTheFreakingWaveform(rawAdcLessPedVec, channel, rawAdcLessPedVec);
+    //float raw_noise = fixTheFreakingWaveform(rawAdcLessPedVec, channel, rawAdcLessPedVec);
+    float raw_noise = digitVec->GetSigma();
     
     // Recover a measure of the noise on the channel for use in the ROI finder
     //float raw_noise = getTruncatedRMS(rawAdcLessPedVec);

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -2,7 +2,7 @@
 
 # The *parent* line must the first non-commented line and defines this product and version
 # The version must be of the form vxx_yy_zz (e.g. v01_02_03)
-parent icaruscode v09_42_01
+parent icaruscode v09_42_02
 
 defaultqual e20
 
@@ -37,13 +37,13 @@ table_fragment_end
 # Add the dependent product and version
 
 product                   version
-sbncode                   v09_42_01
+sbncode                   v09_42_02
 icarusalg                 v09_42_00
 icarusutil                v09_37_01
 icarus_signal_processing  v09_37_01
 icarus_data               v09_42_00
 fftw                      v3_3_9
-libwda                    v2_29_1
+libwda                    v2_30_0
 
 cetbuildtools	          v8_18_04	-	only_for_build
 end_product_list


### PR DESCRIPTION
Sorry to combine two relatively independent things! 
1) The 1d drift simulation outputs all channels to its RawDigits, including those that are not physical. This matches the data and enables the coherent noise subtraction to work without having to otherwise know that there are only 32 channels that are real. Probably this is something that needs to be addressed... Meanwhile, the 2d simulation only outputs "live" channels with the result that the process of decoding and coherent noise subtraction was causing some channels to be "lost". This PR introduces a way to recognize when this is happening and to patch those channels back in. Note this required a bit of interface modifications in order to allow to change the number of channels to use in the coherent noise subtraction on the fly. 
2) This PR also introduces a new TPC purity monitoring module meant to enable switching the current 2D approach to one utilizing reconstructed objects starting with pandora tracks and using gauss hits. 
