### PR TITLE
Adding additional tools for TPC-CRT matching

### DIFF
--- a/icaruscode/CRT/CMakeLists.txt
+++ b/icaruscode/CRT/CMakeLists.txt
@@ -444,7 +444,76 @@ simple_plugin(CRTTPCMatchingAna module
               ${ROOT_ROOFIT}
               ${ROOT_ROOFITCORE}
 )
-
+simple_plugin(CRTTPCEvtDisp module
+              icaruscode_CRTData
+              icaruscode_CRT
+              sbnobj_Common_CRT
+              icaruscode_CRTUtils
+              larcorealg_Geometry
+              larcore_Geometry_Geometry_service
+              larsim_Simulation lardataobj_Simulation
+              larsim_MCCheater_BackTrackerService_service
+              larsim_MCCheater_ParticleInventoryService_service
+              lardata_Utilities
+              larevt_Filters
+              lardataobj_RawData
+              lardataobj_RecoBase
+              lardataobj_AnalysisBase
+              lardata_RecoObjects
+              larpandora_LArPandoraInterface
+              larcorealg_Geometry
+              nusimdata_SimulationBase
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              art_Persistency_Common canvas
+              art_Persistency_Provenance canvas
+              art_Utilities canvas
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${ROOT_GEOM}
+              ${ROOT_XMLIO}
+              ${ROOT_GDML}
+              ${ROOT_SPECTRUM}
+              ${ROOT_ROOFIT}
+              ${ROOT_ROOFITCORE}
+)
+simple_plugin(CRTTPCTruthEff module
+              icaruscode_CRTData
+              icaruscode_CRT
+              sbnobj_Common_CRT
+              icaruscode_CRTUtils
+              larcorealg_Geometry
+              larcore_Geometry_Geometry_service
+              larsim_Simulation lardataobj_Simulation
+              larsim_MCCheater_BackTrackerService_service
+              larsim_MCCheater_ParticleInventoryService_service
+              lardata_Utilities
+              larevt_Filters
+              lardataobj_RawData
+              lardataobj_RecoBase
+              lardataobj_AnalysisBase
+              lardata_RecoObjects
+              larpandora_LArPandoraInterface
+              larcorealg_Geometry
+              nusimdata_SimulationBase
+              ${ART_FRAMEWORK_SERVICES_REGISTRY}
+              ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+              ${ART_ROOT_IO_TFILESERVICE_SERVICE}
+              art_Persistency_Common canvas
+              art_Persistency_Provenance canvas
+              art_Utilities canvas
+              ${MF_MESSAGELOGGER}
+              ${MF_UTILITIES}
+              ${ROOT_BASIC_LIB_LIST}
+              ${ROOT_GEOM}
+              ${ROOT_XMLIO}
+              ${ROOT_GDML}
+              ${ROOT_SPECTRUM}
+              ${ROOT_ROOFIT}
+              ${ROOT_ROOFITCORE}
+)
 install_headers()
 install_fhicl()
 install_source()

