### PR TITLE
Update WireCell configs

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/icarus/nf.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/nf.jsonnet
@@ -3,23 +3,29 @@
 local g = import 'pgraph.jsonnet';
 local wc = import 'wirecell.jsonnet';
 
-function(params, anode, chndbobj, n, name='')
+local default_dft = { type: 'FftwDFT' };
+
+function(params, anode, chndbobj, n, name='', dft=default_dft)
   {
 
     local single = {
       type: 'pdOneChannelNoise',
       name: name,
+      uses: [dft, chndbobj, anode],
       data: {
         noisedb: wc.tn(chndbobj),
         anode: wc.tn(anode),
+        dft: wc.tn(dft),
       },
     },
     local grouped = {
       type: 'mbCoherentNoiseSub',
       name: name,
+      uses: [dft, chndbobj, anode],
       data: {
         noisedb: wc.tn(chndbobj),
         anode: wc.tn(anode),
+        dft: wc.tn(dft),
         rms_threshold: 0.0,
       },
     },

--- a/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
@@ -127,9 +127,10 @@ base {
 
         fields: ["garfield-icarus-fnal-rev1.json.bz2"],
 
-	noise: ["icarus_noise_model_int_TPCEE.json.bz2","icarus_noise_model_int_TPCEW.json.bz2","icarus_noise_model_int_TPCWE.json.bz2","icarus_noise_model_int_TPCWW.json.bz2"],
-        coherent_noise: ["icarus_noise_model_coh_TPCEE.json.bz2","icarus_noise_model_coh_TPCEW.json.bz2","icarus_noise_model_coh_TPCWE.json.bz2","icarus_noise_model_coh_TPCWW.json.bz2"],
-
+       noise: ["icarus_noise_model_int_TPCEE.json.bz2","icarus_noise_model_int_TPCEW.json.bz2","icarus_noise_model_int_TPCWE.json.bz2","icarus_noise_model_int_TPCWW.json.bz2"],
+       // coherent_noise: ["icarus_noise_model_coh_TPCEE.json.bz2","icarus_noise_model_coh_TPCEW.json.bz2","icarus_noise_model_coh_TPCWE.json.bz2","icarus_noise_model_coh_TPCWW.json.bz2"],	
+	wiregroups: "icarus_group_to_channel_map.json.bz2",
+	noisegroups: ["icarus_noise_model_coh_by_board_TPCEE.json.bz2","icarus_noise_model_coh_by_board_TPCEW.json.bz2","icarus_noise_model_coh_by_board_TPCWE.json.bz2","icarus_noise_model_coh_by_board_TPCWW.json.bz2"],
         chresp: null,
     },
 

--- a/icaruscode/TPC/ICARUSWireCell/icarus/sim.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/sim.jsonnet
@@ -46,13 +46,14 @@ function(params, tools) {
         name: "empericalnoise-" + anode.name,
         data: {
             anode: wc.tn(anode),
+            dft: wc.tn(tools.dft),
             chanstat: if std.type(csdb) == "null" then "" else wc.tn(csdb),
             spectra_file: params.files.noise,
             nsamples: params.daq.nticks,
             period: params.daq.tick,
             wire_length_scale: 1.0*wc.cm, // optimization binning
         },
-        uses: [anode] + if std.type(csdb) == "null" then [] else [csdb],
+        uses: [anode, tools.dft] + if std.type(csdb) == "null" then [] else [csdb],
     },
     local noise_models = [make_noise_model(anode) for anode in tools.anodes],
 
@@ -62,10 +63,11 @@ function(params, tools) {
         name: "addnoise-" + model.name,
         data: {
             rng: wc.tn(tools.random),
+            dft: wc.tn(tools.dft),
             model: wc.tn(model),
 	    nsamples: params.daq.nticks,
             replacement_percentage: 0.02, // random optimization
-        }}, nin=1, nout=1, uses=[model]),
+        }}, nin=1, nout=1, uses=[tools.random, tools.dft, model]),
 
     local noises = [add_noise(model) for model in noise_models],
     

