### PR TITLE
Produce calibration ntuples independent of stage1 [SBN2022A]

### DIFF
--- a/icaruscode/Decode/fcl/stage1_produce_calibtuples_MC.fcl
+++ b/icaruscode/Decode/fcl/stage1_produce_calibtuples_MC.fcl
@@ -1,0 +1,15 @@
+#include "stage1_multiTPC_icarus_gauss_MC.fcl"
+process_name: Calib
+
+physics: {
+  analyzers: @local::physics.analyzers
+  outana: @local::physics.outana
+}
+
+physics.analyzers.caloskimE.SelectEvents: @erase
+physics.analyzers.caloskimW.SelectEvents: @erase
+
+outputs: @erase
+source: @erase
+
+services.message: @local::icarus_message_services_interactive

--- a/icaruscode/Decode/fcl/stage1_produce_calibtuples_MC_numi.fcl
+++ b/icaruscode/Decode/fcl/stage1_produce_calibtuples_MC_numi.fcl
@@ -1,0 +1,15 @@
+#include "stage1_multiTPC_icarus_gauss_numi_MC.fcl"
+process_name: Calib
+
+physics: {
+  analyzers: @local::physics.analyzers
+  outana: @local::physics.outana
+}
+
+physics.analyzers.caloskimE.SelectEvents: @erase
+physics.analyzers.caloskimW.SelectEvents: @erase
+
+outputs: @erase
+source: @erase
+
+services.message: @local::icarus_message_services_interactive

--- a/icaruscode/Decode/fcl/stage1_produce_calibtuples_data.fcl
+++ b/icaruscode/Decode/fcl/stage1_produce_calibtuples_data.fcl
@@ -1,0 +1,15 @@
+#include "stage1_multiTPC_nofilter_icarus_gauss.fcl"
+process_name: Calib
+
+physics: {
+  analyzers: @local::physics.analyzers
+  outana: @local::physics.outana
+}
+
+physics.analyzers.caloskimE.SelectEvents: @erase
+physics.analyzers.caloskimW.SelectEvents: @erase
+
+outputs: @erase
+source: @erase
+
+services.message: @local::icarus_message_services_interactive

--- a/icaruscode/Decode/fcl/stage1_produce_calibtuples_data_numi.fcl
+++ b/icaruscode/Decode/fcl/stage1_produce_calibtuples_data_numi.fcl
@@ -1,0 +1,15 @@
+#include "stage1_multiTPC_nofilter_icarus_gauss_numi.fcl"
+process_name: Calib
+
+physics: {
+  analyzers: @local::physics.analyzers
+  outana: @local::physics.outana
+}
+
+physics.analyzers.caloskimE.SelectEvents: @erase
+physics.analyzers.caloskimW.SelectEvents: @erase
+
+outputs: @erase
+source: @erase
+
+services.message: @local::icarus_message_services_interactive


### PR DESCRIPTION
Add fcl files to produce calibration ntuples separately from rest of stage1, runs on produced stage1 files. Tested on run 7033 BNB and NuMI data and also small numbers of NuMI cosmic MC and shown to reproduce both TPC and PMT calibration ntuples.