### PR TITLE
Trigger decoder final updates

### DIFF
--- a/icaruscode/Decode/DaqDecoderICARUSTrigger_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSTrigger_module.cc
@@ -34,6 +34,7 @@ namespace daq
     DaqDecoderICARUSTrigger & operator = (DaqDecoderICARUSTrigger const &) = delete;
     DaqDecoderICARUSTrigger & operator = (DaqDecoderICARUSTrigger &&) = delete;
 
+    void beginRun(art::Run& run) override;
     void produce(art::Event & e) override;
     
   private:
@@ -46,11 +47,19 @@ namespace daq
   
   DaqDecoderICARUSTrigger::DaqDecoderICARUSTrigger(fhicl::ParameterSet const & params): art::EDProducer{params}, fInputTag(params.get<std::string>("FragmentsLabel", "daq:ICARUSTriggerUDP"))
   {
+    consumes<artdaq::Fragments>(fInputTag);
+    
     fDecoderTool = art::make_tool<IDecoder>(params.get<fhicl::ParameterSet>("DecoderTool"));
     fDecoderTool->produces(producesCollector());
 
     return;
   }
+  
+  void DaqDecoderICARUSTrigger::beginRun(art::Run& run)
+  {
+    fDecoderTool->setupRun(run);
+  }
+  
   
   void DaqDecoderICARUSTrigger::produce(art::Event & event)
   {

--- a/icaruscode/Decode/DataProducts/TriggerConfiguration.h
+++ b/icaruscode/Decode/DataProducts/TriggerConfiguration.h
@@ -141,9 +141,9 @@ struct icarus::TriggerConfiguration {
   // --- BEGIN -- Derived quantities -------------------------------------------
 
   /**
-      * @brief returns the effective gate width corrected for the veto delay in us 
-      * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
-      *
+   * @brief returns the effective gate width corrected for the veto delay in us 
+   * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
+   *
    */
   float getGateWidth( std::size_t source ) const {
 
@@ -157,9 +157,9 @@ struct icarus::TriggerConfiguration {
 
 
   /**
-      * @brief returns the width of the drift gate used for out-of-time light activity in us       
-      * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
-      *
+   * @brief returns the width of the drift gate used for out-of-time light activity in us       
+   * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
+   *
    */
   float getDriftGateWidth( std::size_t source ) const {
 
@@ -169,10 +169,10 @@ struct icarus::TriggerConfiguration {
   }
 
   /**
-      * @brief returns the prescale value used to open the offbeam gates with respect to the total number of 
-      * beam gates seen       
-      * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
-      *
+   * @brief returns the prescale value used to open the offbeam gates with respect to the total number of 
+   * beam gates seen       
+   * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
+   *
    */
   unsigned int getOffBeamRate( std::size_t source ) const {
      
@@ -181,10 +181,10 @@ struct icarus::TriggerConfiguration {
   }
 
   /**
-      * @brief returns the prescale value used to collect MinBias triggers with respect to the total number of 
-      * gates seen of a particula type   
-      * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
-      *
+   * @brief returns the prescale value used to collect MinBias triggers with respect to the total number of 
+   * gates seen of a particula type   
+   * @param source is the value of the sbn::bits::triggerSource enum type corresponding to the type of gate 
+   *
    */
   unsigned int getMinBiasPrescale( std::size_t source ) const {
 
@@ -219,65 +219,65 @@ struct icarus::TriggerConfiguration {
   
   
   /**
-    * @brief Dumps the content of the configuration into `out` stream.
-    * @param out stream to dump the information into
-    * @param indent indentation string
-    * @param firstIndent special indentation string for the first line
-    * @param verbosity (default: `DefaultDumpVerbosity`) level of verbosity
-    * 
-    * The indentation string is prepended to each new line of the dump.
-    * The first line indentation string is prepended before the first line of
-    * the dump. The dump ends on a new empty line.
-    * 
-    * The amount of information printed depends on the `verbosity` level:
-    * 
-    * * `0`: Boardreader configuration
-    * * `1`: FPGA configuration
-    * * `2`: SPEXI configuration
-    * 
-  */
-
-    void dump(std::ostream& out,
-      std::string const& indent, std::string const& firstIndent,
-      unsigned int verbosity = MaxDumpVerbosity
-    ) const;
-  
-    /**
-      * @brief Dumps the content of the configuration into `out` stream.
-      * @param out stream to dump the information into
-      * @param indent indentation level
-      * @see `dump(std::ostream&, std::string const&, std::string const&, unsigned int) const`
-      * 
-      * Version of `dump()` with same first indentation level as the rest, and
-      * default verbosity.
+   * @brief Dumps the content of the configuration into `out` stream.
+   * @param out stream to dump the information into
+   * @param indent indentation string
+   * @param firstIndent special indentation string for the first line
+   * @param verbosity (default: `DefaultDumpVerbosity`) level of verbosity
+   * 
+   * The indentation string is prepended to each new line of the dump.
+   * The first line indentation string is prepended before the first line of
+   * the dump. The dump ends on a new empty line.
+   * 
+   * The amount of information printed depends on the `verbosity` level:
+   * 
+   * * `0`: Boardreader configuration
+   * * `1`: FPGA configuration
+   * * `2`: SPEXI configuration
+   * 
    */
-    void dump(std::ostream& out, std::string const& indent = "") const
-      { dump(out, indent, indent); }
-  
-    /**
-      * @brief Dumps the content of the gate configuration into `out` stream.
-      * @param out stream to dump the information into
-      * @param gateConfig the gate to be dumped
-      * @param indent (default: none) indentation string
-      * @see `dump(std::ostream&, std::string const&, std::string const&, unsigned int) const`
-      * 
-      * Version of `dump()` with the specified `verbosity` level and same first
-      * indentation level as the rest.
-      */
-    void dumpGateConfig(std::ostream& out, 
-      icarus::TriggerConfiguration::GateConfig const& gateConfig, 
-      std::string const& indent
-    ) const;
 
-    void dump(std::ostream& out,
-      unsigned int verbosity,
-      std::string const& indent = ""
-      ) const
-    { dump(out, indent, indent, verbosity); }
+  void dump(std::ostream& out,
+    std::string const& indent, std::string const& firstIndent,
+    unsigned int verbosity = MaxDumpVerbosity
+  ) const;
   
-    // -- END ---- Dump facility -------------------------------------------------
+  /**
+   * @brief Dumps the content of the configuration into `out` stream.
+   * @param out stream to dump the information into
+   * @param indent indentation level
+   * @see `dump(std::ostream&, std::string const&, std::string const&, unsigned int) const`
+   * 
+   * Version of `dump()` with same first indentation level as the rest, and
+   * default verbosity.
+   */
+   void dump(std::ostream& out, std::string const& indent = "") const
+     { dump(out, indent, indent); }
   
- 
+  /**
+   * @brief Dumps the content of the gate configuration into `out` stream.
+   * @param out stream to dump the information into
+   * @param gateConfig the gate to be dumped
+   * @param indent (default: none) indentation string
+   * @see `dump(std::ostream&, std::string const&, std::string const&, unsigned int) const`
+   * 
+   * Version of `dump()` with the specified `verbosity` level and same first
+   * indentation level as the rest.
+   */
+  void dumpGateConfig(std::ostream& out, 
+    icarus::TriggerConfiguration::GateConfig const& gateConfig, 
+    std::string const& indent
+  ) const;
+
+  void dump(std::ostream& out,
+    unsigned int verbosity,
+    std::string const& indent = ""
+    ) const
+  { dump(out, indent, indent, verbosity); }
+  
+  // -- END ---- Dump facility -------------------------------------------------
+  
+  
 }; // sbn::ICARUSTriggerConfiguration
 
 //------------------------------------------------------------------------------

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -331,8 +331,8 @@ namespace daq
     // or via the parser
     icarus::details::KeyedCSVparser parser;
     parser.addPatterns({
-	{ "Cryo. (EAST|WEST) Connector . and .", 1U }
-	, { "Trigger Type", 1U }
+        { "Cryo. (EAST|WEST) Connector . and .", 1U }
+        , { "Trigger Type", 1U }
       });
     //auto const parsedData = icarus::details::KeyedCSVparser{}(firstLine(data));
     auto const parsedData = parser(firstLine(data)); 
@@ -362,15 +362,15 @@ namespace daq
     } // if has gate information
     std::uint64_t enablegate_ts { artdaq_ts };
     if (auto pEnableGateInfo = parsedData.findItem("Enable_TS");
-	pEnableGateInfo && (pEnableGateInfo->nValues() == 3)
-	) {
+        pEnableGateInfo && (pEnableGateInfo->nValues() == 3)
+        ) {
       // if gate information is found, it must be complete
       //enablegate_count = pEnableGateInfo->getNumber<unsigned int>(0U);
 
       uint64_t const raw_en_ts = makeTimestamp( // raw and uncorrected too
-					       pEnableGateInfo->getNumber<unsigned int>(1U),
-					       pEnableGateInfo->getNumber<unsigned int>(2U)
-						);
+                                               pEnableGateInfo->getNumber<unsigned int>(1U),
+                                               pEnableGateInfo->getNumber<unsigned int>(2U)
+                                                );
 
       // assuming the raw times from the fragment are on the same time scale 
       // (same offset corrections)
@@ -402,7 +402,7 @@ namespace daq
       std::string_view const dataLine = firstLine(data);
       try {
         //auto const parsedData = icarus::details::KeyedCSVparser{}(dataLine);
-	auto const parsedData = parser(dataLine);
+        auto const parsedData = parser(dataLine);
         std::cout << "Parsed data (from " << dataLine.size() << " characters): "
           << parsedData << std::endl;
       }
@@ -426,49 +426,49 @@ namespace daq
     sbn::triggerSource beamGateBit;
     switch (gate_type) {
       case TriggerGateTypes::BNB:{         
-	beamGateBit = sbn::triggerSource::BNB;
-	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesBNB();
-	fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampBNB();
-	fTriggerExtra->gateCount = datastream_info.gate_id_BNB;
-	fTriggerExtra->triggerCount = frag.getTotalTriggerBNB();
-	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerBNB();
-	break;
+        beamGateBit = sbn::triggerSource::BNB;
+        fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesBNB();
+        fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampBNB();
+        fTriggerExtra->gateCount = datastream_info.gate_id_BNB;
+        fTriggerExtra->triggerCount = frag.getTotalTriggerBNB();
+        fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerBNB();
+        break;
       }
       case TriggerGateTypes::NuMI:{        
-	beamGateBit = sbn::triggerSource::NuMI;
-	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesNuMI();
-	fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampNuMI();
-	fTriggerExtra->gateCount = datastream_info.gate_id_NuMI;
-	fTriggerExtra->triggerCount = frag.getTotalTriggerNuMI();
-	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerNuMI();
-	break;
+        beamGateBit = sbn::triggerSource::NuMI;
+        fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesNuMI();
+        fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampNuMI();
+        fTriggerExtra->gateCount = datastream_info.gate_id_NuMI;
+        fTriggerExtra->triggerCount = frag.getTotalTriggerNuMI();
+        fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerNuMI();
+        break;
       }
       case TriggerGateTypes::OffbeamBNB:{  
-	beamGateBit = sbn::triggerSource::OffbeamBNB;
-	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesBNBOff();
-	fTriggerExtra->previousTriggerTimestamp= frag.getLastTimestampBNBOff();
-	fTriggerExtra->gateCount = datastream_info.gate_id_BNBOff;
-	fTriggerExtra->triggerCount = frag.getTotalTriggerBNBOff();
-	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerBNBOff();
-	break;
+        beamGateBit = sbn::triggerSource::OffbeamBNB;
+        fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesBNBOff();
+        fTriggerExtra->previousTriggerTimestamp= frag.getLastTimestampBNBOff();
+        fTriggerExtra->gateCount = datastream_info.gate_id_BNBOff;
+        fTriggerExtra->triggerCount = frag.getTotalTriggerBNBOff();
+        fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerBNBOff();
+        break;
       }
       case TriggerGateTypes::OffbeamNuMI:{ 
-	beamGateBit = sbn::triggerSource::OffbeamNuMI;
-	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesNuMIOff();
-	fTriggerExtra->previousTriggerTimestamp= frag.getLastTimestampNuMIOff();
-	fTriggerExtra->gateCount = datastream_info.gate_id_NuMIOff;
-	fTriggerExtra->triggerCount = frag.getTotalTriggerNuMIOff();
-	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerNuMIOff();
-	break;
+        beamGateBit = sbn::triggerSource::OffbeamNuMI;
+        fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesNuMIOff();
+        fTriggerExtra->previousTriggerTimestamp= frag.getLastTimestampNuMIOff();
+        fTriggerExtra->gateCount = datastream_info.gate_id_NuMIOff;
+        fTriggerExtra->triggerCount = frag.getTotalTriggerNuMIOff();
+        fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerNuMIOff();
+        break;
       }
       case TriggerGateTypes::Calib:{       
-	beamGateBit = sbn::triggerSource::Calib;
-	fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesCalib();
-	fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampCalib();
-	//fTriggerExtra->gateCount = datastream_info.gate_id_calib;
-	fTriggerExtra->triggerCount = frag.getTotalTriggerCalib();
-	fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerCalib();
-	break;
+        beamGateBit = sbn::triggerSource::Calib;
+        fTriggerExtra->gateCountFromPreviousTrigger = frag.getDeltaGatesCalib();
+        fTriggerExtra->previousTriggerTimestamp = frag.getLastTimestampCalib();
+        //fTriggerExtra->gateCount = datastream_info.gate_id_calib;
+        fTriggerExtra->triggerCount = frag.getTotalTriggerCalib();
+        fTriggerExtra->anyTriggerCountFromPreviousTrigger = frag.getLastTriggerCalib();
+        break;
       }
       default:                            beamGateBit = sbn::triggerSource::Unknown;
     } // switch gate_type
@@ -521,18 +521,18 @@ namespace daq
       ? 0UL: parsedData.getItem("Cryo1 EAST counts").getNumber<unsigned long int>(0),
       // LVDSstatus
       {
-	(triggerLocation & 1) // EE
-	? encodeLVDSbits(
-			 sbn::ExtraTriggerInfo::EastCryostat, 2, /* any of the connectors */
-			 parsedData.getItem("Cryo1 EAST Connector 2 and 3").getNumber<std::uint64_t>(0, 16)
-			 )
-	: 0ULL,
-	(triggerLocation & 1) // EW
-	? encodeLVDSbits(
-			 sbn::ExtraTriggerInfo::EastCryostat, 0, /* any of the connectors */
-			 parsedData.getItem("Cryo1 EAST Connector 0 and 1").getNumber<std::uint64_t>(0, 16)
-			 )
-	: 0ULL
+        (triggerLocation & 1) // EE
+        ? encodeLVDSbits(
+                         sbn::ExtraTriggerInfo::EastCryostat, 2, /* any of the connectors */
+                         parsedData.getItem("Cryo1 EAST Connector 2 and 3").getNumber<std::uint64_t>(0, 16)
+                         )
+        : 0ULL,
+        (triggerLocation & 1) // EW
+        ? encodeLVDSbits(
+                         sbn::ExtraTriggerInfo::EastCryostat, 0, /* any of the connectors */
+                         parsedData.getItem("Cryo1 EAST Connector 0 and 1").getNumber<std::uint64_t>(0, 16)
+                         )
+        : 0ULL
       }
     };
     fTriggerExtra->cryostats[sbn::ExtraTriggerInfo::WestCryostat]
@@ -542,25 +542,25 @@ namespace daq
       ? 0UL: parsedData.getItem("Cryo2 WEST counts").getNumber<unsigned long int>(0),
       // LVDSstatus
       {
-	(triggerLocation & 2) // WE
-	? encodeLVDSbits(
-			 sbn::ExtraTriggerInfo::WestCryostat, 2, /* any of the connectors */
-			 parsedData.getItem("Cryo2 WEST Connector 2 and 3").getNumber<std::uint64_t>(0, 16)
-			 )
-	: 0ULL,
-	(triggerLocation & 2) // WW
-	? encodeLVDSbits(
-			 sbn::ExtraTriggerInfo::WestCryostat, 0, /* any of the connectors */
-			 parsedData.getItem("Cryo2 WEST Connector 0 and 1").getNumber<std::uint64_t>(0, 16)
-			 )
-	: 0ULL
+        (triggerLocation & 2) // WE
+        ? encodeLVDSbits(
+                         sbn::ExtraTriggerInfo::WestCryostat, 2, /* any of the connectors */
+                         parsedData.getItem("Cryo2 WEST Connector 2 and 3").getNumber<std::uint64_t>(0, 16)
+                         )
+        : 0ULL,
+        (triggerLocation & 2) // WW
+        ? encodeLVDSbits(
+                         sbn::ExtraTriggerInfo::WestCryostat, 0, /* any of the connectors */
+                         parsedData.getItem("Cryo2 WEST Connector 0 and 1").getNumber<std::uint64_t>(0, 16)
+                         )
+        : 0ULL
       }
     };
     // we expect the LVDS status bits
 
     for (auto const& cryoInfo [[maybe_unused]]: fTriggerExtra->cryostats)
       for (auto LVDS [[maybe_unused]]: cryoInfo.LVDSstatus)
-	assert((LVDS & 0xFF000000FF000000) == 0);             
+        assert((LVDS & 0xFF000000FF000000) == 0);
     
     //
     // absolute time trigger (raw::ExternalTrigger)

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -668,6 +668,10 @@ namespace daq
         fBeamGateInfo->emplace_back
           (simGateStart.value(), gateWidth.value(), sim::kNuMI);
         break;
+      case TriggerGateTypes::Calib:
+        fBeamGateInfo->emplace_back
+          (simGateStart.value(), gateWidth.value(), sim::kUnknown);
+        break;
       default:
         mf::LogWarning("TriggerDecoder") << "Unsupported gate type #" << gate_type;
     } // switch gate_type

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -328,7 +328,17 @@ namespace daq
     fTriggerConfigTag = pset.get<std::string>("TrigConfigLabel");
     fDiagnosticOutput = pset.get<bool>("DiagnosticOutput", false);
     fDebug = pset.get<bool>("Debug", false);
-    fOffset = pset.get<long long int>("TimeOffset", 0);
+    if (pset.has_key("TimeOffset")) {
+      if (auto offset = pset.get<long long int>("TimeOffset"); offset == 0) {
+        mf::LogWarning("TriggerDecoder")
+          << "Configuration parameter 'TimeOffset' has been dropped.\n";
+      }
+      else { // unforgiving: dropping non-zero offset changes output
+        throw art::Exception(art::errors::Configuration)
+          << "Adding offset (configuration parameter 'TimeOffset', here set to "
+          << offset << " seconds) is not supported any more.\n";
+      }
+    }
     return;
   }
   

--- a/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
+++ b/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
@@ -109,6 +109,7 @@ TriggerDecoderTool: {
 
 TriggerDecoderV2Tool: {
    tool_type:          TriggerDecoderV2
+   TriggerConfigLabel: @nil # must override
 }
 
 

--- a/icaruscode/Decode/fcl/decodePMT_icarus.fcl
+++ b/icaruscode/Decode/fcl/decodePMT_icarus.fcl
@@ -79,15 +79,16 @@ physics: {
   
   producers: {
     
-    PMTconfig:  @local::extractPMTconfig
+    triggerconfig: @local::extractTriggerConfig
+    pmtconfig:     @local::extractPMTconfig
     
-    daqTrigger: @local::decodeTrigger
+    daqTrigger:    @local::decodeTriggerV2
     
-    daqPMT:     @local::decodePMT
+    daqPMT:        @local::decodePMT
     
   }
   
-  decoding: [ PMTconfig, daqTrigger, daqPMT ]
+  decoding: [ triggerconfig, pmtconfig, daqTrigger, daqPMT ]
   streams: [ rootoutput ]
 }
 
@@ -108,7 +109,8 @@ outputs: {
 
 # ------------------------------------------------------------------------------
 
-physics.producers.daqPMT.PMTconfigTag: PMTconfig # required
+physics.producers.daqTrigger.DecoderTool.TrigConfigLabel: triggerconfig # required
+physics.producers.daqPMT.PMTconfigTag: pmtconfig # required
 physics.producers.daqPMT.TriggerTag:   daqTrigger # required
 
 # services.Geometry.Name: icarus_splitwires # for runs < 548x

--- a/icaruscode/Decode/fcl/decodeTrigger_icarus.fcl
+++ b/icaruscode/Decode/fcl/decodeTrigger_icarus.fcl
@@ -1,0 +1,51 @@
+#include "services_common_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+#include "decoderdefs_icarus.fcl"
+
+process_name: DecodeTrg
+
+services: {
+  
+                     @table::icarus_art_services
+  message:           @local::icarus_message_services_interactive_debug
+  
+                     @table::icarus_geometry_services
+  DetectorClocksService: @local::icarus_detectorclocks
+}
+
+
+physics: {
+  
+  producers: {
+    
+//     pmtconfig:  @local::extractPMTconfig
+    triggerconfig: @local::extractTriggerConfig
+    
+    daqTrigger: @local::decodeTriggerV2
+    
+//     daqPMT:     @local::decodePMT
+    
+  }
+  
+//   decoding: [ PMTconfig, triggerconfig, daqTrigger, daqPMT ]
+  decoding: [ triggerconfig, daqTrigger ]
+  streams: [ rootoutput ]
+}
+
+outputs: {
+  rootoutput: {
+                      @table::icarus_rootoutput
+    dataTier:        "decoded"
+    fileProperties:   { maxInputFiles: 1 }
+    checkFileName:    false
+    compressionLevel: 501
+    
+    outputCommands:  [ "drop *_*_*_*", "keep *_*_*_DecodeTrg" ]
+  } # rootoutput
+} # outputs 
+
+
+physics.producers.daqTrigger.DecoderTool.TrigConfigLabel: triggerconfig
+physics.producers.daqTrigger.DecoderTool.DiagnosticOutput: true
+physics.producers.daqTrigger.DecoderTool.Debug: true
+

--- a/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
+++ b/icaruscode/Decode/fcl/decoderdefs_icarus.fcl
@@ -3,7 +3,7 @@
 BEGIN_PROLOG
 
 extractTriggerConfig: { 
-		    module_type: TriggerConfigurationExtraction
+                    module_type:        TriggerConfigurationExtraction
 }
 
 extractPMTconfig: {
@@ -59,9 +59,9 @@ decodeTrigger: {
 }
 
 decodeTriggerV2: {
-		   module_type:	        DaqDecoderICARUSTrigger
-		   FragmentsLabel:	"daq:ICARUSTriggerV2"
-		   DecoderTool:		@local::TriggerDecoderV2Tool
+                    module_type:        DaqDecoderICARUSTrigger
+                    FragmentsLabel:     "daq:ICARUSTriggerV2"
+                    DecoderTool:        @local::TriggerDecoderV2Tool
 }
 
 END_PROLOG

--- a/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
+++ b/icaruscode/Decode/fcl/stage0_icarus_defs.fcl
@@ -31,7 +31,8 @@ icarus_stage0_analyzers:
                   }
 }
 
-# set the name of our `extractPMTconfig` and trigger decoder modules
+# set the name of our `extractPMTconfig` and `extractTriggerConfig` for our decoders
+decodeTriggerV2.DecoderTool.TrigConfigLabel: triggerconfig
 decodePMT.PMTconfigTag: pmtconfig
 decodePMT.TriggerTag:   daqTrigger
 
@@ -40,7 +41,8 @@ icarus_stage0_producers:
 {
 
   ### configuration extraction
-  pmtconfig:                      { module_type: PMTconfigurationExtraction }
+  triggerconfig:                  @local::extractTriggerConfig
+  pmtconfig:                      @local::extractPMTconfig
 
   ### Decoder definitions
   daqTrigger:                     @local::decodeTrigger
@@ -49,7 +51,6 @@ icarus_stage0_producers:
 
   daqTPCROI:                      @local::decodeTPCROI
 
-  pmtconfig:                      @local::extractPMTconfig
   daqPMT:                         @local::decodePMT
 
   daqCRT:                         @local::crtdaq_icarus
@@ -139,23 +140,28 @@ icarus_stage0_filters:
 
 ### Below are a list of convenient sequences that can be used for production/typical users. ###
 
-icarus_stage0_trigger_BNB:         [ daqTrigger,
+icarus_stage0_trigger_BNB:         [ triggerconfig,
+                                     daqTrigger,
                                      triggerfilterBNB 
                                    ]
 
-icarus_stage0_trigger_NuMI:        [ daqTrigger,
+icarus_stage0_trigger_NuMI:        [ triggerconfig,
+                                     daqTrigger,
                                      triggerfilterNuMI 
                                    ]
 
-icarus_stage0_trigger_OffbeamBNB:  [ daqTrigger,
+icarus_stage0_trigger_OffbeamBNB:  [ triggerconfig,
+                                     daqTrigger,
                                      triggerfilterOffbeamBNB 
                                    ]
 
-icarus_stage0_trigger_OffbeamNuMI: [ daqTrigger,
+icarus_stage0_trigger_OffbeamNuMI: [ triggerconfig,
+                                     daqTrigger,
                                      triggerfilterOffbeamNuMI 
                                    ]
 
-icarus_stage0_trigger_Unknown:     [ daqTrigger,
+icarus_stage0_trigger_Unknown:     [ triggerconfig,
+                                     daqTrigger,
                                      triggerfilterUnknown
                                    ]
 
@@ -185,7 +191,8 @@ icarus_purity_monitor:             [
                                      purityana1
                                    ]
 
-icarus_stage0_PMT:                 [ daqTrigger,
+icarus_stage0_PMT:                 [ triggerconfig,
+                                     daqTrigger,
                                      pmtconfig,
                                      daqPMT,
                                      pmtconfigbaselines,


### PR DESCRIPTION
This request adds a couple of missing features to the trigger decoder and polishes the code.
I consider this the final release of the decoder for the current version of the trigger, barred fixes.

The added features:
1. the beam gate time is corrected for the artificial veto (currently, 4 µs) used to effectively extend the PMT readout ahead of the beam
2. the width of the gate is correctly saved in the `sim::BeamGateInfo` data product
3. support is added for calibration type of gates

The first two features leverage on the new module by @ascarpel which saves the configuration of the trigger in a data product, where both veto and beam gate duration are stored. This comes with the addition in all the relevant workflows of that module.

In addition, the documentation of the trigger decoder has been completed describing in detail the content of the trigger data products.

Finally, the code has been polished.
The offset option has been deprecated and will trigger an exception if specified with a non-neutral value. This is a feature that I believe was already added, but must have been lost in the game of the merges.
Obsolete and temporary code has been removed, as some debugging messages.
In a couple of locations, the code has been restructured (e.g. the creation of `sim::BeamGateInfo` has been refactored).

The branch has been tested on top of `v09_56_00` running on a file of run 8650 (special minimum bias run) the configurations `decodeTrigger_icarus.fcl`, `decodePMT_icarus.fcl` and `stage0_run1_icarus.fcl`.

I would like @jzettle  to take a look at the code changes for approval, and @SFBayLaser  to check the changes in the Stage0 job configuration to check that the workflow is fine.

I consider this pull request a *high priority*, because it fixes the beam gate time which is otherwise broken.

List of commits:
- Indentation fixes
- Trigger decoder uses trigger configuration from input
- Added BeamGateInfo object in trigger output for calibration runs
- Trigger decoding tool code cleanup.
- Removed unsupported `TimeOffset` parameter from trigger decoding.
