### PR TITLE
Update CRTHit timing structure; tsN_ns now only saves the last 9 digi…

### DIFF
--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -260,9 +260,9 @@ sbn::crt::CRTHit CRTHitRecoAlg::FillCRTHit(vector<uint8_t> tfeb_id, map<uint8_t,
     crtHit.pesmap      = tpesmap;
     crtHit.peshit      = peshit;
     crtHit.ts0_s_corr  = time0 / 1'000'000'000; 
-    crtHit.ts0_ns      = time0;
+    crtHit.ts0_ns      = time0 % 1'000'000'000;
     crtHit.ts0_ns_corr = time0; 
-    crtHit.ts1_ns      = time1;
+    crtHit.ts1_ns      = time1 % 1'000'000'000;
     crtHit.ts0_s       = time0 / 1'000'000'000;
     crtHit.plane       = plane;
     crtHit.x_pos       = x;


### PR DESCRIPTION
This is same as https://github.com/SBNSoftware/icaruscode/pull/396, but based on [release/SBN2022A](https://github.com/SBNSoftware/icaruscode/tree/release/SBN2022A). Also the related PR is created in `sbnobj` : https://github.com/SBNSoftware/sbnobj/pull/54