### PR TITLE
Removed ultra-spamming debug message from MC OpHit

### DIFF
--- a/icaruscode/PMT/OpReco/ICARUSMCOpHit_module.cc
+++ b/icaruscode/PMT/OpReco/ICARUSMCOpHit_module.cc
@@ -145,7 +145,6 @@ void ICARUSMCOpHit::produce(art::Event& e)
     for(auto const& time_photon_pair : time_m) {
 
       auto const& this_time = time_photon_pair.first;
-      std::cout << "Channel=" << opch << ", time=" << this_time << ", " << time_m[this_time] << std::endl;
 
       if(this_time > (oph_time + _merge_period) && in_window) {
 	recob::OpHit oph(opch, 


### PR DESCRIPTION
See for example [a 78 MB C.I. test log](https://dbweb8.fnal.gov:8443/LarCI/app/ns:icarus/storage/docs/2022/07/15/stdout%23wFKx93s.log) explaining what this means.

This is GitHub coding: untested!