### PR TITLE
Included new version of trigger decoder framework in development release

### DIFF
--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -47,8 +47,16 @@ namespace sbn {
     // --- BEGIN -- Generic bit functions --------------------------------------
     /// @name Generic bit functions
     /// @{
+    //template <typename EnumType>
+    //using mask_t = std::underlying_type_t<EnumType>;
+    
     template <typename EnumType>
-    using mask_t = std::underlying_type_t<EnumType>;
+      struct mask_t {
+	using bits_t = EnumType; ///< Enumeration type of the bits.
+	using maskbits_t = std::underlying_type_t<EnumType>; ///< Bit data type.   
+	maskbits_t bits { 0 };
+	operator maskbits_t() const { return bits; }
+      }; // mask_t   
     
     /// Returns the value of specified `bit` (conversion like `enum` to `int`).
     template <typename EnumType>
@@ -86,60 +94,87 @@ namespace sbn {
       NuMI,        ///< Type of beam: NuMI.
       OffbeamBNB,  ///< Type of Offbeam: BNB
       OffbeamNuMI, ///< Type of Offbeam: NuMI
-      Calibration, ///< Type of source: calibration trigger
+      Calib,     ///< Type of Offbeam: Calibration
       // ==> add here if more are needed <==
       NBits    ///< Number of bits currently supported.
     }; // triggerSource
+
+    /// Type of mask with `triggerSource` bits.                                                                                 
+    using triggerSourceMask = mask_t<triggerSource>;
+
     
-    /// Returns a mnemonic short name of the beam type.
-    std::string bitName(triggerSource bit);
-
-
-    /// Location of the trigger inside the detector 
+    /// Location or locations generating a trigger.                                                                                 
     enum class triggerLocation: unsigned int {
-      CryoEast,   ///< Identification of the East cryostat 
-      CryoWest,   ///< Identification of the West cryostat 
-      // ==> add here if more are needed <==
-      NBits       ///< Number of Bits currently supported 
-    }; // triggerLocation 
+        CryoEast,    ///< A trigger happened in the east cryostat.
+	CryoWest,    ///< A trigger happened in the west cryostat.
+	TPCEE,       ///< A trigger happened in the east cryostat, east TPC.
+	TPCEW,       ///< A trigger happened in the east cryostat, west TPC.
+	TPCWE,       ///< A trigger happened in the west cryostat, east TPC.
+	TPCWW,       ///< A trigger happened in the west cryostat, west TPC.   
+	// ==> add here if more are needed <==
+	NBits    ///< Number of bits currently supported. 
+	}; // triggerLocation                    
+                                                                                 
+    /// Type of mask with `triggerLocation` bits.
+    using triggerLocationMask = mask_t<triggerLocation>;
 
+    /// Type representing the type(s) of this trigger.
+    enum class triggerType: unsigned int {
+        Majority,    ///< A minimum number of close-by PMT pairs above threshold was reached.
+	MinimumBias, ///< Data collected at gate opening with no further requirement imposed.
+	// ==> add here if more are needed <==
+	NBits    ///< Number of bits currently supported.
+	}; // triggerType
+
+    /// Type of mask with `triggerType` bits. 
+    using triggerTypeMask = mask_t<triggerType>;
+    
     /// Trigger window mode 
     enum class triggerWindowMode: unsigned int {
       Separated,    ///< Separated, non-overlapping contigous window
-      Overlapping,  ///< Overlaping windows
-      //==> add here if more are needed <==
-      NBits     ///< Number of Bits currently supported
-    };
+	Overlapping,  ///< Overlaping windows
+	//==> add here if more are needed <==
+	NBits     ///< Number of Bits currently supported
+	};
 
-    /// Returns a mnemonic short name for the trigger window mode.
-    std::string bitName(triggerWindowMode bit);
+    
 
     /// Enabled gates in the trigger configuration. See register 0X00050008 in docdb SBN-doc-23778-v1
     enum class gateSelection: unsigned int {
       GateBNB,                     ///<Enable receiving BNB early warning signal (gatedBES) to open BNB gates 
-      DriftGateBNB,                ///<Enable BNB early-early warning signal ($1D) for light out-of-time in BNB gates
-      GateNuMI,                    ///<Enable NuMI early warning signal (MIBS$74) to open NuMI gates 
-      DriftGateNuMI,               ///<Enable receiving NuMI early-early warning signal ($AD) for light out-of-time in NuMI gates
-      GateOffbeamBNB,              ///<Enable Offbeam gate for BNB 
-      DriftGateOffbeamBNB,         ///<Enable Offbeam drift gate BNB (for light out-of-time in offbeam gates)
-      GateOffbeamNuMI,             ///<Enable Offbeam gate for NuMI 
-      DriftGateOffbeamNuMI,        ///<Enable Offbeam drift gate NuMI (for light out-of-time in offbeam gates)
-      GateCalibration,             ///<Enable Calibration gate  
-      DriftGateCalibration,        ///<Enable Calibration drift gate (for light out-of-time in calibration gates)
-      MinbiasGateBNB,              ///<Enable MinBias triggers for the BNB stream 
-      MinbiasGateNuMI,             ///<Enable MinBias triggers for the NuMI stream 
-      MinbiasGateOffbeamBNB,       ///<Enabke MinBias triggers for the Offbeam BNB stream
-      MinbiasGateOffbeamNuMI,      ///<Enable MinBias triggers for the Offbeam NuMI stream
-      MinbiasGateCalibration,      ///<Enable MinBias triggers for the Calibration stream
-      MinbiasDriftGateBNB,         ///<Enable light out-of-time for MinBias triggers in BNB stream
-      MinbiasDriftGateNuMI,        ///<Enable light out-of-time for MinBias triggers in NuMI stream
-      MinbiasDriftGateOffbeamBNB,  ///<Enable light out-of-time for MinBias triggers in Offbeam BNB stream 
-      MinbiasDriftGateOffbeamNuMI, ///<Enable light out-of-time for MinBias triggers in Offbeam NuMI stream
-      MinbiasDriftGateCalibration, ///<Enable light out-of-time for MinBias triggers in Calibration stream
-      // ==> add here if more are needed <==
+	DriftGateBNB,                ///<Enable BNB early-early warning signal ($1D) for light out-of-time in BNB gates
+	GateNuMI,                    ///<Enable NuMI early warning signal (MIBS$74) to open NuMI gates 
+	DriftGateNuMI,               ///<Enable receiving NuMI early-early warning signal ($AD) for light out-of-time in NuMI gates
+	GateOffbeamBNB,              ///<Enable Offbeam gate for BNB 
+	DriftGateOffbeamBNB,         ///<Enable Offbeam drift gate BNB (for light out-of-time in offbeam gates)
+	GateOffbeamNuMI,             ///<Enable Offbeam gate for NuMI 
+	DriftGateOffbeamNuMI,        ///<Enable Offbeam drift gate NuMI (for light out-of-time in offbeam gates)
+	GateCalibration,             ///<Enable Calibration gate  
+	DriftGateCalibration,        ///<Enable Calibration drift gate (for light out-of-time in calibration gates)
+	MinbiasGateBNB,              ///<Enable MinBias triggers for the BNB stream 
+	MinbiasGateNuMI,             ///<Enable MinBias triggers for the NuMI stream 
+	MinbiasGateOffbeamBNB,       ///<Enabke MinBias triggers for the Offbeam BNB stream
+	MinbiasGateOffbeamNuMI,      ///<Enable MinBias triggers for the Offbeam NuMI stream
+	MinbiasGateCalibration,      ///<Enable MinBias triggers for the Calibration stream
+	MinbiasDriftGateBNB,         ///<Enable light out-of-time for MinBias triggers in BNB stream
+	MinbiasDriftGateNuMI,        ///<Enable light out-of-time for MinBias triggers in NuMI stream
+	MinbiasDriftGateOffbeamBNB,  ///<Enable light out-of-time for MinBias triggers in Offbeam BNB stream 
+	MinbiasDriftGateOffbeamNuMI, ///<Enable light out-of-time for MinBias triggers in Offbeam NuMI stream
+	MinbiasDriftGateCalibration, ///<Enable light out-of-time for MinBias triggers in Calibration stream
+	// ==> add here if more are needed <==
       NBits
-    }; // gateSelection
+	}; // gateSelection
 
+    using gateSelectionMask = mask_t<gateSelection>;
+
+    /// Returns a mnemonic short name of the beam type.
+    std::string bitName(triggerSource bit);
+    /// Returns a mnemonic short name of the trigger location.
+    std::string bitName(triggerLocation bit);
+    /// Returns a mnemonic short name of the trigger type.
+    std::string bitName(triggerType bit);
+    /// Returns a mnemonic short name for the trigger window mode.
+    std::string bitName(triggerWindowMode bit);
     /// Returns a mnemonic short name for the trigger window mode.
     std::string bitName(gateSelection bit);
 
@@ -149,7 +184,11 @@ namespace sbn {
   } // namespace bits
   
   using bits::triggerSource; // import symbol
+  using bits::triggerSourceMask;
+  using bits::triggerType;
+  using bits::triggerTypeMask;
   using bits::triggerLocation;
+  using bits::triggerLocationMask;
   using bits::triggerWindowMode;
   using bits::gateSelection;
   
@@ -171,7 +210,7 @@ constexpr auto sbn::bits::mask(EnumType bit, OtherBits... otherBits)
 {
   unsigned int m { 1U << value(bit) };
   if constexpr(sizeof...(OtherBits) > 0U) m |= mask(otherBits...);
-  return m;
+  return { m };
 } // sbn::mask()
 
 
