### PR TITLE
Explicit setting for PMT gain

### DIFF
--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -68,18 +68,22 @@ icarus_photoelectronresponse_gaussian: {
 # of April 2020), which come from data analysis from the BNL group.
 # 
 # In particular, raise and fall times are reported to be 1.4 and 3.2 ns for
-# the PMT, and 1.8 and 4.2 ns including the 37 m cable distortion.
+# the PMT, and 1.8 and 4.2 ns including the cable distortion at CERN (10 m),
+# which is not the setup of the actual ICARUS detector (37 m).
 # The average gain is considered to be 7 x 10^6 (somehow lower than the nominal
-# 10^7 used below).
+# 10^7 which we had targetted).
 # Attenuation from the cable is considered negligible.
 # 
 # The peak charge is computed starting from the charge of a photoelectron
-# (-1.6 x 10^-4 pC), multiplied by the gain (7 x 10^6). At signal peak time,
+# (-1.6 x 10^-7 pC), multiplied by the gain (7 x 10^6). At signal peak time,
 # the current from that charge is -0.14 mA, i.e. a voltage drop on 50 ohm
-# of -7.06 mV.
+# of -7.07 mV. In this parametrisation, we inject the gain and let the code
+# compute the amplitude.
 # The digitizer converts a range up to 2 volt with 14 bit, which translates into
 # about 8.192 ADC/mV and 409.6 ADC/mA.
-# In short, the peak signal is expected to be -7.06 mV, -0.14 mA, -57.86 ADC.
+# In short, the peak signal is expected to be -7.07 mV, -0.14 mA, -57.93 ADC.
+# 
+# The integral of the shape is 191.407 ADC (time 0 to infinity, 2 ns sampling).
 # 
 icarus_photoelectronresponse_exponentials: {
   
@@ -89,7 +93,7 @@ icarus_photoelectronresponse_exponentials: {
   TransitTime:               "55.1 ns"
   RaiseTimeConstant:         "1.8 ns"
   FallTimeConstant:          "4.2 ns"
-  PeakCurrent:               -0.14125 # mA; way more digits than meaningful
+  Gain:                      7e6      # => PeakCurrent: -0.14144 mA
   ADC:                       409.6  # ADC / mA
   
 } # icarus_photoelectronresponse_exponentials

--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -40,6 +40,18 @@ BEGIN_PROLOG
 ################################################################################
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Detector and readout parameters
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+icarus_settings_opdet: {
+  
+  nominalPMTgain: 7.0e6  # PMT multiplication gain factor
+  
+} # icarus_settings_opdet
+
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Single photoelectron response configurations
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #
@@ -93,7 +105,7 @@ icarus_photoelectronresponse_exponentials: {
   TransitTime:               "55.1 ns"
   RaiseTimeConstant:         "1.8 ns"
   FallTimeConstant:          "4.2 ns"
-  Gain:                      7e6      # => PeakCurrent: -0.14144 mA
+  Gain:                      @local::icarus_settings_opdet.nominalPMTgain  # Gain = 7.0e6 => PeakCurrent: -0.14144 mA
   ADC:                       409.6  # ADC / mA
   
 } # icarus_photoelectronresponse_exponentials
@@ -176,7 +188,7 @@ icarus_pmtsimulationalg_noise: {
     # the second stage is 3.4 R, etc. The value of R is not necessary.
     # Only multiplication stages are included.
     VoltageDistribution:    [ 17.4, 3.4, 5.0, 3.33, 1.67, 1.0, 1.2, 1.5, 2.2, 3.0 ]
-    Gain:                   1e7            # total typical PMT gain
+    Gain:                   @local::icarus_settings_opdet.nominalPMTgain  # total typical PMT gain
   } # PMTspecs
 
 } # icarus_pmtsimulationalg_noise


### PR DESCRIPTION
The interface of the current single photon response (SPR) has been updated to receive the PMT gain as a parameter to determine the expected amplitude of the signal.
At the same time, the parameter is now also shared (via common configuration definition) with the gain fluctuation simulation.

Breaking change
================

There is no really breaking change in physics, but there will be changes.
So ok, yes, it is a breaking change.
The amplitude of the single photon response is slightly changed (O(0.1%)) because of rounding.
Also the gain used as a reference to compute the fluctuations is changed (sensibly: from 10^7^ to 7 10^6^), which scales down all the gains from all PMT stages down. As the gain of the first stage, leading the fluctuation, decreases, its _relative_ Poisson uncertainty increases. In other words, larger fluctuations will occur (note that the gain used in the creation of the waveforms has effectively _not_ changed, since it's taken from the SPR which already was, and still is, 7 10^6^, while the fluctuation is changed from 10^7^). Anyway, each stage gain is decreased by only 3.5%, so the increase in fluctuation won't likely be noticeable.