--- a/icaruscode/CRT/CRTTPCEvtDisp_module.cc
+++ b/icaruscode/CRT/CRTTPCEvtDisp_module.cc
@@ -1,0 +1,603 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       CRTTPCEvtDisp
+// Plugin Type: analyzer (Unknown Unknown)
+// File:        CRTTPCEvtDisp_module.cc
+//
+// Generated at Wed Feb 16 22:07:45 2022 by Biswaranjan Behera using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+// Framework includes
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Atom.h"
+#include "cetlib/pow.h" // cet::sum_of_squares()
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Utilities/Exception.h"
+#include "larsim/MCCheater/BackTrackerService.h"
+#include "larsim/MCCheater/ParticleInventoryService.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
+
+// LArSoft includes
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/Simulation/SimChannel.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/Track.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include "larcorealg/CoreUtils/NumericUtils.h"
+
+// icaruscode includes
+#include "icaruscode/CRT/CRTUtils/CRTBackTracker.h"
+#include "icaruscode/CRT/CRTUtils/RecoUtils.h"
+#include "sbnobj/Common/CRT/CRTHit.hh"
+#include "icaruscode/CRT/CRTUtils/CRTT0MatchAlg_evtdisp.h"
+//#include "icaruscode/CRT/CRTUtils/CRTBackTracker.h"
+#include "icaruscode/CRT/CRTUtils/CRTCommonUtils.h"
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
+
+#include "canvas/Persistency/Common/FindMany.h"
+#include "canvas/Persistency/Common/FindOne.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/PtrVector.h"
+
+#include "lardataobj/RecoBase/PFParticle.h"
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/RecoBase/PFParticleMetadata.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TVector3.h"
+#include "TFile.h"
+
+// C++ includes
+#include <map>
+#include <vector>
+#include <string>
+
+namespace icarus {
+  class CRTTPCEvtDisp;
+}
+
+
+class icarus::CRTTPCEvtDisp : public art::EDAnalyzer {
+public:
+  explicit CRTTPCEvtDisp(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  CRTTPCEvtDisp(CRTTPCEvtDisp const&) = delete;
+  CRTTPCEvtDisp(CRTTPCEvtDisp&&) = delete;
+  CRTTPCEvtDisp& operator=(CRTTPCEvtDisp const&) = delete;
+  CRTTPCEvtDisp& operator=(CRTTPCEvtDisp&&) = delete;
+
+  // Called once, at start of the job
+  virtual void beginJob() override;
+
+  // Called once per event
+  virtual void analyze(const art::Event& event) override;
+
+  // Called once, at end of the job
+  virtual void endJob() override;
+
+  //Find where a track crosses the cathode
+  void simple_getCatCrossXYZ(recob::Track trk, double &my_x, double &my_y, double &my_z);
+  void getCatCrossXYZ(recob::Track trk, double &my_x, double &my_y, double &my_z);
+
+  // Calculate the distance from the track crossing point to CRT overlap coordinates
+  double DistToCrtHit(TVector3 trackPos, sbn::crt::CRTHit crtHit);
+
+  void reconfigure(fhicl::ParameterSet const & p);
+
+private:
+  art::ServiceHandle<art::TFileService> tfs;
+  TTree* trevtdisp;
+
+  icarus::crt::CRTBackTracker bt;
+
+  bool pfp_cathodecrosser, simple_cathodecrosser, is_best_DCA_startDir, is_best_DCA_endDir;
+  int hit_id, num_t0s;
+  int fEvent, fRun, fSubRun;
+  long track_id, meta_track_id;
+  double t0min, t0max, crtTime, simpleDCA_startDir, simpleDCA_endDir;
+  double startDir_x, startDir_y, startDir_z;
+  double endDir_x, endDir_y, endDir_z;
+  double tpc_track_start_x, tpc_track_start_y, tpc_track_start_z;
+  double tpc_track_end_x, tpc_track_end_y, tpc_track_end_z;
+  double crt_hit_pos_x, crt_hit_pos_y, crt_hit_pos_z;
+  double catcross_x, catcross_y, catcross_z;
+  double simple_catcross_x, simple_catcross_y, simple_catcross_z;
+  std::vector<double> track_t0s;
+
+  //Branch variables for MC work
+  int tpc_trueID, crt_trueID;
+  std::vector<double> mcpart_start_x, mcpart_start_y, mcpart_start_z;
+  std::vector<double> mcpart_end_x, mcpart_end_y, mcpart_end_z;
+  std::vector<double> mcpart_px, mcpart_py, mcpart_pz;
+  std::vector<int> mcpart_ids;// crt_trueIDs;
+  std::vector<int> mcpart_pdg;
+  // Declare member data here.
+  art::InputTag              fCRTHitLabel;   ///< name of CRT producer
+  std::vector<art::InputTag> fTPCTrackLabel; ///< labels for source of tracks
+  art::InputTag              fTriggerLabel;  ///< labels for trigger 
+  art::InputTag 	     fSimModuleLabel;      ///< name of detsim producer
+  std::vector<art::InputTag> fPFParticleLabel; ///< labels for source of PFParticle
+  bool                       fVerbose;       ///< print information about what's going on
+  bool			     fIsData;        ///< switch for if this is data or MC
+
+  TH1D *ht0_cc;// = new TH1D("ht0_cc","Cathode Crossing Tracks T0 - All Available CRT Hit times (ns)",1000,-4000000,4000000);
+
+  CRTT0MatchAlg_evtdisp t0Alg;
+
+  geo::GeometryCore const* fGeometryService;   ///< pointer to Geometry provider
+  icarus::crt::CRTCommonUtils* fCrtutils;
+
+  //add trigger data product vars
+  unsigned int m_gate_type;
+  std::string  m_gate_name;
+  uint64_t     m_trigger_timestamp;
+  uint64_t     m_gate_start_timestamp;
+  uint64_t     m_trigger_gate_diff;
+  uint64_t     m_gate_crt_diff;
+
+  int            fCrtRegion;    //CRT hit region code
+
+
+};
+
+
+icarus::CRTTPCEvtDisp::CRTTPCEvtDisp(fhicl::ParameterSet const& p)
+  : EDAnalyzer{p}  // ,
+//, fSimModuleLabel(p.get<fhicl::ParameterSet>("SimModuleLabel"))
+  , bt(p.get<fhicl::ParameterSet>("CRTBackTrack"))
+  , t0Alg(p.get<fhicl::ParameterSet>("t0Alg"))
+  , fCrtutils(new icarus::crt::CRTCommonUtils())
+  
+  // More initializers here.
+{
+  // Call appropriate consumes<>() for any products to be retrieved by this module.
+  fGeometryService = lar::providerFrom<geo::Geometry>();
+  reconfigure(p);
+}
+
+void icarus::CRTTPCEvtDisp::reconfigure(fhicl::ParameterSet const & p)
+{
+  fCRTHitLabel        =  p.get<art::InputTag> ("CRTHitLabel", "crthit");
+  fTPCTrackLabel      =  p.get< std::vector<art::InputTag> >("TPCTrackLabel",             {""});
+  fTriggerLabel       =  p.get<art::InputTag>("TriggerLabel","daqTrigger");
+  fVerbose            =  p.get<bool>("Verbose");
+  fIsData	      =  p.get<bool>("IsData");
+  fSimModuleLabel     =  p.get<art::InputTag> ("SimModuleLabel","largeant");
+  fPFParticleLabel    =  p.get< std::vector<art::InputTag> >("PFParticleLabel",             {""});
+} // CRTT0Matching::reconfigure()
+
+void icarus::CRTTPCEvtDisp::beginJob()
+{
+
+  // Access tfileservice to handle creating and writing histograms
+  trevtdisp= tfs->make<TTree>("trevtdisp","trevtdisp");
+
+  trevtdisp->Branch("event", &fEvent, "event/I");
+  trevtdisp->Branch("run", &fRun, "run/I");
+  trevtdisp->Branch("subrun", &fSubRun, "subrun/I");
+  trevtdisp->Branch("pfp_cathodecrosser",&pfp_cathodecrosser,"pfp_cathodecrosser/O");
+  trevtdisp->Branch("simple_cathodecrosser",&simple_cathodecrosser,"simple_cathodecrosser/O");
+  trevtdisp->Branch("is_best_DCA_startDir",&is_best_DCA_startDir,"is_best_DCA_startDir/O");
+  trevtdisp->Branch("is_best_DCA_endDir",&is_best_DCA_endDir,"is_best_DCA_endDir/O");
+  trevtdisp->Branch("hit_id",&hit_id,"hit_id/I");
+  trevtdisp->Branch("track_id",&track_id,"track_id/L");
+  trevtdisp->Branch("meta_track_id",&meta_track_id,"meta_track_id/L");
+  trevtdisp->Branch("t0min",&t0min,"t0min/D");
+  trevtdisp->Branch("t0max",&t0max,"t0max/D");
+  trevtdisp->Branch("crtTime",&crtTime,"crtTime/D");
+  trevtdisp->Branch("simpleDCA_startDir",&simpleDCA_startDir,"simpleDCA_startDir/D");
+  trevtdisp->Branch("simpleDCA_endDir",&simpleDCA_endDir,"simpleDCA_endDir/D");
+  trevtdisp->Branch("startDir_x",&startDir_x,"startDir_x/D");
+  trevtdisp->Branch("startDir_y",&startDir_y,"startDir_y/D");
+  trevtdisp->Branch("startDir_z",&startDir_z,"startDir_z/D");
+  trevtdisp->Branch("endDir_x",&endDir_x,"endDir_x/D");
+  trevtdisp->Branch("endDir_y",&endDir_y,"endDir_y/D");
+  trevtdisp->Branch("endDir_z",&endDir_z,"endDir_z/D");
+  trevtdisp->Branch("tpc_track_start_x",&tpc_track_start_x,"tpc_track_start_x/D");
+  trevtdisp->Branch("tpc_track_start_y",&tpc_track_start_y,"tpc_track_start_y/D");
+  trevtdisp->Branch("tpc_track_start_z",&tpc_track_start_z,"tpc_track_start_z/D");
+  trevtdisp->Branch("tpc_track_end_x",&tpc_track_end_x,"tpc_track_end_x/D");
+  trevtdisp->Branch("tpc_track_end_y",&tpc_track_end_y,"tpc_track_end_y/D");
+  trevtdisp->Branch("tpc_track_end_z",&tpc_track_end_z,"tpc_track_end_z/D");
+  trevtdisp->Branch("crt_hit_pos_x",&crt_hit_pos_x,"crt_hit_pos_x/D");
+  trevtdisp->Branch("crt_hit_pos_y",&crt_hit_pos_y,"crt_hit_pos_y/D");
+  trevtdisp->Branch("crt_hit_pos_z",&crt_hit_pos_z,"crt_hit_pos_z/D");
+  trevtdisp->Branch("crtRegion",  &fCrtRegion,"crtRegion/I");
+
+  trevtdisp->Branch("tpc_trueID",&tpc_trueID,"tpc_trueID/I");
+  trevtdisp->Branch("crt_trueID",&crt_trueID,"crt_trueID/I");
+  trevtdisp->Branch("mcpart_ids",&mcpart_ids);
+  trevtdisp->Branch("track_t0s",&track_t0s);
+
+  trevtdisp->Branch("num_t0s",&num_t0s,"num_t0s/I");
+
+  trevtdisp->Branch("mcpart_start_x",&mcpart_start_x);
+  trevtdisp->Branch("mcpart_start_y",&mcpart_start_y);
+  trevtdisp->Branch("mcpart_start_z",&mcpart_start_z);
+  trevtdisp->Branch("mcpart_end_x",&mcpart_end_x);
+  trevtdisp->Branch("mcpart_end_y",&mcpart_end_y);
+  trevtdisp->Branch("mcpart_end_z",&mcpart_end_z);
+  trevtdisp->Branch("mcpart_px",&mcpart_px);
+  trevtdisp->Branch("mcpart_py",&mcpart_py);
+  trevtdisp->Branch("mcpart_pz",&mcpart_pz);
+  trevtdisp->Branch("mcpart_pdg",&mcpart_pdg);
+
+  trevtdisp->Branch("catcross_x",&catcross_x,"catcross_x/D");
+  trevtdisp->Branch("catcross_y",&catcross_y,"catcross_y/D");
+  trevtdisp->Branch("catcross_z",&catcross_z,"catcross_z/D");
+
+  trevtdisp->Branch("simple_catcross_x",&simple_catcross_x,"simple_catcross_x/D");
+  trevtdisp->Branch("simple_catcross_y",&simple_catcross_y,"simple_catcross_y/D");
+  trevtdisp->Branch("simple_catcross_z",&simple_catcross_z,"simple_catcross_z/D");
+
+  meta_track_id=0;
+  for(int i = 30; i < 50 + 1; i++){
+    std::string tagger = "All";
+    if (i>=35 && i<40) continue;
+    if (i==48 || i==49) continue;
+    // if(i < ){
+    tagger = fCrtutils->GetRegionNameFromNum(i);//fCrtGeo.GetTagger(i).name;
+  }
+
+  ht0_cc = tfs->make<TH1D>("h_t0cc","Track T0 - CRT Hit Time (ns)",1000,-5e6,5e6);
+
+  //*/
+}
+
+void icarus::CRTTPCEvtDisp::analyze(const art::Event& event)
+{
+
+  fEvent  = event.id().event();
+  fRun    = event.run();
+  fSubRun = event.subRun();
+
+
+  if(!fIsData){  
+    auto particleHandle = event.getValidHandle<std::vector<simb::MCParticle>>(fSimModuleLabel);
+
+    bt.Initialize(event);
+    std::map<int, simb::MCParticle> particles;
+
+    // Loop over the true particles
+    mcpart_ids.clear();
+    for (auto const& particle: (*particleHandle)){
+      
+      // Make map with ID
+      int partID = particle.TrackId();
+      particles[partID] = particle;
+      std::cout << "Particle ID: " << partID << std::endl;
+      mcpart_ids.push_back(partID);
+
+      mcpart_start_x.push_back(particle.Position().X());
+      mcpart_start_y.push_back(particle.Position().Y());
+      mcpart_start_z.push_back(particle.Position().Z());
+
+      mcpart_end_x.push_back(particle.EndPosition().X());
+      mcpart_end_y.push_back(particle.EndPosition().Y());
+      mcpart_end_z.push_back(particle.EndPosition().Z());
+
+      mcpart_px.push_back(particle.Momentum().Px());
+      mcpart_py.push_back(particle.Momentum().Py());
+      mcpart_pz.push_back(particle.Momentum().Pz());
+
+      mcpart_pdg.push_back(particle.PdgCode());
+    }//end loop over particles assigning IDs
+  }//end if(!fIsData)
+  //----------------------------------------------------------------------------------------------------------
+  //                                          GETTING PRODUCTS
+  //----------------------------------------------------------------------------------------------------------
+  //add trigger info
+  if( !fTriggerLabel.empty() ) {
+
+    art::Handle<sbn::ExtraTriggerInfo> trigger_handle;
+    event.getByLabel( fTriggerLabel, trigger_handle );
+    if( trigger_handle.isValid() ) {
+      sbn::triggerSource bit = trigger_handle->sourceType;
+      m_gate_type = (unsigned int)bit;
+      m_gate_name = bitName(bit);
+      m_trigger_timestamp = trigger_handle->triggerTimestamp;
+      m_gate_start_timestamp =  trigger_handle->beamGateTimestamp;
+      m_trigger_gate_diff = trigger_handle->triggerTimestamp - trigger_handle->beamGateTimestamp;
+    }//end if( trigger_handle.isValid() )
+    else{
+      mf::LogError("CRTTPCEvtDisp:") << "No raw::Trigger associated to label: " << fTriggerLabel.label() << "\n" ;
+    }//end else
+  }//end if( !fTriggerLabel.empty() )
+  else {
+    mf::LogError("CRTTPCEvtDisp:") << "Trigger Data product " << fTriggerLabel.label() << " not found!\n" ;
+  }//end else
+
+
+  // Get CRT hits from the event
+  art::Handle< std::vector<sbn::crt::CRTHit>> crtHitHandle;
+  std::vector<art::Ptr<sbn::crt::CRTHit> > crtHitList;
+  if (event.getByLabel(fCRTHitLabel, crtHitHandle))
+    art::fill_ptr_vector(crtHitList, crtHitHandle);
+
+  
+  //  auto tpcTrackHandle = event.getValidHandle<std::vector<recob::Track>>(fTPCTrackLabel);
+  //art::FindManyP<recob::Hit> findManyHits(tpcTrackHandle, event, fTPCTrackLabel);
+
+  std::vector<sbn::crt::CRTHit> crtHits;
+  int hit_i = 0;
+  double minHitTime = 99999;
+  double maxHitTime = -99999;
+
+  for(auto const& hit : (*crtHitHandle)){
+    double hitTime = double(m_gate_start_timestamp - hit.ts0_ns)/1e3;
+    hitTime = -hitTime+1e6;
+    //double hitTime = (double)(int)hit.ts0_ns * 1e-3;
+    if(hitTime < minHitTime) minHitTime = hitTime;
+    if(hitTime > maxHitTime) maxHitTime = hitTime;
+
+    crtHits.push_back(hit);
+    hit_i++;
+  }
+
+  //Temp for debugging MC
+  std::cout << "# of TPC tracks:\t" << fTPCTrackLabel.size();
+  std::cout << "# of CRT Hits:\t" << crtHits.size();
+
+  //Begin building association between TPC tracks in the event and their T0s (if they have them)
+  art::Handle<std::vector<recob::Track>> pandoratrkHandle;
+  std::vector<art::Ptr<recob::Track>> pandoratrks;
+  if(event.getByLabel("pandoraTrackGausCryoW",pandoratrkHandle)){ art::fill_ptr_vector(pandoratrks,pandoratrkHandle); }//end if(event.getByLabel("pandoraTrackGausCryoW",pandoratrkHandle)
+
+  art::Handle< std::vector<recob::PFParticle>> pfpListHandle;
+  event.getByLabel("pandoraGausCryoW",pfpListHandle);
+
+  art::FindManyP<recob::PFParticle> fmpfp(pandoratrkHandle, event, "pandoraTrackGausCryoW");
+  art::FindManyP<anab::T0> fmt0pandora(pfpListHandle, event, "pandoraGausCryoW");
+
+  for(size_t i=0; i<pandoratrks.size(); ++i){}//end loop over pandoratrks.size()
+
+  //----------------------------------------------------------------------------------------------------------
+  //                                DISTANCE OF CLOSEST APPROACH ANALYSIS
+  //----------------------------------------------------------------------------------------------------------cc
+
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+  auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(event, clockData);
+
+
+  // if(fVerbose) std::cout<<"----------------- DCA Analysis -------------------"<<std::endl;
+
+  icarus::match_geometry thiscand;
+
+  int temp_track_id =0;
+  for(const auto& trackLabel : fTPCTrackLabel)
+    {
+      auto it = &trackLabel - fTPCTrackLabel.data();
+
+      // Get reconstructed tracks from the event    
+      auto tpcTrackHandle = event.getValidHandle<std::vector<recob::Track>>(trackLabel);
+      if (!tpcTrackHandle.isValid()) continue;
+
+      std::cout << "New TPC track label!\n";  
+
+      art::FindManyP<recob::Hit> findManyHits(tpcTrackHandle, event, trackLabel);
+
+      //Begin building association between TPC tracks in the event and their T0s (if they have them)
+      std::cout << "size of the track label: " << trackLabel << std::endl;
+
+      // Get reconstructed tracks from the event
+      //Get PFParticles
+      //Get PFParticles
+      auto pfpListHandle = event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel[it]);
+      if (!pfpListHandle.isValid()) continue;
+
+
+//      art::Handle< std::vector<recob::PFParticle> > pfpListHandle;
+//      event.getByLabel("pandoraGausCryoE", pfpListHandle);
+
+      //Get PFParticle-Track association
+      art::FindManyP<recob::PFParticle> fmpfp(tpcTrackHandle, event, trackLabel);
+
+      //Get T0-PFParticle association
+      art::FindManyP<anab::T0> fmt0pandora(pfpListHandle, event, fPFParticleLabel[it]);
+
+      std::cout << "# track: " << (*tpcTrackHandle).size() << std::endl;
+
+      // Loop over reconstructed tracks
+      for (auto const& tpcTrack : (*tpcTrackHandle)){
+
+	track_t0s.clear();
+
+	std::cout << "New TPC track!\n";
+
+        //Find PFParticle for track i
+        //art::Ptr::key() gives the index in the vector
+        auto pfps = fmpfp.at(tpcTrack.ID());
+
+	if(pfps.empty()) num_t0s = 0;
+
+	pfp_cathodecrosser = false;
+        if (!pfps.empty()){ 
+           //Find T0 for PFParticle
+           auto t0s = fmt0pandora.at(pfps[0].key());
+	   num_t0s = t0s.size();
+           if (!t0s.empty()){ //Get T0
+	      for(size_t i=0; i<t0s.size(); i++){
+                 track_t0s.push_back(t0s[0]->Time());
+		 pfp_cathodecrosser = true;
+	 	 catcross_x = DBL_MAX;
+		 catcross_y = DBL_MAX;
+		 catcross_z = DBL_MAX;
+		 simple_catcross_x = DBL_MAX;
+		 simple_catcross_y = DBL_MAX;
+		 simple_catcross_z = DBL_MAX;
+		 getCatCrossXYZ(tpcTrack, catcross_x, catcross_y, catcross_z);
+		 simple_getCatCrossXYZ(tpcTrack, simple_catcross_x, simple_catcross_y, simple_catcross_z);
+	      }//end loop over t0s
+	   }//end if(!t0s.empty())
+	}//end if(!pfps.empty())
+	
+	std::vector<art::Ptr<recob::Hit>> hits = findManyHits.at(tpcTrack.ID());
+
+	if(!fIsData){
+		//Using the vector of art Ptrs to recob::Hit, we can use RecoUtils.* to get the likely truth ID:
+		int track_trueID = RecoUtils::TrueParticleIDFromTotalTrueEnergy(clockData,hits,false);
+		std::cout << "TPC track true ID = " << track_trueID << "\n";
+		tpc_trueID = track_trueID;
+	}//end if(fIsData)
+	std::vector<match_geometry> closest = t0Alg.GetClosestCRTHit(detProp, tpcTrack, hits, crtHits, m_trigger_timestamp, event, fIsData);
+
+	if(!pfps.empty()){
+           	auto t0s = fmt0pandora.at(pfps[0].key());
+		if(!t0s.empty()){
+			for(int i=0;i<(int)crtHits.size(); i++){
+
+				double temp_crttime; 
+				if(fIsData) { temp_crttime = double(m_trigger_timestamp - crtHits[i].ts0_ns);
+					      temp_crttime = -temp_crttime+1e9; 				}//end if(fIsDataData)
+				else {	      temp_crttime = 1600 - crtHits[i].ts0_ns/1e3; }
+
+				double subtracted_time = t0s[0]->Time() - temp_crttime;
+				std::cout << "SHOULD SEE ht0_cc->Fill(): " << subtracted_time <<"ns\n";
+				ht0_cc->Fill(subtracted_time);
+			}//end loop over all CRT Hits
+		}//end if(!t0s.empty)
+	}//end if(!pfps.empty() && !t0s.empty())
+  	std::cout << "found " << closest.size() << " possible candidates\n";
+	for(int i=0; i<(int)closest.size(); i++){
+
+		sbn::crt::CRTHit checkhit = closest[i].thishit;
+
+		if(!fIsData) crt_trueID = bt.TrueIdFromTotalEnergy(event,checkhit);
+		thiscand = closest[i];
+		simple_cathodecrosser = thiscand.simple_cathodecrosser;
+		is_best_DCA_startDir = thiscand.is_best_DCA_startDir;
+		is_best_DCA_endDir = thiscand.is_best_DCA_endDir;
+		hit_id = thiscand.hit_id;
+		track_id = temp_track_id; 
+		t0min = thiscand.t0min;
+		t0max = thiscand.t0max;
+		simpleDCA_startDir = thiscand.simpleDCA_startDir;
+
+		crtTime = thiscand.crtTime;// std::cout << "crtTime (us): " << crtTime << std::endl;
+		simpleDCA_endDir = thiscand.simpleDCA_endDir;
+
+		startDir_x = thiscand.startDir.X();
+		startDir_y = thiscand.startDir.Y();
+		startDir_z = thiscand.startDir.Z();
+
+		endDir_x = thiscand.endDir.X();
+		endDir_y = thiscand.endDir.Y();
+		endDir_z = thiscand.endDir.Z();
+
+		tpc_track_start_x = thiscand.tpc_track_start.X();
+		tpc_track_start_y = thiscand.tpc_track_start.Y();
+		tpc_track_start_z = thiscand.tpc_track_start.Z();
+
+		tpc_track_end_x = thiscand.tpc_track_end.X();
+		tpc_track_end_y = thiscand.tpc_track_end.Y();
+		tpc_track_end_z = thiscand.tpc_track_end.Z();
+
+		crt_hit_pos_x = thiscand.crt_hit_pos.X();
+		crt_hit_pos_y = thiscand.crt_hit_pos.Y();
+		crt_hit_pos_z = thiscand.crt_hit_pos.Z();
+
+		fCrtRegion=(int)fCrtutils->AuxDetRegionNameToNum(thiscand.thishit.tagger);
+
+		trevtdisp->Fill();
+
+	}//end loop over vector of CRTHit-TPC track candidate pairs
+		meta_track_id++;
+		temp_track_id++;
+      } // track loops in each tracklebel
+    } // end loop over TPC tracks
+
+}
+void icarus::CRTTPCEvtDisp::endJob()
+{
+//	TFile *ftemp = new TFile("tempfile.root","update");
+//	ht0_cc->Write();
+//	ftemp->Close();
+} // CRTT0Matching::endJob()
+
+void icarus::CRTTPCEvtDisp::simple_getCatCrossXYZ(recob::Track trk, double &my_x, double &my_y, double &my_z){
+
+	size_t ntrk = trk.NPoints();
+	std::vector<double> x, y, z, x_diff;
+//	double xsum=0, xavg;
+//	bool isEast;
+	std::pair<double,double> cathode_yz;
+	double dist_min = DBL_MAX; int dist_min_pos = INT_MAX;
+
+	//Begin by extracting coordinates into arrays
+	for(size_t i=0; i<ntrk; i++){
+		geo::Point_t thispt = trk.LocationAtPoint((int)i);
+		x.push_back(thispt.X()); y.push_back(thispt.Y()); z.push_back(thispt.Z());
+//		xsum+=x[i];
+		x_diff.push_back(std::abs(x[i]) - 210.215);
+		if(x_diff[i]<=dist_min) { dist_min=x_diff[i]; dist_min_pos = i; }
+	}//end loop over track points
+//	xavg=xsum/(int)ntrk;
+//	if(xavg>0) isEast = false;
+//	else if(xavg<0) isEast = true;
+//	else if(xavg==0) { std::cout << "Average X of a track ==0?\n"; break; }
+
+	my_x = x[dist_min_pos];
+	my_y = y[dist_min_pos];
+	my_z = z[dist_min_pos];
+
+}//end definition of std::pair<int,int> getCatCrossYZ(std::vector<art::Ptr<recob::Hit>> trk_hits)
+void icarus::CRTTPCEvtDisp::getCatCrossXYZ(recob::Track trk, double &my_x, double &my_y, double &my_z){
+
+	size_t ntrk = trk.NPoints();
+	std::vector<double> x, y, z, x_left_diff, x_right_diff;
+	std::pair<double,double> cathode_yz;
+	double left_dist_min = DBL_MAX; int left_dist_min_pos = INT_MAX;
+	double right_dist_min = DBL_MAX; int right_dist_min_pos = INT_MAX;
+	double xsum=0, xavg;
+
+	//Begin by extracting coordinates into arrays
+	for(size_t i=0; i<ntrk; i++){
+		geo::Point_t thispt = trk.LocationAtPoint((int)i);
+		x.push_back(thispt.X()); y.push_back(thispt.Y()); z.push_back(thispt.Z());
+		if(std::abs(x.back())<210.215) {
+			x_left_diff.push_back(std::abs(std::abs(x[i]) - 210.25));
+			if(x_left_diff.back()<=left_dist_min) { left_dist_min=x_left_diff.back(); left_dist_min_pos = i; }
+		}//end if(std::abs(x[i])<210.215)
+		else if(std::abs(x.back())>=210.215) {
+			x_right_diff.push_back(std::abs(std::abs(x[i]) - 210.25));
+			if(x_right_diff.back()<=right_dist_min) { right_dist_min=x_right_diff.back(); right_dist_min_pos = i; }
+		}//end if(std::abs(x[i])<210.215)
+		xsum+=x.back();
+	}//end loop over track points
+	xavg = xsum/ntrk;
+
+	TVector3 leftpt(x[left_dist_min_pos],y[left_dist_min_pos],z[left_dist_min_pos]);
+	TVector3 rightpt(x[right_dist_min_pos],y[right_dist_min_pos],z[right_dist_min_pos]);
+
+	//calculate parameters for a line that passes through the two points:
+	double mxy = (leftpt.Y() - rightpt.Y())/(leftpt.X()-rightpt.X());
+	double mxz = (leftpt.Z() - rightpt.Z())/(leftpt.X()-rightpt.X());
+
+	double bxy = leftpt.Y() - mxy*leftpt.X();
+	double bxz = leftpt.Z() - mxz*leftpt.X();
+
+	if(xavg>0) my_x = 210.215; 
+	else if(xavg<=0) my_x = -210.215;
+	my_y = mxy*my_x + bxy;
+	my_z = mxz*my_x + bxz;
+
+}//end definition of std::pair<int,int> getCatCrossYZ(std::vector<art::Ptr<recob::Hit>> trk_hits)
+
+DEFINE_ART_MODULE(icarus::CRTTPCEvtDisp)

