### PR TITLE
New optical hit baseline algorithm for data, old for MC [SBN2022A]

### DIFF
--- a/icaruscode/Decode/fcl/stage0_multiTPC_rawpmt_icarus_MC.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_rawpmt_icarus_MC.fcl
@@ -32,7 +32,12 @@ outputs.outBNB.dataTier: "reconstructed"
 outputs.outBNB.outputCommands: ["keep *_*_*_*", "drop *_MCDecodeTPCROI_*_*", "drop *_decon1droi_*_*","drop raw::RawDigits_*_*_*" ]
 
 # Set the expected input for ophit
-physics.producers.ophit.InputModule: "opdaq"
+# physics.producers.ophit.InputModule: "opdaq"
+# temporary for a while: use a special MC configuration different from data;
+# data configuration is described in SBN DocDB 24969; MC configuration below
+# is the one used for data before that one
+physics.producers.ophit: @local::icarus_ophit_MC
+physics.producers.ophitfull: @local::icarus_ophitdebugger_MC
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq3:PHYSCRATEDATATPCWW","daq2:PHYSCRATEDATATPCWE","daq1:PHYSCRATEDATATPCEW","daq0:PHYSCRATEDATATPCEE"]

--- a/icaruscode/PMT/OpReco/fcl/icarus_ophitfinder.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_ophitfinder.fcl
@@ -29,6 +29,24 @@ icarus_opreco_pedestal_rmsslider.NumPreSample:      10
 icarus_opreco_pedestal_rmsslider.NumPostSample:     20
 
 ##
