### PR TITLE
Update CRTHit timing structure

### DIFF
--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -49,7 +49,7 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(vector<art::Ptr<CRTDat
     char type   = fCrtutils->GetAuxDetType(adid);
 
     /// Looking for data within +/- 3ms within trigger time stamp
-    /// Here t0 - trigger time -ve, only adding 1s makes the value +ve or -ve
+    /// Here t0 - trigger time -ve
     if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp)) > fCrtWindow)) continue;
     
     if ( type == 'm'){

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -50,7 +50,7 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(vector<art::Ptr<CRTDat
 
     /// Looking for data within +/- 3ms within trigger time stamp
     /// Here t0 - trigger time -ve, only adding 1s makes the value +ve or -ve
-    if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp) + 1e9) > fCrtWindow)) continue;
+    if (fData && (std::fabs(int64_t(crtList[febdat_i]->fTs0 - trigger_timestamp)) > fCrtWindow)) continue;
     
     if ( type == 'm'){
       for(int chan=0; chan<32; chan++) {
@@ -260,9 +260,9 @@ sbn::crt::CRTHit CRTHitRecoAlg::FillCRTHit(vector<uint8_t> tfeb_id, map<uint8_t,
     crtHit.pesmap      = tpesmap;
     crtHit.peshit      = peshit;
     crtHit.ts0_s_corr  = time0 / 1'000'000'000; 
-    crtHit.ts0_ns      = time0;
+    crtHit.ts0_ns      = time0 % 1'000'000'000;
     crtHit.ts0_ns_corr = time0; 
-    crtHit.ts1_ns      = time1;
+    crtHit.ts1_ns      = time1 % 1'000'000'000;
     crtHit.ts0_s       = time0 / 1'000'000'000;
     crtHit.plane       = plane;
     crtHit.x_pos       = x;


### PR DESCRIPTION
This PR is related to https://github.com/SBNSoftware/sbnobj/pull/52.
- When looking at https://github.com/SBNSoftware/sbnobj/blob/v09_13_12/sbnobj/Common/CRT/CRTHit.hh#L49-L50, `sbn::crt::CRTHit::ts0_ns` and `sbn::crt::CRTHit::ts1_ns` should be the last 9 digits of the full timestamp in ns, but we've been saving the entire timestamp to them. This is fixed in this PR.
- Also, the 1 second shift in the trigger time is (or will be? @jzettle) fixed in the recent data, so the corresponding manual-shift is removed in the CRTHit reconstruction. This part has been already applied in the [release/SBN2022A](https://github.com/SBNSoftware/icaruscode/tree/release/SBN2022A) branch by https://github.com/SBNSoftware/icaruscode/pull/384.