### PR TITLE
Changed misleading message in ICARUSFlashAssAna

### DIFF
--- a/icaruscode/PMT/OpReco/ICARUSFlashAssAna_module.cc
+++ b/icaruscode/PMT/OpReco/ICARUSFlashAssAna_module.cc
@@ -628,7 +628,14 @@ void opana::ICARUSFlashAssAna::analyze(art::Event const& e) {
       e.getByLabel( label, flash_handle );
 
       // We want our flashes to be valid and not empty
-      if( flash_handle.isValid() && !flash_handle->empty()) {
+      if( !flash_handle.isValid() ) {
+        mf::LogError("ICARUSFlashAssAna")
+           << "Not found a recob::OpFlash with label '" << label.encode() << "'"; 
+      } else if ( flash_handle->empty() ) {
+        mf::LogWarning("ICARUSFlashAssAna")
+           << "No recob::OpFlash in collection with label '" << label.encode() << "'"; 
+      }
+      else {
 
         art::FindManyP<recob::OpHit> ophitsPtr( flash_handle, e, label );
 
@@ -678,12 +685,6 @@ void opana::ICARUSFlashAssAna::analyze(art::Event const& e) {
 
           fOpFlashTrees[iFlashLabel]->Fill();
         }
-      }
-
-      else {
-
-        mf::LogError("ICARUSFlashAssAna")
-           << "Not found a recob::OpFlash with label '" << label.encode() << "'"; 
       }
     } 
 


### PR DESCRIPTION
A message suggesting that the optical flash data product was not found was printed even when the data product was there but empty. Example:
```
%MSG-e ICARUSFlashAssAna:  ICARUSFlashAssAna:simpleLightAna@BeginModule  23-Mar-2022 13:14:22 CDT
 run: 7033 subRun: 1 event: 192799
Not found a recob::OpFlash with label 'opflashCryoE'
%MSG
%MSG-e ICARUSFlashAssAna:  ICARUSFlashAssAna:simpleLightAna@BeginModule  23-Mar-2022 13:14:22 CDT
 run: 7033 subRun: 1 event: 192799
Not found a recob::OpFlash with label 'opflashCryoW'
%MSG
```
This fix prints a different message in case the data product is not found and in case it is empty.

This is a GitHub change, I did not compile it and count on the integration test to do it for me.