### PR TITLE
WireCell Noise Model Update

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
+++ b/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
@@ -32,7 +32,9 @@ icarus_simwire_wirecell:
             //   "wclsFrameSaver:spthresholds"
         ]
         // Make available parameters via Jsonnet's std.extVar()
-        params: {}
+        params: {
+	    files_fields: "garfield-icarus-fnal-rev1.json.bz2"
+	}
         structs: {
             # load values from simulationservices_icarus.fcl
             # Longitudinal diffusion constant [cm2/ns]
@@ -44,6 +46,9 @@ icarus_simwire_wirecell:
             lifetime: @local::icarus_detproperties.Electronlifetime
             # Electron drift speed, assumes a certain applied E-field [mm/us]
             # driftSpeed: 1.565
+            # Scaling Parameters from int and coh noise components
+	    int_noise_scale: 1.0
+	    coh_noise_scale: 1.09
         }
     }
 }

--- a/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
@@ -127,10 +127,10 @@ base {
 
         fields: ["garfield-icarus-fnal-rev1.json.bz2"],
 
-       noise: ["icarus_noise_model_int_TPCEE.json.bz2","icarus_noise_model_int_TPCEW.json.bz2","icarus_noise_model_int_TPCWE.json.bz2","icarus_noise_model_int_TPCWW.json.bz2"],
+       // noise: ["icarus_noise_model_int_TPCEE.json.bz2","icarus_noise_model_int_TPCEW.json.bz2","icarus_noise_model_int_TPCWE.json.bz2","icarus_noise_model_int_TPCWW.json.bz2"],
        // coherent_noise: ["icarus_noise_model_coh_TPCEE.json.bz2","icarus_noise_model_coh_TPCEW.json.bz2","icarus_noise_model_coh_TPCWE.json.bz2","icarus_noise_model_coh_TPCWW.json.bz2"],	
 	wiregroups: "icarus_group_to_channel_map.json.bz2",
-	noisegroups: ["icarus_noise_model_coh_by_board_TPCEE.json.bz2","icarus_noise_model_coh_by_board_TPCEW.json.bz2","icarus_noise_model_coh_by_board_TPCWE.json.bz2","icarus_noise_model_coh_by_board_TPCWW.json.bz2"],
+	noisegroups: ["icarus_noise_model_int_by_board_TPCEE.json.bz2","icarus_noise_model_int_by_board_TPCEW.json.bz2","icarus_noise_model_int_by_board_TPCWE.json.bz2","icarus_noise_model_int_by_board_TPCWW.json.bz2","icarus_noise_model_coh_by_board_TPCEE.json.bz2","icarus_noise_model_coh_by_board_TPCEW.json.bz2","icarus_noise_model_coh_by_board_TPCWE.json.bz2","icarus_noise_model_coh_by_board_TPCWW.json.bz2"],
         chresp: null,
     },
 

--- a/icaruscode/TPC/ICARUSWireCell/wcls-multitpc-sim-drift-simchannel.fcl
+++ b/icaruscode/TPC/ICARUSWireCell/wcls-multitpc-sim-drift-simchannel.fcl
@@ -61,7 +61,9 @@ physics :{
 
               # Electron drift speed, assumes a certain applied E-field [mm/us]
               # driftSpeed: 1.565
-            }
+              int_noise_scale: 1.0
+              coh_noise_scale: 1.09
+	        }
 
          }
       }


### PR DESCRIPTION
PR to change configurations to interface with new wc version 0.22.0

Allow intrinsic noise to be simulated from input histograms. Groups are set by board, but can be any

PS. icarus_data must be updated with new noise files . Check with @rennney if LArSoft has required changes before merge