### PR TITLE
DumpTriggerConfiguration module to print trigger configuration on screen

### DIFF
--- a/fcl/utilities/dump_triggerconfig_icarus.fcl
+++ b/fcl/utilities/dump_triggerconfig_icarus.fcl
@@ -1,0 +1,65 @@
+#
+# File:     dump_triggerconfig_icarus.fcl
+# Purpose:  Dump on screen trigger configuration from DAQ.
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     June 13, 2022
+# Version:  1.0
+#
+# This module extracts and then dumps the trigger configuration stored in the
+# FHiCL configuration of that file(s), one per run.
+# All output is poured into standard output.
+#
+#
+# Input: (data) files with FHiCL configuration of trigger.
+#
+# Service dependencies:
+# - message facility
+# 
+# Changes:
+# 20220611 (petrillo@slac.stanford.edu) [v1.0]
+#   first version (from `dump_pmtconfig_icarus.fcl` 1.0)
+#
+
+#include "messages_icarus.fcl"
+
+
+# ------------------------------------------------------------------------------
+process_name: DumpTrgCfg
+
+
+# ------------------------------------------------------------------------------
+services: {
+  
+  message: @local::icarus_message_services_interactive
+  
+} # services
+
+
+# ------------------------------------------------------------------------------
+physics: {
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  producers: {
+    trgconfig: { module_type: TriggerConfigurationExtraction }
+  }
+  
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  analyzers: {
+  
+    dumptrgconfig: {
+    
+      module_type:  DumpTriggerConfiguration
+      
+      TriggerConfigurationTag: "trgconfig"
+      
+    } # dumptrgconfig
+
+  } # analyzers
+  
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  extractors: [ trgconfig ]
+  dumpers:    [ dumptrgconfig ]
+  
+} # physics
+
+
+# ------------------------------------------------------------------------------

--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -105,71 +105,71 @@ namespace sbn {
       NBits    ///< Number of bits currently supported.
     }; // triggerSource
 
-    /// Type of mask with `triggerSource` bits.                                                                                 
+    /// Type of mask with `triggerSource` bits.
     using triggerSourceMask = mask_t<triggerSource>;
 
     
-    /// Location or locations generating a trigger.                                                                                 
+    /// Location or locations generating a trigger.
     enum class triggerLocation: unsigned int {
-        CryoEast,    ///< A trigger happened in the east cryostat.
-	CryoWest,    ///< A trigger happened in the west cryostat.
-	TPCEE,       ///< A trigger happened in the east cryostat, east TPC.
-	TPCEW,       ///< A trigger happened in the east cryostat, west TPC.
-	TPCWE,       ///< A trigger happened in the west cryostat, east TPC.
-	TPCWW,       ///< A trigger happened in the west cryostat, west TPC.   
-	// ==> add here if more are needed <==
-	NBits    ///< Number of bits currently supported. 
-	}; // triggerLocation                    
-                                                                                 
+      CryoEast,    ///< A trigger happened in the east cryostat.
+      CryoWest,    ///< A trigger happened in the west cryostat.
+      TPCEE,       ///< A trigger happened in the east cryostat, east TPC.
+      TPCEW,       ///< A trigger happened in the east cryostat, west TPC.
+      TPCWE,       ///< A trigger happened in the west cryostat, east TPC.
+      TPCWW,       ///< A trigger happened in the west cryostat, west TPC.
+      // ==> add here if more are needed <==
+      NBits    ///< Number of bits currently supported.
+    }; // triggerLocation
+
     /// Type of mask with `triggerLocation` bits.
     using triggerLocationMask = mask_t<triggerLocation>;
 
     /// Type representing the type(s) of this trigger.
     enum class triggerType: unsigned int {
-        Majority,    ///< A minimum number of close-by PMT pairs above threshold was reached.
-	MinimumBias, ///< Data collected at gate opening with no further requirement imposed.
-	// ==> add here if more are needed <==
-	NBits    ///< Number of bits currently supported.
-	}; // triggerType
+      Majority,    ///< A minimum number of close-by PMT pairs above threshold was reached.
+      MinimumBias, ///< Data collected at gate opening with no further requirement imposed.
+      // ==> add here if more are needed <==
+      NBits    ///< Number of bits currently supported.
+    }; // triggerType
 
-    /// Type of mask with `triggerType` bits. 
+    /// Type of mask with `triggerType` bits.
     using triggerTypeMask = mask_t<triggerType>;
     
