### PR TITLE
TPC related updates for the SBN2022A production release

### DIFF
--- a/fcl/detsim/standard_detsim_icarus.fcl
+++ b/fcl/detsim/standard_detsim_icarus.fcl
@@ -93,8 +93,3 @@ physics.producers.daq3.TPCVec:              [ [1, 2], [1, 3] ]
 
 # ------------------------------------------------------------------------------
 outputs.rootoutput: @local::icarus_rootoutput
-
-
-# Temporarily tone down the noise level
-#
-services.SignalShapingICARUSService.NoiseFactVec:  [ [ 1.0, 1.0, 1.0 ], [ 1.0, 1.0, 1.0 ], [ 1.0, 1.0, 1.0 ] ]

--- a/icaruscode/Analysis/ICARUSPurityDQM_module.cc
+++ b/icaruscode/Analysis/ICARUSPurityDQM_module.cc
@@ -98,17 +98,32 @@ namespace icarus {
     TH1F* puritytpc2;
     TH1F* puritytpc3;
     
+
+
+
     TH1F* purityvalues;
     TH1F* purityvalues2;
-    //TH1F* purityvalues3;
-    
+    TH1F* h_hit_height;
+       TH1F* h_hit_area;
+     TH2D* h_hit_height_area;
+
     TH1F* h_basediff;
     TH1F* h_base1;
     TH1F* h_base2;
     TH1F* h_basebase;
-    
+       TH1F* h_ratio;
+       TH1F* h_ratio_after;
+        TH1F* h_ratio_after_2;
+       TH2D* h_ratio_after_3;
+       TH2D* h_ratio_3;
+
 
     TH1F* h_rms;
+    TH1F* h_errors;
+    TH1F* h_hittime;
+    TH1F* h_hittime_2;
+    TH1F* h_hittime_3;
+
     //TH1F* fRun; 
     //TH2D* fRunSub;
 
@@ -116,14 +131,38 @@ namespace icarus {
     //short fPrintLevel;
 
     float fValoretaufcl; 
+    float fmaxfcl;
+    float fminfcl;
+    float fdisfcl;
     int fcryofcl;
+    int fquantevoltefcl;
+
     int fplanefcl;
     int fthresholdfcl;
+    int fdumphitsfcl;
+    int fgruppifcl;
+int fdwclusfcl;
+int fdsclusfcl;
     bool fPersistPurityInfo;
     
     TNtuple* purityTuple;
     bool fFillAnaTuple;
 
+      TTree* fpurTree;
+      int run_tree;
+      int subrun_tree;
+      int event_tree;
+      int tpc_tree;
+      int qhits_tree;
+      float dwire_tree;
+      float dtime_tree;
+      float earea_tree;
+      float marea_tree;
+      float slope_tree;
+      float errslope_tree;
+      float chi_tree;
+
+      
   }; // class ICARUSPurityDQM
   
 }
