### PR TITLE
Include CRTHits in calibration ntuples

### DIFF
--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -200,6 +200,8 @@ namespace crt {
     vector<vector<int>> fDetPDG; /// signal inducing particle(s)' PDG code
 
     //CRT hit product vars
+    int      fHitRun;
+    int      fHitSubRun;
     int      fHitEvent;
     float    fXHit; ///< reconstructed X position of CRT hit (cm)
     float    fYHit; ///< reconstructed Y position of CRT hit (cm)
@@ -321,6 +323,8 @@ namespace crt {
     fDAQNtuple->Branch("gate_start_timestamp", &m_gate_start_timestamp, "gate_start_timestamp/l");
 
     // Define the branches of our SimHit n-tuple
+    fHitNtuple->Branch("Run",         &fHitRun,         "Run/I");
+    fHitNtuple->Branch("SubRun",      &fHitSubRun,      "SubRun/I");
     fHitNtuple->Branch("event",       &fHitEvent,    "event/I");
     fHitNtuple->Branch("nHit",        &fNHit,        "nHit/I");
     fHitNtuple->Branch("x",           &fXHit,        "x/F");
@@ -484,6 +488,8 @@ namespace crt {
       for ( auto const& hit : *crtHitHandle )
         {
 	  fNHit++;
+	  fHitRun = fRun;
+	  fHitSubRun = fSubRun;
 	  fHitEvent = fEvent;
 	  fXHit    = hit.x_pos;
 	  fYHit    = hit.y_pos;

--- a/icaruscode/Decode/fcl/stage1_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage1_icarus_defs.fcl
@@ -77,6 +77,17 @@ icarus_stage1_analyzers:
   caloskimE: @local::caloskim_cryoe_nodigits_goldentracks
   caloskimW: @local::caloskim_cryow_nodigits_goldentracks
   simpleLightAna: @local::ICARUSFlashAssAna
+  CRTDataAnalysis: 
+  {
+    module_type:   "CRTDataAnalysis"
+    CRTHitLabel:   "crthit"
+    CRTDAQLabel:   "daqCRT"
+    TriggerLabel:  "daqTrigger"
+    QPed:                 60     # Pedestal offset [ADC]
+    QSlope:               70     # Pedestal slope [ADC/photon]
+    PEThresh:             7.5    # PE threshold above which charge amplitudes used
+    CrtWindow:            3e6    # time window for looking data within trigger timestamp [ns]
+  }
 }
 
 icarus_stage1_analyzers.caloskimE.SelectEvents: [reco]

--- a/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss.fcl
@@ -9,7 +9,7 @@ physics.reco: [ flashfilter,
                 @sequence::icarus_crthit,
                 caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
 
-physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
 physics.trigger_paths:     [ reco ]
 physics.end_paths:         [ outana, stream1 ]
 outputs.out1.fileName:     "%ifb_%tc-%p.root"

--- a/icaruscode/Decode/fcl/stage1_multiTPC_nofilter_icarus_gauss.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_nofilter_icarus_gauss.fcl
@@ -8,7 +8,7 @@ physics.reco: [ @sequence::icarus_filter_cluster3D,
                 @sequence::icarus_crthit,
                 caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
 
-physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
 physics.trigger_paths:     [ reco ]
 physics.end_paths:         [ outana, stream1 ]
 outputs.out1.fileName:     "%ifb_%tc-%p.root"


### PR DESCRIPTION
This pull request adds the CRTHit information into the calibration ntuples using a CRTDataAnalysis module that was already in place from the ICARUS CRT group. The solution might be a bit klugey due to my fcl inexperience. Will happily take suggestions but this worked on the stage1 processing on a BNB data file from ICARUS, run 7926 on both stage1 fcl paths tested and could access CRTHit information. Adding people I think would want to know about this as reviewers.