### PR TITLE
Creating "run1" fhicl files for stage0 processing of data

### DIFF
--- a/icaruscode/Decode/fcl/stage0_icarus_driver_common.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_driver_common.fcl
@@ -66,6 +66,9 @@ outputs:
    dataTier: "reconstructed"
    compressionLevel: 1
    saveMemoryObjectThreshold: 0
+   fileName: "%ifb_%tc-%p.root"
+   fileProperties: {maxInputFiles: 1}
+   checkFileName: false
  }
  outBNB:
  {

--- a/icaruscode/Decode/fcl/stage0_icarus_driver_common.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_driver_common.fcl
@@ -45,6 +45,7 @@ physics:
 
  #reco sequence and trigger_paths to be defined elsewhere
 
+ streamCommon:         [ outCommon ]
  streamBNB:            [ outBNB ]
  streamNUMI:           [ outNUMI ]
  streamOffbeamBNB:     [ outOffbeamBNB ]
@@ -59,6 +60,13 @@ physics:
 #entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
 outputs:
 {
+ outCommon:
+ {
+   module_type: RootOutput
+   dataTier: "reconstructed"
+   compressionLevel: 1
+   saveMemoryObjectThreshold: 0
+ }
  outBNB:
  {
    module_type: RootOutput

--- a/icaruscode/Decode/fcl/stage0_run1_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_icarus.fcl
@@ -1,0 +1,24 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the path we'll execute
+physics.path:     [ @sequence::icarus_stage0_data ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamCommon ]
+
+outputs.outCommon.fileName: "%ifb_%tc-%p.root"
+
+# Drop the artdaq format files on output
+outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ path ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ path ]

--- a/icaruscode/Decode/fcl/stage0_run1_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_icarus.fcl
@@ -14,8 +14,6 @@ physics.outana:        [ purityinfoana0, purityinfoana1 ]
 physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamCommon ]
 
-outputs.outCommon.fileName: "%ifb_%tc-%p.root"
-
 # Drop the artdaq format files on output
 outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
 

--- a/icaruscode/Decode/fcl/stage0_run1_icarus_lite.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_icarus_lite.fcl
@@ -14,5 +14,5 @@
 #include "stage0_run1_icarus.fcl"
 
 # Drop truth data products.
-outputs.outCommon.outputCommands: [ @sequence::outputs.outBNB.outputCommands,
+outputs.outCommon.outputCommands: [ @sequence::outputs.outCommon.outputCommands,
                                     @sequence::reco_drops ]

--- a/icaruscode/Decode/fcl/stage0_run1_icarus_lite.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_icarus_lite.fcl
@@ -1,0 +1,18 @@
+#-------------------------------------------------------------------
+#
+# Name: stage0_multiTPC_splitstream_nofilter_icarus_lite.fcl
+#
+# Purpose: Lite version of stage0_multiTPC_splitstream_nofilter_icarus.fcl
+#
+# Created: 31-Mar-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "reco_drops.fcl"
+#include "stage0_run1_icarus.fcl"
+
+# Drop truth data products.
+outputs.outCommon.outputCommands: [ @sequence::outputs.outBNB.outputCommands,
+                                    @sequence::reco_drops ]

--- a/icaruscode/Decode/fcl/stage0_run1_raw_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_raw_icarus.fcl
@@ -1,0 +1,8 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_run1_icarus.fcl"
+
+# Drop the artdaq format files on output
+outputs.outCommon.outputCommands:  ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]

--- a/icaruscode/Decode/fcl/stage0_run1_raw_icarus_lite.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_raw_icarus_lite.fcl
@@ -15,5 +15,5 @@
 
 # Drop truth data products.
 
-outputs.outCommon.outputCommands: [ @sequence::outputs.outBNB.outputCommands,
+outputs.outCommon.outputCommands: [ @sequence::outputs.outCommon.outputCommands,
                                     @sequence::reco_drops ]

--- a/icaruscode/Decode/fcl/stage0_run1_raw_icarus_lite.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_raw_icarus_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: stage0_run1_raw_icarus_lite.fcl
+#
+# Purpose: Lite version of stage0_run1_raw_icarus.fcl
+#
+# Created: 31-Mar-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "reco_drops.fcl"
+#include "stage0_run1_raw_icarus.fcl"
+
+# Drop truth data products.
+
+outputs.outCommon.outputCommands: [ @sequence::outputs.outBNB.outputCommands,
+                                    @sequence::reco_drops ]

--- a/icaruscode/Decode/fcl/stage0_run1_rawpmt_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_rawpmt_icarus.fcl
@@ -17,8 +17,6 @@ physics.outana:        [ purityinfoana0, purityinfoana1 ]
 physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamCommon ]
 
-outputs.outCommon.fileName: "BNB_%ifb_%tc-%p.root"
-
 # Drop the artdaq format files on output
 outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
 

--- a/icaruscode/Decode/fcl/stage0_run1_rawpmt_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_rawpmt_icarus.fcl
@@ -1,0 +1,27 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+## 
+## It drops TPC raw digits but not the PMT ones.
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the paths we'll execute depending on data
+#physics.pathOptical: [ @sequence::icarus_stage0_pmt ]
+physics.path:         [ @sequence::icarus_stage0_data ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamCommon ]
+
+outputs.outCommon.fileName: "BNB_%ifb_%tc-%p.root"
+
+# Drop the artdaq format files on output
+outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ path ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ path ]

