### PR TITLE
Updates to enable using 1D ROIs on 2D deconvolution, also noise filter updates

### DIFF
--- a/icaruscode/Decode/DecoderTools/TPCDecoderFilter1D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCDecoderFilter1D_tool.cc
@@ -191,6 +191,7 @@ private:
 
 TPCDecoderFilter1D::TPCDecoderFilter1D(fhicl::ParameterSet const &pset)
 {
+    std::cout << "TPCDecoderFilter1D is calling configure method" << std::endl;
     this->configure(pset);
 
     fSelectVals.clear();
@@ -247,8 +248,10 @@ void TPCDecoderFilter1D::configure(fhicl::ParameterSet const &pset)
     {
         for(int plane = 0; plane < 3; plane++)
         {
-            if (plane < 2) fFFTFilterFunctionVec.emplace_back(std::make_unique<icarus_signal_processing::WindowFFTFilter>(fFFTSigmaValsVec[plane], fFFTCutoffValsVec[plane]));
+            if (plane < 3) fFFTFilterFunctionVec.emplace_back(std::make_unique<icarus_signal_processing::WindowFFTFilter>(fFFTSigmaValsVec[plane], fFFTCutoffValsVec[plane]));
             else           fFFTFilterFunctionVec.emplace_back(std::make_unique<icarus_signal_processing::NoFFTFilter>());
+
+            mf::LogInfo("TPCDecoderFilter1D") << "FFT setup for plane " << plane << ", SigmaVals: " << fFFTSigmaValsVec[plane].first << "/" << fFFTSigmaValsVec[plane].second << ", cutoff: " << fFFTCutoffValsVec[plane].first << "/" << fFFTCutoffValsVec[plane].second << std::endl;
         }
     }
 
@@ -465,6 +468,7 @@ void TPCDecoderFilter1D::process_fragment(detinfo::DetectorClocksData const&,
                 else std::cout << fChannelIDVec[channelOnBoard] << "-" << widVec[0].Cryostat << "/" << widVec[0].TPC << "/" << widVec[0].Plane << "/" << widVec[0].Wire << "=" << fFullRMSVals[channelOnBoard] << " * ";
             }
         }
+
         if (fDiagnosticOutput) std::cout << std::endl;
     
         // Run the coherent filter

--- a/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
@@ -227,12 +227,17 @@ void TPCNoiseFilter1DMC::configure(fhicl::ParameterSet const &pset)
 
     fFFTFilterFunctionVec.clear();
 
+    std::cout << "TPCDecoderFilter1D configure, fUseFFTFilter: " << fUseFFTFilter << std::endl;
+
     if (fUseFFTFilter)
     {
         for(int plane = 0; plane < 3; plane++)
         {
-            if (plane < 2) fFFTFilterFunctionVec.emplace_back(std::make_unique<icarus_signal_processing::WindowFFTFilter>(fFFTSigmaValsVec[plane], fFFTCutoffValsVec[plane]));
+//            if (plane < 2) fFFTFilterFunctionVec.emplace_back(std::make_unique<icarus_signal_processing::WindowFFTFilter>(fFFTSigmaValsVec[plane], fFFTCutoffValsVec[plane]));
+            if (plane < 5) fFFTFilterFunctionVec.emplace_back(std::make_unique<icarus_signal_processing::WindowFFTFilter>(fFFTSigmaValsVec[plane], fFFTCutoffValsVec[plane]));
             else           fFFTFilterFunctionVec.emplace_back(std::make_unique<icarus_signal_processing::NoFFTFilter>());
+
+            std::cout << "TPCDecoderFilter1D FFT setup for plane " << plane << ", SigmaVals: " << fFFTSigmaValsVec[plane].first << "/" << fFFTSigmaValsVec[plane].second << ", cutoff: " << fFFTCutoffValsVec[plane].first << "/" << fFFTCutoffValsVec[plane].second << std::endl;
         }
     }
 