+## ICARUS "old" baseline settings: see SBN DocDB 24969
+## Labelled as "MC" here because at this time they appear to work better for MC.
+##
+icarus_opreco_pedestal_MC_DocDB24969: { # based on icarus_opreco_pedestal_rmsslider
+  Name:             "UB"
+  BeamGateSamples:    1
+  SampleSize:        20
+  Threshold:          4
+  MaxSigma:           4
+  NumPreSample:      10
+  NumPostSample:     20
+  PedRangeMax:    15200
+  PedRangeMin:    14640
+  NWaveformsToFile:   0
+  Verbose:        false
+} # icarus_opreco_pedestal_MC_DocDB24969
+
+##
 ## ICARUS tuning: see SBN DocDB 24969
 ##
 icarus_opreco_pedestal_DocDB24969: {
@@ -36,7 +54,7 @@ icarus_opreco_pedestal_DocDB24969: {
   SampleSize:              20    # unchanged
   NPrePostSamples:          5    # unchanged
   Threshold:                1.5  # was: 4
-  MaxSigma:                 5    # was: 5
+  MaxSigma:                 5    # was: 4
   DiffADCCounts:            2    # unchanged
   DiffBetweenGapsThreshold: 2    # unchanged
   PedRangeMax:          16000    # was: 15200
@@ -70,6 +88,23 @@ icarus_opreco_hit_slidingwindow.EndNSigmaThreshold:  1 # ADC threshold (N*pedeta
 icarus_opreco_hit_slidingwindow.MinPulseWidth:       2 # The width of a pulse needs to be equal or larger than this to be recorded
 icarus_opreco_hit_slidingwindow.Verbosity:           false
 
+
+icarus_opreco_hit_slidingwindow_201910: { # based on icarus_opreco_hit_slidingwindow
+  @table::standard_algo_slidingwindow
+  PositivePolarity:    false
+  NumPreSample:        5
+  NumPostSample:      10
+  ADCThreshold:       10 # ADC threshold (absolute) above pedestal mean to fire a pulse
+  NSigmaThreshold:     3 # ADC threshold (N*pedestal sigma) above pedestal mean to fire a pulse
+  TailADCThreshold:    6 # ADC threshold (absolute) below which next pulse is allowed to fire
+  TailNSigmaThreshold: 2 # ADC threshold (N*pedestal sigma) below which next pulse is allowed to fire
+  EndADCThreshold:     2 # ADC threshold (absolute) at which the pulse ends
+  EndNSigmaThreshold:  1 # ADC threshold (N*pedetal sigma) at which the pulse ends
+  MinPulseWidth:       5 # The width of a pulse needs to be equal or larger than this to be recorded
+  Verbosity:           false
+} # icarus_opreco_hit_slidingwindow_201910
+
+
 icarus_opreco_hit_cfd: @local::standard_algo_cfd
 icarus_opreco_hit_cfd.Fraction:    0.9
 icarus_opreco_hit_cfd.Delay:       2
@@ -77,7 +112,7 @@ icarus_opreco_hit_cfd.PeakThresh:  7.5
 icarus_opreco_hit_cfd.StartThresh: 5.0
 icarus_opreco_hit_cfd.EndThresh:   1.5
 
-icarus_ophit:
+icarus_ophit: # some basic configuration
 {
    module_type:    "OpHitFinder"
    GenModule:      "generator"
@@ -92,16 +127,26 @@ icarus_ophit:
                          # PE = arae / SPEArea + SPEShift
    UseStartTime:   true  # record pulse start time rather than peak (max) time
    reco_man:       @local::standard_preco_manager
-   HitAlgoPset:    @local::icarus_opreco_hit_slidingwindow
-   PedAlgoPset:    @local::icarus_opreco_pedestal_DocDB24969
+   HitAlgoPset:    @local::icarus_opreco_hit_slidingwindow_201910
+   PedAlgoPset:    @local::icarus_opreco_pedestal_MC_DocDB24969
 }
 
 icarus_ophitdebugger: @local::icarus_ophit
 icarus_ophitdebugger.module_type: "FullOpHitFinder"
 icarus_ophitdebugger.OutputFile:  "ophit_debug.root"
 
+# this is the "standard" ICARUS configuration for MC optical hit reconstruction:
+icarus_ophit_MC: @local::icarus_ophit
+icarus_ophit_MC.InputModule: "opdaq"
+
+icarus_ophitdebugger_MC: @local::icarus_ophit_MC
+icarus_ophitdebugger_MC.module_type: "FullOpHitFinder"
+icarus_ophitdebugger_MC.OutputFile:  "ophit_debug.root"
+
+# this is the "standard" ICARUS configuration for data optical hit reconstruction:
 icarus_ophit_data: @local::icarus_ophit
 icarus_ophit_data.InputModule: "daqPMT"
+icarus_ophit_data.PedAlgoPset: @local::icarus_opreco_pedestal_DocDB24969
 
 icarus_ophitdebugger_data: @local::icarus_ophit_data
 icarus_ophitdebugger_data.module_type: "FullOpHitFinder"


### PR DESCRIPTION
It has been decided to revert the optical hit baseline algorithm choice to the "old" one tuned a couple of years ago _only in simulation_, because the new one that works well with data does not do the same with simulation.

This pull request attempts to sever the two configurations (data and MC) by defining two template configurations (`icarus_ophit_data` and `icarus_ophit_MC`) that job configurations can pick appropriately.

As the name implies, this pull request is meant to be included in the release for the SBN2022A production.

## Stage 0 configurations

Stage0 configuration is by default designed for data, and optical reconstruction settings are taken from the "data" configuration (`icarus_ophit_data`). This was true also before this pull request, which effectively just introduces only the `MC` variant.
The Stage0 MC configuration is not as centralized as the data one, and the job configuration files do not draw from a configuration specific to MC, but rather used to implicitly use the data one (from Stage0 data configuration) and change the input tag (`daqPMT` → `opdaq`). Now that change has become a whole change in `ophit` module label settings (picking `icarus_ophit_MC` configuration).
This needs to happen _on each Stage0 MC file_, and **this pull request changes only `stage0_multiTPC_rawpmt_icarus_MC.fcl`**. The other Stage0 job configurations that do not derive from this one need to be updated. The only configuration that I am aware being used in the production, `stage0_multiTPC_icarus_MC.fcl`, is already served as it does derive from the aforementioned one.