--- a/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
@@ -15,8 +15,6 @@ physics.outana:        [ purityinfoana0, purityinfoana1 ]
 physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamCommon ]
 
-outputs.outCommon.fileName: "BNB_%ifb_%tc-%p.root"
-
 # Drop the artdaq format files on output
 outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
 

--- a/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
@@ -1,0 +1,28 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the paths we'll execute depending on data
+#physics.pathOptical: [ @sequence::icarus_stage0_pmt ]
+physics.path:         [ @sequence::icarus_stage0_2d_data ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamCommon ]
+
+outputs.outCommon.fileName: "BNB_%ifb_%tc-%p.root"
+
+# Drop the artdaq format files on output
+outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+# Override the roi finder input 
+physics.producers.roifinder.WireModuleLabelVec:   ["decon2droiWW:looseLf","decon2droiWE:looseLf","decon2droiEW:looseLf","decon2droiEE:looseLf"]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ pathCommon ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ pathCommon ]

--- a/icaruscode/Decode/fcl/stage0_run1_wc_icarus_lite.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_wc_icarus_lite.fcl
@@ -15,5 +15,5 @@
 
 # Drop truth data products.
 
-outputs.outCommon.outputCommands: [ @sequence::outputs.outBNB.outputCommands,
+outputs.outCommon.outputCommands: [ @sequence::outputs.outCommon.outputCommands,
                                     @sequence::reco_drops ]

--- a/icaruscode/Decode/fcl/stage0_run1_wc_icarus_lite.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_wc_icarus_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: stage0_run1_wc_icarus_lite.fcl
+#
+# Purpose: Lite version of stage0_run1_wc_icarus.fcl
+#
+# Created: 31-Mar-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "reco_drops.fcl"
+#include "stage0_run1_wc_icarus.fcl"
+
+# Drop truth data products.
+
+outputs.outCommon.outputCommands: [ @sequence::outputs.outBNB.outputCommands,
+                                    @sequence::reco_drops ]


### PR DESCRIPTION
The daq system is now sending up the data separated by stream type (e.g. "BNB") and it is not longer necessary, or even possible, to filter the data at stage0. These fhicl files are meant to be used for running stage0 on data without filtering to streams. I have also taken this opportunity to try to rationalize the fhicl naming scheme a bit, removing some old terminology (e.g. "multiTPC") that really no longer has context. Hopefully "run1" is descriptive to the use here! 

I have tested in limited capacity on a sample BNB file provided to me. 