### PR TITLE
1sec shift is now removed between gate_start_timestamp and CRTHit T0

### DIFF
--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -403,8 +403,8 @@ namespace crt {
       }      
       */
       /// Looking for data within +/- 3ms within trigger time stamp
-      /// Here t0 - trigger time -ve, only adding 1s makes the value +ve or -ve
-      //    if (std::fabs(int64_t(crtList[febdat_i]->fTs0 - m_trigger_timestamp) + 1e9) > fCrtWindow) continue;
+      /// Here t0 - trigger time -ve
+      //    if (std::fabs(int64_t(crtList[febdat_i]->fTs0 - m_trigger_timestamp)) > fCrtWindow) continue;
       if ( type == 'm'){
 	for(int chan=0; chan<32; chan++) {
 	  std::pair<double,double> const chg_cal = fChannelMap->getSideCRTCalibrationMap((int)crtList[febdat_i]->fMac5,chan);

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -49,8 +49,8 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(vector<art::Ptr<CRTDat
     char type   = fCrtutils->GetAuxDetType(adid);
 
     /// Looking for data within +/- 3ms within trigger time stamp
-    /// Here t0 - trigger time -ve, only adding 1s makes the value +ve or -ve
-    if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp) + 1e9) > fCrtWindow)) continue;
+    /// Here t0 - trigger time -ve
+    if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp)) > fCrtWindow)) continue;
     
     if ( type == 'm'){
       for(int chan=0; chan<32; chan++) {


### PR DESCRIPTION
There used to be a 1sec difference between the gate_start_timestamp and T0 of CRTHit, but this was updated in https://github.com/SBNSoftware/icaruscode/pull/373.
We now don't need manual shifts when applying the timing cuts on CRTData. This should be merged before the production starts.