-    /// Trigger window mode 
+    /// Trigger window mode
     enum class triggerWindowMode: unsigned int {
       Separated,    ///< Separated, non-overlapping contigous window
-	Overlapping,  ///< Overlaping windows
-	//==> add here if more are needed <==
-	NBits     ///< Number of Bits currently supported
-	};
+      Overlapping,  ///< Overlaping windows
+      //==> add here if more are needed <==
+      NBits     ///< Number of Bits currently supported
+    };
 
     
 
     /// Enabled gates in the trigger configuration. See register 0X00050008 in docdb SBN-doc-23778-v1
     enum class gateSelection: unsigned int {
-      GateBNB,                     ///<Enable receiving BNB early warning signal (gatedBES) to open BNB gates 
-	DriftGateBNB,                ///<Enable BNB early-early warning signal ($1D) for light out-of-time in BNB gates
-	GateNuMI,                    ///<Enable NuMI early warning signal (MIBS$74) to open NuMI gates 
-	DriftGateNuMI,               ///<Enable receiving NuMI early-early warning signal ($AD) for light out-of-time in NuMI gates
-	GateOffbeamBNB,              ///<Enable Offbeam gate for BNB 
-	DriftGateOffbeamBNB,         ///<Enable Offbeam drift gate BNB (for light out-of-time in offbeam gates)
-	GateOffbeamNuMI,             ///<Enable Offbeam gate for NuMI 
-	DriftGateOffbeamNuMI,        ///<Enable Offbeam drift gate NuMI (for light out-of-time in offbeam gates)
-	GateCalibration,             ///<Enable Calibration gate  
-	DriftGateCalibration,        ///<Enable Calibration drift gate (for light out-of-time in calibration gates)
-	MinbiasGateBNB,              ///<Enable MinBias triggers for the BNB stream 
-	MinbiasGateNuMI,             ///<Enable MinBias triggers for the NuMI stream 
-	MinbiasGateOffbeamBNB,       ///<Enabke MinBias triggers for the Offbeam BNB stream
-	MinbiasGateOffbeamNuMI,      ///<Enable MinBias triggers for the Offbeam NuMI stream
-	MinbiasGateCalibration,      ///<Enable MinBias triggers for the Calibration stream
-	MinbiasDriftGateBNB,         ///<Enable light out-of-time for MinBias triggers in BNB stream
-	MinbiasDriftGateNuMI,        ///<Enable light out-of-time for MinBias triggers in NuMI stream
-	MinbiasDriftGateOffbeamBNB,  ///<Enable light out-of-time for MinBias triggers in Offbeam BNB stream 
-	MinbiasDriftGateOffbeamNuMI, ///<Enable light out-of-time for MinBias triggers in Offbeam NuMI stream
-	MinbiasDriftGateCalibration, ///<Enable light out-of-time for MinBias triggers in Calibration stream
-	// ==> add here if more are needed <==
+      GateBNB,                     ///<Enable receiving BNB early warning signal (gatedBES) to open BNB gates
+      DriftGateBNB,                ///<Enable BNB early-early warning signal ($1D) for light out-of-time in BNB gates
+      GateNuMI,                    ///<Enable NuMI early warning signal (MIBS$74) to open NuMI gates
+      DriftGateNuMI,               ///<Enable receiving NuMI early-early warning signal ($AD) for light out-of-time in NuMI gates
+      GateOffbeamBNB,              ///<Enable Offbeam gate for BNB
+      DriftGateOffbeamBNB,         ///<Enable Offbeam drift gate BNB (for light out-of-time in offbeam gates)
+      GateOffbeamNuMI,             ///<Enable Offbeam gate for NuMI
+      DriftGateOffbeamNuMI,        ///<Enable Offbeam drift gate NuMI (for light out-of-time in offbeam gates)
+      GateCalibration,             ///<Enable Calibration gate
+      DriftGateCalibration,        ///<Enable Calibration drift gate (for light out-of-time in calibration gates)
+      MinbiasGateBNB,              ///<Enable MinBias triggers for the BNB stream
+      MinbiasGateNuMI,             ///<Enable MinBias triggers for the NuMI stream
+      MinbiasGateOffbeamBNB,       ///<Enabke MinBias triggers for the Offbeam BNB stream
+      MinbiasGateOffbeamNuMI,      ///<Enable MinBias triggers for the Offbeam NuMI stream
+      MinbiasGateCalibration,      ///<Enable MinBias triggers for the Calibration stream
+      MinbiasDriftGateBNB,         ///<Enable light out-of-time for MinBias triggers in BNB stream
+      MinbiasDriftGateNuMI,        ///<Enable light out-of-time for MinBias triggers in NuMI stream
+      MinbiasDriftGateOffbeamBNB,  ///<Enable light out-of-time for MinBias triggers in Offbeam BNB stream
+      MinbiasDriftGateOffbeamNuMI, ///<Enable light out-of-time for MinBias triggers in Offbeam NuMI stream
+      MinbiasDriftGateCalibration, ///<Enable light out-of-time for MinBias triggers in Calibration stream
+      // ==> add here if more are needed <==
       NBits
-	}; // gateSelection
+    }; // gateSelection
 
     using gateSelectionMask = mask_t<gateSelection>;
 
@@ -280,47 +280,47 @@ inline std::string sbn::bits::bitName(triggerSource bit) {
     + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
 
-// -----------------------------------------------------------------------------                                              
+// -----------------------------------------------------------------------------
 
 inline std::string sbn::bits::bitName(triggerLocation bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case triggerLocation::CryoEast: return "Cryo E"s;
-  case triggerLocation::CryoWest: return "Cryo W"s;
-  case triggerLocation::TPCEE:    return "TPC EE"s;
-  case triggerLocation::TPCEW:    return "TPC EW"s;
-  case triggerLocation::TPCWE:    return "TPC WE"s;
-  case triggerLocation::TPCWW:    return "TPC WW"s;
-  case triggerLocation::NBits:    return "<invalid>"s;
-  } // switch 
+    case triggerLocation::CryoEast: return "Cryo E"s;
+    case triggerLocation::CryoWest: return "Cryo W"s;
+    case triggerLocation::TPCEE:    return "TPC EE"s;
+    case triggerLocation::TPCEW:    return "TPC EW"s;
+    case triggerLocation::TPCWE:    return "TPC WE"s;
+    case triggerLocation::TPCWW:    return "TPC WW"s;
+    case triggerLocation::NBits:    return "<invalid>"s;
+  } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerLocation{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
-} // sbn::bitName(triggerLocation)                                                                                                
+    + std::to_string(value(bit)) + " }): unknown bit"s);
+} // sbn::bitName(triggerLocation)
 
