### PR TITLE
Fixed faulty printout of sbn::ExtraTrigInfo

### DIFF
--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
@@ -28,7 +28,7 @@ namespace {
   
   template <typename T>
   std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
-    std::uint64_t const timestamp = wrapper.timestamp;
+    T const timestamp = wrapper.timestamp;
     if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
       out << (timestamp / 1'000'000'000) << "."
         << std::setfill('0') << std::setw(9) << (timestamp % 1'000'000'000)


### PR DESCRIPTION
Very minor fix (the time correction was 2-complemented when dumping the object to an output stream, instead of 36.0 it looked like 2⁶⁴/1e9 - 36).
Review not really needed.