--- a/icaruscode/CRT/CRTTPCMatchingAna_module.cc
+++ b/icaruscode/CRT/CRTTPCMatchingAna_module.cc
@@ -25,13 +25,12 @@
 #include "canvas/Utilities/Exception.h"
 #include "larsim/MCCheater/BackTrackerService.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
-
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 
 // LArSoft includes
 #include "lardataobj/Simulation/SimChannel.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Track.h"
-#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
@@ -44,6 +43,7 @@
 #include "icaruscode/CRT/CRTUtils/CRTT0MatchAlg.h"
 //#include "icaruscode/CRT/CRTUtils/CRTBackTracker.h"
 #include "icaruscode/CRT/CRTUtils/CRTCommonUtils.h"
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
 
 #include "TH1.h"
 #include "TH2.h"
@@ -90,31 +90,47 @@ public:
 private:
 
   // Declare member data here.
-  art::InputTag fCRTHitLabel;   ///< name of CRT producer
-  art::InputTag fTPCTrackLabel; ///< name of CRT producer
-  bool          fVerbose;             ///< print information about what's going on
+  art::InputTag              fCRTHitLabel;   ///< name of CRT producer
+  std::vector<art::InputTag> fTPCTrackLabel; ///< labels for source of tracks
+  art::InputTag              fTriggerLabel;  ///< labels for trigger 
+  bool                       fVerbose;       ///< print information about what's going on
 
   CRTT0MatchAlg t0Alg;
