### PR TITLE
Feature/howard write nu id features v09 42 00

### DIFF
--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
@@ -38,7 +38,7 @@
 		<MvaName>NeutrinoId</MvaName>
 		<MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
 		<MaximumNeutrinos>999</MaximumNeutrinos>
-		<ShouldWriteFeatures>true</ShouldWriteFeatures>
+		<PersistFeatures>true</PersistFeatures>
 	    </tool>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
@@ -38,6 +38,7 @@
 		<MvaName>NeutrinoId</MvaName>
 		<MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
 		<MaximumNeutrinos>999</MaximumNeutrinos>
+		<ShouldWriteFeatures>true</ShouldWriteFeatures>
 	    </tool>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
@@ -40,6 +40,7 @@
 		<MvaName>NeutrinoId</MvaName>
 		<MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
 		<MaximumNeutrinos>999</MaximumNeutrinos>
+		<ShouldWriteFeatures>true</ShouldWriteFeatures>
 	    </tool>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
@@ -40,7 +40,7 @@
 		<MvaName>NeutrinoId</MvaName>
 		<MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
 		<MaximumNeutrinos>999</MaximumNeutrinos>
-		<ShouldWriteFeatures>true</ShouldWriteFeatures>
+		<PersistFeatures>true</PersistFeatures>
 	    </tool>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>


### PR DESCRIPTION
Two extra parameters to switch on the persistence of BDT inputs in the Pandora metadata.

**NOTE!!!** Don't merge until some updates from LArPandoraContent are in. Relies on a PR there from Henry but wanted to start putting in PRs for review.