@@ -221,24 +260,54 @@ inline std::string sbn::bits::bitName(triggerSource bit) {
     case triggerSource::NuMI:        return "NuMI"s;
     case triggerSource::OffbeamBNB:  return "OffbeamBNB"s;
     case triggerSource::OffbeamNuMI: return "OffbeamNuMI"s;
-    case triggerSource::Calibration: return "Calibration"s;
+    case triggerSource::Calib:       return "Calib"s;
     case triggerSource::NBits:       return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerSource{ "s
     + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
 
+// -----------------------------------------------------------------------------                                              
+
+inline std::string sbn::bits::bitName(triggerLocation bit) {
+
+  using namespace std::string_literals;
+  switch (bit) {
+  case triggerLocation::CryoEast: return "Cryo E"s;
+  case triggerLocation::CryoWest: return "Cryo W"s;
+  case triggerLocation::TPCEE:    return "TPC EE"s;
+  case triggerLocation::TPCEW:    return "TPC EW"s;
+  case triggerLocation::TPCWE:    return "TPC WE"s;
+  case triggerLocation::TPCWW:    return "TPC WW"s;
+  case triggerLocation::NBits:    return "<invalid>"s;
+  } // switch 
+  throw std::runtime_error("sbn::bits::bitName(triggerLocation{ "s
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName(triggerLocation)                                                                                                
+
+// -----------------------------------------------------------------------------                                  
+inline std::string sbn::bits::bitName(triggerType bit) {
+
+  using namespace std::string_literals;
+  switch (bit) {
+  case triggerType::Majority:    return "majority"s;
+  case triggerType::MinimumBias: return "minimum bias"s;
+  case triggerType::NBits:       return "<invalid>"s;
+  } // switch
+  throw std::runtime_error("sbn::bits::bitName(triggerType{ "s
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName(triggerType)
 
 inline std::string sbn::bits::bitName(triggerWindowMode bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-    case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
-    case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
-    case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
+  case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
+  case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
+  case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerWindowMode{ "s
-    + std::to_string(value(bit)) + " }): unknown bit"s);
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
 } // triggerWindowMode
 
 
@@ -246,34 +315,31 @@ inline std::string sbn::bits::bitName(gateSelection bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-    case gateSelection::GateBNB:                     return "GateBNB"s;
-    case gateSelection::DriftGateBNB:                return "DriftGateBNB"s;
-    case gateSelection::GateNuMI:                    return "GateNuMI"s;
-    case gateSelection::DriftGateNuMI:               return "DriftGateNuMI"s;
-    case gateSelection::GateOffbeamBNB:              return "GateOffbeamBNB"s;
-    case gateSelection::DriftGateOffbeamBNB:         return "DriftGateOffbeamBNB"s;
-    case gateSelection::GateOffbeamNuMI:             return "GateOffbeamNuMI"s;
-    case gateSelection::DriftGateOffbeamNuMI:        return "DriftGateOffbeamNuMI"s;
-    case gateSelection::GateCalibration:             return "GateCalibration"s;
-    case gateSelection::DriftGateCalibration:        return "DriftGateCalibration"s;
-    case gateSelection::MinbiasGateBNB:              return "MinbiasGateBNB"s;
-    case gateSelection::MinbiasGateNuMI:             return "MinbiasGateNuMI"s;
-    case gateSelection::MinbiasGateOffbeamBNB:       return "MinbiasGateOffbeamBNB"s;
-    case gateSelection::MinbiasGateOffbeamNuMI:      return "MinbiasGateOffbeamNuMI"s;
-    case gateSelection::MinbiasGateCalibration:      return "MinbiasGateCalibration"s;
-    case gateSelection::MinbiasDriftGateBNB:         return "MinbiasDriftGateBNB"s;
-    case gateSelection::MinbiasDriftGateNuMI:        return "MinbiasDriftGateNuMI"s;
-    case gateSelection::MinbiasDriftGateOffbeamBNB:  return "MinbiasDriftGateOffbeamBNB"s;
-    case gateSelection::MinbiasDriftGateOffbeamNuMI: return "MinbiasDriftGateOffbeamNuMI"s;
-    case gateSelection::MinbiasDriftGateCalibration: return "MinbiasDriftGateCalibration"s;
-    case gateSelection::NBits:                       return "NBits"s;
+  case gateSelection::GateBNB:                     return "GateBNB"s;
+  case gateSelection::DriftGateBNB:                return "DriftGateBNB"s;
+  case gateSelection::GateNuMI:                    return "GateNuMI"s;
+  case gateSelection::DriftGateNuMI:               return "DriftGateNuMI"s;
+  case gateSelection::GateOffbeamBNB:              return "GateOffbeamBNB"s;
+  case gateSelection::DriftGateOffbeamBNB:         return "DriftGateOffbeamBNB"s;
+  case gateSelection::GateOffbeamNuMI:             return "GateOffbeamNuMI"s;
+  case gateSelection::DriftGateOffbeamNuMI:        return "DriftGateOffbeamNuMI"s;
+  case gateSelection::GateCalibration:             return "GateCalibration"s;
+  case gateSelection::DriftGateCalibration:        return "DriftGateCalibration"s;
+  case gateSelection::MinbiasGateBNB:              return "MinbiasGateBNB"s;
+  case gateSelection::MinbiasGateNuMI:             return "MinbiasGateNuMI"s;
+  case gateSelection::MinbiasGateOffbeamBNB:       return "MinbiasGateOffbeamBNB"s;
+  case gateSelection::MinbiasGateOffbeamNuMI:      return "MinbiasGateOffbeamNuMI"s;
+  case gateSelection::MinbiasGateCalibration:      return "MinbiasGateCalibration"s;
+  case gateSelection::MinbiasDriftGateBNB:         return "MinbiasDriftGateBNB"s;
+  case gateSelection::MinbiasDriftGateNuMI:        return "MinbiasDriftGateNuMI"s;
+  case gateSelection::MinbiasDriftGateOffbeamBNB:  return "MinbiasDriftGateOffbeamBNB"s;
+  case gateSelection::MinbiasDriftGateOffbeamNuMI: return "MinbiasDriftGateOffbeamNuMI"s;
+  case gateSelection::MinbiasDriftGateCalibration: return "MinbiasDriftGateCalibration"s;
+  case gateSelection::NBits:                       return "NBits"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(gateSelection{ "s
-    + std::to_string(value(bit)) + " }): unknown bit"s);
+			   + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
-
-
-// -----------------------------------------------------------------------------
 
 namespace icarus {
 
@@ -291,7 +357,7 @@ namespace icarus {
     static constexpr std::size_t kNuMI           = sbn::bits::value<triggerSource>(triggerSource::NuMI);
     static constexpr std::size_t kOffBeamBNB     = sbn::bits::value<triggerSource>(triggerSource::OffbeamBNB);
     static constexpr std::size_t kOffBeamNuMI    = sbn::bits::value<triggerSource>(triggerSource::OffbeamNuMI);
-    static constexpr std::size_t kCalibration    = sbn::bits::value<triggerSource>(triggerSource::Calibration);
+    static constexpr std::size_t kCalibration    = sbn::bits::value<triggerSource>(triggerSource::Calib);
     static constexpr std::size_t kNTriggerSource = sbn::bits::value<triggerSource>(triggerSource::NBits);
 
   }
@@ -299,5 +365,7 @@ namespace icarus {
 
 }
 
-#endif // SBNOBJ_COMMON_TRIGGER_BEAMBITS_H
 
+// -----------------------------------------------------------------------------
+
+#endif // SBNOBJ_COMMON_TRIGGER_BEAMBITS_H

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -1426,7 +1426,7 @@ void icarus::DaqDecoderICARUSPMT::produce(art::Event& event) {
     if (triggerInfo.bits) {
       log << " {";
       for (std::string const& name
-        : sbn::bits::names<sbn::triggerSource>(triggerInfo.bits))
+        : sbn::bits::names<sbn::triggerSource>({(unsigned int) triggerInfo.bits }))
       {
         log << ' ' << name;
       }

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
@@ -29,6 +29,7 @@ namespace {
   template <typename T>
   std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
     T const timestamp = wrapper.timestamp;
+    //std::uint64_t const timestamp = wrapper.timestamp;
     if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
       out << (timestamp / 1'000'000'000) << "."
         << std::setfill('0') << std::setw(9) << (timestamp % 1'000'000'000)
@@ -73,6 +74,40 @@ namespace {
   
   
   // ---------------------------------------------------------------------------
+
+  struct LVDSmaskDumper { std::uint64_t bits; };
+
+  LVDSmaskDumper dumpLVDSmask(std::uint64_t bits) { return { bits }; }
+
+  std::ostream& operator<< (std::ostream& out, LVDSmaskDumper wrapper) {
+    std::uint64_t const bits { wrapper.bits };
+
+    auto dumpBoard = [&out](std::uint8_t bits)
+      {
+        static constexpr char symbols[2] = { '-', 'x' };
+	std::uint8_t mask = 0x80;
+        do { out << symbols[(bits & mask)? 1: 0]; } while (mask >>= 1);
+      };
+    auto boardBits = [](std::uint64_t bits, short int board) -> std::uint8_t
+      { return static_cast<std::uint8_t>((bits >> (board * 8)) & 0xFF); };
+
+    // positions 3 and 7 are empty 
+    dumpBoard(boardBits(bits, 6));
+    out << ' ';
+    dumpBoard(boardBits(bits, 5));
+    out << ' ';
+    dumpBoard(boardBits(bits, 4));
+    out << ' ';
+    out << ' ';
+    dumpBoard(boardBits(bits, 2));
+    out << ' ';
+    dumpBoard(boardBits(bits, 1));
+    out << ' ';
+    dumpBoard(boardBits(bits, 0));
+
+    return out;
+  } // operator<< (LVDSmaskDumper)            
+
   
 } // local namespace
 
@@ -94,6 +129,10 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
       << " at " << dumpTimestamp(info.beamGateTimestamp)
       << " (diff: "
       << timestampDiff(info.beamGateTimestamp, info.triggerTimestamp) << " ns)"
+    << "\n"
+    << "enable gate opened at " << dumpTimestamp(info.enableGateTimestamp)
+    << " (" << timestampDiff(info.beamGateTimestamp, info.enableGateTimestamp)
+    << " ns before the gate)"
     << "\n"
       << "counts from this source: trigger="
         << dumpTriggerCount(info.triggerCount)
@@ -130,7 +169,39 @@ std::ostream& sbn::operator<< (std::ostream& out, ExtraTriggerInfo const& info)
     out << "\nCorrection applied to the timestamps: "
       << dumpTimestamp(info.WRtimeToTriggerTime);
   }
-  
+  if (info.triggerLocationBits != 0) {
+    out << "\nLocation(s) of trigger:";
+    for (std::string const& bitName: names(info.triggerLocation()))
+      out << " " << bitName;
+  }
+  out << "\nWest cryostat: "
+      << info.cryostats[ExtraTriggerInfo::WestCryostat].triggerCount
+      << " triggers";
+  if (auto const& cryo = info.cryostats[ExtraTriggerInfo::WestCryostat];
+      cryo.hasLVDS()
+      ) {
+    out
+      << "\n  west wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
+      << "\n  east wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
+      ;
+  }
+
+  out << "\nEast cryostat: "
+      << info.cryostats[ExtraTriggerInfo::EastCryostat].triggerCount
+      << " triggers";
+  if (auto const& cryo = info.cryostats[ExtraTriggerInfo::EastCryostat];
+      cryo.hasLVDS()
+      ) {
+    out
+      << "\n  west wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::WestPMTwall])
+      << "\n  east wall:  "
+      << dumpLVDSmask(cryo.LVDSstatus[ExtraTriggerInfo::EastPMTwall])
+      ;
+  }
+
   
   return out;
 } // sbn::operator<< (ExtraTriggerInfo)

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.h
@@ -15,6 +15,7 @@
 #include "icaruscode/Decode/BeamBits.h"
 
 // C/C++ standard libraries
+#include <array>
 #include <iosfwd> // std::ostream
 #include <limits> // std::numeric_limits<>
 #include <cstdint> // std::uint64_t
@@ -57,6 +58,12 @@ struct sbn::ExtraTriggerInfo {
   
   /// Type of this gate (`sbn::triggerSource::NBits` marks this object invalid).
   sbn::triggerSource sourceType { sbn::triggerSource::NBits };
+
+  /// Type of this trigger (see `sbn::triggerType`).
+  sbn::triggerType triggerType { sbn::triggerType::NBits };
+
+  /// Absolute timestamp of the opening of the enable gate [ns]
+  std::uint64_t enableGateTimestamp { NoTimestamp };
   
   
   // --- BEGIN -- Since the beginning of the run -------------------------------
@@ -147,6 +154,103 @@ struct sbn::ExtraTriggerInfo {
   
   /// @}
   // --- END ---- Decoding information -----------------------------------------
+
+  // --- BEGIN -- Trigger topology ---------------------------------------------
+  /**
+   * @name Trigger topology
+   * 
+   * The information is represented in groups of cryostats and, within each of
+   * them, of PMT "walls", that is groups of PMT lying on the same geometric
+   * plane (in SBN detectors that is behind each anode).
+   * 
+   * Currently the information is represented by fixed size arrays, because the
+   * overhead of a variable length container (`std::vector`) is comparable to
+   * the data itself.
+   */
+  /// @{
+  
+  /// Maximum number of cryostats in the detector.
+  static constexpr std::size_t MaxCryostats { 2 };
+  
+  /// Maximum number of PMT "walls" in a cryostat.
+  static constexpr std::size_t MaxWalls { 2 };
+
+  /// Mnemonic index for the east cryostat.
+  static constexpr std::size_t EastCryostat { 0 };
+  
+  /// Mnemonic index for the west cryostat.
+  static constexpr std::size_t WestCryostat { 1 };
+  
+  /// Mnemonic index for the east PMT wall within a cryostat.
+  static constexpr std::size_t EastPMTwall { 0 };
+  
+  /// Mnemonic index for the west PMT wall within a cryostat.
+  static constexpr std::size_t WestPMTwall { 1 };
+  
+  
+  /// Trigger data pertaining a single cryostat.
+  struct CryostatInfo {
+    /// Count of triggers in this cryostat.
+    unsigned long int triggerCount { 0 };
+    
+    /**
+     * @brief Status of LVDS signals from PMT pairs at the time of the trigger.
+     * 
+     * There is one status per PMT wall (index mnemonic constants: `EastPMTwall`
+     * and `WestPMTwall`).
+     * 
+     * 
+     * ICARUS
+     * -------
+     * 
+     * Bits are 48 per wall, 8 pairs from each on 6 PMT readout boards.
+     * For the position of the PMT generating a LVDS channel, refer to the
+     * configuration of the trigger emulation.
+     * 
+     * The 48 bits are distributed in the value as follow:
+     * * the south part (lower _z_, lower channel number) is in the first 32-bit
+     * * the north part (upper _z_, higher channel number) is in the last 32-bit
+     * 
+     * The 8 most significant bits of each 32-bit half-word are zeroed.
+     * Then the most significant bits match the lowest channel numbers (lower
+     * _z_). Splitting the detector in six regions (of 15 PMT each) so that it
+     * looks, from south to north: `AA|BB|CC|DD|EE|FF`, the bit mask of the six
+     * parts (each with 15 PMT, 8 LVDS channels, 8 bits) looks like:
+     * `00AABBCC'00DDEEFF`.
+     */
+    std::array<std::uint64_t, MaxWalls> LVDSstatus { 0U, 0U };
+    
+    /// Returns whether there is some recorded LVDS activity.
+    constexpr bool hasLVDS() const;
+    
+  }; // CryostatInfo
+  
+  
+  /// Bits for the trigger location (@see `triggerLocation()`).
+  unsigned int triggerLocationBits { 0U };
+  //sbn::triggerLocation triggerLocationBits { sbn::triggerSource::NBits  }
+  /// Status of each LVDS channel in each PMT wall at trigger time.
+  std::array<CryostatInfo, MaxCryostats> cryostats;
+  
+  /**
+   * @brief Returns the location of the trigger.
+   * 
+   * The returned value is a mask of `sbn::bits::triggerLocation` bits.
+   * To test the state of a bit, it needs to be converted into a mask, e.g.:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * bool onTPCEE
+   *   = extraTriggerInfo.triggerLocation() & mask(sbn::triggerLocation::TPCEE);
+   * bool onTPCxE = extraTriggerInfo.triggerLocation()
+   *   & mask(sbn::triggerLocation::TPCEE, sbn::triggerLocation::TPCWE);
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  sbn::bits::triggerLocationMask triggerLocation() const
+    { return { triggerLocationBits }; }
+  
+  
+  /// @}
+  // --- END ---- Trigger topology ---------------------------------------------
+  
   
   
   /// Returns whether this object contains any valid information.
@@ -175,6 +279,15 @@ namespace sbn {
 }
 
 // -----------------------------------------------------------------------------
+
+constexpr bool sbn::ExtraTriggerInfo::CryostatInfo::hasLVDS() const {
+  // C++20:
+  //  return std::ranges::any_of(LVDSstatus, std::identity{});   
+  for (std::uint64_t bits: LVDSstatus) if (bits) return true;
+  return false;
+} // sbn::ExtraTriggerInfo::CryostatInfo::empty()
+
+
 
 
 #endif // SBNOBJ_COMMON_TRIGGER_EXTRATRIGGERINFO_H

--- a/icaruscode/Decode/DataProducts/classes_def.xml
+++ b/icaruscode/Decode/DataProducts/classes_def.xml
@@ -19,25 +19,25 @@
   <!-- sbn::ExtraTriggerInfo -->
 
   <!--   class -->
-  <class name="sbn::ExtraTriggerInfo" ClassVersion="11" >
+  <class name="sbn::ExtraTriggerInfo" ClassVersion="13" >
+   <version ClassVersion="13" checksum="1967722932"/>
+   <version ClassVersion="12" checksum="2254850881"/>
    <version ClassVersion="11" checksum="2691428079"/>
    <version ClassVersion="10" checksum="2751074963"/>
   </class>
   
     <!-- dependencies -->
     <enum name="sbn::bits::triggerSource" ClassVersion="10" />
+    <enum name="sbn::bits::triggerLocation" ClassVersion="10" />
+    <enum name="sbn::bits::triggerType" ClassVersion="10" />
+    <class name="sbn::ExtraTriggerInfo::CryostatInfo" ClassVersion="10" >
+     <version ClassVersion="10" checksum="313789291"/>
+    </class>
 
-    <!-- art pointers and wrappers -->
-    <class name="art::Ptr<sbn::ExtraTriggerInfo>"/>
-    <class name="art::Wrapper<sbn::ExtraTriggerInfo>"/>
-
-  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-  <!-- sbn::ICARUSTriggerConfiguration -->
-
-  <!--   class -->
-  <class name="icarus::TriggerConfiguration" ClassVersion="10" >
+     <class name="icarus::TriggerConfiguration" ClassVersion="11" >
+      <version ClassVersion="11" checksum="2294188438"/>
    <version ClassVersion="10" checksum="3222464842"/>
-  </class>
+     </class>
 
     <!-- dependencies -->
     <class name="icarus::TriggerConfiguration::CryoConfig" ClassVersion="10">
@@ -50,6 +50,10 @@
     <!-- art pointers and wrappers -->
     <class name="art::Ptr<icarus::TriggerConfiguration>"/>
     <class name="art::Wrapper<icarus::TriggerConfiguration>"/>
+
+    <!-- art pointers and wrappers -->
+    <class name="art::Ptr<sbn::ExtraTriggerInfo>"/>
+    <class name="art::Wrapper<sbn::ExtraTriggerInfo>"/>
 
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->

--- a/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
+++ b/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
@@ -177,8 +177,10 @@ auto icarus::TriggerConfigurationExtractor::extractTriggerConfiguration
   rc.tpcTriggerDelay        
     = spexiParams.get<unsigned int>("TPCTriggerDelay.value");
 
-  sbn::bits::mask_t<sbn::gateSelection> gateSelection          
-    = std::stoul( spexiParams.get<std::string>("GateSelection.value"), nullptr, 16);
+
+  
+  sbn::bits::mask_t<sbn::gateSelection> gateSelection
+    { (unsigned int) std::stoul( spexiParams.get<std::string>("GateSelection.value"), nullptr, 16) };  
 
   // Read the prescale configuraton as string for now 
   auto prescaleMinBiasBeam = 
@@ -294,7 +296,7 @@ std::optional<fhicl::ParameterSet>
 icarus::TriggerConfigurationExtractor::readTriggerConfig
   (fhicl::ParameterSet const& pset, std::string const& key) const
 {
-  static std::string const ExpectedFragmentType = "ICARUSTriggerUDP";
+  static std::string const ExpectedFragmentType = "ICARUSTriggerV2";
   
   std::optional<fhicl::ParameterSet> config;
   

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -1,0 +1,678 @@
+////////////////////////////////////////////////
+//   
+//    File: TriggerDecoderV2_tool.cc
+//       
+//    Description: Extracting ICARUS trigger fragment information from new fragment necessary after trigger information  
+//
+//    Author: Jacob Zettlemoyer, FNAL
+//
+///////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Persistency/Common/PtrMaker.h"
+#include "art/Utilities/ToolMacros.h"
+#include "cetlib/cpu_timer.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
+#include "lardataalg/Utilities/quantities/spacetime.h" // util::quantities::nanosecond
+#include "lardataobj/RawData/ExternalTrigger.h" //JCZ: TBD, placeholder for now to represent the idea
+#include "lardataobj/RawData/TriggerData.h" // raw::Trigger
+#include "lardataobj/Simulation/BeamGateInfo.h" //JCZ:, another placeholder I am unsure if this and above will be combined at some point into a dedicated object 
+
+#include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh"
+
+// #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h" // maybe future location of:
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
+#include "icaruscode/Decode/DecoderTools/IDecoder.h"
+// #include "sbnobj/Common/Trigger/BeamBits.h" // maybe future location of:
+#include "icaruscode/Decode/BeamBits.h" // sbn::triggerSource
+#include "icaruscode/Decode/DecoderTools/Dumpers/FragmentDumper.h" // dumpFragment()
+#include "icaruscode/Decode/DecoderTools/details/KeyedCSVparser.h"
+#include "icarusalg/Utilities/BinaryDumpUtils.h" // hexdump() DEBUG
+
+#include <cstdlib>
+#include <iostream>
+#include <iomanip> // std::setw(), std::setfill()
+#include <string_view>
+#include <memory>
+#include <array>
+
+
+using namespace std::string_literals;
+
+namespace daq 
+{
+  
+  /**
+   * @brief Tool decoding the trigger information from DAQ.
+   * 
+   * Produces:
+   * * `std::vector<raw::ExternalTrigger>` containing the absolute trigger time
+   *     stamp from the White Rabbit system, and a trigger count;
+   *     it always includes a single entry (zero _might_ be supported).
+   * * `std::vector<raw::Trigger>` containing:
+   *     * `TriggerTime()`: the relative time of the trigger as reported in the
+   *         White Rabbit timestamp, measured in the
+   *         @ref DetectorClocksElectronicsTime "electronics time scale" (for
+   *         ICARUS it will always be
+   *         `detinfo::DetectorClocksData::TriggerTime()`).
+   *     * `BeamGateTime()`: relative time of the announced arrival of the beam
+   *         (currently not available) also in
+   *         @ref DetectorClocksElectronicsTime "electronics time scale".
+   *     * `TriggerCount()`: the trigger count from the beginning of the run.
+   *     * `TriggerBits()`: includes the beam(s) with an open gate when the
+   *         trigger happened (currently only one beam gate per trigger);
+   *         definitions are in `sbn::beamType` namespace.
+   * 
+   *     It always includes a single entry (zero _might_ be supported).
+   * * `std::vector<sim::BeamGateInfo>` containing information on the "main"
+   *     beam gate associated to each trigger (a way to say that if by any
+   *     chance there are more than one bits set for the trigger, this gate
+   *     will pick only one of them):
+   *     * `Start()`: relative time of the announced arrival of the beam
+   *         (currently not available), in
+   *         @ref DetectorClocksSimulationTime "simulation time scale".
+   *     * `Width()`: duration of the gate, in nanoseconds; currently set to a
+   *         nominal value.
+   *     * `BeamType()`: the type of the beam gate being described (BNB, NuMI).
+   * * `sbn::ExtraTriggerInfo`: the most complete collection of information,
+   *     duplicating also some from the other data products. Some of the
+   *     information is not available yet: if a count is not available, its
+   *     value is set to `0` (which is an invalid value because their valid
+   *     range starts with `1` since they include the current event), and if a
+   *     timestamp is not available it is set to
+   *     `sbn::ExtraTriggerInfo::NoTimestamp`; these two conditions can be
+   *     checked with static methods 
+   *     `sbn::ExtraTriggerInfo::isValidTimestamp()` and 
+   *     `sbn::ExtraTriggerInfo::isValidCount()` respectively.
+   *     Note that differently from the usual, this is a _single object_, not
+   *     a collection; also, this data product has no instance name.
+   *     The information already available includes:
+   *     * `sourceType`: the type of beam or trigger source, a value from
+   *         `sbn::triggerSource` (equivalent to `raw::Trigger::TriggerBits()`,
+   *         but in the form of an enumerator rather than a bit mask).
+   *     * `triggerTimestamp`: same as `raw::ExternalTrigger::GetTrigTime()`
+   *         (nanoseconds from the Epoch, Coordinated Universal Time).
+   *     * `beamGateTimestamp`: absolute time of the beam gate opening as
+   *         reported by the trigger hardware, directly comparable with
+   *         `triggerTimestamp` (same scale and unit).
+   *     * `triggerID`: same as `raw::ExternalTrigger::GetTrigID()`. Should
+   *         match the event number.
+   *     * `gateID`: the count of gates since the beginning of the run, as
+   *         reported by the trigger hardware.
+   * 
+   * Besides the main data product (empty instance name) an additional
+   * `std::vector<raw::ExternalTrigger>` data product with instance name
+   * `"previous"` is also produced, which relays the same kind of information
+   * but for the _previous_ trigger. This information also comes from the
+   * trigger DAQ. If no previous trigger is available, this collection will be
+   * empty.
+   * 
+   * 
+   * Timestamps and corrections
+   * ---------------------------
+   * 
+   * The reference trigger time is driven by the trigger fragment time, which
+   * is expected to have been derived from the actual trigger time from the
+   * White Rabbit system properly corrected to UTC by the board reader.
+   * 
+   * All absolute timestamps are corrected to be on that same scale.
+   * The absolute timestamps related to the White Rabbit time are added an
+   * offset to achieve this correction; this offset is stored in the data
+   * product (`sbn::ExtraTriggerInfo::WRtimeToTriggerTime`).
+   * 
+   */
+  class TriggerDecoder : public IDecoder
+  {
+    using nanoseconds = util::quantities::nanosecond;
+  public:
+    explicit TriggerDecoder(fhicl::ParameterSet const &pset);
+    
+    virtual void produces(art::ProducesCollector&) override;
+    virtual void configure(const fhicl::ParameterSet&) override;
+    virtual void initializeDataProducts() override;
+    virtual void process_fragment(const artdaq::Fragment &fragment) override;
+    virtual void outputDataProducts(art::Event &event) override;
+   
+  private: 
+    using TriggerCollection = std::vector<raw::ExternalTrigger>;
+    using TriggerPtr = std::unique_ptr<TriggerCollection>;
+    using RelativeTriggerCollection = std::vector<raw::Trigger>;
+    using BeamGateInfoCollection = std::vector<sim::BeamGateInfo>;
+    using BeamGateInfoPtr = std::unique_ptr<BeamGateInfoCollection>;
+    using ExtraInfoPtr = std::unique_ptr<sbn::ExtraTriggerInfo>;
+    TriggerPtr fTrigger;
+    TriggerPtr fPrevTrigger;
+    std::unique_ptr<RelativeTriggerCollection> fRelTrigger;
+    ExtraInfoPtr fTriggerExtra;
+    BeamGateInfoPtr fBeamGateInfo; 
+    bool fDiagnosticOutput; //< Produces large number of diagnostic messages, use with caution!
+    bool fDebug; //< Use this for debugging this tool
+    int fOffset; //< Use this to determine additional correction needed for TAI->UTC conversion from White Rabbit timestamps. Needs to be changed if White Rabbit firmware is changed and the number of leap seconds changes! 
+    //Add in trigger data member information once it is selected, current LArSoft object likely not enough as is
+    
+    // uint64_t fLastTimeStamp = 0;
+   
+    long fLastEvent = 0;
+    
+    detinfo::DetectorTimings const fDetTimings; ///< Detector clocks and timings.
+    
+    /// Creates a `ICARUSTriggerInfo` from a generic fragment.
+    icarus::ICARUSTriggerV2Fragment makeTriggerFragment
+      (artdaq::Fragment const& fragment) const;
+    
+    /// Parses the trigger data packet with the "standard" parser.
+    icarus::ICARUSTriggerInfo parseTriggerString(std::string_view data) const;
+    
+    /// Name of the data product instance for the current trigger.
+    static std::string const CurrentTriggerInstanceName;
+    
+    /// Name of the data product instance for the previous trigger.
+    static std::string const PreviousTriggerInstanceName;
+    
+    static constexpr double UnknownBeamTime = std::numeric_limits<double>::max();
+    
+    /// Codes of gate types from the trigger hardware.
+    struct TriggerGateTypes {
+      static constexpr int BNB { 1 };
+      static constexpr int NuMI { 2 };
+      static constexpr int OffbeamBNB { 3 };
+      static constexpr int OffbeamNuMI { 4 };
+      static constexpr int Calib { 5 };
+    }; 
+    
+    static constexpr nanoseconds BNBgateDuration { 1600. };
+    static constexpr nanoseconds NuMIgateDuration { 9500. };
+    
+    static std::string_view firstLine
+      (std::string const& s, std::string const& endl = "\0\n\r"s);
+    
+    /// Combines second and nanosecond counts into a 64-bit timestamp.
+    static std::uint64_t makeTimestamp(unsigned int s, unsigned int ns)
+      { return s * 1000000000ULL + ns; }
+    /// Returns the difference `a - b`.
+    static long long int timestampDiff(std::uint64_t a, std::uint64_t b)
+      { return static_cast<long long int>(a) - static_cast<long long int>(b); }
+
+    /// Encodes the `connectorWord` LVDS bits from the specified `cryostat`
+    /// and `connector` into the format required by `sbn::ExtraTriggerInfo`.
+    static std::uint64_t encodeLVDSbits
+    (short int cryostat, short int connector, std::uint64_t connectorWord);
+    
+  };
+
+
+  std::string const TriggerDecoder::CurrentTriggerInstanceName {};
+  std::string const TriggerDecoder::PreviousTriggerInstanceName { "previous" };
+  
+
+  TriggerDecoder::TriggerDecoder(fhicl::ParameterSet const &pset)
+    : fDetTimings
+      { art::ServiceHandle<detinfo::DetectorClocksService>()->DataForJob() }
+  {
+    this->configure(pset);
+  }
+
+  
+  void TriggerDecoder::produces(art::ProducesCollector& collector) 
+  {
+    collector.produces<TriggerCollection>(CurrentTriggerInstanceName);
+    collector.produces<TriggerCollection>(PreviousTriggerInstanceName);
+    collector.produces<RelativeTriggerCollection>(CurrentTriggerInstanceName);
+    collector.produces<BeamGateInfoCollection>(CurrentTriggerInstanceName);
+    collector.produces<sbn::ExtraTriggerInfo>(CurrentTriggerInstanceName);
+  }
+    
+
+  void TriggerDecoder::configure(fhicl::ParameterSet const &pset) 
+  {
+    fDiagnosticOutput = pset.get<bool>("DiagnosticOutput", false);
+    fDebug = pset.get<bool>("Debug", false);
+    fOffset = pset.get<long long int>("TimeOffset", 0);
+    return;
+  }
+  
+  void TriggerDecoder::initializeDataProducts()
+  {
+    //use until different object chosen 
+    //fTrigger = new raw::Trigger();
+    fTrigger = std::make_unique<TriggerCollection>();
+    fPrevTrigger = std::make_unique<TriggerCollection>();
+    fRelTrigger = std::make_unique<RelativeTriggerCollection>();
+    fBeamGateInfo = BeamGateInfoPtr(new BeamGateInfoCollection);
+    fTriggerExtra = std::make_unique<sbn::ExtraTriggerInfo>();
+    return;
+  }
+  
+  
+  icarus::ICARUSTriggerV2Fragment TriggerDecoder::makeTriggerFragment
+    (artdaq::Fragment const& fragment) const
+  {
+    try {
+      return icarus::ICARUSTriggerV2Fragment { fragment };
+    }
+    catch(std::exception const& e) {
+      mf::LogSystem("TriggerDecoder")
+        << "Error while creating trigger fragment from:\n"
+          << sbndaq::dumpFragment(fragment)
+        << "\nError message: " << e.what();
+      throw;
+    }
+    catch(...) {
+      mf::LogSystem("TriggerDecoder")
+        << "Unidentified exception while creating trigger fragment from:"
+          << sbndaq::dumpFragment(fragment);
+      throw;
+    }
+  } // TriggerDecoder::parseTriggerString()
+
+  
+  icarus::ICARUSTriggerInfo TriggerDecoder::parseTriggerString
+    (std::string_view data) const
+  {
+    try {
+      return icarus::parse_ICARUSTriggerV2String(data.data());
+    }
+    catch(std::exception const& e) {
+      mf::LogSystem("TriggerDecoder")
+        << "Error while running standard parser on " << data.length()
+        << "-char long trigger string:\n==>|" << data
+        << "|<==\nError message: " << e.what();
+      throw;
+    }
+    catch(...) {
+      mf::LogSystem("TriggerDecoder")
+        << "Unidentified exception while running standard parser on "
+        << data.length() << "-char long trigger string:\n==>|" << data << "|.";
+      throw;
+    }
+  } // TriggerDecoder::parseTriggerString()
+
+  
+
+  void TriggerDecoder::process_fragment(const artdaq::Fragment &fragment)
+  {
+    // artdaq_ts is reworked by the trigger board reader to match the corrected
+    // trigger time; to avoid multiple (potentially inconsistent) corrections,
+    // the decoder trusts it and references all the times with respect to it.
+    uint64_t const artdaq_ts = fragment.timestamp();
+    icarus::ICARUSTriggerV2Fragment frag { makeTriggerFragment(fragment) };
+    std::string data = frag.GetDataString();
+    char *buffer = const_cast<char*>(data.c_str());
+
+    icarus::ICARUSTriggerInfo datastream_info = parseTriggerString(buffer);
+    uint64_t const raw_wr_ts // this is raw, unadultered, uncorrected
+      = makeTimestamp(frag.getWRSeconds(), frag.getWRNanoSeconds());
+    
+    // correction (explicitly converted to signed)
+    int64_t const WRtimeToTriggerTime
+      = static_cast<int64_t>(artdaq_ts) - raw_wr_ts;
+    auto const correctWRtime = [WRtimeToTriggerTime](uint64_t time)
+      { return time + WRtimeToTriggerTime; };
+    assert(correctWRtime(raw_wr_ts) == artdaq_ts);
+    
+    // --- END ---- TEMPORARY --------------------------------------------------
+    int gate_type = datastream_info.gate_type;
+    long delta_gates_bnb [[maybe_unused]] = frag.getDeltaGatesBNB();
+    long delta_gates_numi [[maybe_unused]] = frag.getDeltaGatesNuMI();
+    long delta_gates_offbeam_bnb [[maybe_unused]] = frag.getDeltaGatesBNBOff();
+    long delta_gates_offbeam_numi [[maybe_unused]] = frag.getDeltaGatesNuMIOff();
+    long delta_gates_other [[maybe_unused]] = frag.getDeltaGatesOther();
+    uint64_t lastTrigger = 0;
+    
+    // --- BEGIN -- TEMPORARY --------------------------------------------------
+    // remove this part when the beam gate timestamp is available via fragment
+    // or via the parser
+    icarus::details::KeyedCSVparser parser;
+    parser.addPatterns({
+	{ "Cryo. (EAST|WEST) Connector . and .", 1U }
+	, { "Trigger Type", 1U }
+      });
+    //auto const parsedData = icarus::details::KeyedCSVparser{}(firstLine(data));
+    auto const parsedData = parser(firstLine(data)); 
+    unsigned int beamgate_count { std::numeric_limits<unsigned int>::max() };
+    std::uint64_t beamgate_ts { artdaq_ts }; // we cheat
+    /* [20210717, petrillo@slac.stanford.edu] `(pBeamGateInfo->nValues() == 3)`:
+     * this is an attempt to "support" a few Run0 runs (6017 to roughly 6043)
+     * which have the beam gate information truncated; this workaround should
+     * be removed when there is enough ICARUS data that these runs become
+     * uninteresting.
+     */
+    if (auto pBeamGateInfo = parsedData.findItem("Beam_TS");
+      pBeamGateInfo && (pBeamGateInfo->nValues() == 3)
+    ) {
+      // if gate information is found, it must be complete
+      beamgate_count = pBeamGateInfo->getNumber<unsigned int>(0U);
+      
+      uint64_t const raw_bg_ts = makeTimestamp( // raw and uncorrected too
+        pBeamGateInfo->getNumber<unsigned int>(1U),
+        pBeamGateInfo->getNumber<unsigned int>(2U)
+        );
+      
+      // assuming the raw times from the fragment are on the same time scale
+      // (same offset corrections)
+      beamgate_ts += raw_bg_ts - raw_wr_ts;
+      
+    } // if has gate information
+    std::uint64_t enablegate_ts { artdaq_ts };
+    if (auto pEnableGateInfo = parsedData.findItem("Enable_TS");
+	pEnableGateInfo && (pEnableGateInfo->nValues() == 3)
+	) {
+      // if gate information is found, it must be complete
+      //enablegate_count = pEnableGateInfo->getNumber<unsigned int>(0U);
+
+      uint64_t const raw_en_ts = makeTimestamp( // raw and uncorrected too
+					       pEnableGateInfo->getNumber<unsigned int>(1U),
+					       pEnableGateInfo->getNumber<unsigned int>(2U)
+						);
+
+      // assuming the raw times from the fragment are on the same time scale 
+      // (same offset corrections)
+
+      enablegate_ts += raw_en_ts - raw_wr_ts;
+    } // if has gate information          
+    
+    auto connectorInfoE_01 = parsedData.findItem("Cryo1 EAST Connector 0 and 1");    
+    uint64_t connectorLVDS_E_01 = connectorInfoE_01->getNumber<uint64_t>(0,16);
+    auto connectorInfoE_23 = parsedData.findItem("Cryo1 EAST Connector 2 and 3");
+    uint64_t connectorLVDS_E_23 = connectorInfoE_23->getNumber<uint64_t>(0,16);
+    auto connectorInfoW_01 = parsedData.findItem("Cryo2 WEST Connector 0 and 1");
+    uint64_t connectorLVDS_W_01 = connectorInfoW_01->getNumber<uint64_t>(0,16);
+    auto connectorInfoW_23 = parsedData.findItem("Cryo2 WEST Connector 2 and 3");
+    uint64_t connectorLVDS_W_23 = connectorInfoW_23->getNumber<uint64_t>(0,16);
+
+    // --- END ---- TEMPORARY --------------------------------------------------
+    
+    if(fDiagnosticOutput || fDebug)
+    {
+      std::cout << "Full Timestamp = " << artdaq_ts
+        << "\nBeam gate " << beamgate_count << " at "
+        << (beamgate_ts/1'000'000'000) << "." << std::setfill('0')
+        << std::setw(9) << (beamgate_ts%1'000'000'000) << std::setfill(' ')
+        << " s (" << timestampDiff(beamgate_ts, artdaq_ts)
+        << " ns relative to trigger)" << std::endl;
+      
+      // note that this parsing is independent from the one used above
+      std::string_view const dataLine = firstLine(data);
+      try {
+        //auto const parsedData = icarus::details::KeyedCSVparser{}(dataLine);
+	auto const parsedData = parser(dataLine);
+        std::cout << "Parsed data (from " << dataLine.size() << " characters): "
+          << parsedData << std::endl;
+      }
+      catch(icarus::details::KeyedCSVparser::Error const& e) {
+        mf::LogError("TriggerDecoder")
+          << "Error parsing " << dataLine.length()
+          << "-char long trigger string:\n==>|" << dataLine
+          << "|<==\nError message: " << e.what() << std::endl;
+        throw;
+      }
+      
+      if (fDebug) { // this grows tiresome quickly when processing many events
+        std::cout << "Trigger packet content:\n" << dataLine
+          << "\nFull trigger fragment dump:"
+          << sbndaq::dumpFragment(fragment) << std::endl;
+      }
+    }
+    //
+    // extra trigger info
+    //
+    sbn::triggerSource beamGateBit;
+    switch (gate_type) {
+      case TriggerGateTypes::BNB:{         
+	beamGateBit = sbn::triggerSource::BNB;
+	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesBNB();
+	fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampBNB();
+	fTriggerExtra->gateCount = datastream_info.gate_id_BNB;
+	fTriggerExtra->triggerCount = frag.getTotalTriggerBNB();
+	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerBNB();
+	break;
+      }
+      case TriggerGateTypes::NuMI:{        
+	beamGateBit = sbn::triggerSource::NuMI;
+	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesNuMI();
+	fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampNuMI();
+	fTriggerExtra->gateCount = datastream_info.gate_id_NuMI;
+	fTriggerExtra->triggerCount = frag.getTotalTriggerNuMI();
+	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerNuMI();
+	break;
+      }
+      case TriggerGateTypes::OffbeamBNB:{  
+	beamGateBit = sbn::triggerSource::OffbeamBNB;
+	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesBNBOff();
+	fTriggerExtra->previousTriggerTimestamp= frag.getLastTimestampBNBOff();
+	fTriggerExtra->gateCount = datastream_info.gate_id_BNBOff;
+	fTriggerExtra->triggerCount = frag.getTotalTriggerBNBOff();
+	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerBNBOff();
+	break;
+      }
+      case TriggerGateTypes::OffbeamNuMI:{ 
+	beamGateBit = sbn::triggerSource::OffbeamNuMI;
+	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesNuMIOff();
+	fTriggerExtra->previousTriggerTimestamp= frag.getLastTimestampNuMIOff();
+	fTriggerExtra->gateCount = datastream_info.gate_id_NuMIOff;
+	fTriggerExtra->triggerCount = frag.getTotalTriggerNuMIOff();
+	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerNuMIOff();
+	break;
+      }
+      case TriggerGateTypes::Calib:{       
+	beamGateBit = sbn::triggerSource::Calib;
+	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesCalib();
+	fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampCalib();
+	//fTriggerExtra->gateCount = datastream_info.gate_id_calib;
+	fTriggerExtra->triggerCount = frag.getTotalTriggerCalib();
+	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerCalib();
+	break;
+      }
+      default:                            beamGateBit = sbn::triggerSource::Unknown;
+    } // switch gate_type
+    
+    fTriggerExtra->sourceType = beamGateBit;
+    fTriggerExtra->triggerTimestamp = artdaq_ts;
+    fTriggerExtra->beamGateTimestamp = beamgate_ts;
+    fTriggerExtra->enableGateTimestamp = enablegate_ts;
+    fTriggerExtra->triggerID = datastream_info.wr_event_no; //all triggers (event ID)
+    fTriggerExtra->gateID = datastream_info.gate_id; //all gate types (gate ID)
+    fTriggerExtra->anyGateCountFromAnyPreviousTrigger = frag.getDeltaGates();
+    fTriggerExtra->anyPreviousTriggerTimestamp = frag.getLastTimestamp();
+    //fTriggerExtra->anyPreviousTriggerSourceType = frag.getLastTriggerType();
+    sbn::triggerSource previousTriggerSourceBit;
+    if(frag.getLastTriggerType() == 1)
+      previousTriggerSourceBit = sbn::triggerSource::BNB;
+    else if(frag.getLastTriggerType() == 2)
+      previousTriggerSourceBit = sbn::triggerSource::NuMI;
+    else if(frag.getLastTriggerType() == 3)
+      previousTriggerSourceBit = sbn::triggerSource::OffbeamBNB;
+    else if(frag.getLastTriggerType() == 4)
+      previousTriggerSourceBit = sbn::triggerSource::OffbeamNuMI;
+    else if(frag.getLastTriggerType() == 5)
+      previousTriggerSourceBit = sbn::triggerSource::Calib;
+    else
+      previousTriggerSourceBit = sbn::triggerSource::Unknown;
+    fTriggerExtra->anyPreviousTriggerSourceType = previousTriggerSourceBit;
+
+    std::cout << datastream_info.gate_id_BNB << " " << frag.getDeltaGatesBNB() << " " << gate_type << std::endl;
+    std::cout << connectorLVDS_E_01 << " " << connectorLVDS_E_23 << " " << connectorLVDS_W_01 << " " << connectorLVDS_W_23 << " " << std::hex << connectorLVDS_E_01 << " " << connectorLVDS_E_23 << " " << connectorLVDS_W_01 << " " << connectorLVDS_W_23 << std::dec << std::endl;
+    
+    /* TODO (may need to add WRtimeToTriggerTime to some timestamps):
+    fTriggerExtra->anyPreviousTriggerSourceType
+    */
+    fTriggerExtra->WRtimeToTriggerTime = WRtimeToTriggerTime;
+    sbn::bits::triggerLocationMask locationMask;
+    // trigger location: 0x01=EAST; 0x02=WEST; 0x07=ALL                                                                  
+    int const triggerLocation = parsedData.getItem("Trigger Source").getNumber<int>(0);
+    if(triggerLocation == 1)
+      locationMask = mask(sbn::triggerLocation::CryoEast);
+    else if(triggerLocation == 2)
+      locationMask = mask(sbn::triggerLocation::CryoWest);
+    else if(triggerLocation == 7)
+      locationMask = mask(sbn::triggerLocation::CryoEast, sbn::triggerLocation::CryoWest);
+    fTriggerExtra->triggerLocationBits = locationMask;
+    fTriggerExtra->cryostats[sbn::ExtraTriggerInfo::EastCryostat]
+      = {
+      // triggerCount      
+      (fTriggerExtra->triggerID <= 1)
+      ? 0UL: parsedData.getItem("Cryo1 EAST counts").getNumber<unsigned long int>(0),
+      // LVDSstatus
+      {
+	(triggerLocation & 1) // EE
+	? encodeLVDSbits(
+			 sbn::ExtraTriggerInfo::EastCryostat, 2, /* any of the connectors */
+			 parsedData.getItem("Cryo1 EAST Connector 2 and 3").getNumber<std::uint64_t>(0, 16)
+			 )
+	: 0ULL,
+	(triggerLocation & 1) // EW
+	? encodeLVDSbits(
+			 sbn::ExtraTriggerInfo::EastCryostat, 0, /* any of the connectors */
+			 parsedData.getItem("Cryo1 EAST Connector 0 and 1").getNumber<std::uint64_t>(0, 16)
+			 )
+	: 0ULL
+      }
+    };
+    fTriggerExtra->cryostats[sbn::ExtraTriggerInfo::WestCryostat]
+      = {
+      // triggerCount      
+      (fTriggerExtra->triggerID <= 1)
+      ? 0UL: parsedData.getItem("Cryo2 WEST counts").getNumber<unsigned long int>(0),
+      // LVDSstatus
+      {
+	(triggerLocation & 2) // WE
+	? encodeLVDSbits(
+			 sbn::ExtraTriggerInfo::WestCryostat, 2, /* any of the connectors */
+			 parsedData.getItem("Cryo2 WEST Connector 2 and 3").getNumber<std::uint64_t>(0, 16)
+			 )
+	: 0ULL,
+	(triggerLocation & 2) // WW
+	? encodeLVDSbits(
+			 sbn::ExtraTriggerInfo::WestCryostat, 0, /* any of the connectors */
+			 parsedData.getItem("Cryo2 WEST Connector 0 and 1").getNumber<std::uint64_t>(0, 16)
+			 )
+	: 0ULL
+      }
+    };
+    // we expect the LVDS status bits
+
+    for (auto const& cryoInfo [[maybe_unused]]: fTriggerExtra->cryostats)
+      for (auto LVDS [[maybe_unused]]: cryoInfo.LVDSstatus)
+	assert((LVDS & 0xFF000000FF000000) == 0);             
+    
+    //
+    // absolute time trigger (raw::ExternalTrigger)
+    //
+    fTrigger->emplace_back
+      (fTriggerExtra->triggerID, fTriggerExtra->triggerTimestamp);
+    
+    //
+    // previous absolute time trigger (raw::ExternalTrigger)
+    //
+    if(fTriggerExtra->triggerID == 1)
+    {
+      fLastEvent = 0;
+    }
+    else 
+    {
+      fLastEvent = fTriggerExtra->triggerID - 1;
+      lastTrigger = fTriggerExtra->anyPreviousTriggerTimestamp;
+      fPrevTrigger->emplace_back(fLastEvent, lastTrigger);
+    }
+    
+    //
+    // beam gate
+    //
+    // beam gate - trigger: hope it's negative...
+    nanoseconds const gateStartFromTrigger{
+      static_cast<double>(timestampDiff
+        (fTriggerExtra->beamGateTimestamp, fTriggerExtra->triggerTimestamp)
+        )
+      }; // narrowing!!
+    auto const elecGateStart = fDetTimings.TriggerTime() + gateStartFromTrigger;
+    auto const simGateStart = fDetTimings.toSimulationTime(elecGateStart);
+    switch (gate_type) {
+      case TriggerGateTypes::BNB:
+        fBeamGateInfo->emplace_back
+          (simGateStart.value(), BNBgateDuration.value(), sim::kBNB);
+        break;
+      case TriggerGateTypes::NuMI:
+        fBeamGateInfo->emplace_back
+          (simGateStart.value(), NuMIgateDuration.value(), sim::kNuMI);
+        break;
+      case TriggerGateTypes::OffbeamBNB:
+        fBeamGateInfo->emplace_back
+          (simGateStart.value(), BNBgateDuration.value(), sim::kBNB);
+        break;
+      case TriggerGateTypes::OffbeamNuMI:
+        fBeamGateInfo->emplace_back
+          (simGateStart.value(), NuMIgateDuration.value(), sim::kNuMI);
+        break;
+      default:
+        mf::LogWarning("TriggerDecoder") << "Unsupported gate type #" << gate_type;
+    } // switch gate_type
+    
+    //
+    // relative time trigger (raw::Trigger)
+    //
+    fRelTrigger->emplace_back(
+      static_cast<unsigned int>(datastream_info.wr_event_no), // counter
+      fDetTimings.TriggerTime().value(),                      // trigger_time
+      elecGateStart.value(),                                  // beamgate_time
+      mask(beamGateBit)                                       // bits
+      );
+    
+    //Once we have full trigger data object, set up and place information into there
+    return;
+  }
+
+  void TriggerDecoder::outputDataProducts(art::Event &event)
+  {
+    //Place trigger data object into raw data store 
+    event.put(std::move(fTrigger), CurrentTriggerInstanceName);
+    event.put(std::move(fRelTrigger), CurrentTriggerInstanceName);
+    event.put(std::move(fPrevTrigger), PreviousTriggerInstanceName);
+    event.put(std::move(fBeamGateInfo), CurrentTriggerInstanceName);
+    event.put(std::move(fTriggerExtra));
+    return;
+  }
+
+  std::string_view TriggerDecoder::firstLine
+    (std::string const& s, std::string const& endl /* = "\0\n\r" */)
+  {
+    return { s.data(), std::min(s.find_first_of(endl), s.size()) };
+  }
+  
+
+  std::uint64_t TriggerDecoder::encodeLVDSbits
+  (short int cryostat, short int connector, std::uint64_t connectorWord)
+  {
+    /*                                                     
+     * Encoding of the LVDS channels from the trigger:
+     * * east wall:  `00<C0P2><C0P1><C0P0>00<C1P2><C1P1><C1P0>`
+     * * west wall:  `00<C2P2><C2P1><C2P0>00<C3P2><C3P1><C3P0>`                                                                               
+     * The prescription from `sbn::ExtraTriggerInfo` translates into:
+     * * east wall:  `00<C3P2><C3P1><C3P0>00<C2P2><C2P1><C2P0>`
+     * * west wall:  `00<C1P2><C1P1><C1P0>00<C0P2><C0P1><C0P0>`                                                                               
+     * Therefore, the two 32-bit half-words need to be swapped
+     * This holds for both cryostats, and both walls.  
+     */
+
+    std::uint64_t lsw = connectorWord & 0xFFFFFFFFULL;
+    std::uint64_t msw = connectorWord >> 32ULL;
+    assert(connectorWord == ((msw << 32ULL) | lsw));
+    std::swap(lsw, msw);
+    return (msw << 32ULL) | lsw;
+  } // TriggerDecoder::encodeLVDSbits()       
+  
+  DEFINE_ART_CLASS_TOOL(TriggerDecoder)
+
+}
+
+
+
+
+
+  

--- a/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
+++ b/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
@@ -107,5 +107,9 @@ TriggerDecoderTool: {
    tool_type:          TriggerDecoder
 }
 
+TriggerDecoderV2Tool: {
+   tool_type:          TriggerDecoderV2
+}
+
 
 END_PROLOG

--- a/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
+++ b/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
@@ -2,6 +2,9 @@
 
 BEGIN_PROLOG
 
+extractTriggerConfig: { 
+		    module_type: TriggerConfigurationExtraction
+}
 
 extractPMTconfig: {
                     module_type:        PMTconfigurationExtraction

--- a/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
+++ b/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
@@ -2,9 +2,6 @@
 
 BEGIN_PROLOG
 
-extractTriggerConfig: { 
-                    module_type: TriggerConfigurationExtraction
-}
 
 extractPMTconfig: {
                     module_type:        PMTconfigurationExtraction
@@ -56,6 +53,12 @@ decodeTrigger: {
                     module_type:        DaqDecoderICARUSTrigger
                     FragmentsLabel:     "daq:ICARUSTriggerUDP"
                     DecoderTool:        @local::TriggerDecoderTool
+}
+
+decodeTriggerV2: {
+		   module_type:	        DaqDecoderICARUSTrigger
+		   FragmentsLabel:	"daq:ICARUSTriggerV2"
+		   DecoderTool:		@local::TriggerDecoderV2Tool
 }
 
 END_PROLOG

--- a/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
@@ -54,7 +54,7 @@ icarus_stage0_producers:
 
   daqCRT:                         @local::crtdaq_icarus
 
-  daqTrigger:                     @local::decodeTrigger
+  daqTrigger:                     @local::decodeTriggerV2
 
   ### calwire producers
   decon1droi:                     @local::icarus_decon1droi

--- a/icaruscode/Decode/fcl/stage0_icarus_defs_olddata.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs_olddata.fcl
@@ -1,0 +1,353 @@
+##
+##  ICARUS definitions for the first stage of data processing
+##  modeled on standard version
+##
+
+#include "services_common_icarus.fcl"
+
+#include "decoderdefs_icarus.fcl"
+#include "recowire_icarus.fcl"
+#include "hitfindermodules_icarus.fcl"
+#include "icarus_ophitfinder.fcl"
+#include "icarus_flashfinder.fcl"
+#include "trigger_emulation_icarus.fcl"
+#include "crt_decoderdefs_icarus.fcl"
+#include "wcls-decode-to-sig-base.fcl"
+
+BEGIN_PROLOG
+
+### Analyzers employed during stage 0 processing ###
+icarus_stage0_analyzers:
+{
+  purityinfoana0: { module_type:     "TPCPurityInfoAna"
+                    PurityInfoLabel: "purityana0"
+                    PrintInfo:       false
+                    SelectEvents:    [ reco ]
+                  }
+  purityinfoana1: { module_type:     "TPCPurityInfoAna"
+                    PurityInfoLabel: "purityana1"
+                    PrintInfo:       false
+                    SelectEvents:    [ reco ]
+                  }
+}
+
+# set the name of our `extractPMTconfig` and trigger decoder modules
+decodePMT.PMTconfigTag: pmtconfig
+decodePMT.TriggerTag:   daqTrigger
+
+### This is the complete list of all producers! ###
+icarus_stage0_producers:
+{
+
+  ### configuration extraction
+  pmtconfig:                      { module_type: PMTconfigurationExtraction }
+
+  ### Decoder definitions
+  daqTrigger:                     @local::decodeTrigger
+
+  daqTPC:                         @local::decodeTPC
+
+  daqTPCROI:                      @local::decodeTPCROI
+
+  pmtconfig:                      @local::extractPMTconfig
+  daqPMT:                         @local::decodePMT
+
+  daqCRT:                         @local::crtdaq_icarus
+
+  daqTrigger:                     @local::decodeTrigger
+
+  ### calwire producers
+  decon1droi:                     @local::icarus_decon1droi
+
+  ### wire-cell decon producers
+  decon2droi:                     @local::standard_wirecell_sigproc
+  decon2droiEE:                   @local::standard_wirecell_sigproc
+  decon2droiEW:                   @local::standard_wirecell_sigproc
+  decon2droiWE:                   @local::standard_wirecell_sigproc
+  decon2droiWW:                   @local::standard_wirecell_sigproc
+
+  ### ROI finding on complete deconvolved waveforms
+  roifinder:                      @local::icarus_roifinder
+
+  ### hit-finder producers
+  gaushit:                        @local::gaus_hitfinder_icarus
+  gaushitTPCWW:                   @local::gaus_hitfinder_icarus
+  gaushitTPCWE:                   @local::gaus_hitfinder_icarus
+  gaushitTPCEW:                   @local::gaus_hitfinder_icarus
+  gaushitTPCEE:                   @local::gaus_hitfinder_icarus
+
+  ### trigger emulation foundation
+  pmtconfigbaselines:             @local::icarus_pmtconfigbaselines
+  pmtthr:                         @local::icarus_pmtdiscriminatethr
+  
+  ### Optical hit finder
+  ophit:                          @local::icarus_ophit_data
+  ophitfull:                      @local::icarus_ophitdebugger_data
+  opflashCryoE:                   @local::ICARUSSimpleFlashDataCryoE
+  opflashCryoW:                   @local::ICARUSSimpleFlashDataCryoW
+
+  ### Purity monitoring
+  purityana0:                     { module_type: "ICARUSPurityDQM" }
+  purityana1:                     { module_type: "ICARUSPurityDQM" }
+}
+
+icarus_stage0_filters:
+{
+   flashfilterBNB: { module_type:         "FilterOpFlash" 
+                     OpFlashProducerList: ["opflashCryoE","opflashCryoW"] 
+#                     WindowStartTime:     -1489.6 # -1489.4 - 0.2us safe margin
+#                     WindowEndTime:       -1487.6 # -1487.8 + 0.2us safe margin
+#                     WindowStartTime:     -1490.8 # 9.6 us - 1500 us offset - 0.4us safe margin
+#                     WindowEndTime:       -1488.4 # 11.2 -1500 us offset + 0.4us safe margin
+                     WindowStartTime:     -0.2 # Gate is now recentered by Gianluca/Andrea
+                     WindowEndTime:        1.8 
+                   }
+   flashfilterNuMI: { module_type:         "FilterOpFlash" 
+                      OpFlashProducerList: ["opflashCryoE","opflashCryoW"] 
+                      WindowStartTime:     -0.2 
+                      WindowEndTime:        9.8 
+                    }
+
+   triggerfilterBNB:       {  module_type:        "TriggerTypeFilter"
+                              TriggerDataLabel:   "daqTrigger"
+                              TriggerType:        "BNB"
+                           }
+
+   triggerfilterNuMI:      {  module_type:        "TriggerTypeFilter"
+                              TriggerDataLabel:   "daqTrigger"
+                              TriggerType:        "NuMI"
+                           }
+
+   triggerfilterOffbeamBNB:  {  module_type:        "TriggerTypeFilter"
+                                TriggerDataLabel:   "daqTrigger"
+                                TriggerType:        "OffbeamBNB"
+                             }
+
+   triggerfilterOffbeamNuMI: {  module_type:        "TriggerTypeFilter"
+                                TriggerDataLabel:   "daqTrigger"
+                                TriggerType:        "OffbeamNuMI"
+                             }
+
+
+   triggerfilterUnknown:  {  module_type:        "TriggerTypeFilter"
+                             TriggerDataLabel:   "daqTrigger"
+                             TriggerType:        "Unknown"
+                          }
+}
+
+
+### Below are a list of convenient sequences that can be used for production/typical users. ###
+
+icarus_stage0_trigger_BNB:         [ daqTrigger,
+                                     triggerfilterBNB 
+                                   ]
+
+icarus_stage0_trigger_NuMI:        [ daqTrigger,
+                                     triggerfilterNuMI 
+                                   ]
+
+icarus_stage0_trigger_OffbeamBNB:  [ daqTrigger,
+                                     triggerfilterOffbeamBNB 
+                                   ]
+
+icarus_stage0_trigger_OffbeamNuMI: [ daqTrigger,
+                                     triggerfilterOffbeamNuMI 
+                                   ]
+
+icarus_stage0_trigger_Unknown:     [ daqTrigger,
+                                     triggerfilterUnknown
+                                   ]
+
+icarus_stage0_multiTPC_TPC:        [ decon1droi,
+                                     roifinder
+                                   ]
+
+icarus_stage0_multiTPC_2d_TPC:     [ decon2droiEE,
+                                     decon2droiEW,
+                                     decon2droiWE,
+                                     decon2droiWW,
+                                     roifinder
+                                   ]
+
+icarus_stage0_EastHits_TPC:        [ gaushitTPCEW,
+                                     gaushitTPCEE
+                                   ]
+
+icarus_stage0_WestHits_TPC:        [ gaushitTPCWW,
+                                     gaushitTPCWE
+                                   ]
+
+icarus_purity_monitor:             [
+                                     purityana0,
+                                     purityana1
+                                   ]
+
+icarus_stage0_PMT:                 [ daqTrigger,
+                                     pmtconfig,
+                                     daqPMT,
+                                     pmtconfigbaselines,
+                                     pmtthr,
+                                     ophit,
+                                     opflashCryoE,
+                                     opflashCryoW
+                                   ]
+
+icarus_stage0_PMT_BNB:             [ @sequence::icarus_stage0_PMT,
+                                     flashfilterBNB
+                                   ]
+
+icarus_stage0_PMT_NuMI:            [ @sequence::icarus_stage0_PMT,
+                                     flashfilterNuMI
+                                   ]
+
+icarus_stage0_multiTPC:            [ @sequence::icarus_stage0_multiTPC_TPC,
+                                     @sequence::icarus_stage0_EastHits_TPC,
+                                     @sequence::icarus_stage0_WestHits_TPC,
+                                     @sequence::icarus_purity_monitor
+                                   ]
+
+icarus_stage0_2d_multiTPC:         [ @sequence::icarus_stage0_multiTPC_2d_TPC,
+                                     @sequence::icarus_stage0_EastHits_TPC,
+                                     @sequence::icarus_stage0_WestHits_TPC,
+                                     @sequence::icarus_purity_monitor
+                                   ]
+
+icarus_stage0_crt:                 [
+                                     daqCRT
+                                   ]
+
+icarus_stage0_data:                [
+                                     @sequence::icarus_stage0_PMT, 
+                                     daqTPCROI, 
+                                     @sequence::icarus_stage0_multiTPC,
+                                     @sequence::icarus_stage0_crt
+                                   ]
+
+icarus_stage0_2d_data:             [
+                                     @sequence::icarus_stage0_PMT, 
+                                     daqTPCROI, 
+                                     @sequence::icarus_stage0_2d_multiTPC,
+                                     @sequence::icarus_stage0_crt
+                                   ]
+
+### Below we include overrides for the modules above
+
+### Handle multiple TPC readout with single instances
+icarus_stage0_producers.daqTPC.FragmentsLabelVec:                                              ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.daqTPCROI.FragmentsLabelVec:                                           ["daq:PHYSCRATEDATATPCWW","daq:PHYSCRATEDATATPCWE","daq:PHYSCRATEDATATPCEW","daq:PHYSCRATEDATATPCEE"]
+
+### Set up for the 1D deconvolution - turn OFF ROI finding
+icarus_stage0_producers.decon1droi.RawDigitLabelVec:                                           ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.decon1droi.ROIFinderToolVec.ROIFinderToolPlane0:                       @local::icarus_noproifinder_0
+icarus_stage0_producers.decon1droi.ROIFinderToolVec.ROIFinderToolPlane1:                       @local::icarus_noproifinder_1
+icarus_stage0_producers.decon1droi.ROIFinderToolVec.ROIFinderToolPlane2:                       @local::icarus_noproifinder_2
+
+### Set up for the 2D deconvolution
+icarus_stage0_producers.decon2droi.wcls_main.inputers:                                         ["wclsRawFrameSource:rfsrc0"]
+icarus_stage0_producers.decon2droi.wcls_main.outputers:                                        ["wclsFrameSaver:spsaver0"]
+icarus_stage0_producers.decon2droi.wcls_main.params.raw_input_label:                           "daqTPC"
+icarus_stage0_producers.decon2droi.wcls_main.params.tpc_volume_label:                          0
+icarus_stage0_producers.decon2droi.wcls_main.params.signal_output_form:                        "dense"
+
+icarus_stage0_producers.decon2droiEE.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc0"]
+icarus_stage0_producers.decon2droiEE.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver0"]
+icarus_stage0_producers.decon2droiEE.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCEE"
+icarus_stage0_producers.decon2droiEE.wcls_main.params.tpc_volume_label:                        0
+icarus_stage0_producers.decon2droiEE.wcls_main.params.signal_output_form:                      "dense"
+
+icarus_stage0_producers.decon2droiEW.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc1"]
+icarus_stage0_producers.decon2droiEW.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver1"]
+icarus_stage0_producers.decon2droiEW.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCEW"
+icarus_stage0_producers.decon2droiEW.wcls_main.params.tpc_volume_label:                        1
+icarus_stage0_producers.decon2droiEW.wcls_main.params.signal_output_form:                      "dense"
+
+icarus_stage0_producers.decon2droiWE.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc2"]
+icarus_stage0_producers.decon2droiWE.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver2"]
+icarus_stage0_producers.decon2droiWE.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCWE"
+icarus_stage0_producers.decon2droiWE.wcls_main.params.tpc_volume_label:                        2
+icarus_stage0_producers.decon2droiWE.wcls_main.params.signal_output_form:                      "dense"
+
+icarus_stage0_producers.decon2droiWW.wcls_main.inputers:                                       ["wclsRawFrameSource:rfsrc3"]
+icarus_stage0_producers.decon2droiWW.wcls_main.outputers:                                      ["wclsFrameSaver:spsaver3"]
+icarus_stage0_producers.decon2droiWW.wcls_main.params.raw_input_label:                         "daqTPCROI:PHYSCRATEDATATPCWW"
+icarus_stage0_producers.decon2droiWW.wcls_main.params.tpc_volume_label:                        3
+icarus_stage0_producers.decon2droiWW.wcls_main.params.signal_output_form:                      "dense"
+
+### Set up to output ROIs from full waveforms
+
+icarus_stage0_producers.roifinder.WireModuleLabelVec:                                          ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE","decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.roifinder.OutInstanceLabelVec:                                         ["PHYSCRATEDATATPCWW","PHYSCRATEDATATPCWE","PHYSCRATEDATATPCEW","PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.roifinder.OutputMorphed:                                               false
+
+### Set up hit finding for multiple TPC readout
+icarus_stage0_producers.gaushitTPCWW.CalDataModuleLabel:                                       "roifinder:PHYSCRATEDATATPCWW"
+icarus_stage0_producers.gaushitTPCWE.CalDataModuleLabel:                                       "roifinder:PHYSCRATEDATATPCWE"
+icarus_stage0_producers.gaushitTPCEW.CalDataModuleLabel:                                       "roifinder:PHYSCRATEDATATPCEW"
+icarus_stage0_producers.gaushitTPCEE.CalDataModuleLabel:                                       "roifinder:PHYSCRATEDATATPCEE"
+
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane0:                     @local::candhitfinder_standard      # Sets hit finding for plane 0
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane0.Plane:               0
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:        9.
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane1:                     @local::candhitfinder_standard      # Sets hit finding for plane 1
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane1.Plane:               1
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:        9.5
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane2:                     @local::candhitfinder_standard      # Sets hit finding for plane 2
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane2.Plane:               2
+icarus_stage0_producers.gaushitTPCWW.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:        9.
+
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane0:                     @local::candhitfinder_standard      # Sets hit finding for plane 0
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane0.Plane:               0
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:        9.
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane1:                     @local::candhitfinder_standard      # Sets hit finding for plane 1
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane1.Plane:               1
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:        9.5
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane2:                     @local::candhitfinder_standard      # Sets hit finding for plane 2
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane2.Plane:               2
+icarus_stage0_producers.gaushitTPCWE.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:        9.
+
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane0:                     @local::candhitfinder_standard      # Sets hit finding for plane 0
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane0.Plane:               0
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:        9.
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane1:                     @local::candhitfinder_standard      # Sets hit finding for plane 1
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane1.Plane:               1
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:        9.5
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane2:                     @local::candhitfinder_standard      # Sets hit finding for plane 2
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane2.Plane:               2
+icarus_stage0_producers.gaushitTPCEW.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:        9.
+
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane0:                     @local::candhitfinder_standard      # Sets hit finding for plane 0
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane0.Plane:               0
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:        9.
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane1:                     @local::candhitfinder_standard      # Sets hit finding for plane 1
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane1.Plane:               1
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:        9.5
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane2:                     @local::candhitfinder_standard      # Sets hit finding for plane 2
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane2.Plane:               2
+icarus_stage0_producers.gaushitTPCEE.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:        9.
+
+### Optical hit finding
+icarus_stage0_producers.ophit.InputModule:                                                     "daqPMT"
+icarus_stage0_producers.ophit.InputLabels:                                                     []
+
+### Default purity monitor settings (single TPC readout assumed)
+icarus_stage0_producers.purityana0.RawModuleLabel:                                             ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.purityana0.ValoreTauFCL:                                               600000.
+icarus_stage0_producers.purityana0.CryostatFCL:                                                0
+icarus_stage0_producers.purityana0.PlaneFCL:                                                   2
+icarus_stage0_producers.purityana0.ThresholdFCL:                                               3
+icarus_stage0_producers.purityana0.PersistPurityInfo:                                          false
+icarus_stage0_producers.purityana0.FillAnaTuple:                                               false
+icarus_stage0_producers.purityana0.PersistPurityInfo:                                          false
+icarus_stage0_producers.purityana0.FillAnaTuple:                                               false
+
+icarus_stage0_producers.purityana1.RawModuleLabel:                                             ["daqTPCROI:PHYSCRATEDATATPCWW","daqTPCROI:PHYSCRATEDATATPCWE","daqTPCROI:PHYSCRATEDATATPCEW","daqTPCROI:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.purityana1.ValoreTauFCL:                                               600000.
+icarus_stage0_producers.purityana1.CryostatFCL:                                                1
+icarus_stage0_producers.purityana1.PlaneFCL:                                                   2
+icarus_stage0_producers.purityana1.ThresholdFCL:                                               3
+icarus_stage0_producers.purityana1.PersistPurityInfo:                                          false
+icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
+icarus_stage0_producers.purityana1.PersistPurityInfo:                                          false
+icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
+
+END_PROLOG

--- a/icaruscode/Decode/fcl/stage0_icarus_driver_common_olddata.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_driver_common_olddata.fcl
@@ -1,0 +1,103 @@
+##
+##  Shared art job configuartions for ICARUS reco
+##
+#include "stage0_icarus_defs_olddata.fcl"
+#include "services_common_icarus.fcl"
+#include "channelmapping_icarus.fcl"
+
+process_name: Stage0
+
+services:
+{
+  TFileService:           { }
+  IICARUSChannelMap:      @local::icarus_channelmappinggservice
+                          @table::icarus_wirecalibration_minimum_services
+}
+
+#source is a root file
+source:
+{
+  module_type: RootInput
+  maxEvents:  10        # Number of events to create
+  saveMemoryObjectThreshold: 0
+}
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+
+ producers:
+ {
+     @table::icarus_stage0_producers
+ }
+
+ filters:
+ {
+     @table::icarus_stage0_filters
+ }
+
+ analyzers:
+ {
+     @table::icarus_stage0_analyzers
+ }
+
+ #reco sequence and trigger_paths to be defined elsewhere
+
+ streamBNB:            [ outBNB ]
+ streamNUMI:           [ outNUMI ]
+ streamUnknown:        [ outUnknown ]
+ end_paths:            [ streamBNB ]
+
+}
+
+#block to define where the output goes.  if you defined a filter in the physics
+#block and put it in the trigger_paths then you need to put a SelectEvents: {SelectEvents: [XXX]}
+#entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
+outputs:
+{
+ outBNB:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+ }
+ outNUMI:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+ }
+ outUnknown:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+ }
+}
+
+# Include this as per directive of Kazu and Andrea (circa March 25, 2021) for introduction of the filter
+#services.DetectorClocksService.InheritClockConfig: false
+
+### Here we try to suppress known and pointless messages
+### See https://cdcvs.fnal.gov/redmine/projects/messagefacility/wiki for details
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       default:
+       {
+         limit: -1  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_nofilter_rawpmt_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_nofilter_rawpmt_icarus.fcl
@@ -1,0 +1,50 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+## 
+## It drops TPC raw digits but not the PMT ones.
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the paths we'll execute depending on data
+#physics.pathOptical: [ @sequence::icarus_stage0_pmt ]
+physics.pathBNB:     [ @sequence::icarus_stage0_trigger_BNB,     @sequence::icarus_stage0_data ]
+physics.pathNUMI:    [ @sequence::icarus_stage0_trigger_NuMI,    @sequence::icarus_stage0_data ]
+
+physics.pathOffbeamBNB:     [ @sequence::icarus_stage0_trigger_OffbeamBNB,  @sequence::icarus_stage0_data]
+physics.pathOffbeamNUMI:    [ @sequence::icarus_stage0_trigger_OffbeamNuMI, @sequence::icarus_stage0_data ]
+
+physics.pathUnknown: [ @sequence::icarus_stage0_trigger_Unknown, @sequence::icarus_stage0_data ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ pathBNB, pathNUMI, pathOffbeamBNB, pathOffbeamNUMI, pathUnknown ]
+physics.end_paths:     [ outana, streamBNB, streamNUMI, streamOffbeamBNB, streamOffbeamNUMI, streamUnknown ]
+
+outputs.outBNB.fileName: "BNB_%ifb_%tc-%p.root"
+outputs.outBNB.SelectEvents: [ pathBNB ]
+
+outputs.outNUMI.fileName: "NUMI_%ifb_%tc-%p.root"
+outputs.outNUMI.SelectEvents: [ pathNUMI ]
+
+outputs.outOffbeamBNB.fileName: "OffbeamBNB_%ifb_%tc-%p.root"
+outputs.outOffbeamBNB.SelectEvents: [ pathOffbeamBNB ]
+
+outputs.outOffbeamNUMI.fileName: "OffbeamNUMI_%ifb_%tc-%p.root"
+outputs.outOffbeamNUMI.SelectEvents: [ pathOffbeamNUMI ]
+
+outputs.outUnknown.fileName: "UNK_%ifb_%tc-%p.root"
+outputs.outUnknown.SelectEvents: [ pathUnknown ]
+
+# Drop the artdaq format files on output
+outputs.outBNB.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outNUMI.outputCommands:        ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outOffbeamBNB.outputCommands:  ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outOffbeamNUMI.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outUnknown.outputCommands:     ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ pathBNB, pathNUMI, pathOffbeamBNB, pathOffbeamNUMI, pathUnknown ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ pathBNB, pathNUMI, pathOffbeamBNB, pathOffbeamNUMI, pathUnknown ]

--- a/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_nofilter_rawpmt_icarus_olddata.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_splitstream_nofilter_rawpmt_icarus_olddata.fcl
@@ -1,0 +1,39 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+## 
+## It drops TPC raw digits but not the PMT ones.
+##
+#include "stage0_icarus_driver_common_olddata.fcl"
+
+process_name: stage0
+
+## Define the paths we'll execute depending on data
+#physics.pathOptical: [ @sequence::icarus_stage0_pmt ]
+physics.pathBNB:     [ @sequence::icarus_stage0_trigger_BNB,     @sequence::icarus_stage0_data ]
+physics.pathNUMI:    [ @sequence::icarus_stage0_trigger_NuMI,    @sequence::icarus_stage0_data ]
+
+physics.pathUnknown: [ @sequence::icarus_stage0_trigger_Unknown, @sequence::icarus_stage0_data ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ pathBNB, pathNUMI, pathUnknown ]
+physics.end_paths:     [ outana, streamBNB, streamNUMI, streamUnknown ]
+
+outputs.outBNB.fileName: "BNB_%ifb_%tc-%p.root"
+outputs.outBNB.SelectEvents: [ pathBNB ]
+
+outputs.outNUMI.fileName: "NUMI_%ifb_%tc-%p.root"
+outputs.outNUMI.SelectEvents: [ pathNUMI ]
+
+outputs.outUnknown.fileName: "UNK_%ifb_%tc-%p.root"
+outputs.outUnknown.SelectEvents: [ pathUnknown ]
+
+# Drop the artdaq format files on output
+outputs.outBNB.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outNUMI.outputCommands:        ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outUnknown.outputCommands:     ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ pathBNB, pathNUMI, pathUnknown ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ pathBNB, pathNUMI, pathUnknown ]

--- a/icaruscode/Decode/fcl/test_trigger_decode.fcl
+++ b/icaruscode/Decode/fcl/test_trigger_decode.fcl
@@ -32,7 +32,7 @@ physics:
     producers:
     {
         #daqPMT:      @local::decodePMT
-	daqTrigger:  @local::decodeTrigger
+	daqTrigger:  @local::decodeTriggerV2
 	
     }
 


### PR DESCRIPTION
This PR adds the new trigger decoding framework to the develop branch. Same caveats as for the original PR to the production branch: https://github.com/SBNSoftware/icaruscode/pull/398 that it only works on data taken with the latest DAQ release or before the implementation of the new trigger system. In the near future I will create a separate branch to handle this data.

Tested with all 4 existing data streams with only the trigger decoder and also the full stage0 processing for run 8353