### PR TITLE
Feature/jskim crt hit reco timing shift

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -256,6 +256,7 @@ cafmaker.TrackMCSLabel: "pandoraTrackMCS"
 cafmaker.TrackRangeLabel: "pandoraTrackRange"
 cafmaker.CRTHitLabel: "crthit"
 cafmaker.CRTTrackLabel: "crttrack"
+cafmaker.CRTSimT0Offset: 1600000 # ns, https://github.com/SBNSoftware/icaruscode/blob/v09_37_02_01/icaruscode/CRT/crtsimmodules_icarus.fcl#L11
 cafmaker.TriggerLabel: "daqTrigger"
 cafmaker.FlashTrigLabel: "" # unavailable
 cafmaker.SimChannelLabel: "largeant"

--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -403,8 +403,8 @@ namespace crt {
       }      
       */
       /// Looking for data within +/- 3ms within trigger time stamp
-      /// Here t0 - trigger time -ve, only adding 1s makes the value +ve or -ve
-      //    if (std::fabs(int64_t(crtList[febdat_i]->fTs0 - m_trigger_timestamp) + 1e9) > fCrtWindow) continue;
+      /// Here t0 - trigger time -ve
+      //    if (std::fabs(int64_t(crtList[febdat_i]->fTs0 - m_trigger_timestamp)) > fCrtWindow) continue;
       if ( type == 'm'){
 	for(int chan=0; chan<32; chan++) {
 	  std::pair<double,double> const chg_cal = fChannelMap->getSideCRTCalibrationMap((int)crtList[febdat_i]->fMac5,chan);

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -49,8 +49,8 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(vector<art::Ptr<CRTDat
     char type   = fCrtutils->GetAuxDetType(adid);
 
     /// Looking for data within +/- 3ms within trigger time stamp
-    /// Here t0 - trigger time -ve, only adding 1s makes the value +ve or -ve
-    if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp) + 1e9) > fCrtWindow)) continue;
+    /// Here t0 - trigger time -ve
+    if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp)) > fCrtWindow)) continue;
     
     if ( type == 'm'){
       for(int chan=0; chan<32; chan++) {


### PR DESCRIPTION
This is a combined one of #377 and #378.
- There used to be a 1sec difference between the gate_start_timestamp and T0 of CRTHit, but this was updated in #373.
We now don't need manual shifts when applying the timing cuts on CRTData. This should be merged before the production starts.
- This is related to https://github.com/SBNSoftware/sbncode/pull/251. Using trigger timing information to convert CRT T0 timestamps to relative time. For this, trigger label is added, and also a MC default T0offset is set by a parameter.