### PR TITLE
Update of CRT Hit Reconstruction: Top CRT TS0 corrected for fiber pro…

### DIFF
--- a/icaruscode/CRT/CRTCalibrationAnalysis_module.cc
+++ b/icaruscode/CRT/CRTCalibrationAnalysis_module.cc
@@ -128,7 +128,7 @@ namespace crt {
     auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
     fTriggerOffset = trigger_offset(clockData);
 
-    for(int i=1; i<94; i++){
+    for(int i=1; i<232; i++){
       
       macToHistos[i] = new vector<TH1F*>();
       

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -986,8 +986,8 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(vector<art::Ptr<CRTData>> coinData) 
     //    t1hit = std::accumulate(t1trigs.begin(), t1trigs.end()) / (uint64_t)t1trigs.size();
 
     for(uint64_t const t : ttrigs){
-      if (region=="North" || region=="South") /*thit += t;*/ thit += t-uint64_t(200.*fPropDelay);
-      else /*thit += t;*/thit += t-uint64_t(400.*fPropDelay);
+      if (region=="North" || region=="South") /*thit += t;*/ thit += t-uint64_t(200.*fPropDelay)-fSiPMtoFEBdelay;
+      else /*thit += t;*/thit += t-uint64_t(400.*fPropDelay)-fSiPMtoFEBdelay;
       //thit += t;
       //thit += t-uint64_t(400.*fPropDelay);
       if (fVerbose) 
@@ -998,7 +998,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(vector<art::Ptr<CRTData>> coinData) 
     thit=thit/uint64_t(ttrigs.size());
 
     for(double const t1 : t1trigs)
-      t1hit +=   t1-uint64_t(400.*fPropDelay);
+      t1hit +=   t1-uint64_t(400.*fPropDelay)-fSiPMtoFEBdelay;
          
 
     t1hit=t1hit/uint64_t(t1trigs.size());

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -29,6 +29,7 @@ void CRTHitRecoAlg::reconfigure(const Config& config){
     fPEThresh = config.PEThresh();
     ftopGain = config.topGain();
     ftopPed = config.topPed();
+    fSiPMtoFEBdelay = config.SiPMtoFEBdelay();
     fCoinWindow = config.CoinWindow();
     fCrtWindow = config.CrtWindow();
     foutCSVFile = config.outCSVFile();
@@ -372,14 +373,14 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeTopHit(art::Ptr<CRTData> data){
     if(adsid_max<8){
         thit -= (uint64_t)round(abs((92+hitpos.X())*fPropDelay));
         thit1 -= (uint64_t)round(abs((92+hitpos.X())*fPropDelay));
-	thit -= 11; //Correction for 11 ns signal cable from SiPM to FEB
-	thit1 -= 11; //Correction for 11 ns signal cable from SiPM to FEB
+	thit -= fSiPMtoFEBdelay; //Correction for 12 ns signal cable from SiPM to FEB
+	thit1 -= fSiPMtoFEBdelay; //Correction for 12 ns signal cable from SiPM to FEB
     }
     else{
         thit -= (uint64_t)round(abs((92+hitpos.Z())*fPropDelay));
         thit1 -= (uint64_t)round(abs((92+hitpos.Z())*fPropDelay));
-	thit -= 11; //Correction for 11 ns signal cable from SiPM to FEB
-	thit1 -= 11; //Correction for 11 ns signal cable from SiPM to FEB
+	thit -= fSiPMtoFEBdelay; //Correction for 12 ns signal cable from SiPM to FEB
+	thit1 -= fSiPMtoFEBdelay; //Correction for 12 ns signal cable from SiPM to FEB
     }
  
     adGeo.LocalToWorld(hitlocal,hitpoint); //tranform from module to world coords

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -115,6 +115,14 @@ class icarus::crt::CRTHitRecoAlg {
       Name("PEThresh"),
 	Comment("threshold in photoelectrons above which charge amplitudes used in hit reco")
 	};
+    fhicl::Atom<double> topGain {
+      Name("topGain"),
+        Comment("Dummy Gain value for Top CRT")
+        };
+    fhicl::Atom<double> topPed {
+      Name("topPed"),
+        Comment("Dummy Pedestal value for Top CRT")
+        };
     fhicl::Atom<uint64_t> CoinWindow {
       Name("CoinWindow"),
 	Comment("window for finding side CRT trigger coincidences [ns]")
@@ -161,6 +169,8 @@ class icarus::crt::CRTHitRecoAlg {
   double fQSlope;         ///< Pedestal slope of SiPMs [ADC/photon]
   double fPropDelay;      ///< propegation time [ns/cm]
   double fPEThresh;       ///< threshold[PE] above which charge amplitudes used in hit reco
+  double ftopGain;        ///< Dummy Top CRT Gain Value
+  double ftopPed;         ///< Dummy Top CRT Pedestal Value
   uint64_t fCoinWindow;   ///< Coincidence window used for grouping side CRT triggers [ns]
   uint64_t fCrtWindow;    ///< Looking data window within trigger timestamp [ns]
   std::ofstream filecsv;

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -123,6 +123,10 @@ class icarus::crt::CRTHitRecoAlg {
       Name("topPed"),
         Comment("Dummy Pedestal value for Top CRT")
         };
+    fhicl::Atom<double> SiPMtoFEBdelay {
+      Name("SiPMtoFEBdelay"),
+	Comment("Delay for SiPM to FEB signal correction 11.6 [ns]")
+	};
     fhicl::Atom<uint64_t> CoinWindow {
       Name("CoinWindow"),
 	Comment("window for finding side CRT trigger coincidences [ns]")
@@ -171,6 +175,7 @@ class icarus::crt::CRTHitRecoAlg {
   double fPEThresh;       ///< threshold[PE] above which charge amplitudes used in hit reco
   double ftopGain;        ///< Dummy Top CRT Gain Value
   double ftopPed;         ///< Dummy Top CRT Pedestal Value
+  double fSiPMtoFEBdelay; ///< SiPM to FEB cable induced delay: 11.6 [ns]
   uint64_t fCoinWindow;   ///< Coincidence window used for grouping side CRT triggers [ns]
   uint64_t fCrtWindow;    ///< Looking data window within trigger timestamp [ns]
   std::ofstream filecsv;

--- a/icaruscode/CRT/crthitproducer_icarus.fcl
+++ b/icaruscode/CRT/crthitproducer_icarus.fcl
@@ -30,9 +30,6 @@ source:
   maxEvents:  -1 
 }
 
-services.Geometry.GDML: "icarus_complete_overburden_20220518.gdml"
-services.Geometry.ROOT: "icarus_complete_overburden_20220518.gdml"
-
 # This is empty, because we're not writing an output file with art::Event objects.
 outputs:
 {

--- a/icaruscode/CRT/crthitproducer_icarus.fcl
+++ b/icaruscode/CRT/crthitproducer_icarus.fcl
@@ -30,6 +30,9 @@ source:
   maxEvents:  -1 
 }
 
+services.Geometry.GDML: "icarus_complete_overburden_20220518.gdml"
+services.Geometry.ROOT: "icarus_complete_overburden_20220518.gdml"
+
 # This is empty, because we're not writing an output file with art::Event objects.
 outputs:
 {

--- a/icaruscode/CRT/crtsimhitproducer.fcl
+++ b/icaruscode/CRT/crtsimhitproducer.fcl
@@ -8,6 +8,9 @@ standard_crtsimhitrecoalg:
     UseReadoutWindow:     false  # Only reconstruct hits within readout window
     PropDelay:            0.062 # group velocity in WLS fiber [ns/cm]
     PEThresh:             7.5    # PE threshold above which charge amplitudes used
+    topGain:              110    # Dummy value for Top CRT Gain [ADC]
+    topPed:		  160    # Dummy value for Top CRT Pedestal [ADC]
+    SiPMtoFEBdelay:       0      # Delay correction for signal propagation from SiPM to FEB, set 0 for Simulation, tbd [ns] 
     CoinWindow:           150    # time window for finding side CRT trigger coincidences [ns]
     CrtWindow:            3e6    # time window for looking data within trigger timestamp [ns]
     outCSVFile:           false  # write the information in to a csv file

--- a/icaruscode/CRT/crtsimhitproducer.fcl
+++ b/icaruscode/CRT/crtsimhitproducer.fcl
@@ -23,7 +23,7 @@ standard_crthitrecoalg:
     QSlope:               70     # Pedestal slope [ADC/photon]
     topGain:              110    # Dummy value for Top CRT Gain [ADC]
     topPed:               160    # Dummy value for Top CRT Pedestal [ADC]
-    SiPMtoFEBdelay        12     # Delay correction for signal propagation from SiPM to FEB, measured value is 11.6 [ns]
+    SiPMtoFEBdelay:        12     # Delay correction for signal propagation from SiPM to FEB, measured value is 11.6 [ns]
     UseReadoutWindow:     false  # Only reconstruct hits within readout window
     PropDelay:            0.062 # group velocity in WLS fiber [ns/cm]
     PEThresh:             7.5    # PE threshold above which charge amplitudes used

--- a/icaruscode/CRT/crtsimhitproducer.fcl
+++ b/icaruscode/CRT/crtsimhitproducer.fcl
@@ -21,6 +21,8 @@ standard_crthitrecoalg:
     Verbose:              false  # dump runtime info
     QPed:                 60     # Pedestal offset [ADC]
     QSlope:               70     # Pedestal slope [ADC/photon]
+    topGain:              110    # Dummy value for Top CRT Gain [ADC]
+    topPed:               160    # Dummy value for Top CRT Pedestal [ADC]
     UseReadoutWindow:     false  # Only reconstruct hits within readout window
     PropDelay:            0.062 # group velocity in WLS fiber [ns/cm]
     PEThresh:             7.5    # PE threshold above which charge amplitudes used

--- a/icaruscode/CRT/crtsimhitproducer.fcl
+++ b/icaruscode/CRT/crtsimhitproducer.fcl
@@ -23,6 +23,7 @@ standard_crthitrecoalg:
     QSlope:               70     # Pedestal slope [ADC/photon]
     topGain:              110    # Dummy value for Top CRT Gain [ADC]
     topPed:               160    # Dummy value for Top CRT Pedestal [ADC]
+    SiPMtoFEBdelay        12     # Delay correction for signal propagation from SiPM to FEB, measured value is 11.6 [ns]
     UseReadoutWindow:     false  # Only reconstruct hits within readout window
     PropDelay:            0.062 # group velocity in WLS fiber [ns/cm]
     PEThresh:             7.5    # PE threshold above which charge amplitudes used


### PR DESCRIPTION
…pagation, TS1 included in HitTree, TS0/TS1 corrected SiPM to FEB delay, Dummy Gain/Pedestal for Top CRT included in fcl files (crtsimhitproducer.fcl)