@@ -272,7 +277,8 @@ void TPCNoiseFilter1DMC::process_fragment(detinfo::DetectorClocksData const&,
 
     if (fFilterFunctionVec.size() < numChannels) fFilterFunctionVec.resize(numChannels);
 
-    icarus_signal_processing::Denoiser1D           denoiser;
+    icarus_signal_processing::Denoiser1D_Protect   denoiser;
+//    icarus_signal_processing::Denoiser1D           denoiser;
     icarus_signal_processing::WaveformTools<float> waveformTools;
 
     // Make a pass throught to do pedestal corrections and get raw waveform information

--- a/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
@@ -277,8 +277,8 @@ void TPCNoiseFilter1DMC::process_fragment(detinfo::DetectorClocksData const&,
 
     if (fFilterFunctionVec.size() < numChannels) fFilterFunctionVec.resize(numChannels);
 
-    icarus_signal_processing::Denoiser1D_Protect   denoiser;
-//    icarus_signal_processing::Denoiser1D           denoiser;
+//    icarus_signal_processing::Denoiser1D_Protect   denoiser;
+    icarus_signal_processing::Denoiser1D           denoiser;
     icarus_signal_processing::WaveformTools<float> waveformTools;
 
     // Make a pass throught to do pedestal corrections and get raw waveform information

--- a/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
+++ b/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
@@ -92,8 +92,8 @@ TPCNoiseFilter1DTool: {
     Threshold:          [12.0, 12.0, 12.0] #[8., 7.0 , 8.0] #[2.75, 2.75, 2.75] # changing threshold scheme from dynamic to static
     FilterModeVec:      ["e","g","d"]
     UseFFTFilter:       false
-    FFTSigmaVals:       [ [1.5,20.], [1.5,20.], [2.0,20.] ]
-    FFTCutoffVals:      [ [8.,800.], [8.,800.], [3.0,800.] ]
+    FFTSigmaVals:       [ [1.5,20.], [1.5,20.], [1.5,20.] ]
+    FFTCutoffVals:      [ [8.,800.], [8.,800.], [4.0,800.] ]
     FragmentIDMap:      [ [0,0x140C], [1,0x140E], [2,0x1410], [6,0x1414], [8,0x150E], [9,0x1510] ]
 }
 

--- a/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
@@ -68,6 +68,7 @@ icarus_stage0_producers:
 
   ### ROI finding on complete deconvolved waveforms
   roifinder:                      @local::icarus_roifinder
+  roifinder2d:                    @local::icarus_roifinder
 
   ### hit-finder producers
   gaushit:                        @local::gaus_hitfinder_icarus
@@ -162,11 +163,13 @@ icarus_stage0_multiTPC_TPC:        [ decon1droi,
                                      roifinder
                                    ]
 
-icarus_stage0_multiTPC_2d_TPC:     [ decon2droiEE,
+icarus_stage0_multiTPC_2d_TPC:     [ decon1droi,
+                                     roifinder,
+                                     decon2droiEE,
                                      decon2droiEW,
                                      decon2droiWE,
                                      decon2droiWW,
-                                     roifinder
+                                     roifinder2d
                                    ]
 
 icarus_stage0_EastHits_TPC:        [ gaushitTPCEW,
@@ -274,10 +277,20 @@ icarus_stage0_producers.decon2droiWW.wcls_main.params.tpc_volume_label:         
 icarus_stage0_producers.decon2droiWW.wcls_main.params.signal_output_form:                      "dense"
 
 ### Set up to output ROIs from full waveforms
-
 icarus_stage0_producers.roifinder.WireModuleLabelVec:                                          ["decon1droi:PHYSCRATEDATATPCWW","decon1droi:PHYSCRATEDATATPCWE","decon1droi:PHYSCRATEDATATPCEW","decon1droi:PHYSCRATEDATATPCEE"]
 icarus_stage0_producers.roifinder.OutInstanceLabelVec:                                         ["PHYSCRATEDATATPCWW","PHYSCRATEDATATPCWE","PHYSCRATEDATATPCEW","PHYSCRATEDATATPCEE"]
 icarus_stage0_producers.roifinder.OutputMorphed:                                               false
+
+icarus_stage0_producers.roifinder2d.ROIFinderToolVec:                                          { ROIFinderPlane0: @local::decoderroifinder_0
+                                                                                                 ROIFinderPlane1: @local::decoderroifinder_1
+                                                                                                 ROIFinderPlane2: @local::decoderroifinder_2
+                                                                                               }
+icarus_stage0_producers.roifinder2d.ROIFinderToolVec.ROIFinderPlane0.ROILabelVec:              ["roifinder:PHYSCRATEDATATPCWW","roifinder:PHYSCRATEDATATPCWE","roifinder:PHYSCRATEDATATPCEW","roifinder:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.roifinder2d.ROIFinderToolVec.ROIFinderPlane0.ROILabelVec:              ["roifinder:PHYSCRATEDATATPCWW","roifinder:PHYSCRATEDATATPCWE","roifinder:PHYSCRATEDATATPCEW","roifinder:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.roifinder2d.ROIFinderToolVec.ROIFinderPlane0.ROILabelVec:              ["roifinder:PHYSCRATEDATATPCWW","roifinder:PHYSCRATEDATATPCWE","roifinder:PHYSCRATEDATATPCEW","roifinder:PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.roifinder2d.WireModuleLabelVec:                                        ["decon2droiWW:looseLf","decon2droiWE:looseLf","decon2droiEW:looseLf","decon2droiEE:looseLf"]
+icarus_stage0_producers.roifinder2d.OutInstanceLabelVec:                                       ["PHYSCRATEDATATPCWW","PHYSCRATEDATATPCWE","PHYSCRATEDATATPCEW","PHYSCRATEDATATPCEE"]
+icarus_stage0_producers.roifinder2d.OutputMorphed:                                             false
 
 ### Set up hit finding for multiple TPC readout
 icarus_stage0_producers.gaushitTPCWW.CalDataModuleLabel:                                       "roifinder:PHYSCRATEDATATPCWW"

--- a/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
@@ -16,7 +16,7 @@ physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamCommon ]
 
 # Drop the artdaq format files on output
-outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*", "drop *_roifindr_*_*" ]
+outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*", "drop *_decon2Droi*_*_*", "drop *_roifindr_*_*" ]
 
 # Override the hit finder input 
 physics.producers.gaushitTPCWW.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCWW"

--- a/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
+++ b/icaruscode/Decode/fcl/stage0_run1_wc_icarus.fcl
@@ -16,11 +16,14 @@ physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamCommon ]
 
 # Drop the artdaq format files on output
-outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*", "drop *_roifindr_*_*" ]
 
-# Override the roi finder input 
-physics.producers.roifinder.WireModuleLabelVec:   ["decon2droiWW:looseLf","decon2droiWE:looseLf","decon2droiEW:looseLf","decon2droiEE:looseLf"]
+# Override the hit finder input 
+physics.producers.gaushitTPCWW.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCWW"
+physics.producers.gaushitTPCWE.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCWE"
+physics.producers.gaushitTPCEW.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCEW"
+physics.producers.gaushitTPCEE.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCEE"
 
 ## Modify the event selection for the purity analyzers
-physics.analyzers.purityinfoana0.SelectEvents:    [ pathCommon ]
-physics.analyzers.purityinfoana1.SelectEvents:    [ pathCommon ]
+physics.analyzers.purityinfoana0.SelectEvents:    [ path ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ path ]

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
@@ -388,7 +388,7 @@ void  ROIFinder::processPlane(size_t                      idx,
     icarus_signal_processing::ArrayFloat outputArray(dataArray.size(),icarus_signal_processing::VectorFloat(dataArray[0].size(),0.));
     icarus_signal_processing::ArrayBool  selectedVals(dataArray.size(),icarus_signal_processing::VectorBool(dataArray[0].size(),false));
 
-    fROIToolMap.at(planeID.Plane)->FindROIs(event, dataArray, mapItr->first, outputArray, selectedVals);
+    fROIToolMap.at(planeID.Plane)->FindROIs(event, dataArray, channelVec, mapItr->first, outputArray, selectedVals);
 
 //    icarus_signal_processing::ArrayFloat morphedWaveforms(dataArray.size());
 
@@ -464,7 +464,7 @@ void  ROIFinder::processPlane(size_t                      idx,
 
             // Loop through candidate roi's
             size_t startRoi = candidateROIVec.front().first;
-            size_t stopRoi  = startRoi;
+            size_t stopRoi  = candidateROIVec.front().second;    //startRoi;
 
             for(auto& roi : candidateROIVec)
             {

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/IROILocator.h
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/IROILocator.h
@@ -16,6 +16,7 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "larcore/Geometry/Geometry.h"
 #include "art/Framework/Principal/Event.h" 
+#include "larcoreobj/SimpleTypesAndConstants/RawTypes.h"
 
 namespace art { class TFileDirectory; }
 
@@ -38,7 +39,7 @@ namespace icarus_tool
         using PlaneIDVec  = std::vector<geo::PlaneID>;
         
         // Find the ROI's
-        virtual void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) = 0;
+        virtual void FindROIs(const art::Event&, const ArrayFloat&, const std::vector<raw::ChannelID_t>&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) = 0;
     };
 }
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROICannyEdgeDetection_tool.cc
@@ -37,7 +37,7 @@ public:
     void configure(const fhicl::ParameterSet& pset) override;
     void initializeHistograms(art::TFileDirectory&) override {return;}
     
-    void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) override;
+    void FindROIs(const art::Event&, const ArrayFloat&, const std::vector<raw::ChannelID_t>&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) override;
     
 private:
 
@@ -154,7 +154,7 @@ void ROICannyEdgeDetection::configure(const fhicl::ParameterSet& pset)
     return;
 }
 
-void ROICannyEdgeDetection::FindROIs(const art::Event& event, const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs)
+void ROICannyEdgeDetection::FindROIs(const art::Event& event, const ArrayFloat& inputImage, const std::vector<raw::ChannelID_t>& channelVec, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs)
 {
     cet::cpu_timer theClockTotal;
 

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIFromDecoder_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIFromDecoder_tool.cc
@@ -34,7 +34,7 @@ public:
     void configure(const fhicl::ParameterSet& pset) override;
     void initializeHistograms(art::TFileDirectory&) override {return;}
     
-    void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) override;
+    void FindROIs(const art::Event&, const ArrayFloat&, const std::vector<raw::ChannelID_t>&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) override;
     
 private:
     // A magic map because all tools need them
@@ -78,7 +78,7 @@ void ROIFromDecoder::configure(const fhicl::ParameterSet& pset)
     return;
 }
 
-void ROIFromDecoder::FindROIs(const art::Event& event, const ArrayFloat& inputImage, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs)
+void ROIFromDecoder::FindROIs(const art::Event& event, const ArrayFloat& inputImage, const std::vector<raw::ChannelID_t>& channelVec, const geo::PlaneID& planeID, ArrayFloat& output, ArrayBool& outputROIs)
 {
     // First thing is find the correct data product to recover ROIs
     TPCIDToLabelMap::const_iterator tpcItr = fTPCIDToLabelMap.find(planeID.asTPCID());
@@ -110,8 +110,11 @@ void ROIFromDecoder::FindROIs(const art::Event& event, const ArrayFloat& inputIm
         
         event.getByLabel(roiLabel, wireVecHandle);
 
+        // The first task is to build a mapping between channel and ROIs from the input data product. 
         // The input data product will contain information for every plane in a physical TPC... unfortunately, we only want a single plane within
         // a logical TPC... so we need to loop through to find what we want
+        std::unordered_map<raw::ChannelID_t,const recob::Wire*> channelToWireMap;
+
         for(const auto& wireData : *wireVecHandle)
         {
             std::vector<geo::WireID> wireIDVec = fGeometry->ChannelToWire(wireData.Channel());
@@ -126,35 +129,74 @@ void ROIFromDecoder::FindROIs(const art::Event& event, const ArrayFloat& inputIm
                     continue;
                 }
 
-                // Recover this wire's output vector
-                VectorBool& channelData = outputROIs[wireID.Wire];
-
-                // What we need to do is find the ROIs in the input wire data and then translate to the output
-                const recob::Wire::RegionsOfInterest_t signalROIs = wireData.SignalROI();
-
-                for(const auto& range : signalROIs.get_ranges())
-                {
-                    size_t startTick = range.begin_index();
-                    size_t roiLen    = range.data().size();
-                    size_t stopTick  = startTick + roiLen;
-
-                    if (startTick > channelData.size())
-                    {
-                        std::cout << "*** ROI decoder has start tick larger than output array, start: " << startTick << ", array size: " << channelData.size() << std::endl;
-                        continue;
-                    }
-
-                    if (stopTick > channelData.size())
-                    {
-                        std::cout << "*** ROI decoder has ROI length larger than output array, start: " << startTick << ", end: " << stopTick << ", array size: " << channelData.size() << std::endl;
-                        continue;
-                    }
-
-                    std::fill(channelData.begin() + startTick, channelData.begin() + stopTick, true);
-                }
+                channelToWireMap[wireData.Channel()] = &wireData;
             }
         }
 
+        // Now we loop through the input image channels and make the new ROIs
+        for(size_t channelIdx = 0; channelIdx < channelVec.size(); channelIdx++)
+        {
+            raw::ChannelID_t channel = channelVec[channelIdx];
+
+            std::unordered_map<raw::ChannelID_t,const recob::Wire*>::const_iterator wireItr = channelToWireMap.find(channel);
+
+            if (wireItr != channelToWireMap.end())
+            {
+                const recob::Wire& wireData = *(wireItr->second);
+
+                // Get the WireIDs (again)
+                std::vector<geo::WireID> wireIDVec = fGeometry->ChannelToWire(channel);
+
+                for(const auto& wireID : wireIDVec)
+                {
+                    if (wireID.asPlaneID() != planeID) continue;
+
+                    // Recover this wire's output vector
+                    VectorBool& channelData = outputROIs[wireID.Wire];
+
+                    // What we need to do is find the ROIs in the input wire data and then translate to the output
+                    const recob::Wire::RegionsOfInterest_t signalROIs = wireData.SignalROI();
+
+                    if (planeID.Cryostat == 0 && planeID.TPC == 0 && planeID.Plane == 0)
+                    {
+                        std::cout << "  - Finder tool, channel: " << channel << ", idx: " << channelIdx << ", wireID: " << wireID << ", # ROIs: " << signalROIs.get_ranges().size() << std::endl;
+                        std::cout << "    start/len: ";
+                    }
+
+                    for(const auto& range : signalROIs.get_ranges())
+                    {
+                        size_t startTick = range.begin_index();
+                        size_t roiLen    = range.data().size();
+                        size_t stopTick  = startTick + roiLen;
+
+                        if (planeID.Cryostat == 0 && planeID.TPC == 0 && planeID.Plane == 0)
+                        {
+                            std::cout << startTick << "/" << roiLen << " ";
+                        }
+
+                        if (startTick > channelData.size())
+                        {
+                            std::cout << "*** ROI decoder has start tick larger than output array, start: " << startTick << ", array size: " << channelData.size() << std::endl;
+                            continue;
+                        }
+
+                        if (stopTick > channelData.size())
+                        {
+                            std::cout << "*** ROI decoder has ROI length larger than output array, start: " << startTick << ", end: " << stopTick << ", array size: " << channelData.size() << std::endl;
+                            continue;
+                        }
+
+                        std::fill(channelData.begin() + startTick, channelData.begin() + stopTick, true);
+                    }
+
+                    if (planeID.Cryostat == 0 && planeID.TPC == 0 && planeID.Plane == 0) std::cout << std::endl;
+                }
+            }
+            else
+            {
+                std::cout << "*** Not finding ROI information for channel: " << channel << std::endl;
+            }
+        }
     }
 
     return;

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIFromDecoder_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIFromDecoder_tool.cc
@@ -157,22 +157,11 @@ void ROIFromDecoder::FindROIs(const art::Event& event, const ArrayFloat& inputIm
                     // What we need to do is find the ROIs in the input wire data and then translate to the output
                     const recob::Wire::RegionsOfInterest_t signalROIs = wireData.SignalROI();
 
-                    if (planeID.Cryostat == 0 && planeID.TPC == 0 && planeID.Plane == 0)
-                    {
-                        std::cout << "  - Finder tool, channel: " << channel << ", idx: " << channelIdx << ", wireID: " << wireID << ", # ROIs: " << signalROIs.get_ranges().size() << std::endl;
-                        std::cout << "    start/len: ";
-                    }
-
                     for(const auto& range : signalROIs.get_ranges())
                     {
                         size_t startTick = range.begin_index();
                         size_t roiLen    = range.data().size();
                         size_t stopTick  = startTick + roiLen;
-
-                        if (planeID.Cryostat == 0 && planeID.TPC == 0 && planeID.Plane == 0)
-                        {
-                            std::cout << startTick << "/" << roiLen << " ";
-                        }
 
                         if (startTick > channelData.size())
                         {

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIMorphological2D_tool.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROITools/ROIMorphological2D_tool.cc
@@ -37,7 +37,7 @@ public:
     void configure(const fhicl::ParameterSet& pset) override;
     void initializeHistograms(art::TFileDirectory&) override;
     
-    void FindROIs(const art::Event&, const ArrayFloat&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) override;
+    void FindROIs(const art::Event&, const ArrayFloat&, const std::vector<raw::ChannelID_t>&, const geo::PlaneID&, ArrayFloat&, ArrayBool&) override;
     
 private:
     // This is for the baseline...
@@ -91,7 +91,7 @@ void ROIMorphological2D::configure(const fhicl::ParameterSet& pset)
     return;
 }
 
-void ROIMorphological2D::FindROIs(const art::Event& event, const ArrayFloat& constInputImage, const geo::PlaneID& planeID, ArrayFloat& morphedWaveforms, ArrayBool& outputROIs)
+void ROIMorphological2D::FindROIs(const art::Event& event, const ArrayFloat& constInputImage, const std::vector<raw::ChannelID_t>& channelVec, const geo::PlaneID& planeID, ArrayFloat& morphedWaveforms, ArrayBool& outputROIs)
 {
     if (morphedWaveforms.size() != constInputImage.size()) morphedWaveforms.resize(constInputImage.size(),icarus_signal_processing::VectorFloat(constInputImage[0].size()));
 

--- a/icaruscode/TPC/Tracking/cluster3D/SnippetHit3DBuilderICARUS_tool.cc
+++ b/icaruscode/TPC/Tracking/cluster3D/SnippetHit3DBuilderICARUS_tool.cc
@@ -1787,6 +1787,9 @@ void SnippetHit3DBuilderICARUS::CollectArtHits(const art::Event& evt) const
     // Try to output a formatted string
     std::string debugMessage("");
 
+    // Keep track of x position limits
+    std::map<geo::PlaneID,double> planeIDToPositionMap;
+
     // Initialize the plane to hit vector map
     for(size_t cryoIdx = 0; cryoIdx < m_geometry->Ncryostats(); cryoIdx++)
     {
@@ -1805,13 +1808,26 @@ void SnippetHit3DBuilderICARUS::CollectArtHits(const art::Event& evt) const
                              << ", plane 1: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,1))->second
                              << ", plane    2: " << m_PlaneToT0OffsetMap.find(geo::PlaneID(cryoIdx,tpcIdx,2))->second << "\n";
                 outputString << "     Det prop plane 0: " << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,0)) << ", plane 1: "  << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,1)) << ", plane 2: " << det_prop.GetXTicksOffset(geo::PlaneID(cryoIdx,tpcIdx,2)) << ", Trig: " << trigger_offset(clock_data) << "\n";
-                debugMessage += outputString.str();
+                debugMessage += outputString.str() + "\n";
             }
+
+            double xPosition(det_prop.ConvertTicksToX(0., 2, tpcIdx, cryoIdx));
+
+            planeIDToPositionMap[geo::PlaneID(cryoIdx,tpcIdx,2)] = xPosition;
         }
     }
 
     if (!m_weHaveAllBeenHereBefore)
     {
+        for(const auto& planeToPositionPair : planeIDToPositionMap)
+        {
+            std::ostringstream outputString;
+
+            outputString << "***> Plane " << planeToPositionPair.first << " has time=0 position: " << planeToPositionPair.second << "\n";
+
+            debugMessage += outputString.str();
+        }
+
         mf::LogDebug("Cluster3D") << debugMessage << std::endl;
 
         m_weHaveAllBeenHereBefore = true;


### PR DESCRIPTION
The proposed plan for 2D deconvolution is to use the ROIs found in the 1D deconvolution and apply them to the 2D deconvolved waveforms. In principle this was already allowed but it seems was not totally functional so these updates make this chain work. As well there are modifications to the basic fhicl include file to allow this to work. 

In addition some small updates have been made to the noise filtering which are included in this pull request. These do not affect processing of waveforms, but should make event displays a bit cleaner (as the pedestal subtraction is slightly better). 