### PR TITLE
Reimplemented channel mapping query for side CRT.

### DIFF
--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.cxx
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.cxx
@@ -248,16 +248,18 @@ const DigitizerChannelChannelIDPairVec& ICARUSChannelMapProvider::getChannelIDPa
     }
 
     return simmacaddress;
+    
+    /* untested:
+    auto const it = fTopCRTHWtoSimMacAddressPairMap.find(hwmacaddress);
+    return (it == fTopCRTHWtoSimMacAddressPairMap.end())? 0: it->second;
+    */
   }
    
   std::pair<double, double> ICARUSChannelMapProvider::getSideCRTCalibrationMap(int mac5, int chan) const
   {
-    std::pair<double, double> gainandpedestal(-99, -99);
-    for(const auto& pair : fSideCRTChannelToCalibrationMap){
-      if ((int)pair.first.first == mac5 && (int)pair.first.second == chan)
-        gainandpedestal = std::make_pair(pair.second.first, pair.second.second);
-    }
-    return gainandpedestal;
+    auto const itGainAndPedestal = fSideCRTChannelToCalibrationMap.find({ mac5, chan });
+    return (itGainAndPedestal == fSideCRTChannelToCalibrationMap.cend())
+      ? std::pair{ -99., -99. }: itGainAndPedestal->second;
   }
 
 auto ICARUSChannelMapProvider::findPMTfragmentEntry(unsigned int fragmentID) const


### PR DESCRIPTION
I have tested the new implementation by an intermediate version running the same query in the two ways and throwing on mismatch, and successfully running on 2 events. More testing may be desired.

The pattern that I replaced is also present in other parts of the code. This commit also includes a proposal for one of them, but my test did not call that part of the code so the proposed reimplementation was not really tested, which is the reason it stays as a comment.

In case this new implementation turns out being still too slow, further gain may be possibly achieved turning the map into a hash table (`std::unordered_map`).