-
-  //  CRTGeoAlg fCrtGeo;
-  //TPCGeoAlg fTpcGeo;
 
   geo::GeometryCore const* fGeometryService;   ///< pointer to Geometry provider
   icarus::crt::CRTCommonUtils* fCrtutils;
   //  CRTCommonUtils* fCrtutils;
 
+  TTree* fTree;
+  int fEvent;        ///< number of the event being processed
+  int fRun;          ///< number of the run being processed
+  int fSubRun;       ///< number of the sub-run being processed
+  vector<int>            fCrtRegion;    //CRT hit region code
+  vector<double>            fDCA;    //CRT hit region code
+  vector<double>            fDOL;    //CRT hit region code
+  vector<double>            fT0;    //CRT hit region code
+
+  //add trigger data product vars
+  unsigned int m_gate_type;
+  std::string  m_gate_name;
+  uint64_t     m_trigger_timestamp;
+  uint64_t     m_gate_start_timestamp;
+  uint64_t     m_trigger_gate_diff;
+  uint64_t     m_gate_crt_diff;
+
   // Histograms
-  std::map<std::string, TH1D*> hDCA;
-  std::map<std::string, TH1D*> hMatchDCA;
-  std::map<std::string, TH1D*> hNoMatchDCA;
+  std::map<std::string, TH1F*> hDCA;
+  std::map<std::string, TH1F*> hMatchDCA;
+  std::map<std::string, TH1F*> hNoMatchDCA;
 
-  std::map<std::string, TH1D*> hDoL;
-  std::map<std::string, TH1D*> hMatchDoL;
-  std::map<std::string, TH1D*> hNoMatchDoL;
+  std::map<std::string, TH1F*> hDoL;
+  std::map<std::string, TH1F*> hMatchDoL;
+  std::map<std::string, TH1F*> hNoMatchDoL;
 
-  std::map<std::string, TH1D*> hT0;
-  std::map<std::string, TH1D*> hMatchT0;
-  std::map<std::string, TH1D*> hNoMatchT0;
+  std::map<std::string, TH1F*> hT0;
+  std::map<std::string, TH1F*> hMatchT0;
+  std::map<std::string, TH1F*> hNoMatchT0;
+  //*/
 };
 
 
@@ -132,13 +148,11 @@ icarus::CRTTPCMatchingAna::CRTTPCMatchingAna(fhicl::ParameterSet const& p)
 
 void icarus::CRTTPCMatchingAna::reconfigure(fhicl::ParameterSet const & p)
 {
-  fCRTHitLabel = (p.get<art::InputTag> ("CRTHitLabel"));
-  fTPCTrackLabel= (p.get<art::InputTag> ("TPCTrackLabel"));
-  fVerbose = (p.get<bool>("Verbose"));
-  //fTpcTrackModuleLabel = (p.get<art::InputTag> ("TpcTrackModuleLabel"));
-  // fTpcTrackModuleLabel = p.get< std::vector<art::InputTag>>("TpcTrackModuleLabel",std::vector<art::InputTag>() = {"pandoraTrackGausCryoE"});
-  //fCrtHitModuleLabel   = (p.get<art::InputTag> ("CrtHitModuleLabel"));
-
+  fCRTHitLabel        =  p.get<art::InputTag> ("CRTHitLabel", "crthit");
+  fTPCTrackLabel      =  p.get< std::vector<art::InputTag> >("TPCTrackLabel",             {""});
+  fTriggerLabel       =  p.get<art::InputTag>("TriggerLabel","daqTrigger");
+  //fTPCTrackLabel      =  p.get< std::vector<art::InputTag> >("TPCTrackLabel", std::vector<art::InputTag>() = {""});
+  fVerbose            =  p.get<bool>("Verbose");
 } // CRTT0Matching::reconfigure()
 
 void icarus::CRTTPCMatchingAna::beginJob()
@@ -146,22 +160,47 @@ void icarus::CRTTPCMatchingAna::beginJob()
 
   // Access tfileservice to handle creating and writing histograms
   art::ServiceHandle<art::TFileService> tfs;
+
+  fTree = tfs->make<TTree>("matchTree","CRTHit - TPC track matching analysis");
+
+  fTree->Branch("Event",           &fEvent,           "Event/I");
+  fTree->Branch("SubRun",          &fSubRun,          "SubRun/I");
+  fTree->Branch("Run",             &fRun,             "Run/I");
+  //k  vector<float>            fDOL;    //CRT hit region code
+  //fTree->Branch("CryostataVec",    "std::vector<int>",   &fCryoVec);
+  fTree->Branch("crtRegion",    "std::vector<int>",   &fCrtRegion);
+  fTree->Branch("DCA",    "std::vector<double>",   &fDCA);
+  fTree->Branch("DOL",    "std::vector<double>",   &fDOL);
+  fTree->Branch("t0",     "std::vector<double>",   &fT0);
+  fTree->Branch("gate_type", &m_gate_type, "gate_type/b");
+  fTree->Branch("gate_name", &m_gate_name);
+  fTree->Branch("trigger_timestamp", &m_trigger_timestamp, "trigger_timestamp/l");
+  fTree->Branch("gate_start_timestamp", &m_gate_start_timestamp, "gate_start_timestamp/l");
+  fTree->Branch("trigger_gate_diff", &m_trigger_gate_diff, "trigger_gate_diff/l");
+  fTree->Branch("gate_crt_diff",&m_gate_crt_diff, "gate_crt_diff/l");
+  //  fTree->Branch("Run",             &fRun,             "int/I");
+  
   for(int i = 30; i < 50 + 1; i++){
     std::string tagger = "All";
     if (i < 40) continue;
     if (i==48 || i==49) continue;
     // if(i < ){
     tagger = fCrtutils->GetRegionNameFromNum(i);//fCrtGeo.GetTagger(i).name;
-    std::cout << "tagger: " << tagger.c_str() << std::endl;
-    hDCA[tagger]        = tfs->make<TH1D>(Form("DCA_%s", tagger.c_str()),        "", 50, 0, 100);
-    hDoL[tagger]        = tfs->make<TH1D>(Form("DoL_%s", tagger.c_str()),        "", 100, 0, 0.25);
-    hT0[tagger]        = tfs->make<TH1D>(Form("T0_%s", tagger.c_str()),        "", 600, -3000, 3000);
+    //    std::cout << "tagger: " << tagger.c_str() << std::endl;
+    hDCA[tagger]     = tfs->make<TH1F>(Form("DCA_%s", tagger.c_str()),        "", 50, 0, 100);
+    hDoL[tagger]     = tfs->make<TH1F>(Form("DoL_%s", tagger.c_str()),        "", 100, 0, 0.25);
+    hT0[tagger]      = tfs->make<TH1F>(Form("T0_%s", tagger.c_str()),        "", 600, -3000, 3000);
   }