-// -----------------------------------------------------------------------------                                  
+// -----------------------------------------------------------------------------
 inline std::string sbn::bits::bitName(triggerType bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case triggerType::Majority:    return "majority"s;
-  case triggerType::MinimumBias: return "minimum bias"s;
-  case triggerType::NBits:       return "<invalid>"s;
+    case triggerType::Majority:    return "majority"s;
+    case triggerType::MinimumBias: return "minimum bias"s;
+    case triggerType::NBits:       return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerType{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName(triggerType)
 
 inline std::string sbn::bits::bitName(triggerWindowMode bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
-  case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
-  case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
+    case sbn::bits::triggerWindowMode::Separated:    return "Separated Window"s;
+    case sbn::bits::triggerWindowMode::Overlapping:  return "Overlapping Window"s;
+    case sbn::bits::triggerWindowMode::NBits:    return "<invalid>"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(triggerWindowMode{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // triggerWindowMode
 
 
@@ -328,53 +328,48 @@ inline std::string sbn::bits::bitName(gateSelection bit) {
 
   using namespace std::string_literals;
   switch (bit) {
-  case gateSelection::GateBNB:                     return "GateBNB"s;
-  case gateSelection::DriftGateBNB:                return "DriftGateBNB"s;
-  case gateSelection::GateNuMI:                    return "GateNuMI"s;
-  case gateSelection::DriftGateNuMI:               return "DriftGateNuMI"s;
-  case gateSelection::GateOffbeamBNB:              return "GateOffbeamBNB"s;
-  case gateSelection::DriftGateOffbeamBNB:         return "DriftGateOffbeamBNB"s;
-  case gateSelection::GateOffbeamNuMI:             return "GateOffbeamNuMI"s;
-  case gateSelection::DriftGateOffbeamNuMI:        return "DriftGateOffbeamNuMI"s;
-  case gateSelection::GateCalibration:             return "GateCalibration"s;
-  case gateSelection::DriftGateCalibration:        return "DriftGateCalibration"s;
-  case gateSelection::MinbiasGateBNB:              return "MinbiasGateBNB"s;
-  case gateSelection::MinbiasGateNuMI:             return "MinbiasGateNuMI"s;
-  case gateSelection::MinbiasGateOffbeamBNB:       return "MinbiasGateOffbeamBNB"s;
-  case gateSelection::MinbiasGateOffbeamNuMI:      return "MinbiasGateOffbeamNuMI"s;
-  case gateSelection::MinbiasGateCalibration:      return "MinbiasGateCalibration"s;
-  case gateSelection::MinbiasDriftGateBNB:         return "MinbiasDriftGateBNB"s;
-  case gateSelection::MinbiasDriftGateNuMI:        return "MinbiasDriftGateNuMI"s;
-  case gateSelection::MinbiasDriftGateOffbeamBNB:  return "MinbiasDriftGateOffbeamBNB"s;
-  case gateSelection::MinbiasDriftGateOffbeamNuMI: return "MinbiasDriftGateOffbeamNuMI"s;
-  case gateSelection::MinbiasDriftGateCalibration: return "MinbiasDriftGateCalibration"s;
-  case gateSelection::NBits:                       return "NBits"s;
+    case gateSelection::GateBNB:                     return "GateBNB"s;
+    case gateSelection::DriftGateBNB:                return "DriftGateBNB"s;
+    case gateSelection::GateNuMI:                    return "GateNuMI"s;
+    case gateSelection::DriftGateNuMI:               return "DriftGateNuMI"s;
+    case gateSelection::GateOffbeamBNB:              return "GateOffbeamBNB"s;
+    case gateSelection::DriftGateOffbeamBNB:         return "DriftGateOffbeamBNB"s;
+    case gateSelection::GateOffbeamNuMI:             return "GateOffbeamNuMI"s;
+    case gateSelection::DriftGateOffbeamNuMI:        return "DriftGateOffbeamNuMI"s;
+    case gateSelection::GateCalibration:             return "GateCalibration"s;
+    case gateSelection::DriftGateCalibration:        return "DriftGateCalibration"s;
+    case gateSelection::MinbiasGateBNB:              return "MinbiasGateBNB"s;
+    case gateSelection::MinbiasGateNuMI:             return "MinbiasGateNuMI"s;
+    case gateSelection::MinbiasGateOffbeamBNB:       return "MinbiasGateOffbeamBNB"s;
+    case gateSelection::MinbiasGateOffbeamNuMI:      return "MinbiasGateOffbeamNuMI"s;
+    case gateSelection::MinbiasGateCalibration:      return "MinbiasGateCalibration"s;
+    case gateSelection::MinbiasDriftGateBNB:         return "MinbiasDriftGateBNB"s;
+    case gateSelection::MinbiasDriftGateNuMI:        return "MinbiasDriftGateNuMI"s;
+    case gateSelection::MinbiasDriftGateOffbeamBNB:  return "MinbiasDriftGateOffbeamBNB"s;
+    case gateSelection::MinbiasDriftGateOffbeamNuMI: return "MinbiasDriftGateOffbeamNuMI"s;
+    case gateSelection::MinbiasDriftGateCalibration: return "MinbiasDriftGateCalibration"s;
+    case gateSelection::NBits:                       return "NBits"s;
   } // switch
   throw std::runtime_error("sbn::bits::bitName(gateSelection{ "s
-			   + std::to_string(value(bit)) + " }): unknown bit"s);
+    + std::to_string(value(bit)) + " }): unknown bit"s);
 } // sbn::bitName()
 
-namespace icarus {
 
-  namespace trigger {
+namespace icarus::trigger {
 
-  
-    using triggerLocation = sbn::triggerLocation;
-    using triggerSource   = sbn::triggerSource;
+  using triggerLocation = sbn::triggerLocation;
+  using triggerSource   = sbn::triggerSource;
 
-    static constexpr std::size_t kEast             = sbn::bits::value<triggerLocation>(triggerLocation::CryoEast);
-    static constexpr std::size_t kWest             = sbn::bits::value<triggerLocation>(triggerLocation::CryoWest);
-    static constexpr std::size_t kNTriggerLocation = sbn::bits::value<triggerLocation>(triggerLocation::NBits);
+  static constexpr std::size_t kEast             = sbn::bits::value<triggerLocation>(triggerLocation::CryoEast);
+  static constexpr std::size_t kWest             = sbn::bits::value<triggerLocation>(triggerLocation::CryoWest);
+  static constexpr std::size_t kNTriggerLocation = sbn::bits::value<triggerLocation>(triggerLocation::NBits);
 
-    static constexpr std::size_t kBNB            = sbn::bits::value<triggerSource>(triggerSource::BNB);
-    static constexpr std::size_t kNuMI           = sbn::bits::value<triggerSource>(triggerSource::NuMI);
-    static constexpr std::size_t kOffBeamBNB     = sbn::bits::value<triggerSource>(triggerSource::OffbeamBNB);
-    static constexpr std::size_t kOffBeamNuMI    = sbn::bits::value<triggerSource>(triggerSource::OffbeamNuMI);
-    static constexpr std::size_t kCalibration    = sbn::bits::value<triggerSource>(triggerSource::Calib);
-    static constexpr std::size_t kNTriggerSource = sbn::bits::value<triggerSource>(triggerSource::NBits);
-
-  }
-
+  static constexpr std::size_t kBNB            = sbn::bits::value<triggerSource>(triggerSource::BNB);
+  static constexpr std::size_t kNuMI           = sbn::bits::value<triggerSource>(triggerSource::NuMI);
+  static constexpr std::size_t kOffBeamBNB     = sbn::bits::value<triggerSource>(triggerSource::OffbeamBNB);
+  static constexpr std::size_t kOffBeamNuMI    = sbn::bits::value<triggerSource>(triggerSource::OffbeamNuMI);
+  static constexpr std::size_t kCalibration    = sbn::bits::value<triggerSource>(triggerSource::Calib);
+  static constexpr std::size_t kNTriggerSource = sbn::bits::value<triggerSource>(triggerSource::NBits);
 
 }
 

--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -51,12 +51,18 @@ namespace sbn {
     //using mask_t = std::underlying_type_t<EnumType>;
     
     template <typename EnumType>
-      struct mask_t {
-	using bits_t = EnumType; ///< Enumeration type of the bits.
-	using maskbits_t = std::underlying_type_t<EnumType>; ///< Bit data type.   
-	maskbits_t bits { 0 };
-	operator maskbits_t() const { return bits; }
-      }; // mask_t   
+    struct mask_t {
+      using bits_t = EnumType; ///< Enumeration type of the bits.
+      using maskbits_t = std::underlying_type_t<EnumType>; ///< Bit data type.
+      maskbits_t bits { 0 };
+      operator maskbits_t() const { return bits; }
+    }; // mask_t
+
+    /// Converts a integral type into a mask.
+    template <typename EnumType>
+    mask_t<EnumType> makeMask
+      (typename mask_t<EnumType>::maskbits_t bits) noexcept;
+    
     
     /// Returns the value of specified `bit` (conversion like `enum` to `int`).
     template <typename EnumType>
@@ -197,6 +203,13 @@ namespace sbn {
 
 // -----------------------------------------------------------------------------
 // ---  inline and template implementation
+// -----------------------------------------------------------------------------
+template <typename EnumType>
+auto sbn::bits::makeMask  (typename mask_t<EnumType>::maskbits_t bits) noexcept
+  -> mask_t<EnumType>
+  { return { bits }; }
+
+
 // -----------------------------------------------------------------------------
 template <typename EnumType>
 constexpr auto sbn::bits::value(EnumType bit)

--- a/icaruscode/Decode/CMakeLists.txt
+++ b/icaruscode/Decode/CMakeLists.txt
@@ -6,6 +6,7 @@ art_make(
           EXCLUDE
                         TriggerConfigurationExtraction_module.cc
                         PMTconfigurationExtraction_module.cc
+                        DumpTriggerConfiguration_module.cc
                         DumpPMTconfiguration_module.cc
                         DumpArtDAQfragments_module.cc
                         DaqDecoderICARUSPMT_module.cc
@@ -75,6 +76,13 @@ simple_plugin(TriggerConfigurationExtraction module
 
 simple_plugin(DumpPMTconfiguration module
   sbnobj_Common_PMT_Data
+  ${MF_MESSAGELOGGER}
+  fhiclcpp
+  cetlib_except
+  )
+
+simple_plugin(DumpTriggerConfiguration module
+  icaruscode_Decode_DataProducts
   ${MF_MESSAGELOGGER}
   fhiclcpp
   cetlib_except

--- a/icaruscode/Decode/DataProducts/TriggerConfiguration.cxx
+++ b/icaruscode/Decode/DataProducts/TriggerConfiguration.cxx
@@ -22,15 +22,15 @@ void icarus::TriggerConfiguration::dumpGateConfig
   (std::ostream& out, icarus::TriggerConfiguration::GateConfig const& gateConfig, std::string const& indent) const
 {
   out << std::boolalpha
-    << indent << "Gate Active:              " << gateConfig.hasGate << "\n"
-    << indent << "Drift gate Active         " << gateConfig.hasDriftGate << "\n"
-    << indent << "MinBias Gate Active:      " << gateConfig.hasMinBiasGate << "\n"
-    << indent << "MinBias Drift Gate Active " << gateConfig.hasMinBiasDriftGate << "\n"
-    << indent << "BeamWidth                 " << gateConfig.gateWidth << " ns\n"
-    << indent << "EnableWidth               " << gateConfig.driftGateWidth  << " ns\n"
-    << indent << "EarlyWarningOffset        " << gateConfig.earlyWarningOffset << " ns\n"
-    << indent << "EarlyWarningOffset        " << gateConfig.earlyEarlyWarningOffset << " ns\n"
-    << indent << "PreScale                  " << gateConfig.prescaleMinBias << "\n"
+    << indent << "Gate Active:               " << gateConfig.hasGate << "\n"
+    << indent << "Drift gate Active:         " << gateConfig.hasDriftGate << "\n"
+    << indent << "MinBias Gate Active:       " << gateConfig.hasMinBiasGate << "\n"
+    << indent << "MinBias Drift Gate Active: " << gateConfig.hasMinBiasDriftGate << "\n"
+    << indent << "BeamWidth:                 " << gateConfig.gateWidth << " ns\n"
+    << indent << "EnableWidth:               " << gateConfig.driftGateWidth  << " ns\n"
+    << indent << "EarlyWarningOffset:        " << gateConfig.earlyWarningOffset << " ns\n"
+    << indent << "EarlyEarlyWarningOffset:   " << gateConfig.earlyEarlyWarningOffset << " ns\n"
+    << indent << "PreScale:                  " << gateConfig.prescaleMinBias << "\n"
     << std::noboolalpha
     ;
 }
@@ -55,23 +55,22 @@ void icarus::TriggerConfiguration::dump(std::ostream& out,
     
     // --- verbosity: 0+ -------------------------------------------------------
     out << firstIndent
-      << "\nBasic trigger configuration:\n ";
-      outnl() << " Use Wr time "    << useWrTime << " \n";
-      outnl() << " WR time offset " << wrTimeOffset << " ns \n"; 
+      << "Basic trigger configuration:";
+      outnl() << " Use WR time:    " << std::boolalpha << useWrTime << std::noboolalpha;
+      outnl() << " WR time offset: " << wrTimeOffset;
     
     if (++level > verbosity) break;
     // --- verbosity: 1+ -------------------------------------------------------
-    outnl()
-      << " FPGA Configuration: \n "
-      << " Veto Delay:            "  <<  vetoDelay << " ns,\n"
-      << " MajLevelBeamCryoEAST   "  <<  cryoConfig[icarus::trigger::kEast].majLevelInTime    << " \n"
-      << " MajLevelEnableCryoEAST "  <<  cryoConfig[icarus::trigger::kEast].majLevelDrift  << " \n"
-      << " WindowCryoEAST         "  <<  cryoConfig[icarus::trigger::kEast].slidingWindow   << " \n"
-      << " MajLevelBeamCryoWEST   "  <<  cryoConfig[icarus::trigger::kWest].majLevelInTime    << " \n"
-      << " MajLevelEnableCryoWEST "  <<  cryoConfig[icarus::trigger::kWest].majLevelDrift  << " \n"
-      << " WindowCryoWEST         "  <<  cryoConfig[icarus::trigger::kWest].slidingWindow   << " \n"
-      << " MajorityTriggerType    "  <<  majorityTriggerType                << " \n"
-      << " RunType                "  <<  runType << " ";
+    outnl() << "FPGA Configuration:";
+    outnl() << " Veto Delay:             "  <<  vetoDelay << " ns";
+    outnl() << " MajLevelBeamCryoEAST:   "  <<  cryoConfig[icarus::trigger::kEast].majLevelInTime;
+    outnl() << " MajLevelEnableCryoEAST: "  <<  cryoConfig[icarus::trigger::kEast].majLevelDrift;
+    outnl() << " WindowCryoEAST:         "  <<  cryoConfig[icarus::trigger::kEast].slidingWindow;
+    outnl() << " MajLevelBeamCryoWEST:   "  <<  cryoConfig[icarus::trigger::kWest].majLevelInTime;
+    outnl() << " MajLevelEnableCryoWEST: "  <<  cryoConfig[icarus::trigger::kWest].majLevelDrift;
+    outnl() << " WindowCryoWEST:         "  <<  cryoConfig[icarus::trigger::kWest].slidingWindow;
+    outnl() << " MajorityTriggerType:   '"  <<  majorityTriggerType << "'";
+    outnl() << " RunType:               '"  <<  runType << "'";
 
     out << "\n";
 
@@ -79,26 +78,27 @@ void icarus::TriggerConfiguration::dump(std::ostream& out,
     // --- verbosity: 2+ -------------------------------------------------------
     
     out << indent // absorb the newline from the previous level
-      << "\nSPEXI Configuration: \n ";
+      << "SPEXI Configuration:\n";
       
-      out << "TPCTriggerDelay" << tpcTriggerDelay << " /400 ns \n ";
+      out << indent << " TPCTriggerDelay: " << (tpcTriggerDelay * 0.0004) << " ms ("
+        << tpcTriggerDelay << " x 400 ns)\n";
       
       out << indent << " BNB:\n";
-      dumpGateConfig( out, gateConfig[icarus::trigger::kBNB], indent+" - " );
+      dumpGateConfig( out, gateConfig[icarus::trigger::kBNB], indent+"  - " );
 
       out << indent << " NuMI:\n";
-      dumpGateConfig( out, gateConfig[icarus::trigger::kNuMI], indent+" - " );
+      dumpGateConfig( out, gateConfig[icarus::trigger::kNuMI], indent+"  - " );
 
       out << indent << " Offbeam BNB:\n";
-      dumpGateConfig( out, gateConfig[icarus::trigger::kOffBeamBNB], indent + " - " );
+      dumpGateConfig( out, gateConfig[icarus::trigger::kOffBeamBNB], indent + "  - " );
 
       out << indent << " Offbeam NuMI:\n";
-      dumpGateConfig(out, gateConfig[icarus::trigger::kOffBeamNuMI], indent + " - " );
+      dumpGateConfig(out, gateConfig[icarus::trigger::kOffBeamNuMI], indent + "  - " );
 
 
       out << indent << " Calibration:\n";
-      dumpGateConfig(out, gateConfig[icarus::trigger::kCalibration], indent + " - ");
-      out << indent +" - " << "Period                    " << gateConfig[icarus::trigger::kCalibration].period << " ns\n";
+      dumpGateConfig(out, gateConfig[icarus::trigger::kCalibration], indent + "  - ");
+      out << indent << "  - " << "Period:                    " << gateConfig[icarus::trigger::kCalibration].period << " ns\n";
 
     if (++level > verbosity) break;
     // --- verbosity: 3+ -------------------------------------------------------

--- a/icaruscode/Decode/DataProducts/TriggerConfiguration.h
+++ b/icaruscode/Decode/DataProducts/TriggerConfiguration.h
@@ -83,10 +83,10 @@ struct icarus::TriggerConfiguration {
     /// Rate of gates opened outside the extraction (calculated with respect to the number of gates opened) 
     unsigned long offBeamGateRate = 1U;
 
-    /// Early warning offset for the BNB (NuMI) GatedBES ($MIBS74) in ns 
+    /// Early warning offset for the BNB (NuMI) GatedBES ($MIBS74) in ns; used for the beam gate.
     unsigned long earlyWarningOffset = 0U; 
 
-    /// Early Early warning offset for the BNB (NuMI) $1D ($AE) in ns
+    /// Early Early warning offset for the BNB (NuMI) $1D ($AE) in ns; used for the drift gate.
     unsigned long earlyEarlyWarningOffset = 0U; 
 
     /// Period of two consecutive pulses from the internal pulse generator (valid for calibration gate) in ns
@@ -255,15 +255,15 @@ struct icarus::TriggerConfiguration {
       { dump(out, indent, indent); }
   
     /**
-      * @brief Dumps the content of the configuration into `out` stream.
+      * @brief Dumps the content of the gate configuration into `out` stream.
       * @param out stream to dump the information into
+      * @param gateConfig the gate to be dumped
       * @param indent (default: none) indentation string
       * @see `dump(std::ostream&, std::string const&, std::string const&, unsigned int) const`
       * 
       * Version of `dump()` with the specified `verbosity` level and same first
       * indentation level as the rest.
-   */
-
+      */
     void dumpGateConfig(std::ostream& out, 
       icarus::TriggerConfiguration::GateConfig const& gateConfig, 
       std::string const& indent

--- a/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
+++ b/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
@@ -114,20 +114,41 @@ icarus::TriggerConfiguration icarus::TriggerConfigurationExtractor::extract
   (fhicl::ParameterSet const& pset) const
 {
   
-  icarus::TriggerConfiguration config;
+  std::optional<icarus::TriggerConfiguration> config;
   
   for (std::string const& key: pset.get_names()) {
     
-    std::optional<fhicl::ParameterSet> boardConfig
+    std::optional<fhicl::ParameterSet> triggerConfigPset
       = readTriggerConfig(pset, key);
     
-    if (!boardConfig) continue;
+    if (!triggerConfigPset) continue;
     
-    config = extractTriggerConfiguration(*boardConfig);
+    std::optional triggerConfig
+      = extractTriggerConfiguration(*triggerConfigPset);
+    
+    if (config) {
+      throw cet::exception{ "TriggerConfigurationExtractor" }
+        << "Found multiple configurations for the trigger:"
+        << "\n" << std::string(80, '-') << "\n"
+        << *config
+        << "\n" << std::string(80, '-') << "\n"
+        << "and"
+        << "\n" << std::string(80, '-') << "\n"
+        << *triggerConfig
+        << "\n" << std::string(80, '-') << "\n"
+        ;
+    }
+    
+    config = std::move(triggerConfig);
     
   } // for
+  if (!config) {
+    throw cet::exception{ "TriggerConfigurationExtractor" }
+      << "No trigger configuration found (fragment type: '"
+      << fExpectedFragmentType << "').\n";
+  }
   
-  return config;
+  return *config;
 } // icarus::PMTconfigurationExtractor::extract()
 
 
@@ -177,10 +198,8 @@ auto icarus::TriggerConfigurationExtractor::extractTriggerConfiguration
   rc.tpcTriggerDelay        
     = spexiParams.get<unsigned int>("TPCTriggerDelay.value");
 
-
-  
-  sbn::bits::mask_t<sbn::gateSelection> gateSelection
-    { (unsigned int) std::stoul( spexiParams.get<std::string>("GateSelection.value"), nullptr, 16) };  
+  auto gateSelection = sbn::bits::makeMask<sbn::gateSelection>         
+    (std::stoul( spexiParams.get<std::string>("GateSelection.value"), nullptr, 16));
 
   // Read the prescale configuraton as string for now 
   auto prescaleMinBiasBeam = 
@@ -296,8 +315,6 @@ std::optional<fhicl::ParameterSet>
 icarus::TriggerConfigurationExtractor::readTriggerConfig
   (fhicl::ParameterSet const& pset, std::string const& key) const
 {
-  static std::string const ExpectedFragmentType = "ICARUSTriggerV2";
-  
   std::optional<fhicl::ParameterSet> config;
   
   do { // fake loop for fast exit
@@ -311,7 +328,7 @@ icarus::TriggerConfigurationExtractor::readTriggerConfig
     std::string fragmentType;
     if (!boardPSet.get_if_present("daq.fragment_receiver.generator", fragmentType))
       break;
-    if (fragmentType != ExpectedFragmentType) break;
+    if (fragmentType != fExpectedFragmentType) break;
     
     config.emplace(std::move(boardPSet)); // success
   } while (false);

--- a/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.h
+++ b/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.h
@@ -312,8 +312,11 @@ class icarus::TriggerConfigurationExtractor
   
     public:
   
-  /// Default constructor is sufficient : 
-  TriggerConfigurationExtractor() = default;
+  /// Learns the name of the trigger fragment type.
+  TriggerConfigurationExtractor
+    (std::string const& expectedFragmentType = "ICARUSTriggerUDP")
+    : fExpectedFragmentType{ expectedFragmentType }
+    {}
 
   // --- BEGIN -- Interface ----------------------------------------------------
   /// @name Interface
@@ -342,6 +345,8 @@ class icarus::TriggerConfigurationExtractor
   // --- END ---- Interface ----------------------------------------------------
   
     private:
+  
+  std::string const fExpectedFragmentType;
   
   /// Regular expressions matching all names of supported Trigger configurations.
   static std::vector<std::regex> const ConfigurationNames;

--- a/icaruscode/Decode/DumpTriggerConfiguration_module.cc
+++ b/icaruscode/Decode/DumpTriggerConfiguration_module.cc
@@ -1,0 +1,189 @@
+/**
+ * @file    DumpTriggerConfiguration_module.cc
+ * @brief   Dumps to console the content of `icarus::TriggerConfiguration` data
+ *          product.
+ * @authors Andrea Scarpelli (ascarpell@bnl.gov),
+ *          Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date    June 11, 2022
+ */
+
+// SBN libraries
+#include "icaruscode/Decode/DataProducts/TriggerConfiguration.h"
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Principal/Run.h"
+#include "canvas/Persistency/Provenance/RunID.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <set>
+#include <string>
+#include <sstream> // std::ostringstream
+
+
+//------------------------------------------------------------------------------
+namespace sbn { class DumpTriggerConfiguration; }
+
+/**
+ * @brief Dumps on console the content of `icarus::TriggerConfiguration` data
+ *        product.
+ * 
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * * `icarus::TriggerConfiguration`: configuration of trigger in `art::Run` data
+ *     product. See e.g. `icarus::TriggerConfigurationExtraction` module.
+ * 
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * A terse description of the parameters is printed by running
+ * `lar --print-description DumpTriggerConfiguration`.
+ * 
+ * * `TriggerConfigurationTag` (data product input tag): the tag identifying the
+ *     data product to dump; this data product must be in `art::Run`.
+ * * `Verbosity` (integral, default: maximum): verbosity level used in the
+ *     dump; see `icarus::TriggerConfiguration::dump()` for details.
+ * * `SkipDuplicateRuns` (flag, default: `true`): multiple files can contain
+ *     information from the same run; with this flag set, only the first time
+ *     a run is encountered its trigger configuration is dumped; otherwise, each
+ *     time a run is opened by _art_, its configuration is printed.
+ * * `OutputCategory` (string, default: `DumpTriggerConfiguration`): name of the
+ *     message facility output stream to dump the information into
+ * 
+ */
+class sbn::DumpTriggerConfiguration: public art::EDAnalyzer {
+  
+    public:
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Atom<art::InputTag> TriggerConfigurationTag {
+      Name("TriggerConfigurationTag"),
+      Comment("tag of trigger configuration data product (from art::Run)")
+      };
+
+    fhicl::Atom<unsigned int> Verbosity {
+      Name("Verbosity"),
+      Comment("verbosity level [default: maximum]"),
+      icarus::TriggerConfiguration::MaxDumpVerbosity // default
+      };
+
+    fhicl::Atom<bool> SkipDuplicateRuns {
+      Name("SkipDuplicateRuns"),
+      Comment("print only one trigger configuration from each run"),
+      true // default
+      };
+    
+    fhicl::Atom<std::string> OutputCategory {
+      Name("OutputCategory"),
+      Comment("name of the category used for the output"),
+      "DumpTriggerConfiguration"
+      };
+
+  }; // struct Config
+  
+  using Parameters = art::EDAnalyzer::Table<Config>;
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  // --- BEGIN Constructors ----------------------------------------------------
+  explicit DumpTriggerConfiguration(Parameters const& config);
+  
+  // --- END Constructors ------------------------------------------------------
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Dumps the data product.
+  virtual void beginRun(art::Run const& run) override;
+  
+  /// Does nothing, but it is mandatory.
+  virtual void analyze(art::Event const& event) override {}
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  /// Input trigger configuration tag.
+  art::InputTag const fTriggerConfigurationTag;
+  
+  unsigned int const fVerbosity; ///< Verbosity level used for dumping.
+  
+  bool const fSkipDuplicateRuns; ///< Print only once from each run.
+
+  /// Category used for message facility stream.
+  std::string const fOutputCategory;
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+  std::set<art::RunID> fRuns; ///< Set of runs already encountered.
+  
+}; // sbn::DumpTriggerConfiguration
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+//--- sbn::DumpTriggerConfiguration
+//------------------------------------------------------------------------------
+sbn::DumpTriggerConfiguration::DumpTriggerConfiguration
+  (Parameters const& config)
+  : art::EDAnalyzer(config)
+  // configuration
+  , fTriggerConfigurationTag(config().TriggerConfigurationTag())
+  , fVerbosity              (config().Verbosity())
+  , fSkipDuplicateRuns      (config().SkipDuplicateRuns())
+  , fOutputCategory         (config().OutputCategory())
+{
+  
+  consumes<icarus::TriggerConfiguration, art::InRun>(fTriggerConfigurationTag);
+  
+} // sbn::DumpTriggerConfiguration::DumpTriggerConfiguration()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpTriggerConfiguration::beginRun(art::Run const& run) {
+  
+  if (fSkipDuplicateRuns) {
+    art::RunID const& id = run.id();
+    if (fRuns.count(id)) {
+      mf::LogTrace(fOutputCategory) << id << " has already been encountered.";
+      return;
+    }
+    fRuns.insert(id);
+  } // if skip duplicates
+  
+  auto const& config
+    = run.getProduct<icarus::TriggerConfiguration>(fTriggerConfigurationTag);
+  
+  std::ostringstream sstr;
+  config.dump(sstr, "  ", "", fVerbosity);
+  
+  mf::LogVerbatim(fOutputCategory) << run.id() << ": " << sstr.str();
+  
+
+} // sbn::DumpTriggerConfiguration::beginRun()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(sbn::DumpTriggerConfiguration)
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/Decode/TriggerConfigurationExtraction_module.cc
+++ b/icaruscode/Decode/TriggerConfigurationExtraction_module.cc
@@ -61,6 +61,9 @@ namespace icarus { class TriggerConfigurationExtraction; }
  * 
  * The following configuration parameters are supported:
  * 
+ * * **TriggerFragmentType** (string, default: `ICARUSTriggerV2`):
+ *     name of the type of trigger fragment, used to identify the configuration
+ *     of the trigger.
  * * **Verbose** (flag, default: `false`): if set to `true`, it will print in
  *     full the configuration of the trigger the first time it is read and each time
  *     a different one is found.
@@ -85,6 +88,8 @@ class icarus::TriggerConfigurationExtraction: public art::EDProducer {
   /// Whether trigger configuration inconsistency is fatal.
   bool fRequireConsistency = true;
   
+  std::string fTriggerFragmentType; ///< Name of the trigger fragment type.
+  
   bool fVerbose = false; ///< Whether to print the configuration we read.
   
   std::string fLogCategory; ///< Category tag for messages.
@@ -93,6 +98,12 @@ class icarus::TriggerConfigurationExtraction: public art::EDProducer {
   
   /// Configuration of the module.
   struct Config {
+    
+    fhicl::Atom<std::string> TriggerFragmentType {
+      fhicl::Name("TriggerFragmentType"),
+      fhicl::Comment("the name of the type of trigger fragment from DAQ"),
+      "ICARUSTriggerV2" // default
+      };
     
     fhicl::Atom<bool> Verbose {
       fhicl::Name("Verbose"),
@@ -136,6 +147,7 @@ class icarus::TriggerConfigurationExtraction: public art::EDProducer {
 icarus::TriggerConfigurationExtraction::TriggerConfigurationExtraction
   (Parameters const& config)
   : art::EDProducer(config)
+  , fTriggerFragmentType(config().TriggerFragmentType())
   , fVerbose(config().Verbose())
   , fLogCategory(config().LogCategory())
 {
@@ -151,7 +163,7 @@ icarus::TriggerConfigurationExtraction::TriggerConfigurationExtraction
 void icarus::TriggerConfigurationExtraction::beginRun(art::Run& run) {
   
   icarus::TriggerConfiguration config = extractTriggerReadoutConfiguration
-    (run, icarus::TriggerConfigurationExtractor{});
+    (run, icarus::TriggerConfigurationExtractor{ fTriggerFragmentType });
   
   checkConsistency(config, "run " + std::to_string(run.run()));
   if (!fTriggerConfig.has_value() && fVerbose)


### PR DESCRIPTION
This request adds a `DumpTriggerConfiguration` module to print trigger configuration on screen.
The trigger configuration is expected to be stored into a data product, for which a producer module was recently introduced by @ascarpel.

This pull request also contains a few minor tweaks to the output of that data product on screen, and also indentation fixes and a missing function for `BeamBits.h`. Finally, it also moves the name of the trigger data fragment from hard-coded to a parameter.

Since @ascarpel is the original author of the code, I ask for his review.