### PR TITLE
CRTHit Trees in calibration ntuples [release/SBN2022A]

### DIFF
--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -199,6 +199,8 @@ namespace crt {
     vector<vector<int>> fDetPDG; /// signal inducing particle(s)' PDG code
 
     //CRT hit product vars
+    int      fHitRun;
+    int      fHitSubRun;
     int      fHitEvent;
     float    fXHit; ///< reconstructed X position of CRT hit (cm)
     float    fYHit; ///< reconstructed Y position of CRT hit (cm)
@@ -320,6 +322,8 @@ namespace crt {
     fDAQNtuple->Branch("gate_start_timestamp", &m_gate_start_timestamp, "gate_start_timestamp/l");
 
     // Define the branches of our SimHit n-tuple
+    fHitNtuple->Branch("Run",         &fHitRun,         "Run/I");
+    fHitNtuple->Branch("SubRun",      &fHitSubRun,      "SubRun/I");
     fHitNtuple->Branch("event",       &fHitEvent,    "event/I");
     fHitNtuple->Branch("nHit",        &fNHit,        "nHit/I");
     fHitNtuple->Branch("x",           &fXHit,        "x/F");
@@ -483,6 +487,8 @@ namespace crt {
       for ( auto const& hit : *crtHitHandle )
         {
 	  fNHit++;
+	  fHitRun = fRun;
+	  fHitSubRun = fSubRun;
 	  fHitEvent = fEvent;
 	  fXHit    = hit.x_pos;
 	  fYHit    = hit.y_pos;

--- a/icaruscode/Decode/fcl/stage1_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage1_icarus_defs.fcl
@@ -77,6 +77,19 @@ icarus_stage1_analyzers:
   caloskimE: @local::caloskim_cryoe_nodigits_goldentracks
   caloskimW: @local::caloskim_cryow_nodigits_goldentracks
   simpleLightAna: @local::ICARUSFlashAssAna
+  
+  CRTDataAnalysis:
+  {
+    module_type:   "CRTDataAnalysis"
+    CRTHitLabel:   "crthit"
+    CRTDAQLabel:   "daqCRT"
+    TriggerLabel:  "daqTrigger"
+    QPed:                 60     # Pedestal offset [ADC]
+    QSlope:               70     # Pedestal slope [ADC/photon]
+    PEThresh:             7.5    # PE threshold above which charge amplitudes used
+    CrtWindow:            3e6    # time window for looking data within trigger timestamp [ns]
+  }
+
 }
 
 icarus_stage1_analyzers.caloskimE.SelectEvents: [reco]

--- a/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_icarus_gauss.fcl
@@ -9,7 +9,7 @@ physics.reco: [ flashfilter,
                 @sequence::icarus_crthit,
                 caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
 
-physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
 physics.trigger_paths:     [ reco ]
 physics.end_paths:         [ outana, stream1 ]
 outputs.out1.fileName:     "%ifb_%tc-%p.root"

--- a/icaruscode/Decode/fcl/stage1_multiTPC_nofilter_icarus_gauss.fcl
+++ b/icaruscode/Decode/fcl/stage1_multiTPC_nofilter_icarus_gauss.fcl
@@ -8,7 +8,7 @@ physics.reco: [ @sequence::icarus_filter_cluster3D,
                 @sequence::icarus_crthit,
                 caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
 
-physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
 physics.trigger_paths:     [ reco ]
 physics.end_paths:         [ outana, stream1 ]
 outputs.out1.fileName:     "%ifb_%tc-%p.root"


### PR DESCRIPTION
Identical changes to https://github.com/SBNSoftware/icaruscode/pull/399 but changes made to release/2022A branch so this is included in production. Tested again on a few events in ICARUS BNB data file, run 7926 and able to print out information from CRTHits.