+  //*/
 }
 
 void icarus::CRTTPCMatchingAna::analyze(const art::Event& event)
 {
 
+  fDCA.clear();
+  fDOL.clear();
+  fT0.clear();
+  fCrtRegion.clear();
   // Fetch basic event info
   if(fVerbose){
     std::cout<<"============================================"<<std::endl
@@ -169,9 +208,35 @@ void icarus::CRTTPCMatchingAna::analyze(const art::Event& event)
 	     <<"============================================"<<std::endl;
   }
 
+  fEvent  = event.id().event();
+  fRun    = event.run();
+  fSubRun = event.subRun();
+
   //----------------------------------------------------------------------------------------------------------
   //                                          GETTING PRODUCTS
   //----------------------------------------------------------------------------------------------------------
+  //add trigger info
+  if( !fTriggerLabel.empty() ) {
+
+    art::Handle<sbn::ExtraTriggerInfo> trigger_handle;
+    event.getByLabel( fTriggerLabel, trigger_handle );
+    if( trigger_handle.isValid() ) {
+      sbn::triggerSource bit = trigger_handle->sourceType;
+      m_gate_type = (unsigned int)bit;
+      m_gate_name = bitName(bit);
+      m_trigger_timestamp = trigger_handle->triggerTimestamp;
+      m_gate_start_timestamp =  trigger_handle->beamGateTimestamp;
+      m_trigger_gate_diff = trigger_handle->triggerTimestamp - trigger_handle->beamGateTimestamp;
+
+    }
+    else{
+      mf::LogError("CRTTPCMatchingAna:") << "No raw::Trigger associated to label: " << fTriggerLabel.label() << "\n" ;
+    }
+  }
+  else {
+    mf::LogError("CRTTPCMatchingAna:") << "Trigger Data product " << fTriggerLabel.label() << " not found!\n" ;
+  }
+
 
   // Get CRT hits from the event
   art::Handle< std::vector<sbn::crt::CRTHit>> crtHitHandle;
@@ -179,9 +244,9 @@ void icarus::CRTTPCMatchingAna::analyze(const art::Event& event)
   if (event.getByLabel(fCRTHitLabel, crtHitHandle))
     art::fill_ptr_vector(crtHitList, crtHitHandle);
 
-  // Get reconstructed tracks from the event
-  auto tpcTrackHandle = event.getValidHandle<std::vector<recob::Track>>(fTPCTrackLabel);
-  art::FindManyP<recob::Hit> findManyHits(tpcTrackHandle, event, fTPCTrackLabel);
+  
+  //  auto tpcTrackHandle = event.getValidHandle<std::vector<recob::Track>>(fTPCTrackLabel);
+  //art::FindManyP<recob::Hit> findManyHits(tpcTrackHandle, event, fTPCTrackLabel);
 
   std::vector<sbn::crt::CRTHit> crtHits;
   int hit_i = 0;
@@ -189,7 +254,9 @@ void icarus::CRTTPCMatchingAna::analyze(const art::Event& event)
   double maxHitTime = -99999;
 
   for(auto const& hit : (*crtHitHandle)){
-    double hitTime = (double)(int)hit.ts0_ns * 1e-3;
+    double hitTime = double(m_gate_start_timestamp - hit.ts0_ns)/1e3;
+    hitTime = -hitTime+1e6;
+    //double hitTime = (double)(int)hit.ts0_ns * 1e-3;
     if(hitTime < minHitTime) minHitTime = hitTime;
     if(hitTime > maxHitTime) maxHitTime = hitTime;
 
@@ -204,26 +271,57 @@ void icarus::CRTTPCMatchingAna::analyze(const art::Event& event)
   auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
   auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(event, clockData);
 
-  // if(fVerbose) std::cout<<"----------------- DCA Analysis -------------------"<<std::endl;
-  // Loop over reconstructed tracks
-  for (auto const& tpcTrack : (*tpcTrackHandle)){
-    //      std::cout<<"----------------- why only 4 times -------------------" <<std::endl;
-    // if(fVerbose) std::cout<<"----------------- # track -------------------" << (*tpcTrackHandle).size()<<std::endl;
-    // Get the associated hits
-    std::vector<art::Ptr<recob::Hit>> hits = findManyHits.at(tpcTrack.ID());
-    matchCand closest = t0Alg.GetClosestCRTHit(detProp, tpcTrack, crtHits, event);
-    double sin_angle = -99999;
-    if(closest.dca != -99999){
-      hDCA[closest.thishit.tagger]->Fill(closest.dca);
-      //hDCA["All"]->Fill(closest.dca);
-      sin_angle = closest.dca/closest.extrapLen;
-      hDoL[closest.thishit.tagger]->Fill(sin_angle);
-      // hDoL["All"]->Fill(sin_angle);
-      hT0[closest.thishit.tagger]->Fill(closest.t0);
-    }
-  }
-}
 
+  // if(fVerbose) std::cout<<"----------------- DCA Analysis -------------------"<<std::endl;
+
+  for(const auto& trackLabel : fTPCTrackLabel)
+    {
+      std::cout << "size of the track label: " << trackLabel << std::endl;
+      // Get reconstructed tracks from the event    
+      auto tpcTrackHandle = event.getValidHandle<std::vector<recob::Track>>(trackLabel);
+      if (!tpcTrackHandle.isValid()) continue;
+  
+      art::FindManyP<recob::Hit> findManyHits(tpcTrackHandle, event, trackLabel);
+      std::cout << "# track: " << (*tpcTrackHandle).size() << std::endl;
+      // Loop over reconstructed tracks
+      for (auto const& tpcTrack : (*tpcTrackHandle)){
+	auto idx = &tpcTrack - (*tpcTrackHandle).data();
+
+	if (idx == 1) break;
+	std::vector<art::Ptr<recob::Hit>> hits = findManyHits.at(tpcTrack.ID());
+	int const cryoNumber = hits[idx]->WireID().Cryostat; std::cout << "cryoNumber = " << cryoNumber << std::endl;
+	//	matchCand closest = t0Alg.GetClosestCRTHit(detProp, tpcTrack, crtHits, event);
+	//	std::vector <matchCand> closestvec = t0Alg.GetClosestCRTHit(detProp, tpcTrack, crtHits, event);
+	//matchCand closest = closestvec[idx];// closestvec.back();
+	std::cout<< idx << " [ 1st, last ] = [ " << hits[0]->WireID().TPC << " , " << hits[hits.size()-1]->WireID().TPC 
+		 << " , " << hits[idx]->WireID().Cryostat<< " ] "<< std::endl;
+	matchCand closest = t0Alg.GetClosestCRTHit(detProp, tpcTrack, hits, crtHits, m_trigger_timestamp, false);
+	if(closest.dca >=0 )
+	  mf::LogInfo("CRTTPCMatchingAna")
+	    << "Track # " << idx  <<" Matched time = "<<closest.t0<<" [us] to track "<< tpcTrack.ID()<<" with DCA = "<<closest.dca;
+	/*for (long unsigned int i = 0; i < closestvec.size(); i++){
+
+	  std::cout << "[ #closestvec , closest.dca, closest.extrapLen, closest.thishit.tagger ]=  [ " 
+		    << i <<" , "<< closestvec[i].dca <<" , "<< closestvec[i].extrapLen <<" , "<< closestvec[i].thishit.tagger <<"  ]" <<std::endl;
+	}*/
+	double sin_angle = -99999;
+	if(closest.dca != -99999){
+	  hDCA[closest.thishit.tagger]->Fill(closest.dca);
+	  //hDCA["All"]->Fill(closest.dca);
+	  sin_angle = closest.dca/closest.extrapLen;
+	  hDoL[closest.thishit.tagger]->Fill(sin_angle);
+	  // hDoL["All"]->Fill(sin_angle);
+	  hT0[closest.thishit.tagger]->Fill(closest.t0);
+	  fDCA.push_back(closest.dca);
+	  fDOL.push_back(sin_angle);
+	  fT0.push_back(closest.t0);
+	  // fCrtRegion.push_back(closest.thishit.tagger);
+	  fCrtRegion.push_back(fCrtutils->AuxDetRegionNameToNum(closest.thishit.tagger));
+	} // if closest dca is physical
+      } // track loops in each tracklebel
+    } // trackLabel vector
+  fTree->Fill();
+}
 void icarus::CRTTPCMatchingAna::endJob()
 {
 

--- a/icaruscode/CRT/CRTTPCTruthEff_module.cc
+++ b/icaruscode/CRT/CRTTPCTruthEff_module.cc
@@ -1,0 +1,374 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       CRTTPCTruthEff
+// Plugin Type: analyzer (Unknown Unknown)
+// File:        CRTTPCTruthEff_module.cc
+//
+// Generated at Wed Feb 16 22:07:45 2022 by Biswaranjan Behera using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+// Framework includes
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Atom.h"
+#include "cetlib/pow.h" // cet::sum_of_squares()
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Utilities/Exception.h"
+#include "larsim/MCCheater/BackTrackerService.h"
+#include "larsim/MCCheater/ParticleInventoryService.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
+
+// LArSoft includes
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/Simulation/SimChannel.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/Track.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include "larcorealg/CoreUtils/NumericUtils.h"
+
+// icaruscode includes
+#include "icaruscode/CRT/CRTUtils/CRTBackTracker.h"
+#include "icaruscode/CRT/CRTUtils/RecoUtils.h"
+#include "sbnobj/Common/CRT/CRTHit.hh"
+#include "icaruscode/CRT/CRTUtils/CRTT0MatchAlg.h"
+#include "icaruscode/CRT/CRTUtils/CRTCommonUtils.h"
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
+
+#include "canvas/Persistency/Common/FindMany.h"
+#include "canvas/Persistency/Common/FindOne.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/PtrVector.h"
+
+#include "lardataobj/RecoBase/PFParticle.h"
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/RecoBase/PFParticleMetadata.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TVector3.h"
+#include "TFile.h"
+
+// C++ includes
+#include <map>
+#include <vector>
+#include <string>
+
+namespace icarus {
+  class CRTTPCTruthEff;
+}
+
+class icarus::CRTTPCTruthEff : public art::EDAnalyzer {
+public:
+  explicit CRTTPCTruthEff(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  CRTTPCTruthEff(CRTTPCTruthEff const&) = delete;
+  CRTTPCTruthEff(CRTTPCTruthEff&&) = delete;
+  CRTTPCTruthEff& operator=(CRTTPCTruthEff const&) = delete;
+  CRTTPCTruthEff& operator=(CRTTPCTruthEff&&) = delete;
+
+  // Called once, at start of the job
+  virtual void beginJob() override;
+
+  // Called once per event
+  virtual void analyze(const art::Event& event) override;
+
+  // Called once, at end of the job
+  virtual void endJob() override;
+
+  // Calculate the distance from the track crossing point to CRT overlap coordinates
+  double DistToCrtHit(TVector3 trackPos, sbn::crt::CRTHit crtHit);
+
+  void reconfigure(fhicl::ParameterSet const & p);
+
+private:
+  art::ServiceHandle<art::TFileService> tfs;
+  TTree* trevtdisp;
+
+  icarus::crt::CRTBackTracker bt;
+
+  int fEvent, fRun, fSubRun;
+
+  int track_trueID, crt_trueID, ttl_tpctrks, ttl_crthits;
+  int crt_pdg, trk_pdg, track_mother, crt_mother, track_ancestor, crt_ancestor;
+  int crt_motherlayers, track_motherlayers;
+  double this_dca;
+
+  // Declare member data here.
+  art::InputTag              fCRTHitLabel;   ///< name of CRT producer
+  std::vector<art::InputTag> fTPCTrackLabel; ///< labels for source of tracks
+  art::InputTag              fTriggerLabel;  ///< labels for trigger 
+  art::InputTag 	     fSimModuleLabel;      ///< name of detsim producer
+  std::vector<art::InputTag> fPFParticleLabel; ///< labels for source of PFParticle
+  bool                       fVerbose;       ///< print information about what's going on
+  bool			     fIsData;        ///< switch for if this is data or MC
+
+  CRTT0MatchAlg t0Alg;
+
+  geo::GeometryCore const* fGeometryService;   ///< pointer to Geometry provider
+  icarus::crt::CRTCommonUtils* fCrtutils;
+
+  //add trigger data product vars
+  unsigned int m_gate_type;
+  std::string  m_gate_name;
+  uint64_t     m_trigger_timestamp;
+  uint64_t     m_gate_start_timestamp;
+  uint64_t     m_trigger_gate_diff;
+  uint64_t     m_gate_crt_diff;
+
+  int            fCrtRegion;    //CRT hit region code
+
+
+};
+
+
+icarus::CRTTPCTruthEff::CRTTPCTruthEff(fhicl::ParameterSet const& p)
+  : EDAnalyzer{p}  // ,
+  , bt(p.get<fhicl::ParameterSet>("CRTBackTrack"))
+  , t0Alg(p.get<fhicl::ParameterSet>("t0Alg"))
+  , fCrtutils(new icarus::crt::CRTCommonUtils())
+  
+  // More initializers here.
+{
+  // Call appropriate consumes<>() for any products to be retrieved by this module.
+  fGeometryService = lar::providerFrom<geo::Geometry>();
+  reconfigure(p);
+}
+
+void icarus::CRTTPCTruthEff::reconfigure(fhicl::ParameterSet const & p)
+{
+  fCRTHitLabel        =  p.get<art::InputTag> ("CRTHitLabel", "crthit");
+  fTPCTrackLabel      =  p.get< std::vector<art::InputTag> >("TPCTrackLabel",             {""});
+  fTriggerLabel       =  p.get<art::InputTag>("TriggerLabel","daqTrigger");
+  fVerbose            =  p.get<bool>("Verbose");
+  fIsData	      =  p.get<bool>("IsData");
+  fSimModuleLabel     =  p.get<art::InputTag> ("SimModuleLabel","largeant");
+  fPFParticleLabel    =  p.get< std::vector<art::InputTag> >("PFParticleLabel",             {""});
+} // CRTT0Matching::reconfigure()
+
+void icarus::CRTTPCTruthEff::beginJob()
+{
+  for(int i = 30; i < 50 + 1; i++){
+    std::string tagger = "All";
+    if (i>=35 && i<40) continue;
+    if (i==48 || i==49) continue;
+    // if(i < ){
+    tagger = fCrtutils->GetRegionNameFromNum(i);//fCrtGeo.GetTagger(i).name;
+  }
+
+  trevtdisp= tfs->make<TTree>("trevtdisp","trevtdisp");
+
+  trevtdisp->Branch("fEvent",&fEvent,"fEvent/I");
+  trevtdisp->Branch("crtRegion",&fCrtRegion,"crtRegion/I");
+  trevtdisp->Branch("fRun",&fRun,"fRun/I");
+  trevtdisp->Branch("fSubRun",&fSubRun,"fSubRun/I");
+  trevtdisp->Branch("track_trueID",&track_trueID,"track_trueID/I");
+  trevtdisp->Branch("track_mother",&track_mother,"track_mother/I");
+  trevtdisp->Branch("crt_mother",&crt_mother,"crt_mother/I");
+  trevtdisp->Branch("track_ancestor",&track_ancestor,"track_ancestor/I");
+  trevtdisp->Branch("crt_ancestor",&crt_ancestor,"crt_ancestor/I");
+  trevtdisp->Branch("track_motherlayers",&track_motherlayers,"track_motherlayers/I");
+  trevtdisp->Branch("crt_motherlayers",&crt_motherlayers,"crt_motherlayers/I");
+  trevtdisp->Branch("crt_trueID",&crt_trueID,"crt_trueID/I");
+  trevtdisp->Branch("crt_pdg",&crt_pdg,"crt_pdg/I");
+  trevtdisp->Branch("trk_pdg",&trk_pdg,"trk_pdg/I");
+  trevtdisp->Branch("ttl_tpctrks",&ttl_tpctrks,"ttl_tpctrks/I");
+  trevtdisp->Branch("ttl_crthits",&ttl_crthits,"ttl_crthits/I");
+  trevtdisp->Branch("this_dca",&this_dca,"this_dca/D");
+
+  //*/
+}
+
+void icarus::CRTTPCTruthEff::analyze(const art::Event& event)
+{
+
+  fEvent  = event.id().event();
+  fRun    = event.run();
+  fSubRun = event.subRun();
+
+
+    auto particleHandle = event.getValidHandle<std::vector<simb::MCParticle>>(fSimModuleLabel);
+
+    bt.Initialize(event);
+    std::map<int, simb::MCParticle> particles;
+
+    // Loop over the true particles
+//    mcpart_ids.clear();
+    for (auto const& particle: (*particleHandle)){
+      
+      // Make map with ID
+      int partID = particle.TrackId();
+      particles[partID] = particle;
+    }//end loop over particles in particleHandle
+  //----------------------------------------------------------------------------------------------------------
+  //                                          GETTING PRODUCTS
+  //----------------------------------------------------------------------------------------------------------
+  //add trigger info
+  if( !fTriggerLabel.empty() ) {
+
+    art::Handle<sbn::ExtraTriggerInfo> trigger_handle;
+    event.getByLabel( fTriggerLabel, trigger_handle );
+    if( trigger_handle.isValid() ) {
+      sbn::triggerSource bit = trigger_handle->sourceType;
+      m_gate_type = (unsigned int)bit;
+      m_gate_name = bitName(bit);
+      m_trigger_timestamp = trigger_handle->triggerTimestamp;
+      m_gate_start_timestamp =  trigger_handle->beamGateTimestamp;
+      m_trigger_gate_diff = trigger_handle->triggerTimestamp - trigger_handle->beamGateTimestamp;
+    }//end if( trigger_handle.isValid() )
+    else{
+      mf::LogError("CRTTPCTruthEff:") << "No raw::Trigger associated to label: " << fTriggerLabel.label() << "\n" ;
+    }//end else
+  }//end if( !fTriggerLabel.empty() )
+  else {
+    mf::LogError("CRTTPCTruthEff:") << "Trigger Data product " << fTriggerLabel.label() << " not found!\n" ;
+  }//end else
+
+
+  // Get CRT hits from the event
+  art::Handle< std::vector<sbn::crt::CRTHit>> crtHitHandle;
+  std::vector<art::Ptr<sbn::crt::CRTHit> > crtHitList;
+  if (event.getByLabel(fCRTHitLabel, crtHitHandle))
+    art::fill_ptr_vector(crtHitList, crtHitHandle);
+
+  std::vector<sbn::crt::CRTHit> crtHits;
+  int hit_i = 0;
+  double minHitTime = 99999;
+  double maxHitTime = -99999;
+
+  for(auto const& hit : (*crtHitHandle)){
+    double hitTime = double((1600 - hit.ts0_ns)/1e3);
+    //double hitTime = (double)(int)hit.ts0_ns * 1e-3;
+    if(hitTime < minHitTime) minHitTime = hitTime;
+    if(hitTime > maxHitTime) maxHitTime = hitTime;
+
+    crtHits.push_back(hit);
+    hit_i++;
+  }
+
+  int numtpctrks=(int)fTPCTrackLabel.size(), numcrthits=(int)crtHits.size();
+
+  //Temp for debugging MC
+  std::cout << "# of TPC tracks:\t" << numtpctrks;
+  std::cout << "# of CRT Hits:\t" << numcrthits;
+
+  ttl_tpctrks = numtpctrks; ttl_crthits = numcrthits;
+
+  //Begin building association between TPC tracks in the event and their T0s (if they have them)
+  art::Handle<std::vector<recob::Track>> pandoratrkHandle;
+  std::vector<art::Ptr<recob::Track>> pandoratrks;
+  if(event.getByLabel("pandoraTrackGausCryoW",pandoratrkHandle)){ art::fill_ptr_vector(pandoratrks,pandoratrkHandle); }//end if(event.getByLabel("pandoraTrackGausCryoW",pandoratrkHandle)
+
+  //----------------------------------------------------------------------------------------------------------
+  //                                DISTANCE OF CLOSEST APPROACH ANALYSIS
+  //----------------------------------------------------------------------------------------------------------cc
+
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event);
+  auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(event, clockData);
+
+  // if(fVerbose) std::cout<<"----------------- DCA Analysis -------------------"<<std::endl;
+
+  for(const auto& trackLabel : fTPCTrackLabel)
+    {
+      auto it = &trackLabel - fTPCTrackLabel.data();
+
+      // Get reconstructed tracks from the event    
+      auto tpcTrackHandle = event.getValidHandle<std::vector<recob::Track>>(trackLabel);
+      if (!tpcTrackHandle.isValid()) continue;
+
+      std::cout << "New TPC track label!\n";  
+
+      art::FindManyP<recob::Hit> findManyHits(tpcTrackHandle, event, trackLabel);
+
+      //Begin building association between TPC tracks in the event and their T0s (if they have them)
+      std::cout << "size of the track label: " << trackLabel << std::endl;
+
+      //Get PFParticles
+      auto pfpListHandle = event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel[it]);
+      if (!pfpListHandle.isValid()) continue;
+
+      // Get reconstructed tracks from the event
+      //Get PFParticle-Track association
+      art::FindManyP<recob::PFParticle> fmpfp(tpcTrackHandle, event, trackLabel);
+
+      //Get T0-PFParticle association
+      art::FindManyP<anab::T0> fmt0pandora(pfpListHandle, event, fPFParticleLabel[it]);
+
+      // Loop over reconstructed tracks
+      for (auto const& tpcTrack : (*tpcTrackHandle)){
+
+	this_dca = DBL_MAX; crt_trueID = INT_MAX; track_trueID = INT_MAX; track_mother = INT_MAX;
+
+        //Find PFParticle for track i
+        //art::Ptr::key() gives the index in the vector
+        auto pfps = fmpfp.at(tpcTrack.ID());
+
+	std::vector<art::Ptr<recob::Hit>> hits = findManyHits.at(tpcTrack.ID());
+
+	//Construct histogram for lookint at *all* hits
+	//Using the vector of art Ptrs to recob::Hit, we can use RecoUtils.* to get the likely truth ID:
+	track_trueID = RecoUtils::TrueParticleIDFromTotalRecoHits(clockData,hits,false);
+
+	track_mother = particles[track_trueID].Mother();
+	track_ancestor = track_mother;
+
+
+	std::cout << "New TPC track in the handle!\n";
+	icarus::matchCand closest = t0Alg.GetClosestCRTHit(detProp, tpcTrack, hits, crtHits, m_trigger_timestamp, fIsData);
+	sbn::crt::CRTHit checkhit = closest.thishit;
+	fCrtRegion=(int)fCrtutils->AuxDetRegionNameToNum(closest.thishit.tagger);
+
+	double tempdca =(double) closest.dca;
+	this_dca = tempdca; std::cout << "closest.dca: " << this_dca << std::endl;
+	crt_trueID =  bt.TrueIdFromTotalEnergy(event, checkhit);// std::cout << temp_crt_trueID << std::endl;
+	crt_mother = particles[crt_trueID].Mother();
+	crt_ancestor = crt_mother;
+
+	int tmp_counter = 0;
+	while(track_ancestor%10000000!=0&&tmp_counter<1000){
+
+		track_ancestor = particles[track_ancestor].Mother();
+		std::cout << "loop " << tmp_counter << std::endl;
+		tmp_counter++;
+
+	}//end while(track_mother%10000000!=0||tmp_counter<100)
+	track_motherlayers = tmp_counter;
+	tmp_counter=0;
+	while(crt_ancestor%10000000!=0&&tmp_counter<1000){
+
+		crt_ancestor = particles[crt_ancestor].Mother();
+		std::cout << "loop " << tmp_counter << std::endl;
+		tmp_counter++;
+
+	}//end while(crt_mother%10000000!=0||tmp_counter<100)
+	crt_motherlayers = tmp_counter;
+
+	crt_pdg = particles[crt_trueID].PdgCode();
+	trk_pdg = particles[track_trueID].PdgCode();
+
+	trevtdisp->Fill();
+	
+      }// track loops in each tracklebel
+    }// end loop over TPC tracks
+}
+void icarus::CRTTPCTruthEff::endJob()
+{
+
+} // CRTT0Matching::endJob()
+
+
+DEFINE_ART_MODULE(icarus::CRTTPCTruthEff)