@@ -137,9 +176,17 @@ namespace icarus{
     : EDProducer(pset)
     , fDigitModuleLabel     (pset.get< std::vector<art::InputTag> > ("RawModuleLabel"))
     , fValoretaufcl         (pset.get< float >       ("ValoreTauFCL"))
+    , fmaxfcl               (pset.get< float >       ("FracMaxFCL",0.9))
+    , fminfcl               (pset.get< float >       ("FraxMinFCL",0.05))
+    , fdisfcl               (pset.get< float >       ("DisFCL",3.0))
     , fcryofcl              (pset.get< int >         ("CryostatFCL"))
+    , fquantevoltefcl       (pset.get< int >         ("QuanteFCL",5))
     , fplanefcl             (pset.get< int >         ("PlaneFCL"))
     , fthresholdfcl         (pset.get< int >         ("ThresholdFCL"))
+    , fdumphitsfcl          (pset.get< int >         ("DumpHitFCL",0))
+    , fgruppifcl            (pset.get< int >         ("GruppiFCL",8))
+    , fdwclusfcl            (pset.get< int >         ("DeltaWClusFCL",3))
+    , fdsclusfcl            (pset.get< int >         ("DeltaSClusFCL",100))
     , fPersistPurityInfo    (pset.get< bool  >       ("PersistPurityInfo",false))
     , fFillAnaTuple         (pset.get< bool  >       ("FillAnaTuple",false))
   {
@@ -151,11 +198,11 @@ namespace icarus{
       produces< std::vector<anab::TPCPurityInfo> >("",art::Persistable::No);      
 
     
-//    for(const auto& digitlabel2 : fDigitModuleLabel)
-//      {
-//	
-//	std::cout<<"fDigitModuleLabel "<<digitlabel2<<"\n";
-//      }
+    for(const auto& digitlabel2 : fDigitModuleLabel)
+      {
+	
+	std::cout<<"fDigitModuleLabel "<<digitlabel2<<"\n";
+      }
  
   }
   
@@ -180,16 +227,47 @@ namespace icarus{
     h_rms = tfs->make<TH1F>("h_rms","h_rms",2000,0,20);
     //fRun=tfs->make<TH1F>("fRun","Events per run", 4000,0.5 ,4000.5);
     //fRunSub=tfs->make<TH2D>("fRunSub","Events per run", 4000,0.5 ,4000.5,50,0.5,50.5);
+    h_errors = tfs->make<TH1F>("h_errors","",1000,0,1000);
+
+
+   h_hittime = tfs->make<TH1F>("h_hittime","",2500,-0.5,2499.5);
+   h_hittime_2 = tfs->make<TH1F>("h_hittime_2","",2500,-0.5,2499.5);
+   h_hittime_3 = tfs->make<TH1F>("h_hittime_3","",2500,-0.5,2499.5);
 
     purityvalues2 = tfs->make<TH1F>("purityvalues2","purityvalues2",20000,-10,10);
     puritytpc0 = tfs->make<TH1F>("puritytpc0","puritytpc0",20000,-10,10);
     puritytpc1 = tfs->make<TH1F>("puritytpc1","puritytpc1",20000,-10,10);
     puritytpc2 = tfs->make<TH1F>("puritytpc2","puritytpc2",20000,-10,10);
     puritytpc3 = tfs->make<TH1F>("puritytpc3","puritytpc3",20000,-10,10);
-    //purityvalues3 = tfs->make<TH1F>("purityvalues3","purityvalues3",20000,-10,10);
+    h_hit_height = tfs->make<TH1F>("h_hit_height","h_hit_height",2000,0.5,2000.5);
+    h_hit_area = tfs->make<TH1F>("h_hit_area","h_hit_area",10000,0,10000);
+    h_hit_height_area=tfs->make<TH2D>("h_hit_height_area","", 300,0.5,300.5,2000,0.,2000.);
 
+    h_ratio = tfs->make<TH1F>("h_ratio","h_ratio",20000,0,5);
+    h_ratio_after = tfs->make<TH1F>("h_ratio_after","h_ratio_after",20000,0,5);
+    h_ratio_after_2 = tfs->make<TH1F>("h_ratio_after_2","",2000,0,2);
+    h_ratio_after_3 = tfs->make<TH2D>("h_ratio_after_3","",1300,0,2600,2000,0,2);
+    h_ratio_3 = tfs->make<TH2D>("h_ratio_3","",1300,0,2600,2000,0,2);
+
+
+
+      fpurTree = tfs->make<TTree>("puritytree","tree for the purity studies");
+      fpurTree->Branch("run",&run_tree,"run/I");
+      fpurTree->Branch("subrun",&subrun_tree,"subrun/I");
+      fpurTree->Branch("event",&event_tree,"event/I");
+      fpurTree->Branch("tpc",&tpc_tree,"tpc/I");
+      fpurTree->Branch("qhits",&qhits_tree,"qhits/I");
+      fpurTree->Branch("deltawire",&dwire_tree,"deltawire/F");
+      fpurTree->Branch("deltatime",&dtime_tree,"deltatime/F");
+      fpurTree->Branch("errarea",&earea_tree,"errarea/F");
+      fpurTree->Branch("meanarea",&marea_tree,"meanarea/F");
+      fpurTree->Branch("slope",&slope_tree,"slope/F");
+      fpurTree->Branch("errorslope",&errslope_tree,"errorslope/F");
+      fpurTree->Branch("chisquare",&chi_tree,"chisquare/F");
+
+      
     if(fFillAnaTuple)
-      purityTuple = tfs->make<TNtuple>("purityTuple","Purity Tuple","run:subrun:ev:cryo:tpc:wires:ticks:att:err");
+      purityTuple = tfs->make<TNtuple>("purityTuple","Purity Tuple","run:ev:tpc:att");
 
   }
   
@@ -228,7 +306,25 @@ namespace icarus{
   }
     
   Double_t ICARUSPurityDQM::FoundMeanLog(std::vector<float>* a,float b){
-        
+
+
+  float taglio=0;
+  if(a->size()>0){
+  int punto_taglio=a->size()*(b)+0.5;
+  //cout << punto_taglio << " e " << a->size() << endl;
+  if(punto_taglio==0)punto_taglio=1;
+std::vector<float>* usedhere=new std::vector<float>;
+ for(int j=0;j<(int)a->size();j++)usedhere->push_back((*a)[j]);
+
+  //cout << (*usedhere)[punto_taglio-1] << " PRIMA " << endl;
+std::sort(usedhere->begin(),usedhere->end(), [](float &c, float &d){ return c<d; });
+  //cout << (*usedhere)[punto_taglio-1] << " DOPO " << endl;
+  taglio=(*usedhere)[punto_taglio-1];
+  delete usedhere;
+  }
+  return taglio;
+
+/*        
     int punto_taglio=a->size()*(1-b)+0.5;
     /////std::cout << punto_taglio << " e " << a->size() << std::endl;
     //if(punto_taglio==0)punto_taglio=1;
@@ -249,12 +345,13 @@ namespace icarus{
       }
     //cout << (*usedhere)[punto_taglio] << endl;
     return (*usedhere)[punto_taglio-1];
+*/
   }
       
   void ICARUSPurityDQM::produce(art::Event& evt)
   {
     
-//      std::cout << " Inizia Purity ICARUS Ana - upgraded by WES and OLIVIA " << std::endl;
+      std::cout << " Inizia Purity ICARUS Ana - upgraded by C.FARNESE, WES and OLIVIA " << std::endl;
       // code stolen from TrackAna_module.cc
       art::ServiceHandle<geo::Geometry>      geom;
       unsigned int  fDataSize;
@@ -263,8 +360,8 @@ namespace icarus{
       //InputTag cluster_tag { "fuzzycluster" }; //CH comment trovato con eventdump code
       
       //to get run and event info, you use this "eventAuxillary()" object.
-//      art::Timestamp ts = evt.time();
-//      std::cout << "Processing for Purity " << " Run " << evt.run() << ", " << "Event " << evt.event() << " and Time " << ts.value() << std::endl;
+      //art::Timestamp ts = evt.time();
+      std::cout << "Processing for Purity " << " Run " << evt.run() << ", " << "Event " << evt.event() << " and Time " << evt.time().timeHigh() << std::endl;
     
       //fRun->Fill(evt.run());
       //fRunSub->Fill(evt.run(),evt.subRun());
@@ -276,8 +373,9 @@ namespace icarus{
     
     anab::TPCPurityInfo purity_info;
     purity_info.Run = evt.run();
-    purity_info.Subrun = evt.subRun();
+    purity_info.Subrun = evt.subRun(); //evt.time().timeHigh()-1598580000;//evt.subRun();
     purity_info.Event = evt.event();
+    std::ofstream purh("dump_purity_hits.out",std::ios::app);
 
     for(const auto& digitlabel : fDigitModuleLabel)
       {
@@ -302,29 +400,17 @@ namespace icarus{
 	std::vector<float> *sss0=new std::vector<float>;
 	std::vector<float> *hhh0=new std::vector<float>;
 	std::vector<float> *ehh0=new std::vector<float>;
-	std::vector<int> *www1=new std::vector<int>;
-	std::vector<float> *sss1=new std::vector<float>;
-	std::vector<float> *hhh1=new std::vector<float>;
-	std::vector<float> *ehh1=new std::vector<float>;
 	std::vector<int> *www2=new std::vector<int>;
 	std::vector<float> *sss2=new std::vector<float>;
 	std::vector<float> *hhh2=new std::vector<float>;
 	std::vector<float> *ehh2=new std::vector<float>;
-	std::vector<int> *www3=new std::vector<int>;
-	std::vector<float> *sss3=new std::vector<float>;
-	std::vector<float> *hhh3=new std::vector<float>;
-	std::vector<float> *ehh3=new std::vector<float>;
 	std::vector<int> *ccc0=new std::vector<int>;
-	std::vector<int> *ccc1=new std::vector<int>;
 	std::vector<int> *ccc2=new std::vector<int>;
-	std::vector<int> *ccc3=new std::vector<int>;
 	std::vector<float> *aaa0=new std::vector<float>;
-	std::vector<float> *aaa1=new std::vector<float>;
 	std::vector<float> *aaa2=new std::vector<float>;
-	std::vector<float> *aaa3=new std::vector<float>;
 	
 	
-	
+        short int used[4096];	
 	for(const auto& rawDigit : rawDigitVec)
 	  {
 	    raw::ChannelID_t channel = rawDigit->Channel();
@@ -339,11 +425,11 @@ namespace icarus{
 	    int cryostat=wid.Cryostat;
 	    size_t tpc=wid.TPC;
 	    size_t iWire=wid.Wire;
-	    //std::cout << plane << " " << tpc << " " << cryostat << " " << iWire << std::endl;
+	    //std::cout << channel << " INFO CHANNEL " << plane << " " << tpc << " " << cryostat << " " << iWire << std::endl;
 	    fDataSize = rawDigit->Samples();
 	    rawadc.resize(fDataSize);
 	    
-	    
+	    for(int ijk=0;ijk<4096;ijk++)used[ijk]=0;
 	    //UNCOMPRESS THE DATA.
 	    int pedestal = (int)rawDigit->GetPedestal();
 	    float pedestal2 = rawDigit->GetPedestal();
@@ -354,124 +440,95 @@ namespace icarus{
 	    float quale_sample_massimo;
 	    //    if (plane==0) {
 	    if ((int)plane==fplanefcl && cryostat==fcryofcl){
+	      for(int volte=0;volte<fquantevoltefcl;volte++){	
+            massimo=0;
+           quale_sample_massimo=-1;
 
               TH1F *h111 = new TH1F("h111","delta aree",20000,0,0);
               for (unsigned int ijk=0; ijk<(fDataSize); ijk++)
                 {
-		  //h111->Fill(rawDigit->ADC(ijk)-pedestal2);
-		  //std::cout << rawDigit->ADC(ijk) << " " << rawDigit->ADC(ijk)-pedestal2 << std::endl;
-		  if ((rawDigit->ADC(ijk)-pedestal2)>massimo && ijk>150 && ijk<(fDataSize-150))
+		  if ((rawDigit->ADC(ijk)-pedestal2)>massimo && ijk>150 && ijk<(fDataSize-150) && used[ijk]==0)
 		    {
 		      massimo=(rawDigit->ADC(ijk)-pedestal2);
 		      quale_sample_massimo=ijk;
 		    }
                 }
-              //sigma_pedestal=h111->GetRMS();
-              //h111->Delete();
               float base_massimo_before=0;
               float base_massimo_after=0;
-              for (unsigned int ijk=quale_sample_massimo-150; ijk<quale_sample_massimo-50; ijk++)
+              for (unsigned int ijk=quale_sample_massimo-135; ijk<quale_sample_massimo-35; ijk++)
 		{
                   base_massimo_before+=(rawDigit->ADC(ijk)-pedestal2)*0.01;
 		}
-              for (unsigned int ijk=quale_sample_massimo+50; ijk<quale_sample_massimo+150; ijk++)
+              for (unsigned int ijk=quale_sample_massimo+35; ijk<quale_sample_massimo+135; ijk++)
 		{
                   base_massimo_after+=(rawDigit->ADC(ijk)-pedestal2)*0.01;
 		}
               float basebase=(base_massimo_after+base_massimo_before)*0.5;
-              h_basediff->Fill(fabs(base_massimo_after-base_massimo_before));
-	      h_base1->Fill(base_massimo_before);
-	      h_base2->Fill(base_massimo_after);
-	      h_basebase->Fill(basebase);
-	      //h_basediff2->Fill(base_massimo_before,base_massimo_after);
+              h_basediff->Fill(fabs(base_massimo_after-base_massimo_before)); h_base1->Fill(base_massimo_before);
+	      h_base2->Fill(base_massimo_after); h_basebase->Fill(basebase);
               float areaarea=0;
-	      /*
-		for (unsigned int ijk=quale_sample_massimo-50; ijk<quale_sample_massimo+50; ijk++)
-		{
-		areaarea+=(rawDigit->ADC(ijk)-pedestal2-basebase);
-		}
-	      */
               for (unsigned int ijk=0; ijk<(fDataSize); ijk++)
 		{
                   if (ijk>(quale_sample_massimo-30) && ijk<(quale_sample_massimo+30)) {
-		    //areaarea+=(rawDigit->ADC(ijk)-pedestal2-basebase);
-		    areaarea+=(rawDigit->ADC(ijk)-pedestal2);
+		    if(fabs(base_massimo_after-base_massimo_before)<=sigma_pedestal)areaarea+=(rawDigit->ADC(ijk)-pedestal2-basebase);
+                    if(fabs(base_massimo_after-base_massimo_before)>sigma_pedestal && base_massimo_after<base_massimo_before)areaarea+=(rawDigit->ADC(ijk)-pedestal2-base_massimo_after);
+                    if(fabs(base_massimo_after-base_massimo_before)>sigma_pedestal && base_massimo_after>base_massimo_before)areaarea+=(rawDigit->ADC(ijk)-pedestal2-base_massimo_before);
+
                   }
                   else{
-		    h111->Fill(rawDigit->ADC(ijk)-pedestal2-basebase);
-                  }
-                  
+		    if(used[ijk]==0)h111->Fill(rawDigit->ADC(ijk)-pedestal2-basebase);
+                  }                  
 		}
               sigma_pedestal=h111->GetRMS();
               h111->Delete();
-              //std::cout << "MASSIMO BASE " << massimo << " " << base_massimo_before << " " << base_massimo_after << std::endl;
-              //h_basediff->Fill(fabs(base_massimo_after-base_massimo_before));
-              //h_basediff2->Fill(fabs(base_massimo_after-base_massimo_before),sigma_pedestal);
               h_rms->Fill(sigma_pedestal);
-              if (massimo>(fthresholdfcl*sigma_pedestal) && fabs(base_massimo_after-base_massimo_before)<sigma_pedestal)
-                {
-		  /*
-		  if(cryostat==0 && tpc==0)www0->push_back(iWire);
-		  if(cryostat==0 && tpc==0)sss0->push_back(quale_sample_massimo);
-		  if(cryostat==0 && tpc==0)hhh0->push_back(massimo);
-		  if(cryostat==0 && tpc==0)ehh0->push_back(sigma_pedestal);
-		  if(cryostat==0 && tpc==0)ccc0->push_back(-1);
-		  if(cryostat==0 && tpc==1)www1->push_back(iWire);
-		  if(cryostat==0 && tpc==1)sss1->push_back(quale_sample_massimo);
-		  if(cryostat==0 && tpc==1)hhh1->push_back(massimo);
-		  if(cryostat==0 && tpc==1)ehh1->push_back(sigma_pedestal);
-		  if(cryostat==0 && tpc==1)ccc1->push_back(-1);
-		  if(cryostat==1 && tpc==0)www2->push_back(iWire);
-		  if(cryostat==1 && tpc==0)sss2->push_back(quale_sample_massimo);
-		  if(cryostat==1 && tpc==0)hhh2->push_back(massimo);
-		  if(cryostat==1 && tpc==0)ehh2->push_back(sigma_pedestal);
-		  if(cryostat==1 && tpc==0)ccc2->push_back(-1);
-		  if(cryostat==1 && tpc==1)www3->push_back(iWire);
-		  if(cryostat==1 && tpc==1)sss3->push_back(quale_sample_massimo);
-		  if(cryostat==1 && tpc==1)hhh3->push_back(massimo);
-		  if(cryostat==1 && tpc==1)ehh3->push_back(sigma_pedestal);
-		  if(cryostat==1 && tpc==1)ccc3->push_back(-1);
-		  if(cryostat==0 && tpc==0)aaa0->push_back(areaarea);
-		  if(cryostat==0 && tpc==1)aaa1->push_back(areaarea);
-		  if(cryostat==1 && tpc==0)aaa2->push_back(areaarea);
-		  if(cryostat==1 && tpc==1)aaa3->push_back(areaarea);
-		  */
-		     if(tpc==0)www0->push_back(iWire);		
-		     if(tpc==0)sss0->push_back(quale_sample_massimo);
-		     if(tpc==0)hhh0->push_back(massimo);
-		     if(tpc==0)ehh0->push_back(sigma_pedestal);
-		     if(tpc==0)ccc0->push_back(-1);
-		     if(tpc==1)www1->push_back(iWire);
-		     if(tpc==1)sss1->push_back(quale_sample_massimo);
-		     if(tpc==1)hhh1->push_back(massimo);
-		     if(tpc==1)ehh1->push_back(sigma_pedestal);
-		     if(tpc==1)ccc1->push_back(-1);
-		     if(tpc==2)www2->push_back(iWire);
-		     if(tpc==2)sss2->push_back(quale_sample_massimo);
-		     if(tpc==2)hhh2->push_back(massimo);
-		     if(tpc==2)ehh2->push_back(sigma_pedestal);
-		     if(tpc==2)ccc2->push_back(-1);
-		     if(tpc==3)www3->push_back(iWire);
-		     if(tpc==3)sss3->push_back(quale_sample_massimo);
-		     if(tpc==3)hhh3->push_back(massimo);
-		     if(tpc==3)ehh3->push_back(sigma_pedestal);
-		     if(tpc==3)ccc3->push_back(-1);
-		     if(tpc==0)aaa0->push_back(areaarea);
-		     if(tpc==1)aaa1->push_back(areaarea);
-		     if(tpc==2)aaa2->push_back(areaarea);
-		     if(tpc==3)aaa3->push_back(areaarea);
+              if(fdumphitsfcl==1)purh<<evt.event()<< " " <<iWire<<" "<<tpc<<" "<<cryostat<<" "<<basebase<<" "<<base_massimo_after<<" " <<base_massimo_before<<" "<<pedestal2<<" "<<sigma_pedestal<< " "  << quale_sample_massimo << " " << massimo << std::endl;
 
-		  //std::cout << "MASSIMO " << massimo << " " << quale_sample_massimo << std::endl;
-		  //std::cout << plane << " " << tpc << " " << cryostat << " " << iWire << std::endl;
+              if (massimo>(fthresholdfcl*sigma_pedestal)/* && fabs(base_massimo_after-base_massimo_before)<sigma_pedestal*/)
+                {
+                     if(fdumphitsfcl==1)purh<<iWire<<" "<<tpc<<" "<<cryostat<< " CANDIDATE HIT "  << quale_sample_massimo << " " << massimo << std::endl;
+
+                     if(tpc==0)www0->push_back(iWire+64);            
+                     if(tpc==0)sss0->push_back(quale_sample_massimo);
+                     if(tpc==0)hhh0->push_back(massimo);
+                     if(tpc==0)ehh0->push_back(sigma_pedestal);
+                     if(tpc==0)ccc0->push_back(-1);
+                     if(tpc==1)www0->push_back(iWire+64+2536);
+                     if(tpc==1)sss0->push_back(quale_sample_massimo);
+                     if(tpc==1)hhh0->push_back(massimo);
+                     if(tpc==1)ehh0->push_back(sigma_pedestal);
+                     if(tpc==1)ccc0->push_back(-1);
+                     if(tpc==2)www2->push_back(iWire+64);
+                     if(tpc==2)sss2->push_back(quale_sample_massimo);
+                     if(tpc==2)hhh2->push_back(massimo);
+                     if(tpc==2)ehh2->push_back(sigma_pedestal);
+                     if(tpc==2)ccc2->push_back(-1);
+                     if(tpc==3)www2->push_back(iWire+64+2536);
+                     if(tpc==3)sss2->push_back(quale_sample_massimo);
+                     if(tpc==3)hhh2->push_back(massimo);
+                     if(tpc==3)ehh2->push_back(sigma_pedestal);
+                     if(tpc==3)ccc2->push_back(-1);
+
+		     if(tpc==0)aaa0->push_back(areaarea);
+		     if(tpc==1)aaa0->push_back(areaarea);
+		     if(tpc==2)aaa2->push_back(areaarea);
+		     if(tpc==3)aaa2->push_back(areaarea);
+                     for(int ijk=0;ijk<330;ijk++)
+          {
+	int ent_value=quale_sample_massimo+ijk-165;
+	used[ent_value]=1;
+                }
+
+                }
                 }
             }
 	  }
-	
+//std::cout << "SIZE " << www0->size() << " " << www1->size() << " " << www2->size() << " " << www3->size() << std::endl;	
 	for (unsigned int ijk=0; ijk<www0->size(); ijk++)
 	  {
 	    for (unsigned int ijk2=0; ijk2<www0->size(); ijk2++)
 	      {
-		if (fabs((*www0)[ijk]-(*www0)[ijk2])<5 && ijk!=ijk2 && fabs((*sss0)[ijk]-(*sss0)[ijk2])<150)
+		if (fabs((*www0)[ijk]-(*www0)[ijk2])<fdwclusfcl && ijk!=ijk2 && fabs((*sss0)[ijk]-(*sss0)[ijk2])<fdsclusfcl)
 		  {
 		    if ((*ccc0)[ijk]<0 && (*ccc0)[ijk2]<0)
 		      {
@@ -497,41 +554,13 @@ namespace icarus{
 	      }
 	  }
 	
-	for (unsigned int ijk=0; ijk<www1->size(); ijk++)
-	  {
-	    for (unsigned int ijk2=0; ijk2<www1->size(); ijk2++)
-	      {
-		if (fabs((*www1)[ijk]-(*www1)[ijk2])<5 && ijk!=ijk2 && fabs((*sss1)[ijk]-(*sss1)[ijk2])<150)
-		  {
-		    if ((*ccc1)[ijk]<0 && (*ccc1)[ijk2]<0)
-		      {
-			(*ccc1)[ijk]=ijk+1;
-			(*ccc1)[ijk2]=ijk+1;
-		      }
-		    else if ((*ccc1)[ijk]>0 && (*ccc1)[ijk2]<0)
-		      {
-			(*ccc1)[ijk2]=(*ccc1)[ijk];
-		      }
-		    else if ((*ccc1)[ijk]<0 && (*ccc1)[ijk2]>0)
-		      {
-			(*ccc1)[ijk]=(*ccc1)[ijk2];
-		      }
-		    else if ((*ccc1)[ijk]>0 && (*ccc1)[ijk2]>0)
-		      {
-			for (unsigned int ijk3=0; ijk3<www1->size(); ijk3++)
-			  {
-			    if(((*ccc1)[ijk3])==((*ccc1)[ijk2]))(*ccc1)[ijk3]=(*ccc1)[ijk];
-			  }
-		      }
-		  }
-	      }
-	  }
 	
 	for (unsigned int ijk=0; ijk<www2->size(); ijk++)
 	  {
+            //std::cout << " WWW2 " << ijk << std::endl;
 	    for (unsigned int ijk2=0; ijk2<www2->size(); ijk2++)
 	      {
-		if (fabs((*www2)[ijk]-(*www2)[ijk2])<5 && ijk!=ijk2 && fabs((*sss2)[ijk]-(*sss2)[ijk2])<150)
+		if (fabs((*www2)[ijk]-(*www2)[ijk2])<fdwclusfcl && ijk!=ijk2 && fabs((*sss2)[ijk]-(*sss2)[ijk2])<fdsclusfcl)
 		  {
 		    if ((*ccc2)[ijk]<0 && (*ccc2)[ijk2]<0)
 		      {
@@ -557,45 +586,13 @@ namespace icarus{
 	      }
 	  }
 	
-	for (unsigned int ijk=0; ijk<www3->size(); ijk++)
-	  {
-	    for (unsigned int ijk2=0; ijk2<www3->size(); ijk2++)
-	      {
-		if (fabs((*www3)[ijk]-(*www3)[ijk2])<5 && ijk!=ijk2 && fabs((*sss3)[ijk]-(*sss3)[ijk2])<150)
-		  {
-		    if ((*ccc3)[ijk]<0 && (*ccc3)[ijk2]<0)
-		      {
-			(*ccc3)[ijk]=ijk+1;
-			(*ccc3)[ijk2]=ijk+1;
-		      }
-		    else if ((*ccc3)[ijk]>0 && (*ccc3)[ijk2]<0)
-		      {
-			(*ccc3)[ijk2]=(*ccc3)[ijk];
-		      }
-		    else if ((*ccc3)[ijk]<0 && (*ccc3)[ijk2]>0)
-		      {
-			(*ccc3)[ijk]=(*ccc3)[ijk2];
-		      }
-		    else if ((*ccc3)[ijk]>0 && (*ccc3)[ijk2]>0)
-		      {
-			for (unsigned int ijk3=0; ijk3<www3->size(); ijk3++)
-			  {
-			    if(((*ccc3)[ijk3])==((*ccc3)[ijk2]))(*ccc3)[ijk3]=(*ccc3)[ijk];
-			  }
-		      }
-		  }
-	      }
-	  }
 	
-	
-	
-	
-	Int_t clusters_creation[4][6000];
+	Int_t clusters_creation[4][30000];
 	//Int_t clusters_avewire[4][1000];
-	Int_t clusters_swire[4][6000];
-	Int_t clusters_lwire[4][6000];
-	Int_t clusters_ssample[4][6000];
-	Int_t clusters_lsample[4][6000];
+	Int_t clusters_swire[4][30000];
+	Int_t clusters_lwire[4][30000];
+	Int_t clusters_ssample[4][30000];
+	Int_t clusters_lsample[4][30000];
 	
 	Int_t clusters_nn[1000];
 	Int_t clusters_vi[1000];
@@ -603,10 +600,13 @@ namespace icarus{
 	//Int_t clusters_avewire[4][1000];
 	Int_t clusters_dw[1000];
 	Int_t clusters_ds[1000];
+        Double_t clusters_mw[1000];
+        Double_t clusters_ms[1000];
+        Double_t clusters_mintime[1000];
 	
 	
 	for (unsigned int ijk=0; ijk<4; ijk++) {
-          for (unsigned int ijk2=0; ijk2<6000; ijk2++) {
+          for (unsigned int ijk2=0; ijk2<30000; ijk2++) {
 	    clusters_creation[ijk][ijk2]=0;
 	    clusters_swire[ijk][ijk2]=100000;
 	    clusters_lwire[ijk][ijk2]=0;
@@ -618,6 +618,9 @@ namespace icarus{
 	      clusters_dw[ijk2]=-1;
 	      clusters_ds[ijk2]=-1;
 	      clusters_qq[ijk2]=-1;
+              clusters_mw[ijk2]=-1;
+              clusters_ms[ijk2]=-1;
+              clusters_mintime[ijk2]=-1;
 	    }
           }
 	}
@@ -633,17 +636,6 @@ namespace icarus{
               if((*sss0)[ijk]>clusters_lsample[0][numero])clusters_lsample[0][numero]=(*sss0)[ijk];
 	    }
 	  }
-	for (unsigned int ijk=0; ijk<www1->size(); ijk++)
-	  {
-	    if ((*ccc1)[ijk]>0) {
-              int numero=(*ccc1)[ijk];
-              clusters_creation[1][numero]+=1;
-              if((*www1)[ijk]<clusters_swire[1][numero])clusters_swire[1][numero]=(*www1)[ijk];
-              if((*www1)[ijk]>clusters_lwire[1][numero])clusters_lwire[1][numero]=(*www1)[ijk];
-              if((*sss1)[ijk]<clusters_ssample[1][numero])clusters_ssample[1][numero]=(*sss1)[ijk];
-              if((*sss1)[ijk]>clusters_lsample[1][numero])clusters_lsample[1][numero]=(*sss1)[ijk];
-	    }
-	  }
 	for (unsigned int ijk=0; ijk<www2->size(); ijk++)
 	  {
 	    if ((*ccc2)[ijk]>0) {
@@ -655,29 +647,21 @@ namespace icarus{
               if((*sss2)[ijk]>clusters_lsample[2][numero])clusters_lsample[2][numero]=(*sss2)[ijk];
 	    }
 	  }
-	for (unsigned int ijk=0; ijk<www3->size(); ijk++)
-	  {
-	    if ((*ccc3)[ijk]>0) {
-              int numero=(*ccc3)[ijk];
-              clusters_creation[3][numero]+=1;
-              if((*www3)[ijk]<clusters_swire[3][numero])clusters_swire[3][numero]=(*www3)[ijk];
-              if((*www3)[ijk]>clusters_lwire[3][numero])clusters_lwire[3][numero]=(*www3)[ijk];
-              if((*sss3)[ijk]<clusters_ssample[3][numero])clusters_ssample[3][numero]=(*sss3)[ijk];
-              if((*sss3)[ijk]>clusters_lsample[3][numero])clusters_lsample[3][numero]=(*sss3)[ijk];
-	    }
-	  }
 	
 	int quanti_clusters=0;
 	for (unsigned int ijk=0; ijk<4; ijk++) {
-          for (unsigned int ijk2=0; ijk2<6000; ijk2++) {
+          for (unsigned int ijk2=0; ijk2<30000; ijk2++) {
 	    if(clusters_creation[ijk][ijk2]>50)
               {
-//		std::cout<<clusters_creation[ijk][ijk2] << " CLUSTER MINE " << clusters_swire[ijk][ijk2] << " " << clusters_lwire[ijk][ijk2] << " " << clusters_ssample[ijk][ijk2] << " " << clusters_lsample[ijk][ijk2] << std::endl;
+		std::cout<<clusters_creation[ijk][ijk2] << " CLUSTER MINE " << clusters_swire[ijk][ijk2] << " " << clusters_lwire[ijk][ijk2] << " " << clusters_ssample[ijk][ijk2] << " " << clusters_lsample[ijk][ijk2] << std::endl;
 		clusters_qq[quanti_clusters]=clusters_creation[ijk][ijk2];
 		clusters_vi[quanti_clusters]=ijk;
 		clusters_nn[quanti_clusters]=ijk2;
 		clusters_dw[quanti_clusters]=clusters_lwire[ijk][ijk2]-clusters_swire[ijk][ijk2];
 		clusters_ds[quanti_clusters]=clusters_lsample[ijk][ijk2]-clusters_ssample[ijk][ijk2];
+                clusters_mw[quanti_clusters]=(clusters_lwire[ijk][ijk2]+clusters_swire[ijk][ijk2])*0.5;
+                clusters_ms[quanti_clusters]=(clusters_lsample[ijk][ijk2]+clusters_ssample[ijk][ijk2])*0.5;
+                clusters_mintime[quanti_clusters]=(clusters_ssample[ijk][ijk2]);
 		quanti_clusters+=1;
               }
           }
@@ -686,10 +670,10 @@ namespace icarus{
 	
 	for(int icl = 0; icl < quanti_clusters; ++icl){
 	  if (clusters_qq[icl]>0) {
-//	    std::cout << " CLUSTER INFO " << icl << " " << clusters_qq[icl] << " " << clusters_vi[icl] << " " << clusters_dw[icl] << " " << clusters_ds[icl] << " " << clusters_nn[icl] << std::endl;
+	    std::cout << " CLUSTER INFO " << icl << " " << clusters_qq[icl] << " " << clusters_vi[icl] << " " << clusters_dw[icl] << " " << clusters_ds[icl] << " " << clusters_nn[icl] << std::endl;
 	    int tpc_number=clusters_vi[icl];//qui andrebbe messo il numero di TPC
 	    
-	    if (clusters_ds[icl]>1100 && clusters_dw[icl]>100)
+	    if (clusters_ds[icl]>2250 && clusters_dw[icl]>100)
 	      {//if analisi
 		
 		std::vector<float> *whc=new std::vector<float>;
@@ -704,18 +688,7 @@ namespace icarus{
                       shc->push_back((*sss0)[ijk]);
                       ///ahc->push_back((*hhh0)[ijk]);
                       ahc->push_back((*aaa0)[ijk]);
-                      fahc->push_back((*ehh0)[ijk]);
-		    }
-		  }
-		}
-		if (clusters_vi[icl]==1) {
-		  for (unsigned int ijk=0; ijk<www1->size(); ijk++) {
-		    if ((*ccc1)[ijk]==clusters_nn[icl]) {
-                      whc->push_back((*www1)[ijk]);
-                      shc->push_back((*sss1)[ijk]);
-                      ahc->push_back((*aaa1)[ijk]);
-                      //ahc->push_back((*hhh1)[ijk]);
-                      fahc->push_back((*ehh1)[ijk]);
+                      fahc->push_back((*hhh0)[ijk]);
 		    }
 		  }
 		}
@@ -726,30 +699,25 @@ namespace icarus{
                       shc->push_back((*sss2)[ijk]);
                       ahc->push_back((*aaa2)[ijk]);
                       //ahc->push_back((*hhh2)[ijk]);
-                      fahc->push_back((*ehh2)[ijk]);
-		    }
-		  }
-		}
-		if (clusters_vi[icl]==3) {
-		  for (unsigned int ijk=0; ijk<www3->size(); ijk++) {
-		    if ((*ccc3)[ijk]==clusters_nn[icl]) {
-                      whc->push_back((*www3)[ijk]);
-                      shc->push_back((*sss3)[ijk]);
-                      //ahc->push_back((*hhh3)[ijk]);
-                      ahc->push_back((*aaa3)[ijk]);
-                      fahc->push_back((*ehh3)[ijk]);
+                      fahc->push_back((*hhh2)[ijk]);
 		    }
 		  }
 		}
 		
 		
-//		std::cout << " CLUSTER INFO " << icl << " " << clusters_qq[icl] << " " << whc->size() << std::endl;
+		//std::cout << " CLUSTER INFO " << icl << " " << clusters_qq[icl] << " " << whc->size() << std::endl;
 		
 		
-		if(whc->size()>30)//prima 0
+		if(whc->size()>100)//prima 0
 		  {
 		    float pendenza=0;float intercetta=0;int found_ok=0;
 		    std::vector<int> *escluse=new std::vector<int>;
+/*
+for(int j=0;j<(int)whc->size();j++)
+{
+if(((*shc)[j]-clusters_mintime[icl]<200) || ((*shc)[j]-clusters_mintime[icl])>2150)escluse->push_back(j);
+}
+*/
 		    for(int j=0;j<(int)whc->size();j++)
 		      {
 			if(found_ok<1)
@@ -778,7 +746,7 @@ namespace icarus{
 			    TF1 *fitfunc = gr3->GetFunction("pol1");
 			    pendenza=fitfunc->GetParameter(1);
 			    intercetta=fitfunc->GetParameter(0);
-			    float distance_maximal=3;
+			    float distance_maximal=fdisfcl;
 			    int quella_a_distance_maximal=0;
 			    int found_max=0;
 			    for(int jj=0;jj<quanti;jj++)
@@ -794,7 +762,7 @@ namespace icarus{
 			    if(found_max==0)found_ok=1;
 			  }
 		      }
-//		    std::cout << escluse->size() << " escluse " << whc->size() << " " << found_ok << std::endl;
+		    //std::cout << escluse->size() << " escluse " << whc->size() << " " << found_ok << std::endl;
 		    delete escluse;
 		    std::vector<float> *hittime=new std::vector<float>;
 		    std::vector<float> *hitwire=new std::vector<float>;
@@ -809,15 +777,19 @@ namespace icarus{
 		      {
 			for(int kkk=0;kkk<(int)whc->size();kkk++)
 			  {
-			    if((*ahc)[kkk]>0)
+			    if((*ahc)[kkk]>0)// && (((*shc)[kkk]-clusters_mintime[icl]<200) || ((*shc)[kkk]-clusters_mintime[icl])<2150))
 			      {
 				float distance=(abs(pendenza*((*whc)[kkk]*3)-(*shc)[kkk]*0.628+intercetta))/sqrt(pendenza*pendenza+1);
-				if(distance<=3)
+				if(distance<=fdisfcl)
 				  {
 				    //cout << log((*ahc)[kkk]/(0.4*peach)) << endl;
 				    hittime->push_back((*shc)[kkk]*0.4);
 				    hitwire->push_back((*whc)[kkk]);
 				    hitarea->push_back((*ahc)[kkk]);
+                                    h_hit_height->Fill((*fahc)[kkk]);
+                                    h_hit_area->Fill((*ahc)[kkk]);
+                                    h_hit_height_area->Fill((*fahc)[kkk],(*ahc)[kkk]);
+
 				  }
 			      }
 			  }
@@ -831,24 +803,77 @@ namespace icarus{
 			Double_t ey[10000];
 			Double_t ek[10000];
 			Double_t ez[10000];
-//			std::cout <<  hitarea->size() << " dimensione hitarea" << std::endl;
+			//std::cout <<  hitarea->size() << " dimensione hitarea" << std::endl;
 
-//			std::cout<<""<<std::endl;
-//			std::cout<<"HERE line 802"<<std::endl;
-//			std::cout<<""<<std::endl;
+			//std::cout<<""<<std::endl;
+			//std::cout<<"HERE line 802"<<std::endl;
+			//std::cout<<""<<std::endl;
+                        //std::ofstream purh("dump_purity_hits.out",std::ios::app);
 
 			if(hitarea->size()>100)//prima 30
 			  {
+			    h_ratio->Fill(((float)whc->size())/((float)clusters_dw[icl]));
+                            h_ratio_3->Fill(clusters_ds[icl],((float)whc->size())/((float)clusters_dw[icl]));
+
+                            //std::cout << "RATIO INFO 1 " << (float)hitarea->size() << " " << (float)clusters_dw[icl] << " " << (((float)hitarea->size())/((float)clusters_dw[icl])) << std::endl;	
 			    float minimo=100000;
 			    float massimo=0;
-			    for(int kk=0;kk<(int)hitarea->size();kk++)
-			      {
-				if((*hittime)[kk]>massimo)massimo=(*hittime)[kk];
-				if((*hittime)[kk]<minimo)minimo=(*hittime)[kk];
-			      }
+                            float wire_minimo=100000;
+                            float wire_massimo=0;
+
+                            float delta_sample_selected=0;
+                            float delta_wire_selected=0;
+                            float wire_del_massimo=-1;
+                            float wire_del_minimo=-1;
+                            float sample_massimo=-1;
+                            float sample_minimo=-1;
+                            int quante_hit_nel_range_tempo=0;
+			    purh<< evt.run() << " " << evt.subRun() << "  " << evt.event() << "  -1 " <<  " -1 " << " -1 " << " -1 " << std::endl;
+                            for(int kk=0;kk<(int)hitarea->size();kk++)
+                              {
+				if(fdumphitsfcl==1)purh<< evt.run() << " SELECTED " << evt.subRun() << "  " << evt.event() << "  " << tpc_number <<  " " << (*hitwire)[kk] << " " << (*hittime)[kk] << " " << (*hitarea)[kk] << std::endl;
+
+quante_hit_nel_range_tempo+=1;
+                                if((*hittime)[kk]>massimo)
+                              {
+                               massimo=(*hittime)[kk];
+                               wire_del_massimo=(*hitwire)[kk];
+                              }
+
+
+                                if((*hittime)[kk]<minimo)
+                              {
+                               minimo=(*hittime)[kk];
+                               wire_del_minimo=(*hitwire)[kk];
+                              }
+
+
+                                if((*hitwire)[kk]>wire_massimo)
+                              {
+                               wire_massimo=(*hitwire)[kk];
+                              }
+
+
+                                if((*hitwire)[kk]<wire_minimo)
+                              {
+                               wire_minimo=(*hitwire)[kk];
+                              }
+
+                              }
+
+                                delta_sample_selected=(massimo-minimo)/0.4;
+                                delta_wire_selected=wire_del_massimo-wire_del_minimo;
+                                sample_massimo=massimo/0.4;
+                                sample_minimo=minimo/0.4;
+                            h_ratio_after->Fill(((float)quante_hit_nel_range_tempo)/fabs(delta_wire_selected));
+                            h_ratio_after_2->Fill(((float)quante_hit_nel_range_tempo)/fabs(wire_massimo-wire_minimo+1));
+                            h_ratio_after_3->Fill(delta_sample_selected,((float)quante_hit_nel_range_tempo)/fabs(wire_massimo-wire_minimo+1));
+
+                            //std::cout << "RATIO INFO 2 " << (float)hitarea->size() << " " << fabs(delta_wire_selected) << " " << (((float)hitarea->size())/fabs(delta_wire_selected)) << std::endl;
+
 			    //std::cout << hitarea->size() << std::endl;
 			    //int gruppi=hitarea->size()/50;
-			    int gruppi=8;
+			    int gruppi=fgruppifcl;//originale 8
 			    //std::cout << gruppi << std::endl;
 			    
 			    float steptime=(massimo-minimo)/(gruppi+1);
@@ -869,8 +894,8 @@ namespace icarus{
 				      hitpertaglio->push_back((*hitarea)[kk]*exp((*hittime)[kk]/starting_value_tau));
 				  }
 				/////////std::cout << hitpertaglio->size() << std::endl;
-				float tagliomax=FoundMeanLog(hitpertaglio,0.90);//0.9com//0.8test1
-				float tagliomin=FoundMeanLog(hitpertaglio,0.05);//0.1com//0.05test1
+				float tagliomax=FoundMeanLog(hitpertaglio,fmaxfcl);//0.9
+				float tagliomin=FoundMeanLog(hitpertaglio,fminfcl);//0.05
 				//float tagliomin=0;
 				//float tagliomax=1000000;
 				delete hitpertaglio;
@@ -891,11 +916,27 @@ namespace icarus{
 				  }
 			      }
 			    //std::cout << hitareagood->size() << " hitareagood" << std::endl;    
+if(delta_sample_selected>1900)
+{
+                    for(int k=0;k<(int)whc->size();k++)
+                      {
+                        h_hittime->Fill((*shc)[k]-clusters_mintime[icl]);
+                      }
+                    for(int k=0;k<(int)hittime->size();k++)
+                      {
+                        h_hittime_2->Fill((*hittime)[k]/0.4-clusters_mintime[icl]);
+                      }
+
+                    for(int k=0;k<(int)hittimegood->size();k++)
+                      {
+                        h_hittime_3->Fill((*hittimegood)[k]/0.4-clusters_mintime[icl]);
+                      }
+}
+
 			    for(int k=0;k<(int)hitareagood->size();k++)
 			      {
+                                if(fdumphitsfcl==1)purh<< evt.run() << " AFTER CLEAN " << evt.subRun() << "  " << evt.event() << "  " << tpc_number <<  " " << (*hitwiregood)[k] << " " << (*hittimegood)[k] << " " << (*hitareagood)[k] << std::endl;
 				//if((*hittimegood)[k]-600*0.4<=1000)//correzione 15/08
-				if((*hittimegood)[k]<=2240)
-				  {
 				    tempo[k]=(*hittimegood)[k];
 				    area[k]=log((*hitareagood)[k]);
 				    //std::cout << (*hitareagood)[k] << " " << area[k] << std::endl;
@@ -903,11 +944,10 @@ namespace icarus{
 				    ex[k]=0;
 				    ez[k]=60;
 				    ey[k]=0.23;
-				  }
 			      }
-//			    std::cout<<""<<std::endl;
-//			    std::cout<<"HERE line 872"<<std::endl;
-//			    std::cout<<""<<std::endl;
+			    //std::cout<<""<<std::endl;
+			    //std::cout<<"HERE line 872"<<std::endl;
+			    //std::cout<<""<<std::endl;
 			    TGraphErrors *gr31 = new TGraphErrors(hitareagood->size(),tempo,area,ex,ey);
 			    //TGraphErrors *gr4 = new TGraphErrors(hitareagood->size(),tempo,nologarea,ex,ey);
 			    gr31->Fit("pol1","Q");
@@ -927,25 +967,50 @@ namespace icarus{
                         h111->Fit("gaus","Q");
                         TF1 *fitg = h111->GetFunction("gaus");
                         float error=fitg->GetParameter(2);
-//                        std::cout << " error " << error << std::endl;
-//                        float error_2=sqrt(sum_per_rms_test/(hitareagood->size()-2));
-//                        std::cout << " error vero" << error_2 << std::endl;
+                        //std::cout << " error " << error << std::endl;
+                        //float error_2=sqrt(sum_per_rms_test/(hitareagood->size()-2));
+                        //std::cout << " error vero" << error_2 << std::endl;
                         h111->Delete();
+
+
+
+		      TGraphErrors *gr4 = new TGraphErrors(hitareagood->size(),tempo,nologarea,ex,ey);
+		      gr4->Fit("expo","Q");
+		      TF1 *fite = gr4->GetFunction("expo");
+		      slope_purity=fite->GetParameter(1);
+		      intercetta_purezza=fite->GetParameter(0);
+                      float mean_hit_area=0;
+                      float size_hit_area=hitareagood->size();
+		      TH1F *h111e = new TH1F("h111e","delta aree",100,-1000.,1000.);
+		      for(int k=0;k<(int)hitareagood->size();k++)
+			{
+			  h111e->Fill(nologarea[k]-exp(slope_purity*tempo[k]+intercetta_purezza));
+                          mean_hit_area+=nologarea[k]/size_hit_area;
+			  //cout << nologarea[k]-exp(slope_purity*tempo[k]+intercetta_purezza) << endl;
+			}
+                       
+		      h111e->Fit("gaus","Q");
+		      TF1 *fitge = h111e->GetFunction("gaus");
+		      float error_expo=fitge->GetParameter(2);
+		      std::cout << " errors " << error << " " << error_expo << std::endl;
+		      h_errors->Fill(error_expo);
+		      h111e->Delete();//fitge->Delete();fite->Delete();
+
                         for(int k=0;k<(int)hitareagood->size();k++)
                           {
                             if((*hittimegood)[k]<=2240)
                               {
-                                ek[k]=-nologarea[k]+exp(area[k]+error);
-                                ez[k]=nologarea[k]-exp(area[k]-error);
+                                ek[k]=error_expo;
+                                ez[k]=error_expo;
                                 ey[k]=error;
                               }
                           }
-//			std::cout<<""<<std::endl;
-//			std::cout<<"HERE line 906"<<std::endl;
-//			std::cout<<""<<std::endl;
+			//std::cout<<""<<std::endl;
+			//std::cout<<"HERE line 906"<<std::endl;
+			//std::cout<<""<<std::endl;
 
                         TGraphErrors *gr32 = new TGraphErrors(hitareagood->size(),tempo,area,ex,ey);
-                        gr32->Fit("pol1","Q");
+                        gr32->Fit("pol1");
                   
                         TF1 *fit2 = gr32->GetFunction("pol1");
                         float slope_purity_2=fit2->GetParameter(1);
@@ -959,7 +1024,7 @@ namespace icarus{
                         //std::cout << -1/(slope_purity_2+error_slope_purity_2)+1/slope_purity_2 << std::endl;
                         //std::cout << 1/slope_purity_2-1/(slope_purity_2-error_slope_purity_2) << std::endl;
                         TGraphAsymmErrors *gr41 = new TGraphAsymmErrors (hitareagood->size(),tempo,nologarea,ex,ex,ez,ek);
-                        gr41->Fit("expo","Q");
+                        gr41->Fit("expo");
                         TF1 *fitexo = gr41->GetFunction("expo");
                         float slope_purity_exo=fitexo->GetParameter(1);
                         float error_slope_purity_exo=fitexo->GetParError(1);
@@ -971,20 +1036,39 @@ namespace icarus{
                         //std::cout << fitexo->GetChisquare()/(hitareagood->size()-2) << std::endl;
 			
 			
-                        if((fabs(error_slope_purity_2/slope_purity_2)<5) && fabs(error_slope_purity_exo/slope_purity_exo)<5)
+                        if(fabs(slope_purity_2)<0.01 || fabs(slope_purity_exo)<0.01)
 			  {
 			    if(fabs(slope_purity_2)<0.01)purityvalues->Fill(-slope_purity_2*1000.);
                             if(fabs(slope_purity_2)<0.01)goodpuro << evt.run() << " " << evt.subRun() << "  " << evt.event() << "  " << tpc_number << "  " << slope_purity_2 << "  " << error_slope_purity_2 << " " << chiquadro << " " << clusters_dw[icl] << " " << clusters_ds[icl] << std::endl;
 			    
-			    if(fabs(slope_purity_exo)<0.01)goodpuro2 << evt.run() << " " << evt.subRun() << " " << evt.event() << " " << tpc_number << " " << slope_purity_exo << " " << error_slope_purity_exo << " " << fitexo->GetChisquare()/(hitareagood->size()-2) << " " << clusters_dw[icl] << " " << clusters_ds[icl] << std::endl;
-			    if(fabs(slope_purity_exo)<0.01)purityvalues2->Fill(-slope_purity_exo*1000.);
+			    if(fabs(slope_purity_exo)<0.01)goodpuro2<< evt.run() << " " << evt.subRun() << " " << evt.event() << " " << tpc_number+fcryofcl*10 << " " << slope_purity_exo << " " << error_slope_purity_exo << " " << fitexo->GetChisquare()/(hitareagood->size()-2) << " " << clusters_dw[icl] << " " << clusters_ds[icl] << " " << clusters_mw[icl] << " " << clusters_ms[icl] << " " << delta_wire_selected << " " << delta_sample_selected << " " << sample_minimo << " " << sample_massimo << " " << wire_del_minimo << " " << wire_del_massimo << " " << wire_minimo << " " << wire_massimo << " " << whc->size() << " " << hitarea->size() << " " << quante_hit_nel_range_tempo << " " << error_expo << " " << clusters_mintime[icl] << " " << mean_hit_area << std::endl;
+
+                  
+                  if(fabs(slope_purity_exo)<0.01)
+                  {
+                      run_tree=evt.run();
+                      subrun_tree=evt.subRun();
+                      event_tree=evt.event();
+                      tpc_tree=tpc_number+fcryofcl*10;
+                      slope_tree=-slope_purity_exo*1000;
+                      errslope_tree=error_slope_purity_exo*1000;
+                      chi_tree=fitexo->GetChisquare()/(hitareagood->size()-2);
+                      dtime_tree=delta_sample_selected;
+                      dwire_tree=wire_massimo-wire_minimo+1;
+                      earea_tree=error_expo;
+                      marea_tree=mean_hit_area;
+                      qhits_tree=hitarea->size();
+                      fpurTree->Fill();
+                  }
+                  if(fabs(slope_purity_exo)<0.01)purityvalues2->Fill(-slope_purity_exo*1000.);
+
 			    if(fabs(slope_purity_exo)<0.01 && tpc_number==0)puritytpc0->Fill(-slope_purity_exo*1000.);
 			    if(fabs(slope_purity_exo)<0.01 && tpc_number==1)puritytpc1->Fill(-slope_purity_exo*1000.);
 			    if(fabs(slope_purity_exo)<0.01 && tpc_number==2)puritytpc2->Fill(-slope_purity_exo*1000.);
 			    if(fabs(slope_purity_exo)<0.01 && tpc_number==3)puritytpc3->Fill(-slope_purity_exo*1000.);
 			    
 			  }
-		        if((fabs(error_slope_purity_2/slope_purity_2)<5) && fabs(error_slope_purity_exo/slope_purity_exo)<5 && fabs(slope_purity_exo)<0.01)
+		        if(fabs(slope_purity_exo)<0.01)
                         {	
 
 			  
@@ -993,15 +1077,28 @@ namespace icarus{
 			purity_info.Subrun = evt.subRun();
 			purity_info.Event = evt.event();
 			purity_info.TPC = tpc_number;
-			purity_info.Wires = clusters_dw[icl];
-                        purity_info.Ticks = clusters_ds[icl];
+			purity_info.Wires = delta_wire_selected;
+                        purity_info.Ticks = delta_sample_selected;
 			
 			//if(purity_info.TPC<2) purity_info.Cryostat=0;
 			//else purity_info.Cryostat=1;
 			
 			purity_info.Cryostat=fcryofcl;
 
-			purity_info.Attenuation = slope_purity_exo*-1.;
+			// near/far from cathode tracks                                                                                        
+/*
+			  if(delta_wire_selected< 0){
+			    purity_info.AttenuationNEAR = slope_purity_exo*-1000.;
+			  }
+			  else purity_info.AttenuationNEAR = 0;
+			  if(delta_wire_selected>0){
+                            purity_info.AttenuationFAR = slope_purity_exo*-1000.;
+                          }
+			  else purity_info.AttenuationFAR = 0;
+
+*/
+
+       			purity_info.Attenuation = slope_purity_exo*-1.;
 			purity_info.FracError = error_slope_purity_exo / slope_purity_exo;
                         //purity_info.Attenuation_2 = slope_purity_2*-1.;
                         //purity_info.FracError_2 = error_slope_purity_2 / slope_purity_2;
@@ -1010,15 +1107,10 @@ namespace icarus{
 			//                        purity_info.Ticks = clusters_ds[icl];
 
 			if(fFillAnaTuple)
-			  purityTuple->Fill(purity_info.Run,
-					    purity_info.Event,
-					    purity_info.TPC,
-					    purity_info.Wires,
-					    purity_info.Ticks,
-					    purity_info.Attenuation);
+			  purityTuple->Fill(purity_info.Run,purity_info.Event,purity_info.TPC,purity_info.Wires,purity_info.Ticks,purity_info.Attenuation);
 
-//			std::cout << "Calling again after filling attenuation … " << std::endl;
-//			purity_info.Print();
+			//std::cout << "Calling again after filling attenuation … " << std::endl;
+			purity_info.Print();
 			outputPtrVector->push_back(purity_info);
                         }
 			//std::cout << ts << " is time event " << std::endl;
@@ -1028,7 +1120,7 @@ namespace icarus{
                         //goodpur << timeevent << " is time event " << std::endl;
 			  }
 		      }
-//		    std::cout << "Delete hit stuff." << std::endl;
+		    //std::cout << "Delete hit stuff." << std::endl;
 
 		    delete hittime;
 		    delete hitarea;
@@ -1038,7 +1130,7 @@ namespace icarus{
 		    delete hitwire;
 		  }
 		
-//		std::cout << "Delete cluster stuff." << std::endl;
+		//std::cout << "Delete cluster stuff." << std::endl;
 		
 		delete shc;
 		delete ahc;
@@ -1049,37 +1141,25 @@ namespace icarus{
 	  }
 	}
 
-//	std::cout << "Delete big stuff." << std::endl;
+	//std::cout << "Delete big stuff." << std::endl;
 
 	delete www0;
 	delete sss0;
 	delete hhh0;
 	delete ehh0;
 	delete ccc0;
-	delete www1;
-	delete sss1;
-	delete hhh1;
-	delete ehh1;
-	delete ccc1;
 	delete www2;
 	delete sss2;
 	delete hhh2;
 	delete ehh2;
 	delete ccc2;
-	delete www3;
-	delete sss3;
-	delete hhh3;
-	delete ehh3;
-	delete ccc3;
 	delete aaa0;
-	delete aaa1;
 	delete aaa2;
-	delete aaa3;
 
       }
 
-//    std::cout << "Checking everything in the output..." << std::endl;
-//    std::cout << "There are " << outputPtrVector->size() << " objects in the output vector." << std::endl;
+    std::cout << "Checking everything in the output..." << std::endl;
+    std::cout << "There are " << outputPtrVector->size() << " objects in the output vector." << std::endl;
     /* //don't need this printed here.    
     for (size_t i_info = 0; i_info<outputPtrVector->size(); ++i_info){
       auto info = outputPtrVector->at(i_info);

--- a/icaruscode/Analysis/ICARUSPurityDQM_module.cc
+++ b/icaruscode/Analysis/ICARUSPurityDQM_module.cc
@@ -958,15 +958,20 @@ if(delta_sample_selected>1900)
 			    
 			    TH1F *h111 = new TH1F("h111","delta aree",200,-10,10);
 			    float sum_per_rms_test=0;
+                            int quanti_in_h111=0;
 			    for(int k=0;k<(int)hitareagood->size();k++)
 			      {
 				h111->Fill(area[k]-slope_purity*tempo[k]-intercetta_purezza);
 				sum_per_rms_test+=(area[k]-slope_purity*tempo[k]-intercetta_purezza)*(area[k]-slope_purity*tempo[k]-intercetta_purezza);
+                                if((area[k]-slope_purity*tempo[k]-intercetta_purezza)>-10 && (area[k]-slope_purity*tempo[k]-intercetta_purezza)<10)quanti_in_h111+=1;
 			      }
                        
+                        float error=100.;
+                        if(quanti_in_h111>1){
                         h111->Fit("gaus","Q");
                         TF1 *fitg = h111->GetFunction("gaus");
-                        float error=fitg->GetParameter(2);
+                        error=fitg->GetParameter(2);
+                        }
                         //std::cout << " error " << error << std::endl;
                         //float error_2=sqrt(sum_per_rms_test/(hitareagood->size()-2));
                         //std::cout << " error vero" << error_2 << std::endl;
@@ -981,29 +986,32 @@ if(delta_sample_selected>1900)
 		      intercetta_purezza=fite->GetParameter(0);
                       float mean_hit_area=0;
                       float size_hit_area=hitareagood->size();
+                      int quanti_in_h111e=0;
 		      TH1F *h111e = new TH1F("h111e","delta aree",100,-1000.,1000.);
 		      for(int k=0;k<(int)hitareagood->size();k++)
 			{
 			  h111e->Fill(nologarea[k]-exp(slope_purity*tempo[k]+intercetta_purezza));
                           mean_hit_area+=nologarea[k]/size_hit_area;
+                          if((nologarea[k]-exp(slope_purity*tempo[k]+intercetta_purezza))>-1000. && (nologarea[k]-exp(slope_purity*tempo[k]+intercetta_purezza))<1000)quanti_in_h111e+=1; 
 			  //cout << nologarea[k]-exp(slope_purity*tempo[k]+intercetta_purezza) << endl;
 			}
-                       
+                      
+                      float error_expo=1000.;
+                      if(quanti_in_h111e>1)
+                      { 
 		      h111e->Fit("gaus","Q");
 		      TF1 *fitge = h111e->GetFunction("gaus");
-		      float error_expo=fitge->GetParameter(2);
+		      error_expo=fitge->GetParameter(2);
+                      }
 		      std::cout << " errors " << error << " " << error_expo << std::endl;
 		      h_errors->Fill(error_expo);
 		      h111e->Delete();//fitge->Delete();fite->Delete();
 
                         for(int k=0;k<(int)hitareagood->size();k++)
                           {
-                            if((*hittimegood)[k]<=2240)
-                              {
                                 ek[k]=error_expo;
                                 ez[k]=error_expo;
                                 ey[k]=error;
-                              }
                           }
 			//std::cout<<""<<std::endl;
 			//std::cout<<"HERE line 906"<<std::endl;

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
@@ -185,7 +185,7 @@ void ROIFinder::reconfigure(fhicl::ParameterSet const& pset)
     // Recover the parameters
     fWireModuleLabelVec    = pset.get<std::vector<art::InputTag>>("WireModuleLabelVec",   std::vector<art::InputTag>()={"decon1droi"});
     fOutInstanceLabelVec   = pset.get<std::vector<std::string>>  ("OutInstanceLabelVec",                            {"PHYSCRATEDATA"});
-    fCorrectROIBaseline    = pset.get<bool                      >("CorrectROIBaseline",                                          true);
+    fCorrectROIBaseline    = pset.get<bool                      >("CorrectROIBaseline",                                         false);
     fMinSizeForCorrection  = pset.get<size_t                    >("MinSizeForCorrection",                                          12);
     fMaxSizeForCorrection  = pset.get<size_t                    >("MaxSizeForCorrection",                                         512);
     fOutputMorphed         = pset.get< bool                     >("OutputMorphed",                                               true);

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -90,7 +90,7 @@ icarus_roifinder:
     module_type:           ROIFinder
     WireModuleLabel:       "decon1droi"
     OutInstanceLabelVec:   "PHYSCRATEDATA"
-    CorrectROIBaseline:    true
+    CorrectROIBaseline:    false
     MinSizeForCorrection:  12
     MaxSizeForCorrection:  512
     OutputMorphed:         false

--- a/icaruscode/TPC/Tracking/cluster3D/cluster3dalgorithms_icarus.fcl
+++ b/icaruscode/TPC/Tracking/cluster3D/cluster3dalgorithms_icarus.fcl
@@ -14,7 +14,7 @@ icarus_snippethit3dbuilder:
   PHLowSelection:        10.   #
   DeltaPeakTimeSig:      1.75  # "Significance" of agreement between 2 hit peak times
   WirePitchScaleFactor:  1.9
-  SaveMythicalPoints:    true
+  SaveMythicalPoints:    false
   MaxMythicalChiSquare:  10.
   UseT0Offsets:          false
   MaxHitChiSquare:       6.0

--- a/icaruscode/TPC/Tracking/cluster3D/cluster3dalgorithms_icarus.fcl
+++ b/icaruscode/TPC/Tracking/cluster3D/cluster3dalgorithms_icarus.fcl
@@ -14,9 +14,11 @@ icarus_snippethit3dbuilder:
   PHLowSelection:        10.   #
   DeltaPeakTimeSig:      1.75  # "Significance" of agreement between 2 hit peak times
   WirePitchScaleFactor:  1.9
+  SaveMythicalPoints:    true
+  MaxMythicalChiSquare:  10.
+  UseT0Offsets:          false
   MaxHitChiSquare:       6.0
   OutputHistograms:      false
-  TickCorrectionArray:   [[[0.,0.],[0.,0.],[0.,0.],[0.,0.]],[[0.,0.],[0.,0.],[0.,0.],[0.,0.]]]
 }
 
 END_PROLOG

--- a/icaruscode/TPC/Tracking/cluster3D/cluster3dalgorithms_icarus.fcl
+++ b/icaruscode/TPC/Tracking/cluster3D/cluster3dalgorithms_icarus.fcl
@@ -16,7 +16,7 @@ icarus_snippethit3dbuilder:
   WirePitchScaleFactor:  1.9
   SaveMythicalPoints:    false
   MaxMythicalChiSquare:  10.
-  UseT0Offsets:          false
+  UseT0Offsets:          true
   MaxHitChiSquare:       6.0
   OutputHistograms:      false
 }

--- a/icaruscode/TPC/Utilities/signalservices_icarus.fcl
+++ b/icaruscode/TPC/Utilities/signalservices_icarus.fcl
@@ -18,7 +18,7 @@ ElectronicsResponseTool:
 {
     tool_type:                ElectronicsResponse
     Plane:                    0
-    FCperADCMicroS:           0.02269  # Scaling to match data, from electronics tests it was 0.027
+    FCperADCMicroS:           0.0321  # Scaling to match data, from electronics tests it was 0.027
     ASICShapingTime:          1.3
     ADCPerPCAtLowestASICGain: 5500.
 }
@@ -27,7 +27,7 @@ ElectronicsResponseBesselApproxTool:
 {
     tool_type:                ElectronicsResponseBesselApprox
     Plane:                    0
-    FCperADCMicroS:           0.027
+    FCperADCMicroS:           0.0321  # Scaling to match data, from electronics tests it was 0.027
     ASICShapingTime:          1.3
     ADCPerPCAtLowestASICGain: 5500.
     TimeOffset:               0.0 # note that 1.625 will produce a plot that matches electronics paper

--- a/icaruscode/TPC/Utilities/signalservices_icarus.fcl
+++ b/icaruscode/TPC/Utilities/signalservices_icarus.fcl
@@ -72,7 +72,8 @@ icarus_signalshapingservice:
     PrintResponses:        "false"
     DeconNorm:             1.
     InitialFFTSize:        4096
-    NoiseFactVec:          [ [ 2.3, 2.3, 2.3, 2.3 ], [ 2.3, 2.3, 2.3, 2.3], [ 2.3, 2.3, 2.3, 2.3 ] ]
+                           # Setting the default scaling as per Justin Mueller study (3/17/22)
+    NoiseFactVec:          [ [ 1.151, 1.151, 1.151, 1.151 ], [ 1.152, 1.152, 1.152, 1.152], [ 1.096, 1.096, 1.096, 1.096 ] ]
     StoreHistograms:       true
 
     ResponseTools:

--- a/icaruscode/TPC/Utilities/signalservices_icarus.fcl
+++ b/icaruscode/TPC/Utilities/signalservices_icarus.fcl
@@ -18,7 +18,7 @@ ElectronicsResponseTool:
 {
     tool_type:                ElectronicsResponse
     Plane:                    0
-    FCperADCMicroS:           0.027
+    FCperADCMicroS:           0.02269  # Scaling to match data, from electronics tests it was 0.027
     ASICShapingTime:          1.3
     ADCPerPCAtLowestASICGain: 5500.
 }


### PR DESCRIPTION
This PR includes items for 1) deactivating the code block that was doing the ROI baseline correction, 2) includes the ability to produce "mythical" space points - those comprised of 2 spaces points - and 3) an update to the TPC purity monitor code from Christian to address failures that were causing production jobs to crash. 