### PR TITLE
Fix on key-value CSV file parser

### DIFF
--- a/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.cxx
+++ b/icaruscode/Decode/DecoderTools/details/KeyedCSVparser.cxx
@@ -103,17 +103,21 @@ void icarus::details::KeyedCSVparser::parse
     
     std::string tokenStr { cbegin(token), cend(token) };
     
-    // if there are values pending, this is not a key, period.
     bool bKey = false;
     do {
       
+      // if there are values pending, this is not a key, period;
+      // if all required values have been assigned, the next token is a key.
       if (forcedValues >= 0) {
         bKey = (forcedValues == 0); // if no more forced values, next is key
         --forcedValues;
-        break;
+        // if we know the token is a key, we still need to check for matching
+        // patterns to assign required values
+        if (!bKey) break;
       }
       
-      // if the key may still be a key
+      // the token may still be a key (if `bKey` is true, it is for sure: we can
+      // decide that a non-key (!bKey) is actually a key, but not the opposite)
       for (auto const& [ pattern, values ]: fPatterns) {
         if (!std::regex_match(begin(token), end(token), pattern)) continue;
         bKey = true; // matching a pattern implies this is a key

--- a/icaruscode/Decode/DecoderTools/triggerPacketParser.cxx
+++ b/icaruscode/Decode/DecoderTools/triggerPacketParser.cxx
@@ -35,7 +35,7 @@ boost::program_options::variables_map parseCommandLine(int argc, char** argv) {
   //
   // Declare the supported options.
   //
-  po::options_description inputopt("Inpot/output");
+  po::options_description inputopt("Input/output");
   inputopt.add_options()
     ("input", po::value<std::vector<std::string>>(), "input file")
     ;
@@ -130,7 +130,7 @@ int processTriggerData(std::string const& triggerString) {
       "hex64", {
           "Cryo1 EAST Connector 0 and 1"
         , "Cryo1 EAST Connector 2 and 3"
-        , "Cyo2 WEST Connector 0 and 1" // note the typo
+        , "Cryo2 WEST Connector 0 and 1"
         , "Cryo2 WEST Connector 2 and 3"
       }
     }


### PR DESCRIPTION
The key-value parser can be used to parse a string in the type of format that the trigger hardware uses to communicate its data.
The format is a comma-separated list of words, some of them are keys, and then their values follow.

The parser is intended to be generic and as such it needs some heuristic to figure out whether a work is a key or not. The heuristic currently implemented fails miserably when the value is a hexadecimal number starting with a letter (e.g. `deadbeef`), and to address this the parser allows to specify custom patterns declared to be keys, and how many values such key have.
For example, a string `Hex1, deadbeef, Hex2, a10e, Value, 9` can be parsed specifying that both `Hex1` and `Hex2` (regex pattern `Hex[12]`) are key requiring one value. If this step is omitted, `Hex1`, `deadbeef`, `Hex2` and `cafe` would all be processed as keys (with no associated value).

Now the bug: after the end of a special key and values (in that example, `Hex1` and `deadbeed`), an immediately following special key would not have its number of values honoured (in the example, `Hex2` would not be interpreted as requiring a mandatory value, and `a10e` would be interpreted as another key).

This commit fixes that bug.

Review notes: I recommend skipping the review, since a real review of the change requires detailed understanding of the algorithm and the algorithm itself is not that interesting to learn.