--- a/icaruscode/CRT/CRTUtils/CRTT0MatchAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTT0MatchAlg.h
@@ -74,6 +74,8 @@ namespace icarus{
   class CRTT0MatchAlg {
   public:
 
+
+    /**
     struct Config {
       using Name = fhicl::Name;
       using Comment = fhicl::Comment;
@@ -93,7 +95,7 @@ namespace icarus{
       fhicl::Atom<int> TSMode {
         Name("TSMode"),
 	  Comment(""),
-	  1 /* Value for SBND */
+	  1 // Value for SBND 
 	  }; 
 
       fhicl::Atom<double> TimeCorrection {
@@ -107,13 +109,16 @@ namespace icarus{
 	  Comment(""),
         100.
 	  };
-
+      */
+      /**
       fhicl::Atom<art::InputTag> TPCTrackLabel {
         Name("TPCTrackLabel"),
 	  Comment("")
 	  };
+      */
 
 
+    /*
       fhicl::Atom<int> DirMethod {
 	Name("DirMethod"),
           Comment("1=endpoints (default), 2=average;  must use endpoints if applying SCE position corrections"),
@@ -155,30 +160,45 @@ namespace icarus{
           Comment("Only consider CRT hits with position uncertainties below this value (cm)"),
           1000.0
 	  };
-
+    */
       /* fhicl::Atom<double> DistEndpointAVedge { */
       /*   Name("DistEndpointAVedge"), */
       /*     Comment("Max distance allowed from track endpoint to edge of FV along track extrapolation to CRT hit (cm)"), */
       /*     200.0 */
       /*   }; */
 
+    /*
+      fhicl::Sequence<art::InputTag> TPCTrackLabel {
+	Name("TPCTrackLabel"), 
+	  {"pandoraTrackGausCryoE", "pandoraTrackGausCryoW"}
+      };
+
     };
-          
+    */     
 
-    CRTT0MatchAlg(const Config& config);
-    CRTT0MatchAlg(const Config& config, geo::GeometryCore const *GeometryService, spacecharge::SpaceCharge  const* SCE);
-
+    //    CRTT0MatchAlg(const Config& config);
+    //CRTT0MatchAlg(const Config& config, geo::GeometryCore const *GeometryService, spacecharge::SpaceCharge  const* SCE);
+    /*
   CRTT0MatchAlg(const fhicl::ParameterSet& pset) :
     CRTT0MatchAlg(fhicl::Table<Config>(pset, {})()) {}
     
   CRTT0MatchAlg(const fhicl::ParameterSet& pset, geo::GeometryCore const *GeometryService, spacecharge::SpaceCharge const* SCE) :
     CRTT0MatchAlg(fhicl::Table<Config>(pset, {})(), GeometryService, SCE) {}
+   
+
+  CRTT0MatchAlg(const fhicl::ParameterSet& pset) :
+    CRTT0MatchAlg() {}
     
+  CRTT0MatchAlg(const fhicl::ParameterSet& pset, geo::GeometryCore const *GeometryService, spacecharge::SpaceCharge const* SCE) :
+    CRTT0MatchAlg(pset, GeometryService, SCE) {}
+    */
+
+    explicit CRTT0MatchAlg(const fhicl::ParameterSet& pset);
     CRTT0MatchAlg();
     
-    void reconfigure(const Config& config);
-    
-
+    //void reconfigure(const Config& config);
+     
+    void reconfigure(const fhicl::ParameterSet& pset);
 
     // Utility function that determines the possible x range of a track
     std::pair<double, double> TrackT0Range(detinfo::DetectorPropertiesData const& detProp,
@@ -189,39 +209,56 @@ namespace icarus{
                                  TVector3 trackPos, TVector3 trackDir, sbn::crt::CRTHit crtHit, int driftDirection, double t0);
 
     std::pair<TVector3, TVector3> TrackDirectionAverage(recob::Track track, double frac);
-    std::pair<TVector3, TVector3> TrackDirection(detinfo::DetectorPropertiesData const& detProp,recob::Track track, double frac, double CRTtime, int driftDirection);
+
+    std::pair<TVector3, TVector3> TrackDirection(detinfo::DetectorPropertiesData const& detProp,recob::Track track, 
+						 double frac, double CRTtime, int driftDirection);
+
     std::pair<TVector3, TVector3> TrackDirectionAverageFromPoints(recob::Track track, double frac);
 
     // Keeping ClosestCRTHit function for backwards compatibility
     // *** use GetClosestCRTHit instead
     std::pair<sbn::crt::CRTHit, double> ClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
-						      recob::Track tpcTrack, std::pair<double, double> t0MinMax, std::vector<sbn::crt::CRTHit> crtHits, int driftDirection);
+						      recob::Track tpcTrack, std::pair<double, double> t0MinMax, 
+						      std::vector<sbn::crt::CRTHit> crtHits, int driftDirection, uint64_t trigger_timestamp);
+
+    std::vector<std::pair<sbn::crt::CRTHit, double> >ClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
+								   recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, 
+								   const art::Event& event, uint64_t trigger_timestamp);
+
     std::pair<sbn::crt::CRTHit, double> ClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