--- a/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
@@ -21,6 +21,7 @@ function(params, tools, override = {}) {
     data: {
       // Many parameters omitted here.
       anode: wc.tn(anode),
+      dft: wc.tn(tools.dft),
       field_response: wc.tn(tools.field),
       ftoffset: 0.0, // default 0.0
       ctoffset: 0.0*wc.microsecond, // default -8.0
@@ -68,6 +69,6 @@ function(params, tools, override = {}) {
       process_planes: [0, util.anode_split(anode.data.ident)], // balance the left and right split
 
     } + override,
-  }, nin=1, nout=1, uses=[anode, tools.field, tools.elec_resp] + pc.uses + spfilt),
+  }, nin=1, nout=1, uses=[anode, tools.dft, tools.field, tools.elec_resp] + pc.uses + spfilt),
 
 }

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-decode-to-sig.jsonnet
@@ -124,8 +124,8 @@ local chndb = [{
   type: 'OmniChannelNoiseDB',
   name: 'ocndbperfect%d' % n,
   // data: perfect(params, tools.anodes[n], tools.field, n),
-  data: base(params, tools.anodes[n], tools.field, n),
-  uses: [tools.anodes[n], tools.field],  // pnode extension
+  data: base(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
+  uses: [tools.anodes[n], tools.field, tools.dft],  // pnode extension
 } for n in std.range(0, std.length(tools.anodes) - 1)];
 
 local nf_maker = import 'pgrapher/experiment/icarus/nf.jsonnet';

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-omit-noise.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-omit-noise.jsonnet
@@ -123,8 +123,8 @@ local perfect = import 'pgrapher/experiment/icarus/chndb-base.jsonnet';
 local chndb = [{
   type: 'OmniChannelNoiseDB',
   name: 'ocndbperfect%d' % n,
-  data: perfect(params, tools.anodes[n], tools.field, n),
-  uses: [tools.anodes[n], tools.field],  // pnode extension
+  data: perfect(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
+  uses: [tools.anodes[n], tools.field, tools.dft],  // pnode extension
 } for n in anode_iota];
 
 

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-sim-drift-simchannel.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-sim-drift-simchannel.jsonnet
@@ -140,13 +140,14 @@ local make_noise_model = function(anode, csdb=null) {
     name: "empericalnoise-" + anode.name,
     data: {
         anode: wc.tn(anode),
+        dft: wc.tn(tools.dft),
         chanstat: if std.type(csdb) == "null" then "" else wc.tn(csdb),
         spectra_file: params.files.noise,
         nsamples: params.daq.nticks,
         period: params.daq.tick,
         wire_length_scale: 1.0*wc.cm, // optimization binning
     },
-    uses: [anode] + if std.type(csdb) == "null" then [] else [csdb],
+    uses: [anode, tools.dft] + if std.type(csdb) == "null" then [] else [csdb],
 };
 local noise_model = make_noise_model(mega_anode);
 local add_noise = function(model, n) g.pnode({
@@ -154,10 +155,11 @@ local add_noise = function(model, n) g.pnode({
     name: "addnoise%d-" %n + model.name,
     data: {
         rng: wc.tn(tools.random),
+        dft: wc.tn(tools.dft),
         model: wc.tn(model),
   nsamples: params.daq.nticks,
         replacement_percentage: 0.02, // random optimization
-    }}, nin=1, nout=1, uses=[model]);
+    }}, nin=1, nout=1, uses=[tools.random, tools.dft, model]);
 local noises = [add_noise(noise_model, n) for n in std.range(0,3)];
 
 // local digitizer = sim.digitizer(mega_anode, name="digitizer", tag="orig");

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wct-sim-check.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wct-sim-check.jsonnet
@@ -48,8 +48,8 @@ local perfect = import 'pgrapher/experiment/icarus/chndb-base.jsonnet';
 local chndb = [{
   type: 'OmniChannelNoiseDB',
   name: 'ocndbperfect%d' % n,
-  data: perfect(params, tools.anodes[n], tools.field, n),
-  uses: [tools.anodes[n], tools.field],  // pnode extension
+  data: perfect(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
+  uses: [tools.anodes[n], tools.field, tools.dft],  // pnode extension
 } for n in anode_iota];
 
 local nf_maker = import 'pgrapher/experiment/icarus/nf.jsonnet';
@@ -73,13 +73,14 @@ local make_noise_model = function(anode, csdb=null) {
     name: "empericalnoise-" + anode.name,
     data: {
         anode: wc.tn(anode),
+        dft: wc.tn(tools.dft),
         chanstat: if std.type(csdb) == "null" then "" else wc.tn(csdb),
         spectra_file: params.files.noise,
         nsamples: params.daq.nticks,
         period: params.daq.tick,
         wire_length_scale: 1.0*wc.cm, // optimization binning
     },
-    uses: [anode] + if std.type(csdb) == "null" then [] else [csdb],
+    uses: [anode, tools.dft] + if std.type(csdb) == "null" then [] else [csdb],
 };
 local noise_model = make_noise_model(mega_anode);
 local add_noise = function(model, n) g.pnode({
@@ -87,10 +88,11 @@ local add_noise = function(model, n) g.pnode({
     name: "addnoise%d-" %n + model.name,
     data: {
         rng: wc.tn(tools.random),
+        dft: wc.tn(tools.dft),
         model: wc.tn(model),
   nsamples: params.daq.nticks,
         replacement_percentage: 0.02, // random optimization
-    }}, nin=1, nout=1, uses=[model]);
+    }}, nin=1, nout=1, uses=[tools.random, tools.dft, model]);
 local noises = [add_noise(noise_model, n) for n in std.range(0,3)];
 
 // local digitizer = sim.digitizer(mega_anode, name="digitizer", tag="orig");


### PR DESCRIPTION
Updated wirecell configuration files to work with new Noise Model;

Extra changes involve adapting to the new WC version. Thus, should be merged ONLY with WC 0.18.1 (and corresponding larwirecell)

Noise mode comes in separate PR to icarus_data