### PR TITLE
Fixed absolute trigger timestamp in trigger decoder [SBN2022A]

### DIFF
--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
@@ -19,12 +19,15 @@
 namespace {
   
   // ---------------------------------------------------------------------------
-  struct TimestampDumper { std::uint64_t timestamp; };
+  template <typename T = std::uint64_t>
+  struct TimestampDumper { T timestamp; };
   
-  TimestampDumper dumpTimestamp(std::uint64_t timestamp)
+  template <typename T>
+  TimestampDumper<T> dumpTimestamp(T timestamp)
     { return { timestamp }; }
   
-  std::ostream& operator<< (std::ostream& out, TimestampDumper wrapper) {
+  template <typename T>
+  std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
     std::uint64_t const timestamp = wrapper.timestamp;
     if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
       out << (timestamp / 1'000'000'000) << "."
@@ -123,6 +126,11 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << dumpTriggerCount(info.anyGateCountFromAnyPreviousTrigger)
       << " gates from any source have opened since"
     ;
+  if (info.WRtimeToTriggerTime != ExtraTriggerInfo::UnknownCorrection) {
+    out << "\nCorrection applied to the timestamps: "
+      << dumpTimestamp(info.WRtimeToTriggerTime);
+  }
+  
   
   return out;
 } // sbn::operator<< (ExtraTriggerInfo)

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
@@ -50,6 +50,10 @@ struct sbn::ExtraTriggerInfo {
   static constexpr std::uint64_t NoTimestamp
     = std::numeric_limits<std::uint64_t>::max();
   
+  /// Special timestamp correction value indicating an unknown correction.
+  static constexpr std::int64_t UnknownCorrection
+    = std::numeric_limits<std::int64_t>::max();
+  
   
   /// Type of this gate (`sbn::triggerSource::NBits` marks this object invalid).
   sbn::triggerSource sourceType { sbn::triggerSource::NBits };
@@ -132,6 +136,17 @@ struct sbn::ExtraTriggerInfo {
   
   /// @}
   // --- END ---- Additional timestamps ----------------------------------------
+  
+  
+  // --- BEGIN -- Decoding information -----------------------------------------
+  /// @name Decoding information
+  /// @{
+  
+  /// Correction added to the White Rabbit time to get the trigger time.
+  std::int64_t WRtimeToTriggerTime { UnknownCorrection };
+  
+  /// @}
+  // --- END ---- Decoding information -----------------------------------------
   
   
   /// Returns whether this object contains any valid information.

--- a/icaruscode/Decode/DataProducts/classes_def.xml
+++ b/icaruscode/Decode/DataProducts/classes_def.xml
@@ -19,7 +19,8 @@
   <!-- sbn::ExtraTriggerInfo -->
 
   <!--   class -->
-  <class name="sbn::ExtraTriggerInfo" ClassVersion="10" >
+  <class name="sbn::ExtraTriggerInfo" ClassVersion="11" >
+   <version ClassVersion="11" checksum="2691428079"/>
    <version ClassVersion="10" checksum="2751074963"/>
   </class>
   


### PR DESCRIPTION
The trigger timestamp ultimately comes from the White Rabbit system, which has its time in [International Atomic Time (TAI) standard](https://en.wikipedia.org/wiki/International_Atomic_Time). To properly correct it into the UTC standard we adopted for timestamps some second offsets are necessary.
These are applied the first time by the trigger "board reader" during event building, and the result is currently used to attribute the trigger fragment and the _art_ event an absolute time. The trigger decoder in `icaruscode` also performed (presumably) the same correction as a workaround for a past issue, but a few months ago it went off-sync with the board reader.

This change ultimately trusts the board reader time and rather than attempting to apply the same correction, it learns it from the  time already corrected by the board reader.
This correction offset is also added as a new data member of the `sbn::ExtraTriggerInfo` data product, so that the "raw" value can be determined off-line if needed.

Note that there is a offset parameter which is now unused. I have deliberately changed the name of the parameter since it does not do what the old name suggested (ok, it does nothing at all...).
The intention is to remove that parameter completely in the parallel pull request against `develop`.