-						      recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, const art::Event& event);
-    std::pair<sbn::crt::CRTHit, double> ClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
-						      recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, std::vector<sbn::crt::CRTHit> crtHits);
+						      recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, 
+						      std::vector<sbn::crt::CRTHit> crtHits, uint64_t trigger_timestamp);
 
     // Return the closest CRT hit to a TPC track and the DCA
     matchCand GetClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
-			       recob::Track tpcTrack, std::pair<double, double> t0MinMax, std::vector<sbn::crt::CRTHit> crtHits, int driftDirection);
+			       recob::Track tpcTrack, std::pair<double, double> t0MinMax, 
+			       std::vector<sbn::crt::CRTHit> crtHits, int driftDirection, uint64_t& trigger_timestamp, bool fIsData);
+
+    std::vector<matchCand> GetClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
+					    recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, 
+					    const art::Event& event, uint64_t trigger_timestamp);
 
     matchCand GetClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
-			       recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, const art::Event& event);
-
-    matchCand GetClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
-			       recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, std::vector<sbn::crt::CRTHit> crtHits);
+			       recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, 
+			       std::vector<sbn::crt::CRTHit> crtHits, uint64_t trigger_timestamp, bool fIsData);
 
     // Match track to T0 from CRT hits
+    std::vector<double> T0FromCRTHits(detinfo::DetectorPropertiesData const& detProp,
+				      recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, 
+				      const art::Event& event, uint64_t trigger_timestamp);
+
     double T0FromCRTHits(detinfo::DetectorPropertiesData const& detProp,
-			 recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, const art::Event& event);
-    double T0FromCRTHits(detinfo::DetectorPropertiesData const& detProp,
-			 recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, std::vector<sbn::crt::CRTHit> crtHits);
+			 recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, 
+			 std::vector<sbn::crt::CRTHit> crtHits, uint64_t& trigger_timestamp);
     
     // Match track to T0 from CRT hits, also return the DCA
+    std::vector<std::pair<double, double> >  T0AndDCAFromCRTHits(detinfo::DetectorPropertiesData const& detProp,
+								 recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, 
+								 const art::Event& event, uint64_t trigger_timestamp);
+
     std::pair<double, double>  T0AndDCAFromCRTHits(detinfo::DetectorPropertiesData const& detProp,
-						   recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, const art::Event& event);
-    std::pair<double, double>  T0AndDCAFromCRTHits(detinfo::DetectorPropertiesData const& detProp,
-						   recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, std::vector<sbn::crt::CRTHit> crtHits);
+						   recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, 
+						   std::vector<sbn::crt::CRTHit> crtHits, uint64_t& trigger_timestamp);
  
     // Simple distance of closest approach between infinite track and centre of hit
     double SimpleDCA(sbn::crt::CRTHit hit, TVector3 start, TVector3 direction);
@@ -245,18 +282,17 @@ namespace icarus{
     double fMinTrackLength;
     double fTrackDirectionFrac;
     double fDistanceLimit;
-    int fTSMode;
+    int    fTSMode;
     double fTimeCorrection;
-    int fDirMethod;
-    bool fSCEposCorr;
-    bool fDCAuseBox;
-    bool fDCAoverLength;
+    int    fDirMethod;
+    bool   fSCEposCorr;
+    bool   fDCAuseBox;
+    bool   fDCAoverLength;
     double fDoverLLimit;
     double fPEcut;
     double fMaxUncert;
     //    double fDistEndpointAVedge;
-
-    art::InputTag fTPCTrackLabel;
+    std::vector<art::InputTag> fTPCTrackLabel;
 
   };
 

--- a/icaruscode/CRT/CRTUtils/CRTT0MatchAlg_evtdisp.h
+++ b/icaruscode/CRT/CRTUtils/CRTT0MatchAlg_evtdisp.h
@@ -1,0 +1,182 @@
+#ifndef CRTT0MATCHALG_H_SEEN
+#define CRTT0MATCHALG_H_SEEN
+
+
+///////////////////////////////////////////////
+// CRTT0MatchAlg_evtdisp.h
+//
+// Functions for CRT t0 matching
+// T Brooks (tbrooks@fnal.gov), November 2018
+///////////////////////////////////////////////
+
+// framework
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "fhiclcpp/ParameterSet.h" 
+#include "art/Framework/Principal/Handle.h" 
+#include "canvas/Persistency/Common/Ptr.h" 
+#include "canvas/Persistency/Common/PtrVector.h" 
+#include "art/Framework/Services/Registry/ServiceHandle.h" 
+#include "messagefacility/MessageLogger/MessageLogger.h" 
+#include "canvas/Persistency/Common/FindManyP.h"
+
+// LArSoft
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/Track.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "lardataobj/Simulation/AuxDetSimChannel.h"
+#include "larcore/Geometry/AuxDetGeometry.h"
+#include "larevt/SpaceCharge/SpaceCharge.h"
+#include "larevt/SpaceChargeServices/SpaceChargeService.h"
+#include "lardataobj/RecoBase/PFParticle.h"
+// Utility libraries
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Atom.h"
+#include "cetlib/pow.h" // cet::sum_of_squares()
+
+#include "sbnobj/Common/CRT/CRTHit.hh"
+#include "icaruscode/CRT/CRTUtils/CRTCommonUtils.h"
+//#include "icaruscode/Geometry/GeometryWrappers/TPCGeoAlg.h"
+#include "icaruscode/CRT/CRTUtils/TPCGeoUtil.h"
+
+// c++
+#include <iostream>
+#include <stdio.h>
+#include <sstream>
+#include <vector>
+#include <map>
+#include <utility>
+#include <cmath> 
+#include <memory>
+
+// ROOT
+#include "TVector3.h"
+#include "TGeoManager.h"
+
+
+namespace icarus{
+
+
+  struct  match_geometry {
+    sbn::crt::CRTHit thishit;
+    double t0;
+    double dca;
+    double extrapLen;
+
+
+	//Evtdisp data vars
+	bool simple_cathodecrosser;
+	double t0min;
+	double t0max;
+	double crtTime;
+
+	int hit_id;
+	long track_id;
+	long meta_track_id;
+
+	TVector3 startDir;
+	TVector3 endDir;
+	TVector3 tpc_track_start;
+	TVector3 tpc_track_end;
+	TVector3 crt_hit_pos;
+	double simpleDCA_startDir;
+	double simpleDCA_endDir;
+	bool is_best_DCA_startDir;
+	bool is_best_DCA_endDir;
+
+	//Evtdisp MC vars
+//	TVector3 MC_tpc_trackstart;
+//	TVector3 MC_tpc_trackend;
+//	TVector3 MC_CRTHit_pt;
+	
+
+  };
+
+
+  class CRTT0MatchAlg_evtdisp {
+  public:
+
+    explicit CRTT0MatchAlg_evtdisp(const fhicl::ParameterSet& pset);
+    CRTT0MatchAlg_evtdisp();
+    
+    //void reconfigure(const Config& config);
+     
+    void reconfigure(const fhicl::ParameterSet& pset);
+
+    // Utility function that determines the possible x range of a track
+    std::pair<double, double> TrackT0Range(detinfo::DetectorPropertiesData const& detProp,
+                                           double startX, double endX, int driftDirection, std::pair<double, double> xLimits);
+
+    // Calculate the distance of closest approach (DCA) between the end of a track and a crt hit
+    double DistOfClosestApproach(detinfo::DetectorPropertiesData const& detProp,
+                                 TVector3 trackPos, TVector3 trackDir, sbn::crt::CRTHit crtHit, int driftDirection, double t0);
+
+    std::pair<TVector3, TVector3> TrackDirectionAverage(recob::Track track, double frac);
+
+    std::pair<TVector3, TVector3> TrackDirection(detinfo::DetectorPropertiesData const& detProp,recob::Track track, 
+						 double frac, double CRTtime, int driftDirection);
+
+//    std::pair<TVector3, TVector3> TrackDirectionAverageFromPoints(recob::Track track, double frac);
+
+    // Return the closest CRT hit to a TPC track and the DCA
+    std::vector<match_geometry> GetClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
+			       recob::Track tpcTrack, std::pair<double, double> t0MinMax, 
+			       std::vector<sbn::crt::CRTHit> crtHits, int driftDirection, uint64_t& trigger_timestamp, const art::Event& event, bool IsData);
+
+    std::vector<match_geometry> GetClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
+					    recob::Track tpcTrack, std::vector<sbn::crt::CRTHit> crtHits, 
+					    const art::Event& event, uint64_t trigger_timestamp, bool IsData);
+
+    std::vector<match_geometry> GetClosestCRTHit(detinfo::DetectorPropertiesData const& detProp,
+			       recob::Track tpcTrack, std::vector<art::Ptr<recob::Hit>> hits, 
+			       std::vector<sbn::crt::CRTHit> crtHits, uint64_t trigger_timestamp, const  art::Event& event, bool IsData);
+
+    // Simple distance of closest approach between infinite track and centre of hit
+    double SimpleDCA(sbn::crt::CRTHit hit, TVector3 start, TVector3 direction);
+
+    // Minimum distance from infinite track to CRT hit assuming that hit is a 2D square
+    double DistToCrtHit(sbn::crt::CRTHit hit, TVector3 start, TVector3 end);
+
+    // Distance between infinite line (2) and segment (1)
+    // http://geomalgorithms.com/a07-_distance.html
+    double LineSegmentDistance(TVector3 start1, TVector3 end1, TVector3 start2, TVector3 end2);
+
+    // Intersection between axis-aligned cube and infinite line
+    // (https://www.scratchapixel.com/lessons/3d-basic-rendering/minimal-ray-tracer-rendering-simple-shapes/ray-box-intersection)
+    std::pair<TVector3, TVector3> CubeIntersection(TVector3 min, TVector3 max, TVector3 start, TVector3 end);
+
+    //Determine if the track crosses the cathode
+    bool IsCathodeCrosser(const art::Event& event, recob::Track track, double &timestamp);
+
+  private:
+
+    geo::GeometryCore const* fGeometryService;
+    spacecharge::SpaceCharge  const* fSCE;
+
+    double fMinTrackLength;
+    double fTrackDirectionFrac;
+    double fDistanceLimit;
+    int    fTSMode;
+    double fTimeCorrection;
+    int    fDirMethod;
+    bool   fSCEposCorr;
+    bool   fDCAuseBox;
+    bool   fDCAoverLength;
+    double fDoverLLimit;
+    double fPEcut;
+    double fMaxUncert;
+    bool   fIsData;
+    //    double fDistEndpointAVedge;
+    std::vector<art::InputTag> fTPCTrackLabel;
+
+  };
+
+
+}
+#endif

