### PR TITLE
Fixed absolute trigger timestamp in trigger decoder

### DIFF
--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
@@ -19,12 +19,15 @@
 namespace {
   
   // ---------------------------------------------------------------------------
-  struct TimestampDumper { std::uint64_t timestamp; };
+  template <typename T = std::uint64_t>
+  struct TimestampDumper { T timestamp; };
   
-  TimestampDumper dumpTimestamp(std::uint64_t timestamp)
+  template <typename T>
+  TimestampDumper<T> dumpTimestamp(T timestamp)
     { return { timestamp }; }
   
-  std::ostream& operator<< (std::ostream& out, TimestampDumper wrapper) {
+  template <typename T>
+  std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
     std::uint64_t const timestamp = wrapper.timestamp;
     if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
       out << (timestamp / 1'000'000'000) << "."
@@ -123,6 +126,11 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << dumpTriggerCount(info.anyGateCountFromAnyPreviousTrigger)
       << " gates from any source have opened since"
     ;
+  if (info.WRtimeToTriggerTime != ExtraTriggerInfo::UnknownCorrection) {
+    out << "\nCorrection applied to the timestamps: "
+      << dumpTimestamp(info.WRtimeToTriggerTime);
+  }
+  
   
   return out;
 } // sbn::operator<< (ExtraTriggerInfo)

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
@@ -50,6 +50,10 @@ struct sbn::ExtraTriggerInfo {
   static constexpr std::uint64_t NoTimestamp
     = std::numeric_limits<std::uint64_t>::max();
   
+  /// Special timestamp correction value indicating an unknown correction.
+  static constexpr std::int64_t UnknownCorrection
+    = std::numeric_limits<std::int64_t>::max();
+  
   
   /// Type of this gate (`sbn::triggerSource::NBits` marks this object invalid).
   sbn::triggerSource sourceType { sbn::triggerSource::NBits };
@@ -132,6 +136,17 @@ struct sbn::ExtraTriggerInfo {
   
   /// @}
   // --- END ---- Additional timestamps ----------------------------------------
+  
+  
+  // --- BEGIN -- Decoding information -----------------------------------------
+  /// @name Decoding information
+  /// @{
+  
+  /// Correction added to the White Rabbit time to get the trigger time.
+  std::int64_t WRtimeToTriggerTime { UnknownCorrection };
+  
+  /// @}
+  // --- END ---- Decoding information -----------------------------------------
   
   
   /// Returns whether this object contains any valid information.

--- a/icaruscode/Decode/DataProducts/classes_def.xml
+++ b/icaruscode/Decode/DataProducts/classes_def.xml
@@ -19,7 +19,8 @@
   <!-- sbn::ExtraTriggerInfo -->
 
   <!--   class -->
-  <class name="sbn::ExtraTriggerInfo" ClassVersion="10" >
+  <class name="sbn::ExtraTriggerInfo" ClassVersion="11" >
+   <version ClassVersion="11" checksum="2691428079"/>
    <version ClassVersion="10" checksum="2751074963"/>
   </class>
   

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -153,7 +153,6 @@ namespace daq
     BeamGateInfoPtr fBeamGateInfo; 
     bool fDiagnosticOutput; //< Produces large number of diagnostic messages, use with caution!
     bool fDebug; //< Use this for debugging this tool
-    int fOffset; //< Use this to determine additional correction needed for TAI->UTC conversion from White Rabbit timestamps. Needs to be changed if White Rabbit firmware is changed and the number of leap seconds changes! 
     //Add in trigger data member information once it is selected, current LArSoft object likely not enough as is
     
     // uint64_t fLastTimeStamp = 0;
@@ -227,7 +226,6 @@ namespace daq
   {
     fDiagnosticOutput = pset.get<bool>("DiagnosticOutput", false);
     fDebug = pset.get<bool>("Debug", false);
-    fOffset = pset.get<long long int>("TimeOffset", 0);
     return;
   }
   


### PR DESCRIPTION
This is the twin pull request of #373, this one against `develop`.
This pull request includes those same changes (in fact, same commit), plus the removal of the vestigial `Offset` parameter, as announced in that very pull request.

Commit list, courtesy of `gh`:
- Fixed absolute trigger timestamp in trigger decoder
- Removed "Offset" configuration parameter from trigger decoder
