### PR TITLE
Trigger label added in fcl/caf/cafmaker_defs.fcl

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -256,6 +256,7 @@ cafmaker.TrackMCSLabel: "pandoraTrackMCS"
 cafmaker.TrackRangeLabel: "pandoraTrackRange"
 cafmaker.CRTHitLabel: "crthit"
 cafmaker.CRTTrackLabel: "crttrack"
+cafmaker.TriggerLabel: "daqTrigger"
 cafmaker.FlashTrigLabel: "" # unavailable
 cafmaker.SimChannelLabel: "largeant"
 cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]


### PR DESCRIPTION
Trigger label is added in `fcl/caf/cafmaker_defs.fcl`. This is related to https://github.com/SBNSoftware/sbncode/pull/251 