### PR TITLE
Calibration changes and updated FEB delay measurements for Side CRT timing studies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
-project(icaruscode VERSION 09.42.04 LANGUAGES CXX)
+project(icaruscode VERSION 09.43.00 LANGUAGES CXX)
 
 message(STATUS
   "\n-- ============================================================================="

--- a/icaruscode/CRT/CRTPMTMatchingAna_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingAna_module.cc
@@ -80,7 +80,6 @@ public:
 private:
 
   // Declare member data here.
-  const double LAR_PROP_DELAY = 1.0/(30.0/1.38); //[ns/cm]
 
   bool HitCompare(const art::Ptr<CRTHit>& h1, const art::Ptr<CRTHit>& h2);
   void ClearVecs();

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -45,14 +45,14 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(vector<art::Ptr<CRTDat
   for (size_t febdat_i=0; febdat_i<crtList.size(); febdat_i++) {
     
     uint8_t mac = crtList[febdat_i]->fMac5;
-    int adid  = fCrtutils->MacToAuxDetID(mac,0);
-    char type = fCrtutils->GetAuxDetType(adid);
+    int adid    = fCrtutils->MacToAuxDetID(mac,0);
+    char type   = fCrtutils->GetAuxDetType(adid);
 
     /// Looking for data within +/- 3ms within trigger time stamp
     /// Here t0 - trigger time -ve, only adding 1s makes the value +ve or -ve
     if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp) + 1e9) > fCrtWindow)) continue;
     
-    if ( type == 'c' or type == 'm'){
+    if ( type == 'm'){
       for(int chan=0; chan<32; chan++) {
 	std::pair<double,double> const chg_cal = fChannelMap->getSideCRTCalibrationMap((int)crtList[febdat_i]->fMac5,chan);
 	float pe = (crtList[febdat_i]->fAdc[chan]-chg_cal.second)/chg_cal.first;
@@ -60,7 +60,13 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(vector<art::Ptr<CRTDat
 	presel = true;
 	if(fVerbose)
 	  mf::LogInfo("CRTHitRecoAlg: ") << "\nfebP (mac5, channel, gain, pedestal, adc, pe) = (" << (int)crtList[febdat_i]->fMac5 << ", " << chan << ", " 
-		    << chg_cal.first << ", " << chg_cal.second << "," << crtList[febdat_i]->fAdc[chan] << "," << pe << ")\n";
+					 << chg_cal.first << ", " << chg_cal.second << "," << crtList[febdat_i]->fAdc[chan] << "," << pe << ")\n";
+      }
+    }else if ( type == 'c' ) {
+      for(int chan=0; chan<32; chan++) {
+	float pe = (crtList[febdat_i]->fAdc[chan]-fQPed)/fQSlope;
+	if(pe<=fPEThresh) continue;
+	presel = true;
       }
     }else if ( type == 'd'){
       for(int chan=0; chan<64; chan++) {
@@ -69,21 +75,20 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(vector<art::Ptr<CRTDat
 	presel = true;
       }
     }
-
+  
     if (presel) crtdata.push_back(crtList[febdat_i]);
     presel = false;
     
   }
   mf::LogInfo("CRTHitRecoAlg:") << "Found " << crtdata.size() << " after preselection "<< '\n';
   return crtdata;  
-  
 }
 
 //---------------------------------------------------------------------------------------
 vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(vector<art::Ptr<CRTData>> crtList) {
-
-    vector<pair<CRTHit, vector<int>>> returnHits;
-    vector<int> dataIds;
+  
+  vector<pair<CRTHit, vector<int>>> returnHits;
+  vector<int> dataIds;
   
     uint16_t nMissC = 0, nMissD = 0, nMissM = 0, nHitC = 0, nHitD = 0, nHitM = 0;
     if (fVerbose) mf::LogInfo("CRTHitRecoAlg: ") << "Found " << crtList.size() << " FEB events" << '\n';

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS.xml
@@ -38,6 +38,7 @@
 		<MvaName>NeutrinoId</MvaName>
 		<MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
 		<MaximumNeutrinos>999</MaximumNeutrinos>
+		<PersistFeatures>true</PersistFeatures>
 	    </tool>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Master_ICARUS_NuMI.xml
@@ -40,6 +40,7 @@
 		<MvaName>NeutrinoId</MvaName>
 		<MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
 		<MaximumNeutrinos>999</MaximumNeutrinos>
+		<PersistFeatures>true</PersistFeatures>
 	    </tool>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -2,7 +2,7 @@
 
 # The *parent* line must the first non-commented line and defines this product and version
 # The version must be of the form vxx_yy_zz (e.g. v01_02_03)
-parent icaruscode v09_42_04
+parent icaruscode v09_43_00
 
 defaultqual e20
 
@@ -37,8 +37,8 @@ table_fragment_end
 # Add the dependent product and version
 
 product                   version
-sbncode                   v09_42_04
-icarusalg                 v09_42_00
+sbncode                   v09_43_00
+icarusalg                 v09_43_00
 icarusutil                v09_37_01
 icarus_signal_processing  v09_37_01
 icarus_data               v09_42_04


### PR DESCRIPTION
I've updated a number of things in the CRT calibration code, mostly adding files that allow us to run the calibration on data that comes from the CRT's general decoder as well as helpful macros for executing the full CRT calibration analysis. There are some additions to CrtCal.cc and CrtCal.h that allow the FEB statistics to be included, allowing us to know how many events were present when fitting the ADC spectra to obtain the calibration. Finally, after Francesco Poppi's measurements of the CRT timing signal delay to the Side CRT racks, I recalculated the delay for each FEB based on the cable lengths from the output of the timing fanouts and using a measured conversion factor for the delay per length in the cables. This should hopefully fix some of the issues we were having with timestamps not matching correctly within the CRT.