--- a/icaruscode/CRT/CRTUtils/crtt0matchingalg_icarus.fcl
+++ b/icaruscode/CRT/CRTUtils/crtt0matchingalg_icarus.fcl
@@ -6,7 +6,7 @@ standard_crtt0matchingalg:
     MinTrackLength:      20.                # Minimum track length to perform T0 matching on, default = 20 cm.
                                             #    No attempt is made to tag tracks shorter than this
     TrackDirectionFrac:  0.5                # the fraction of track used to determine direction, don't mess with this
-    TPCTrackLabel:       "pandoraTrackGausCryoE"
+    TrackLabel:       ["pandoraTrackGausCryoE", "pandoraTrackGausCryoW"]
     DirMethod: 1                            # method to determine track direction for extraploation
                                             #   1=endpoints (default), 2=average;  must use endpoints if applying SCE position corrections
     SCEposCorr: true                        # apply SCE position corrections to track before extrapolating

--- a/icaruscode/CRT/crttpcevtdisp_MC.fcl
+++ b/icaruscode/CRT/crttpcevtdisp_MC.fcl
@@ -1,0 +1,91 @@
+# A script to run the analyzer module: CRTTPCEvtDisp
+
+#include "services_icarus_simulation.fcl"
+#include "services_common_icarus.fcl"
+#include "crtt0matchingalg_icarus.fcl"
+#include "simulationservices_icarus.fcl"
+#include "crtbacktracker_icarus.fcl"
+
+
+process_name: CRTTPCEvtDisp
+
+services:
+{
+  # Load the service that manages root files for histograms.
+  TFileService:           { fileName: "crtt0matchingana.root" }
+ # This constrols the display in the output of how long each job step takes for each event. 
+  TimeTracker:            {}
+
+ 
+
+  # This parameter controls the level of descriptive output from various LArSoft modules.
+  message:                @local::icarus_message_services_prod_debug
+                          @table::icarus_common_services
+
+} # services
+
+#space charge service
+services.SpaceChargeService: @local::icarus_spacecharge
+services.ParticleInventoryService: @local::standard_particleinventoryservice
+services.BackTrackerService: @local::standard_backtrackerservice
+
+
+# The 'source' section tells the script to expect an input file with art::Event records.
+source:
+{
+  module_type: RootInput
+
+  # Number of events to analyze; "-1" means all of the events in the input
+  # file. You can override this value with the "-n" option on the command line. 
+  maxEvents:  -1 
+
+}
+
+# This is empty, because we're not writing an output file with art::Event objects.
+outputs:
+{
+  out1:
+  {
+    module_type: RootOutput
+    fileName:    "%ifb_%tc_ana.root"
+    dataTier: "reconstructed"
+    saveMemoryObjectThreshold: 0
+    compressionLevel: 1
+    fastCloning: false
+  }
+}
+
+# The 'physics' section defines and configures some modules to do work on each event.
+physics:
+{
+   analyzers:
+  {
+    CRTTPCEvtDisp:
+    {
+      module_type:         "icaruscode/CRT/CRTTPCEvtDisp"
+      # The input parameters	   
+      CRTHitLabel:         "crthit"           # CRT producer module label
+      TPCTrackLabel:       ["pandoraTrackGausCryoE", "pandoraTrackGausCryoW"]     # Track producer module label
+      PFParticleLabel: 	   ["pandoraGausCryoE", "pandoraGausCryoW"]
+      #TPCTrackLabel:       "pandoraTrackGausCryoE"     # Track producer module label  
+      TriggerLabel:        "daqTrigger"
+      Verbose:             true              # Print extra information about what's going on
+      t0Alg:               @local::standard_crtt0matchingalg
+      IsData:		   false
+      SimModuleLabel:	   "largeant"
+      CRTBackTrack: @local::standard_crtbacktracker
+    }
+  }
+
+  # Schedule job step(s) for execution by defining the analysis module for this job.
+  analysis: [ CRTTPCEvtDisp ]
+
+ # stream1: [ out1 ]
+
+ # trigger_paths: [reco]
+
+  # "end_paths" is a keyword and contains the modules that do not modify the art::Event;
+  # i.e., analyzers and output streams.
+  end_paths: [ analysis ]
+
+}

--- a/icaruscode/CRT/crttpcevtdisp_data.fcl
+++ b/icaruscode/CRT/crttpcevtdisp_data.fcl
@@ -1,0 +1,90 @@
+# A script to run the analyzer module: CRTTPCEvtDisp
+
+#include "services_icarus_simulation.fcl"
+#include "services_common_icarus.fcl"
+#include "crtt0matchingalg_icarus.fcl"
+#include "simulationservices_icarus.fcl"
+#include "crtbacktracker_icarus.fcl"
+
+
+process_name: CRTTPCEvtDisp
+
+services:
+{
+  # Load the service that manages root files for histograms.
+  TFileService:           { fileName: "crtt0matchingana.root" }
+ # This constrols the display in the output of how long each job step takes for each event. 
+  TimeTracker:            {}
+
+ 
+
+  # This parameter controls the level of descriptive output from various LArSoft modules.
+  message:                @local::icarus_message_services_prod_debug
+                          @table::icarus_common_services
+
+} # services
+
+#space charge service
+services.SpaceChargeService: @local::icarus_spacecharge
+services.ParticleInventoryService: @local::standard_particleinventoryservice
+services.BackTrackerService: @local::standard_backtrackerservice
+
+
+# The 'source' section tells the script to expect an input file with art::Event records.
+source:
+{
+  module_type: RootInput
+
+  # Number of events to analyze; "-1" means all of the events in the input
+  # file. You can override this value with the "-n" option on the command line. 
+  maxEvents:  -1 
+
+}
+
+# This is empty, because we're not writing an output file with art::Event objects.
+outputs:
+{
+  out1:
+  {
+    module_type: RootOutput
+    fileName:    "%ifb_%tc_ana.root"
+    dataTier: "reconstructed"
+    saveMemoryObjectThreshold: 0
+    compressionLevel: 1
+    fastCloning: false
+  }
+}
+
+# The 'physics' section defines and configures some modules to do work on each event.
+physics:
+{
+   analyzers:
+  {
+    CRTTPCEvtDisp:
+    {
+      module_type:         "icaruscode/CRT/CRTTPCEvtDisp"
+      # The input parameters	   
+      CRTHitLabel:         "crthit"           # CRT producer module label
+      TPCTrackLabel:       ["pandoraTrackGausCryoE", "pandoraTrackGausCryoW"]     # Track producer module label
+      #TPCTrackLabel:       "pandoraTrackGausCryoE"     # Track producer module label  
+      PFParticleLabel: 	   ["pandoraGausCryoE", "pandoraGausCryoW"]
+      TriggerLabel:        "daqTrigger"
+      Verbose:             true              # Print extra information about what's going on
+      t0Alg:               @local::standard_crtt0matchingalg
+      IsData:		   true
+      CRTBackTrack: @local::standard_crtbacktracker
+    }
+  }
+
+  # Schedule job step(s) for execution by defining the analysis module for this job.
+  analysis: [ CRTTPCEvtDisp ]
+
+ # stream1: [ out1 ]
+
+ # trigger_paths: [reco]
+
+  # "end_paths" is a keyword and contains the modules that do not modify the art::Event;
+  # i.e., analyzers and output streams.
+  end_paths: [ analysis ]
+
+}

--- a/icaruscode/CRT/crttpctrutheff.fcl
+++ b/icaruscode/CRT/crttpctrutheff.fcl
@@ -1,0 +1,91 @@
+# A script to run the analyzer module: CRTTPCTruthEff
+
+#include "services_icarus_simulation.fcl"
+#include "services_common_icarus.fcl"
+#include "crtt0matchingalg_icarus.fcl"
+#include "simulationservices_icarus.fcl"
+#include "crtbacktracker_icarus.fcl"
+
+
+process_name: CRTTPCTruthEff
+
+services:
+{
+  # Load the service that manages root files for histograms.
+  TFileService:           { fileName: "crttrutheff.root" }
+ # This constrols the display in the output of how long each job step takes for each event. 
+  TimeTracker:            {}
+
+ 
+
+  # This parameter controls the level of descriptive output from various LArSoft modules.
+  message:                @local::icarus_message_services_prod_debug
+                          @table::icarus_common_services
+
+} # services
+
+#space charge service
+services.SpaceChargeService: @local::icarus_spacecharge
+services.ParticleInventoryService: @local::standard_particleinventoryservice
+services.BackTrackerService: @local::standard_backtrackerservice
+
+
+# The 'source' section tells the script to expect an input file with art::Event records.
+source:
+{
+  module_type: RootInput
+
+  # Number of events to analyze; "-1" means all of the events in the input
+  # file. You can override this value with the "-n" option on the command line. 
+  maxEvents:  -1 
+
+}
+
+# This is empty, because we're not writing an output file with art::Event objects.
+outputs:
+{
+  out1:
+  {
+    module_type: RootOutput
+    fileName:    "%ifb_%tc_ana.root"
+    dataTier: "reconstructed"
+    saveMemoryObjectThreshold: 0
+    compressionLevel: 1
+    fastCloning: false
+  }
+}
+
+# The 'physics' section defines and configures some modules to do work on each event.
+physics:
+{
+   analyzers:
+  {
+    CRTTPCTruthEff:
+    {
+      module_type:         "icaruscode/CRT/CRTTPCTruthEff"
+      # The input parameters	   
+      CRTHitLabel:         "crthit"           # CRT producer module label
+      TPCTrackLabel:       ["pandoraTrackGausCryoE", "pandoraTrackGausCryoW"]     # Track producer module label
+      PFParticleLabel: 	   ["pandoraGausCryoE", "pandoraGausCryoW"]
+      #TPCTrackLabel:       "pandoraTrackGausCryoE"     # Track producer module label  
+      TriggerLabel:        "daqTrigger"
+      Verbose:             true              # Print extra information about what's going on
+      t0Alg:               @local::standard_crtt0matchingalg
+      IsData:		   false
+      SimModuleLabel:	   "largeant"
+      CRTBackTrack: @local::standard_crtbacktracker
+    }
+  }
+
+  # Schedule job step(s) for execution by defining the analysis module for this job.
+  analysis: [ CRTTPCTruthEff ]
+
+ # stream1: [ out1 ]
+
+ # trigger_paths: [reco]
+
+  # "end_paths" is a keyword and contains the modules that do not modify the art::Event;
+  # i.e., analyzers and output streams.
+  end_paths: [ analysis ]
+
+}


### PR DESCRIPTION
I've made edits to the TPC-CRT matching code which Bishu originally got from SBND code. The T0 matching code should now use the trigger timestamp correctly, and even has the ability to work on both data and MC depending on the fcl. 

I've added some other analysis code to allow for making the "event display" TTrees which contain geometrical and timing data from attempts at matching CRT Hits with TPC tracks. This should work for both MC and data as well. 

Finally, it's still under construction but I also have an efficiency measurement code suite, which I envision as the way to test TPC-CRT matching algorithms with truth data to evaluate how effective a given matching algorithm is. 