### PR TITLE
Various small improvements to decoding implementation

### DIFF
--- a/icaruscode/Decode/BeamBits.h
+++ b/icaruscode/Decode/BeamBits.h
@@ -47,9 +47,9 @@ namespace sbn {
     // --- BEGIN -- Generic bit functions --------------------------------------
     /// @name Generic bit functions
     /// @{
-    //template <typename EnumType>
-    //using mask_t = std::underlying_type_t<EnumType>;
     
+    /// Type for bit masks.
+    /// @note This is a glorified integral type.
     template <typename EnumType>
     struct mask_t {
       using bits_t = EnumType; ///< Enumeration type of the bits.

--- a/icaruscode/Decode/CMakeLists.txt
+++ b/icaruscode/Decode/CMakeLists.txt
@@ -9,6 +9,7 @@ art_make(
                         DumpTriggerConfiguration_module.cc
                         DumpPMTconfiguration_module.cc
                         DumpArtDAQfragments_module.cc
+                        DumpTrigger_module.cc
                         DaqDecoderICARUSPMT_module.cc
           MODULE_LIBRARIES
                         icarus_signal_processing
@@ -94,6 +95,15 @@ simple_plugin(DumpArtDAQfragments module
   ${MF_MESSAGELOGGER}
   fhiclcpp
   cetlib_except
+  )
+
+simple_plugin(DumpTrigger module
+  icaruscode_Decode_DataProducts
+  lardataobj::Simulation
+  lardataobj::RawData
+  messagefacility::MF_MessageLogger
+  fhiclcpp
+  cetlib_except::cetlib_except
   )
 
 install_headers()

--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -178,6 +178,13 @@ namespace icarus { class DaqDecoderICARUSPMT; }
  *     option is set to `true` unless `TriggerTag` is specified empty.
  * * `DataTrees` (list of strings, default: none): list of data trees to be
  *     produced; if none (default), then `TFileService` is not required.
+ * * `SkipWaveforms` (flag, default: `false`) if set, waveforms won't be
+ *     produced; this is intended as a debugging option for jobs where only the
+ *     `DataTrees` are desired.
+ * * `DropRawDataAfterUse` (flag, default: `true`): at the end of processing,
+ *     the framework will be asked to remove the PMT data fragment from memory.
+ *     Set this to `false` in the unlikely case where raw PMT fragments are
+ *     still needed after decoding.
  * * `LogCategory` (string, default: `DaqDecoderICARUSPMT`): name of the message
  *     facility category where the output is sent.
  * 
@@ -360,6 +367,24 @@ namespace icarus { class DaqDecoderICARUSPMT; }
  * available and travels together with the waveform itself in a data structure
  * called "proto-waveform". The extra-information is eventually discarded when
  * putting the actual waveform into the _art_ event.
+ * 
+ * 
+ * ### Processing pipeline
+ * 
+ * Processing happens according to the following structure (in `produce()`):
+ * 1. pre-processing: currently nothing
+ * 2. processing of each board data independently: at this level, all the
+ *    buffers from the 16 channels of a single board are processed together
+ *    (`processBoardFragments()`)
+ *     1. the configuration and parameters specific to this board are fetched
+ *     2. each data fragment is processed independently: at this level, data
+ *        from all 16 channels _at a given time_ are processed together,
+ *        producing up to 16 proto-waveforms
+ *     3. merging of contiguous waveforms is performed
+ * 3. post-processing of proto-waveforms:
+ *     * sorting by time (as opposed as roughly by channel, as they come)
+ * 4. conversion to data products and output
+ * 
  * 
  * 
  * Glossary
@@ -585,6 +610,18 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
       std::vector<std::string>{} // default
       };
     
+    fhicl::Atom<bool> SkipWaveforms {
+      Name("SkipWaveforms"),
+      Comment("do not decode and produce waveforms"),
+      false // default
+      };
+    
+    fhicl::Atom<bool> DropRawDataAfterUse {
+      Name("DropRawDataAfterUse"),
+      Comment("drop PMT data fragments from memory after use"),
+      true // default
+      };
+    
     fhicl::Atom<std::string> LogCategory {
       Name("LogCategory"),
       Comment("name of the category for message stream"),
@@ -653,7 +690,7 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
   struct TriggerInfo_t {
     SplitTimestamp_t time; ///< Time of the trigger (absolute).
     long int relBeamGateTime; ///< Time of beam gate relative to trigger [ns].
-    unsigned int bits = 0x0; ///< Trigger bits.
+    sbn::triggerSourceMask bits; ///< Trigger bits.
     unsigned int gateCount = 0U; ///< Gate number from the beginning of run.
   }; // TriggerInfo_t
   
@@ -711,6 +748,11 @@ class icarus::DaqDecoderICARUSPMT: public art::EDProducer {
   
   /// All board setup settings.
   std::vector<daq::details::BoardSetup_t> const fBoardSetup;
+  
+  bool const fSkipWaveforms; ///< Whether to skip waveform decoding.
+  
+  /// Clear fragment data product cache after use.
+  bool const fDropRawDataAfterUse;
   
   std::string const fLogCategory; ///< Message facility category.
   
@@ -1295,6 +1337,8 @@ icarus::DaqDecoderICARUSPMT::DaqDecoderICARUSPMT(Parameters const& params)
   , fTTTresetEverySecond
     { params().TTTresetEverySecond().value_or(fTriggerTag.has_value()) }
   , fBoardSetup{ params().BoardSetup() }
+  , fSkipWaveforms{ params().SkipWaveforms() }
+  , fDropRawDataAfterUse{ params().DropRawDataAfterUse() }
   , fLogCategory{ params().LogCategory() }
   , fDetTimings
     { art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob() }
@@ -1322,8 +1366,10 @@ icarus::DaqDecoderICARUSPMT::DaqDecoderICARUSPMT(Parameters const& params)
   //
   // produced data products declaration
   //
-  for (std::string const& instanceName: getAllInstanceNames())
-    produces<std::vector<raw::OpDetWaveform>>(instanceName);
+  if (!fSkipWaveforms) {
+    for (std::string const& instanceName: getAllInstanceNames())
+      produces<std::vector<raw::OpDetWaveform>>(instanceName);
+  }
   
   //
   // additional initialization
@@ -1376,7 +1422,9 @@ icarus::DaqDecoderICARUSPMT::DaqDecoderICARUSPMT(Parameters const& params)
       << params().PMTconfigTag.name() << "`"
       ;
   }
-  
+  if (fSkipWaveforms) {
+    log << "\n * PMT WAVEFORMS WILL NOT BE DECODED AND STORED";
+  }
   
   //
   // sanity checks
@@ -1422,14 +1470,10 @@ void icarus::DaqDecoderICARUSPMT::produce(art::Event& event) {
     else
       log << "Trigger from event timestamp: ";
     log << triggerInfo.time << " s, bits: "
-        << icarus::ns::util::bin(triggerInfo.bits);
+        << icarus::ns::util::bin(triggerInfo.bits.bits);
     if (triggerInfo.bits) {
       log << " {";
-      for (std::string const& name
-        : sbn::bits::names<sbn::triggerSource>({(unsigned int) triggerInfo.bits }))
-      {
-        log << ' ' << name;
-      }
+      for (std::string const& name: names(triggerInfo.bits)) log << ' ' << name;
       log << " }";
     } // if
     if (fTriggerTag) log << ", spill count: " << triggerInfo.gateCount;
@@ -1445,7 +1489,7 @@ void icarus::DaqDecoderICARUSPMT::produce(art::Event& event) {
   //
   // output data product initialization
   //
-  std::vector<ProtoWaveform_t> protoWaveforms;
+  std::vector<ProtoWaveform_t> protoWaveforms; // empty if `fSkipWaveforms`
   
   
   // ---------------------------------------------------------------------------
@@ -1515,44 +1559,48 @@ void icarus::DaqDecoderICARUSPMT::produce(art::Event& event) {
   //
   sortWaveforms(protoWaveforms);
   
-  std::vector<ProtoWaveform_t const*> waveformsWithTrigger
-    = findWaveformsWithNominalTrigger(protoWaveforms);
-  mf::LogTrace(fLogCategory) << waveformsWithTrigger.size() << "/"
-    << protoWaveforms.size() << " decoded waveforms include trigger time ("
-    << fNominalTriggerTime << ").";
+  if (!fSkipWaveforms) {
+    std::vector<ProtoWaveform_t const*> const waveformsWithTrigger
+      = findWaveformsWithNominalTrigger(protoWaveforms);
+    mf::LogTrace(fLogCategory) << waveformsWithTrigger.size() << "/"
+      << protoWaveforms.size() << " decoded waveforms include trigger time ("
+      << fNominalTriggerTime << ").";
+  } // if !fSkipWaveforms
   
   // ---------------------------------------------------------------------------
   // output
   //
   
-  // split the waveforms by destination
-  std::map<std::string, std::vector<raw::OpDetWaveform>> waveformProducts;
-  for (std::string const& instanceName: getAllInstanceNames())
-    waveformProducts.emplace(instanceName, std::vector<raw::OpDetWaveform>{});
-  for (ProtoWaveform_t& waveform: protoWaveforms) {
+  if (!fSkipWaveforms) {
+    // split the waveforms by destination
+    std::map<std::string, std::vector<raw::OpDetWaveform>> waveformProducts;
+    for (std::string const& instanceName: getAllInstanceNames())
+      waveformProducts.emplace(instanceName, std::vector<raw::OpDetWaveform>{});
+    for (ProtoWaveform_t& waveform: protoWaveforms) {
+      
+      // on-global and span requirements override even `mustSave()` requirement;
+      // if this is not good, user should not set `mustSave()`!
+      bool const keep =
+        (waveform.onGlobal || !waveform.channelSetup->onGlobalOnly)
+        && (waveform.span() >= waveform.channelSetup->minSpan)
+        ;
+      
+      if (!keep) continue;
+      waveformProducts.at(waveform.channelSetup->category).push_back
+        (std::move(waveform.waveform));
+    } // for
     
-    // on-global and span requirements overrides even `mustSave()` requirement;
-    // if this is not good, user should not set `mustSave()`!
-    bool const keep =
-      (waveform.onGlobal || !waveform.channelSetup->onGlobalOnly)
-      && (waveform.span() >= waveform.channelSetup->minSpan)
-      ;
-    
-    if (!keep) continue;
-    waveformProducts.at(waveform.channelSetup->category).push_back
-      (std::move(waveform.waveform));
-  } // for
-  
-  // put all the categories
-  for (auto&& [ category, waveforms ]: waveformProducts) {
-    mf::LogTrace(fLogCategory)
-      << waveforms.size() << " PMT waveforms saved for "
-      << (category.empty()? "standard": category) << " instance.";
-    event.put(
-      std::make_unique<std::vector<raw::OpDetWaveform>>(std::move(waveforms)),
-      category // the instance name is the category the waveforms belong to
-      );
-  }
+    // put all the categories
+    for (auto&& [ category, waveforms ]: waveformProducts) {
+      mf::LogTrace(fLogCategory)
+        << waveforms.size() << " PMT waveforms saved for "
+        << (category.empty()? "standard": category) << " instance.";
+      event.put(
+        std::make_unique<std::vector<raw::OpDetWaveform>>(std::move(waveforms)),
+        category // the instance name is the category the waveforms belong to
+        );
+    }
+  } // if !fSkipWaveforms
   
 } // icarus::DaqDecoderICARUSPMT::produce()
 
@@ -1580,8 +1628,7 @@ artdaq::Fragments const& icarus::DaqDecoderICARUSPMT::readInputFragments
       << "DaqDecoderICARUSPMT trying data product: '" << inputTag.encode()
       << "'";
     
-    art::Handle<artdaq::Fragments> thisHandle;
-    if (!event.getByLabel<artdaq::Fragments>(inputTag, thisHandle)) continue;
+    auto const& thisHandle = event.getHandle<artdaq::Fragments>(inputTag);
     if (!thisHandle.isValid() || thisHandle->empty()) continue;
     
     mf::LogTrace(fLogCategory)
@@ -1985,7 +2032,7 @@ auto icarus::DaqDecoderICARUSPMT::processFragment(
     
   if (fTreeFragment) fillPMTfragmentTree(fragInfo, triggerInfo, timeStamp);
   
-  return (timeStamp != NoTimestamp)
+  return ((timeStamp != NoTimestamp) && !fSkipWaveforms)
     ? createFragmentWaveforms(fragInfo, boardInfo.channelSetup(), timeStamp)
     : std::vector<ProtoWaveform_t>{}
     ;

--- a/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
+++ b/icaruscode/Decode/DataProducts/ExtraTriggerInfo.cxx
@@ -29,7 +29,6 @@ namespace {
   template <typename T>
   std::ostream& operator<< (std::ostream& out, TimestampDumper<T> wrapper) {
     T const timestamp = wrapper.timestamp;
-    //std::uint64_t const timestamp = wrapper.timestamp;
     if (sbn::ExtraTriggerInfo::isValidTimestamp(timestamp)) {
       out << (timestamp / 1'000'000'000) << "."
         << std::setfill('0') << std::setw(9) << (timestamp % 1'000'000'000)

--- a/icaruscode/Decode/DumpTrigger_module.cc
+++ b/icaruscode/Decode/DumpTrigger_module.cc
@@ -1,0 +1,486 @@
+/**
+ * @file   DumpTrigger_module.cc
+ * @brief  Dumps on console the content of trigger data products.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 22, 2022
+ */
+
+// SBN libraries
+#include "icaruscode/Decode/DataProducts/ExtraTriggerInfo.h"
+#include "icaruscode/Decode/BeamBits.h" // sbn::triggerSource
+#include "icaruscode/Utilities/StreamIndenter.h" // util::addIndent()
+
+// LArSoft libraries
+#include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // simulation_time
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "lardataobj/Simulation/BeamGateInfo.h"
+#include "lardataobj/RawData/ExternalTrigger.h"
+#include "lardataobj/RawData/TriggerData.h" // raw::Trigger
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Principal/Event.h"
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <iomanip> // std::setfill(), std::setw()
+#include <vector>
+#include <optional>
+#include <utility> // std::pair
+#include <string>
+
+
+//------------------------------------------------------------------------------
+namespace sbn { class DumpTrigger; }
+
+/**
+ * @brief Dumps on console the content of trigger data products.
+ * 
+ * Supported trigger types are:
+ * * `std::vector<raw::Trigger>`
+ * * `std::vector<raw::ExternalTrigger>`
+ * * `std::vector<sim::BeamGateInfo>`
+ * * `std::vector<sbn::ExtraTriggerInfo>`
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * * `std::vector<raw::Trigger>`: simple trigger information
+ * * `std::vector<sim::BeamGateInfo>`: beam gate information
+ * * `std::vector<raw::ExternalTrigger>`: additional trigger information
+ * * `sbn::ExtraTriggerInfo`: detailed trigger information
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * All data product tags are optional, but at least one needs to be specified.
+ * If a tag is not specified, the same tag as `TriggerTag` will be attempted
+ * (if specified).
+ * A terse description of the parameters is printed by running
+ * `lar --print-description DumpTrigger`.
+ * 
+ * * `TriggerTag` (data product input tag, optional): the tag identifying the
+ *     data product of the simple trigger information to dump.
+ * * `BeamGateTag` (data product input tag, optional): the tag identifying the
+ *     data product of the beam gate; if explicitly empty, this type of data
+ *     product will not be dumped; if omitted, an attempt to dump a data
+ *     product with the same tag as `TriggerTag` will be performed, and in case
+ *     of failure no message will be printed.
+ * * `ExternalTriggerTag` (data product input tag, optional): the tag
+ *     identifying the data product of the additional standard trigger
+ *     information; this is a standard LArSoft data product that ICARUS abuses
+ *     to store information in a portable way. If explicitly empty, this type of
+ *     data product will not be dumped; if omitted, an attempt to dump a data
+ *     product with the same tag as `TriggerTag` will be performed, and in case
+ *     of failure no message will be printed.
+ * * `ExtraTriggerTag` (data product input tag, optional): the tag identifying
+ *     the data product of the detailed trigger information; this is
+ *     SBN-specific. If explicitly empty, this type of data product will not be
+ *     dumped; if omitted, an attempt to dump a data product with the same tag
+ *     as `TriggerTag` will be performed, and in case of failure no message will
+ *     be printed.
+ * * `Verbosity` (integral, default: maximum): verbosity level used in the
+ *     dump; see `sbn::PMTconfiguration::dump()` for details.
+ * * `OutputCategory` (string, default: `DumpTrigger`): name of the
+ *     message facility output stream to dump the information into.
+ * 
+ */
+class sbn::DumpTrigger: public art::EDAnalyzer {
+  
+    public:
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::OptionalAtom<art::InputTag> TriggerTag {
+      Name{ "TriggerTag" },
+      Comment
+        { "tag of the simple trigger data product (raw::Trigger collection)" }
+      };
+
+    fhicl::OptionalAtom<art::InputTag> BeamGateTag {
+      Name{ "BeamGateTag" },
+      Comment{ "tag of the beam gate information data product" }
+      };
+
+    fhicl::OptionalAtom<art::InputTag> ExternalTriggerTag {
+      Name{ "ExternalTriggerTag" },
+      Comment{
+        "tag of additional trigger information data product"
+        " (raw::ExternalTrigger collection)" 
+        }
+      };
+
+    fhicl::OptionalAtom<art::InputTag> ExtraTriggerTag {
+      Name{ "ExtraTriggerTag" },
+      Comment{ "tag of detailed SBN-specific trigger information data product" }
+      };
+
+    fhicl::Atom<unsigned int> Verbosity {
+      Name{ "Verbosity" },
+      Comment{ "verbosity level [default: maximum]" },
+      std::numeric_limits<unsigned int>::max() // default
+      };
+
+    fhicl::Atom<std::string> OutputCategory {
+      Name{ "OutputCategory" },
+      Comment{ "name of the category used for the output" },
+      "DumpTrigger"
+      };
+
+  }; // struct Config
+  
+  using Parameters = art::EDAnalyzer::Table<Config>;
+  
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  // --- BEGIN Constructors ----------------------------------------------------
+  explicit DumpTrigger(Parameters const& config);
+  
+  // --- END Constructors ------------------------------------------------------
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Does the dumping.
+  virtual void analyze(art::Event const& event) override;
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  using electronics_time = detinfo::timescales::electronics_time; // alias
+  using simulation_time = detinfo::timescales::simulation_time; // alias
+  
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  std::optional<art::InputTag> const fTriggerTag; ///< Input trigger tag.
+  
+  std::optional<art::InputTag> const fBeamGateTag; ///< Input beam gate tag.
+  
+  /// Input additional trigger tag.
+  std::optional<art::InputTag> const fExternalTag;
+  
+  std::optional<art::InputTag> const fExtraTag; /// Input extra trigger tag.
+  
+  unsigned int const fVerbosity; ///< Verbosity level used for dumping.
+  
+  /// Category used for message facility stream.
+  std::string const fOutputCategory;
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+  /// Dumps a simple LArSoft trigger data product.
+  void dumpTrigger(std::vector<raw::Trigger> const& triggers) const;
+  
+  /// Dumps a LArSoft external trigger data product.
+  void dumpTrigger(std::vector<raw::ExternalTrigger> const& triggers) const;
+  
+  /// Dumps a LArSoft beam gate information data product.
+  void dumpBeamGate(std::vector<sim::BeamGateInfo> const& gates) const;
+  
+  /// Dumps a SBN trigger information data product.
+  void dumpTrigger(sbn::ExtraTriggerInfo const& trigger) const;
+  
+  
+  /// Returns the tag to try, and whether it is mandatory to find it.
+  std::pair<art::InputTag, bool> inputTag
+    (std::optional<art::InputTag> const& tag) const;
+  
+  
+  /// Returns `1` if the data product of type `T` specified by `param` must
+  /// be available, `0` otherwise. It also declares it will consume it.
+  template <typename T>
+  unsigned int countConsume(std::optional<art::InputTag> const& param);
+  
+}; // sbn::DumpTrigger
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+namespace {
+  struct dumpTimestamp {
+    raw::TriggerTimeStamp_t ts;
+    dumpTimestamp(raw::TriggerTimeStamp_t ts): ts{ ts } {}
+  }; // dumpTimestamp
+  
+  std::ostream& operator<< (std::ostream& out, dumpTimestamp tsw) {
+    return out << (tsw.ts / 1'000'000'000) << "." << std::setfill('0')
+      << std::setw(9) << (tsw.ts % 1'000'000'000) << std::setfill(' ');
+  } // operator<< (dumpTimestamp)
+  
+  
+  
+} // local namespace
+
+//------------------------------------------------------------------------------
+//--- sbn::DumpTrigger
+//------------------------------------------------------------------------------
+sbn::DumpTrigger::DumpTrigger
+  (Parameters const& config)
+  : art::EDAnalyzer(config)
+  // configuration
+  , fTriggerTag    { config().TriggerTag() }
+  , fBeamGateTag   { config().BeamGateTag() }
+  , fExternalTag   { config().ExternalTriggerTag() }
+  , fExtraTag      { config().ExtraTriggerTag() }
+  , fVerbosity     { config().Verbosity() }
+  , fOutputCategory{ config().OutputCategory() }
+{
+  
+  unsigned int nRequiredTriggers = 0U; // count of required data products
+  
+  /*
+   * data product usage declaration
+   */
+  nRequiredTriggers += countConsume<std::vector<raw::Trigger>>(fTriggerTag);
+  nRequiredTriggers
+    += countConsume<std::vector<sim::BeamGateInfo>>(fBeamGateTag);
+  nRequiredTriggers
+    += countConsume<std::vector<raw::ExternalTrigger>>(fExternalTag);
+  nRequiredTriggers += countConsume<sbn::ExtraTriggerInfo>(fExtraTag);
+  
+  /*
+   * parameter check
+   */
+  if (nRequiredTriggers == 0U) {
+    throw art::Exception{ art::errors::Configuration }
+      << "At least one trigger data product needs to be specified.\n";
+  }
+  
+  /*
+   * print configuration
+   */
+  mf::LogInfo log{ fOutputCategory };
+  log << "Configuration:\n * dump:";
+  
+  if (fTriggerTag) log << "\n - '" << fTriggerTag->encode() << "' (raw::Trigger)";
+  
+  if (auto const [ tag, req ] = inputTag(fExternalTag); !tag.empty()) {
+    log << "\n - '" << tag.encode() << "' (raw::ExternalTrigger)";
+    if (!req) log << " (if available)";
+  }
+  
+  if (auto const [ tag, req ] = inputTag(fExtraTag); !tag.empty()) {
+    log << "\n - '" << tag.encode() << "' (sbn::ExtraTriggerInfo)";
+    if (!req) log << " (if available)";
+  }
+  
+  if (auto const [ tag, req ] = inputTag(fBeamGateTag); !tag.empty()) {
+    log << "\n - '" << tag.encode() << "' (sim::BeamGateInfo)";
+    if (!req) log << " (if available)";
+  }
+  
+} // sbn::DumpTrigger::DumpTrigger()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpTrigger::analyze(art::Event const& event) {
+  
+  mf::LogVerbatim{ fOutputCategory }
+    << "Trigger information in " << event.id() << ":";
+  
+  if (auto const [ tag, req ] = inputTag(fTriggerTag); !tag.empty()) {
+    
+    auto const& handle = event.getHandle<std::vector<raw::Trigger>>(tag);
+    if (handle) {
+      mf::LogVerbatim{ fOutputCategory }
+        << "* raw::Trigger ('" << tag.encode() << "'):";
+      dumpTrigger(*handle);
+    }
+    else if (req) throw *(handle.whyFailed());
+  } // simple trigger
+  
+  
+  if (auto const [ tag, req ] = inputTag(fExternalTag); !tag.empty()) {
+    
+    auto const& handle
+      = event.getHandle<std::vector<raw::ExternalTrigger>>(tag);
+    if (handle) {
+      mf::LogVerbatim{ fOutputCategory }
+        << "* raw::ExternalTrigger ('" << tag.encode() << "'):";
+      dumpTrigger(*handle);
+    }
+    else if (req) throw *(handle.whyFailed());
+  } // external trigger info
+  
+  
+  if (auto const [ tag, req ] = inputTag(fExtraTag); !tag.empty()) {
+    
+    auto const& handle = event.getHandle<sbn::ExtraTriggerInfo>(tag);
+    if (handle) {
+      mf::LogVerbatim{ fOutputCategory }
+        << "* sbn::ExtraTriggerInfo ('" << tag.encode() << "'):";
+      dumpTrigger(*handle);
+    }
+    else if (req) throw *(handle.whyFailed());
+  } // extra trigger info
+  
+  
+  if (auto const [ tag, req ] = inputTag(fBeamGateTag); !tag.empty()) {
+    
+    auto const& handle = event.getHandle<std::vector<sim::BeamGateInfo>>(tag);
+    if (handle) {
+      mf::LogVerbatim{ fOutputCategory }
+        << "* sim::BeamGateInfo ('" << tag.encode() << "'):";
+      dumpBeamGate(*handle);
+    }
+    else if (req) throw *(handle.whyFailed());
+  } // beam gate
+  
+  
+} // sbn::DumpTrigger::analyze()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpTrigger::dumpTrigger
+  (std::vector<raw::Trigger> const& triggers) const
+{
+  static std::string const indent(4U, ' ');
+  
+  if (triggers.empty()) {
+    mf::LogVerbatim{ fOutputCategory } << indent << "no triggers.";
+    return;
+  }
+  if (triggers.size() > 1) {
+    mf::LogVerbatim{ fOutputCategory }
+      << indent << "[" << triggers.size() << " triggers]";
+  }
+  
+  for (auto const& [ iTrigger, trigger]: util::enumerate(triggers)) {
+    mf::LogVerbatim log { fOutputCategory };
+    log << indent;
+    if (triggers.size() > 1) log << "[" << iTrigger << "] ";
+    log << "trigger #" << trigger.TriggerNumber() << " at "
+      << electronics_time{ trigger.TriggerTime() }
+      << ", beam gate at " << electronics_time{ trigger.BeamGateTime() }
+      << ", bits:";
+    if (sbn::bits::triggerSourceMask const bitMask{ trigger.TriggerBits() }) {
+      log << " {";
+      for (std::string const& name: names(bitMask)) log << " " << name;
+      log << " }";
+    }
+    else log << " none";
+  
+  } // for
+  
+} // sbn::DumpTrigger::dumpTrigger()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpTrigger::dumpTrigger
+  (std::vector<raw::ExternalTrigger> const& triggers) const
+{
+  
+  static std::string const indent(4U, ' ');
+  
+  if (triggers.empty()) {
+    mf::LogVerbatim{ fOutputCategory } << indent << "no triggers.";
+    return;
+  }
+  if (triggers.size() > 1) {
+    mf::LogVerbatim{ fOutputCategory }
+      << indent << "[" << triggers.size() << " triggers]";
+  }
+  
+  for (auto const& [ iTrigger, trigger]: util::enumerate(triggers)) {
+    mf::LogVerbatim log { fOutputCategory };
+    log << indent;
+    if (triggers.size() > 1) log << "[" << iTrigger << "] ";
+    log << "trigger ID=" << trigger.GetTrigID()
+      << " at " << dumpTimestamp(trigger.GetTrigTime());
+  
+  } // for
+  
+} // sbn::DumpTrigger::dumpTrigger(ExternalTrigger)
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpTrigger::dumpBeamGate
+  (std::vector<sim::BeamGateInfo> const& gates) const
+{
+  
+  static std::string const indent(4U, ' ');
+  
+  if (gates.empty()) {
+    mf::LogVerbatim{ fOutputCategory } << indent << "no beam gates.";
+    return;
+  }
+  if (gates.size() > 1) {
+    mf::LogVerbatim{ fOutputCategory }
+      << indent << "[" << gates.size() << " beam gates]";
+  }
+  
+  for (auto const& [ iGate, gate]: util::enumerate(gates)) {
+    mf::LogVerbatim log { fOutputCategory };
+    log << indent;
+    simulation_time const start { gate.Start() };
+    simulation_time const end { gate.Start() + gate.Width() };
+    if (gates.size() > 1) log << "[" << iGate << "] ";
+    log << "beam gate [ " << start << " -- " << end << " ] (duration: "
+      << (end - start) << ") of type ";
+    switch (gate.BeamType()) {
+      case sim::kBNB:     log << "BNB"; break;
+      case sim::kNuMI:    log << "NuMI"; break;
+      case sim::kUnknown: log << "unknown"; break;
+      default:
+        log << "unsupported [code=" << static_cast<int>(gate.BeamType()) << "]";
+    } // switch
+  
+  } // for
+  
+} // sbn::DumpTrigger::dumpBeamGate()
+
+
+//------------------------------------------------------------------------------
+void sbn::DumpTrigger::dumpTrigger(sbn::ExtraTriggerInfo const& trigger) const {
+  
+  static std::string const indent(4U, ' ');
+  
+  mf::LogVerbatim{ fOutputCategory } << util::addIndent(indent) << trigger;
+  
+} // sbn::DumpTrigger::dumpTrigger(ExtraTriggerInfo)
+
+
+//------------------------------------------------------------------------------
+std::pair<art::InputTag, bool> sbn::DumpTrigger::inputTag
+  (std::optional<art::InputTag> const& tag) const
+{
+  return
+    { tag.value_or(fTriggerTag.value_or(art::InputTag{})), tag.has_value() };
+} // sbn::DumpTrigger::inputTag()
+
+
+//------------------------------------------------------------------------------
+template <typename T>
+unsigned int sbn::DumpTrigger::countConsume
+  (std::optional<art::InputTag> const& param)
+{
+  auto const [ tag, required ] = inputTag(param);
+  if (tag.empty()) return 0;
+  if (required) consumes<T>(tag);
+  else          mayConsume<T>(tag);
+  return required? 1: 0;
+} // sbn::DumpTrigger::countConsume()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(sbn::DumpTrigger)
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/Decode/fcl/dump_triggers_icarus.fcl
+++ b/icaruscode/Decode/fcl/dump_triggers_icarus.fcl
@@ -1,0 +1,68 @@
+#
+# File:     dump_triggers_icarus.fcl
+# Purpose:  Dump on screen ICARUS data products from trigger decoding.
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     March 22, 2022
+# Version:  1.0
+#
+# This module dumps the specified trigger data products.
+#
+# Input: (data) files with decoded trigger information.
+#
+# Service dependencies:
+# - message facility
+# 
+# Changes:
+# 20220322 (petrillo@slac.stanford.edu) [v1.0]
+#   first version
+#
+
+#include "messages_icarus.fcl"
+
+
+# ------------------------------------------------------------------------------
+process_name: DumpTrg
+
+
+# ------------------------------------------------------------------------------
+services: {
+  
+  message: @local::icarus_message_services_interactive
+  
+} # services
+
+
+services.message.destinations.LogStandardOut.categories.DumpTrigger: { limit: 0 }
+services.message.destinations.DumpLog: {
+  type:      file
+  filename: "DumpTriggers.log"
+  threshold: INFO
+  categories: {
+    DumpTrigger: { limit: -1 }
+    default:     { limit: 0 }
+  }
+} # services.message.destinations.DumpLog
+
+
+# ------------------------------------------------------------------------------
+physics: {
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  analyzers: {
+    dumptrigger: {
+      module_type: DumpTrigger
+      
+      TriggerTag: "daqTrigger"
+      
+      OutputCategory: "DumpTrigger"
+      
+    } # dumptrigger
+  } # analyzers
+  
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  dumpers:    [ dumptrigger ]
+  
+} # physics
+
+
+# ------------------------------------------------------------------------------

--- a/icaruscode/Utilities/ArtHandleTrackerManager.h
+++ b/icaruscode/Utilities/ArtHandleTrackerManager.h
@@ -1,0 +1,1088 @@
+/**
+ * @file   icaruscode/Utilities/ArtHandleTrackerManager.h
+ * @brief  Tracks handles for cache deletion.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 31, 2022
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCORE_UTILITIES_ARTHANDLETRACKERMANAGER_H
+#define ICARUSCORE_UTILITIES_ARTHANDLETRACKERMANAGER_H
+
+
+// framework libraries
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Provenance.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// C/C++ standard libraries
+#include <algorithm> // std::count_if()
+#include <vector>
+#include <memory> // std::unique_ptr<>
+#include <any>
+#include <utility> // std::forward()
+#include <typeinfo>
+
+
+// -----------------------------------------------------------------------------
+namespace util {
+  template <typename Event> struct ArtHandleTrackerInterface;
+  template <typename Event> class ArtHandleTrackerManager;
+  template <typename Event> class LocalArtHandleTrackerManager;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Manages handle trackers for an easy call of `removeCachedProduct()`.
+ * @tparam Event the type of data product source (the "principal") to serve
+ * 
+ * This handle manager is designed to simplify the usage of
+ * `art::Event::removeCachedProduct()` on multiple data products.
+ * 
+ * The envisioned usage model in a single-thread module is the following:
+ * 1. The manager is a data member of the module (in alternative, it should be
+ *    passed down to the places where data products are read, and at a minimum
+ *    it needs to register all the handles it is supposed to "manage").
+ * 2. The manager can ask the event to read a data product anew, and get an
+ *    handle for it. It will register the handle, and return it.
+ *     * The manager can also register an existing handle.
+ * 3. The manager can deliver a stored handle (but that's a slow process in the
+ *    current implementation and it requires the input tag to resolve
+ *    ambiguities).
+ * 4. Upon request, all handles are asked to remove their cached products.
+ *    This request presumably happens at the end of the event-processing
+ *    function (`produce()`, `filter()`, `analyze()`).
+ *    Note that after an handle has its cached data removed, it's `clear()`'ed.
+ * 
+ * An handle manager can serve only one _art_ event at a time.
+ * All handles come from that event (or are assumed to).
+ * 
+ * Example:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * class MyModule: public art::EDAnalyzer {
+ *   
+ *   util::ArtHandleTrackerManager<art::Event> fDataCacheRemover;
+ *   
+ *   art::InputTag const fTag;
+ *   
+ *   // ...
+ *   
+ *   void analyze(art::Event const & event) override
+ *     {
+ *       fDataCacheRemover.useEvent(event);
+ *       
+ *       auto const& handle = fDataCacheRemover.getHandle<MyDataProduct>(fTag);
+ *       
+ *       auto results = processData(*handle); // ... or whatever
+ *       
+ *       fDataCacheRemover.removeCachedProducts(); // free caches after use
+ *       
+ *       results.Write(); // ... or another portion of whatever
+ *     }
+ *   
+ * };
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * Or one can create the handle as preferred, and then register it:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * class MyModule: public art::EDAnalyzer {
+ *   
+ *   util::ArtHandleTrackerManager<art::Event> fDataCacheRemover;
+ *   
+ *   art::InputTag const fTag;
+ *   
+ *   // ...
+ *   
+ *   void analyze(art::Event const & event) override
+ *     {
+ *       fDataCacheRemover.useEvent(event);
+ *       
+ *       auto const& handle = event.getValidHandle<MyDataProduct>(fTag);
+ *       
+ *       fDataCacheRemover.registerHandle(handle);
+ *       
+ *       auto results = processData(*handle); // ... or whatever
+ *       
+ *       fDataCacheRemover.removeCachedProducts(); // free caches after use
+ *       
+ *       results.Write(); // ... or another portion of whatever
+ *     }
+ *   
+ * };
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * 
+ * Technical notes
+ * ================
+ * 
+ * Support for different types of handles
+ * ---------------------------------------
+ * 
+ * Currently, both `art::Handle` and `art::ValidHandle` (and nothing else)
+ * can be created by `ArtHandleTrackerManager`.
+ * The code can be extended to support any object that can be
+ * passed to `art::Event::removeCachedProduct()` (e.g. `art::ProductID`,
+ * if it will ever happen).
+ * 
+ * The current implementation is expected to be able to recognize handles
+ * pointing to the same data product even if they are of different type
+ * (e.g. `art::Handle<T>` and `art::ValidHandle<T>`).
+ * The manager stores a copy of the first type of handle registered for a given
+ * data product; then, if another handle of any type to the same data product
+ * is requested or registered, `registerHandle()` will return the same handle
+ * in argument, and the `getHandle()` family of functions will get and return a
+ * new handle. In both cases, no new registration will happen.
+ * 
+ * 
+ * Multithreading
+ * ---------------
+ * 
+ * The current implementation is inherently not safe for _art_ multithreading.
+ * While the inner data structure don't need global state, and the interface
+ * can easily be extended to allow for no global state as well, the operations
+ * are still performed on all the registered handles at once (meaning, when one
+ * thread asks for `removeCachedProduct()` or `forgetAllHandles()`, data from
+ * all events is affected).
+ * This can be overcome by changing the internal storage (to be reentrant and
+ * possibly by event) and a bit of the interface.
+ * 
+ * The object as it is now can be implemented on top of such object, preserving
+ * the current event information and delivering it to the new manager under the
+ * hood, with minimal overhead.
+ * 
+ * If such feature is needed, ask the author (and be prepared to test it).
+ * 
+ */
+template <typename Event>
+class util::ArtHandleTrackerManager {
+  
+    public:
+  
+  using Event_t = Event; ///< Type of data viewer object to operate with.
+  
+  /// Configuration record.
+  struct Config_t {
+    
+    /// Name of the output category for messages.
+    std::string logCategory = "ArtHandleTrackerManager";
+    
+  }; // Config_t
+  
+  
+  /**
+   * @brief Constructs a handle manager.
+   * @param config (optional) the configuration to be used
+   * @see `useEvent()`
+   * 
+   * An event must be later assigned to it (`useEvent()`) to make it functional.
+   */
+  ArtHandleTrackerManager(Config_t config = {});
+  
+  /**
+   * @brief Constructs a handle manager covering `event`.
+   * @param event the first data viewer (event) object to operate on
+   */
+  ArtHandleTrackerManager(Event_t const& event, Config_t config = {});
+  
+  
+  // --- BEGIN -- Queries ------------------------------------------------------
+  ///@name Queries
+  ///@{
+  
+  /// Returns the number of handles currently tracked.
+  unsigned int nTrackedHandles() const;
+  
+  /// Returns whether the object is associated to an event.
+  bool hasEvent() const;
+  
+  
+  /// @}
+  // --- END ---- Queries ------------------------------------------------------
+  
+  
+  // --- BEGIN -- Registration of data products --------------------------------
+  /// @name Registration of data products
+  /// @{
+  
+  /**
+   * @brief Retrieves an handle from the event, and registers it.
+   * @tparam T type of data product to retrieve
+   * @tparam Args types of the arguments needed by `art::getHandle()`
+   * @param args all the arguments that `art::getHandle()` requires
+   * @return the handle just read and being managed
+   * @see `getValidHandle()`, `registerHandle()`
+   * 
+   * This function wraps `art::Event::getHandle()`, calling it to obtain the
+   * handle and then registering it (like with `registerHandle()`).
+   */
+  template <typename T, typename... Args>
+  art::Handle<T> getHandle(Args&&... args);
+  
+  /**
+   * @brief Retrieves a valid handle from the event, and registers it.
+   * @tparam T type of data product to retrieve
+   * @tparam Args types of the arguments needed by `art::getValidHandle()`
+   * @param args all the arguments that `art::getValidHandle()` requires
+   * @return the handle just read and being managed
+   * @see `getHandle()`, `registerHandle()`
+   * 
+   * This is the `art::ValidHandle` sibling of `getHandle()`.
+   * See that one for details.
+   */
+  template <typename T, typename... Args>
+  art::ValidHandle<T> getValidHandle(Args&&... args);
+  
+  /**
+   * @brief Registers an existing handle.
+   * @tparam Handle the type of handle to register
+   * @param handle the handle to be registered
+   * @return `handle` (pass through)
+   * 
+   * This method registers a copy of `handle` into the manager.
+   */
+  template <typename Handle>
+  decltype(auto) registerHandle(Handle&& handle);
+  
+  /// @}
+  // --- END ---- Registration of data products --------------------------------
+  
+  
+  // --- BEGIN -- Operations ---------------------------------------------------
+  /// @name Operations
+  /// @{
+  
+  /**
+   * @brief Changes the event being served.
+   * @param event the new event being served
+   * @throw art::Exception (code: `art::errors::LogicError`) if there are still
+   *        registered handles
+   * 
+   * The object starts tracking handles of a new event.
+   * 
+   * This method requires that any pending handle has been taken care of
+   * (even if the new event happens to be the same as the old one).
+   * Common options are `removeCachedProductsAndForget()` if cache removal is
+   * desired, or `forgetAllHandles()` if it's not.
+   */
+  void useEvent(Event_t const& event);
+  
+  
+  /**
+   * @brief Clears the cached data products for all tracked handles.
+   * @return the number of tracked handles which had their cache removed
+   * 
+   * This method calls `Event_t::removeCachedProduct()` for all tracked handles.
+   * This is the core functionality of the manager, which removes the cache
+   * of all tracked handles.
+   * 
+   * The _art_ framework always makes the handles used to remove the cache
+   * invalid (`Handle::clear()`).
+   * After the removal, the object stops tracking the handles (like with a call
+   * to `forgetAllHandles()`).
+   * 
+   * Calling this method when there are no handles registered has no effect.
+   */
+  unsigned int removeCachedProducts();
+  
+  /// Stops tracking any handle, without removing their cache first.
+  void forgetAllHandles();
+  
+  
+  /**
+   * @brief Completes the work on the associated `event`.
+   * @param removeCache (default: `true`) removes tracked data product caches
+   * @param event if specified, only acts on cache from this `event`
+   * @return the number of cleared data product caches
+   * 
+   * This is a shortcut for having optional release of cache in a single call,
+   * depending on the value of `removeCache`:
+   *  * if `true`, `removeCachedProducts()` is called and its count is returned;
+   *  * if `false`, `forgetAllHandles()` is called and `0` is returned.
+   * 
+   * In addition, the object is disassociated from the event, and a call to
+   * `useEvent()` will be needed before this object can be operative again.
+   * 
+   * If the `event` parameter is not null, a check is done that the event being
+   * currently used matches `event`, and if not no operation happens (`0` is
+   * returned, but the object is not disassociated from its current event).
+   * 
+   */
+  unsigned int doneWithEvent
+    (bool removeCache = true, art::Event const* event = nullptr);
+  
+  /// @}
+  // --- END ---- Operations ---------------------------------------------------
+  
+  
+    private:
+  
+  /// Type of pointer to any handle tracker.
+  using TrackerPtr = std::unique_ptr<util::ArtHandleTrackerInterface<Event_t>>;
+  
+  
+  // --- BEGIN -- Data ---------------------------------------------------------
+  Event_t const* fEvent = nullptr; ///< Event being manager. Must be present!
+  
+  Config_t const fConfig; ///< Configuration.
+  
+  
+  std::vector<TrackerPtr> fTrackers; ///< List of managed handle trackers.
+  
+  // --- END ---- Data ---------------------------------------------------------
+  
+  
+  /**
+   * @brief Returns the pointer to an handle equivalent to `like`.
+   * @tparam Handle the type of the handle being queried
+   * @return a pointer to the handle, or `nullptr` if not found
+   * 
+   * This is an half-assed method since it needs to know already the exact type
+   * of the handle being queried (it's not even agnostic to the difference
+   * between `art::Handle` and `art::ValidHandle`).
+   * For this reason, it's not really useful to the users, who would probably
+   * want to know if the data product is cached, via any mean.
+   * 
+   * 
+   * ### Technical note
+   * 
+   * Delegating the matching to `util::ArtHandleTrackerInterface` is not possible
+   * (`like` is a template parameter and can't be passed via virtual interface)
+   * and even working around that and finding the match, the returned value needs
+   * to be of type `Handle`, which is not necessarily the type of handle stored
+   * in the tracker.
+   * 
+   * For the full functionality of knowing if a data product is tracked, a
+   * separate registry may be kept, still complicated by the fact that part of
+   * the registry entry is a C++ type (we may need to store a sanitized
+   * `std::type_info` for that).
+   */
+  template <typename Handle>
+  Handle const* findHandle(Handle const& like) const;
+  
+  
+  /// Returns whether `tracker` tracks the same product that `handle` handles.
+  template <typename Handle>
+  static bool handleSameProduct(TrackerPtr tracker, Handle const& handle);
+  
+  
+  /// Checks that the object is in a state where it can perform operations.
+  /// @param where identification of the calling function for error messages
+  /// @throw art::Exception (code: `art::errors::LogicError`) on failure
+  void canOperate(const char* where) const;
+  
+  
+}; // util::ArtHandleTrackerManager
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Variant of `util::ArtHandleTrackerManager` in local scope.
+ * @tparam Event the type of data product source (the "principal") to serve
+ *
+ * This class allows the removal of data products cached in an event.
+ * The general functionality is described in `util::ArtHandleTrackerManager`.
+ * 
+ * This class in particular offers a tuned interface for the case where the
+ * object is local (which is convenient for multithreading and if all the
+ * reading and usage happens in the same scope):
+ *  * the object supports being associated to only one event in its lifetime,
+ *    and the association must be established on construction;
+ *  * removal is automatically performed on destruction at the exit of the
+ *    scope of the object (this is "Resource Acquisition Is Initialization"
+ *    idiom)
+ * 
+ * Whether the object will actually remove the caches can be decided on
+ * construction (by default it does), and then changed with
+ * `setRemoveCachedProducts()`.
+ * The removal can also be anticipated by explicitly calling `doneWithEvent()`
+ * (no `event` parameter is supported), after which the destruction will not
+ * do anything.
+ *
+ * Example:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * void MyModule::analyze(art::Event const & event) override {
+ * 
+ *   util::LocalArtHandleTrackerManager dataCacheRemover{ event };
+ *   
+ *   auto const& handle = dataCacheRemover.getHandle<MyDataProduct>(fTag);
+ *   
+ *   auto results = processData(*handle); // ... or whatever
+ *   
+ *   results.Write(); // ... or another portion of whatever
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ */
+template <typename Event>
+class util::LocalArtHandleTrackerManager {
+  
+  /// The actual manager doing the work.
+  ArtHandleTrackerManager<Event> fManager;
+
+  bool fRemoveCache; ///< Whether to remove cache on destructor.
+  
+    public:
+  
+  /// Type of the _art_ event.
+  using Event_t = typename ArtHandleTrackerManager<Event>::Event_t;
+  
+  /**
+   * @brief Constructor: operates on the specified `event`.
+   * @param event the event this object will operate on
+   * @param removeCache (default: `true`) remove tracked data caches when done
+   * 
+   * 
+   * The parameter `removeCache` controls whether the data caches are removed
+   * on destruction. It may be changed along the way with
+   * `setRemoveCachedProducts()`.
+   * 
+   */
+  LocalArtHandleTrackerManager(Event const& event, bool removeCache = true);
+  
+  /// Destructor; will implement the RAII pattern (i.e. call `doneWithEvent()`).
+  ~LocalArtHandleTrackerManager();
+  
+  
+  // --- BEGIN -- Queries ------------------------------------------------------
+  ///@name Queries
+  ///@{
+  
+  /// Returns the number of handles currently tracked.
+  unsigned int nTrackedHandles() const;
+  
+  /// Returns whether caches will be removed on destruction.
+  /// @see `setRemoveCachedProducts()`
+  bool willRemoveCachedProducts() const;
+  
+  /// @}
+  // --- END ---- Queries ------------------------------------------------------
+  
+  
+  // --- BEGIN -- Registration of data products --------------------------------
+  /// @name Registration of data products
+  /// @{
+  
+  /**
+   * @brief Retrieves an handle from the event, and registers it.
+   * @tparam T type of data product to retrieve
+   * @tparam Args types of the arguments needed by `art::getHandle()`
+   * @param args all the arguments that `art::getHandle()` requires
+   * @return the handle just read and being managed
+   * @see `getValidHandle()`, `registerHandle()`
+   * 
+   * This function wraps `art::Event::getHandle()`, calling it to obtain the
+   * handle and then registering it (like with `registerHandle()`).
+   */
+  template <typename T, typename... Args>
+  art::Handle<T> getHandle(Args&&... args);
+  
+  /**
+   * @brief Retrieves a valid handle from the event, and registers it.
+   * @tparam T type of data product to retrieve
+   * @tparam Args types of the arguments needed by `art::getValidHandle()`
+   * @param args all the arguments that `art::getValidHandle()` requires
+   * @return the handle just read and being managed
+   * @see `getHandle()`, `registerHandle()`
+   * 
+   * This is the `art::ValidHandle` sibling of `getHandle()`.
+   * See that one for details.
+   */
+  template <typename T, typename... Args>
+  art::ValidHandle<T> getValidHandle(Args&&... args);
+  
+  /**
+   * @brief Registers an existing handle.
+   * @tparam Handle the type of handle to register
+   * @param handle the handle to be registered
+   * @return the same `handle` is passed through
+   * 
+   * This method registers a copy of `handle` into the manager.
+   */
+  template <typename Handle>
+  decltype(auto) registerHandle(Handle&& handle);
+  
+  /// @}
+  // --- END ---- Registration of data products --------------------------------
+  
+  
+  // --- BEGIN -- Operations ---------------------------------------------------
+  /// @name Operations
+  /// @{
+  
+  /// @brief Sets whether to remove tracked data caches on destruction or not.
+  /// @param removeCache if `true`, data caches will be removed on destruction
+  void setRemoveCachedProducts(bool removeCache);
+  
+  /**
+   * @brief Clears the cached data products for all tracked handles.
+   * @return the number of tracked handles which had their cache removed
+   * 
+   * This method calls `Event_t::removeCachedProduct()` for all tracked handles.
+   * This is the core functionality of the manager, which removes the cache
+   * of all tracked handles.
+   * 
+   * The _art_ framework always makes the handles used to remove the cache
+   * invalid (`Handle::clear()`).
+   * After the removal, the object stops tracking the handles (like with a call
+   * to `forgetAllHandles()`).
+   * 
+   * Calling this method when there are no handles registered has no effect.
+   */
+  unsigned int removeCachedProducts();
+  
+  /// Stops tracking any handle, without removing their cache first.
+  void forgetAllHandles();
+  
+  
+  /**
+   * @brief Completes the work on the associated `event`.
+   * @param removeCache (default: `true`) removes tracked data product caches
+   * @return the number of cleared data product caches
+   * @see `doneWithEvent()`
+   * 
+   * This is a shortcut for having optional release of cache in a single call,
+   * depending on the value of `removeCache`:
+   *  * if `true`, `removeCachedProducts()` is called and its count is returned;
+   *  * if `false`, `forgetAllHandles()` is called and `0` is returned.
+   * 
+   * Differently from `util::ArtHandleTrackerManager`, the object is _not_
+   * disassociated from the event: new handles can be registered and the
+   * clearing settings are preserved as they are.
+   * To be really done with the event, `setRemoveCachedProducts()` needs to be
+   * set to `false`, and users should refrain from calling
+   * `removeCachedProducts().
+   * 
+   * This method ignores and overrides the value set by
+   * `setRemoveCachedProducts()` and the one at construction.
+   */
+  unsigned int doneWithEvent(bool removeCache);
+  
+  
+  /**
+   * @brief Completes the work on the associated `event`.
+   * @return the number of cleared data product caches
+   * @see `doneWithEvent(bool)`, `setRemoveCachedProducts()`
+   * 
+   * This is a shortcut for having optional release of cache in a single call,
+   * depending on the value of `willRemoveCachedProducts()`:
+   *  * if `true`, `removeCachedProducts()` is called and its count is returned;
+   *  * if `false`, `forgetAllHandles()` is called and `0` is returned.
+   * 
+   * In addition, the object is disassociated from the event, and the object
+   * will not be available for use any more.
+   */
+  unsigned int doneWithEvent();
+  
+  /// @}
+  // --- END ---- Operations ---------------------------------------------------
+  
+}; // util::LocalArtHandleTrackerManager
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Interface to facilitate the use of `util::ArtHandleTracker`
+ *        specializations.
+ * 
+ * This is NOT able to return the type of handle it's handling.
+ * 
+ */
+template <typename Event>
+struct util::ArtHandleTrackerInterface {
+  
+  /// Virtual destructor (does nothing).
+  virtual ~ArtHandleTrackerInterface() = default;
+  
+  /// Removes the cached data product from `event`.
+  /// Handle is cleared and won't be valid any more.
+  bool removeCachedProduct() { return doRemoveCachedProduct(); }
+  
+  
+  /// Returns a container for a pointer to the managed handle. Caveat emptor.
+  std::any handlePtr() const { return doHandlePtr(); }
+  
+  /// Returns the name of the class of handled data product.
+  std::string productClass() const { return doProductClass(); }
+  
+  /// Returns the name of the class of handled data product.
+  std::type_info const* productType() const { return doProductType(); }
+  
+  /// Returns the tag of handled data product.
+  art::InputTag inputTag() const { return doInputTag(); }
+  
+  /// Returns whether this and the `other` objects handle the same data product.
+  bool hasSameDataProduct
+    (util::ArtHandleTrackerInterface<Event> const& other) const
+    {
+      return inputTag() == other.inputTag()
+        && productType() == other.productType();
+    }
+  
+    protected:
+  
+  /// Deferred implementation of `removeCachedProduct()`.
+  virtual bool doRemoveCachedProduct() = 0;
+  
+  /// Deferred implementation of `handlePtr()`.
+  virtual std::any doHandlePtr() const = 0;
+  
+  /// Deferred implementation of `productClass()`.
+  virtual std::string doProductClass() const = 0;
+  
+  /// Deferred implementation of `productType()`.
+  virtual std::type_info const* doProductType() const = 0;
+  
+  /// Deferred implementation of `inputTag()`.
+  virtual art::InputTag doInputTag() const = 0;
+  
+}; // ArtHandleTrackerInterface<>
+
+
+// -----------------------------------------------------------------------------
+// ---  Template implementation
+// -----------------------------------------------------------------------------
+// ---  util::details::ArtHandleTracker
+// -----------------------------------------------------------------------------
+namespace util::details {
+  template <typename Handle, typename Enable = void> class ProvenanceGetter;
+  template <typename T, typename Event> class ArtHandleTracker;
+  
+  /// use candy
+  template <typename Handle>
+  std::string productClassOf(Handle const& handle);
+  template <typename Handle>
+  std::type_info const* productTypeOf(Handle const& handle);
+  template <typename Handle>
+  art::InputTag inputTagOf(Handle const& handle);
+  
+} // namespace util::details
+
+// -----------------------------------------------------------------------------
+/// Helper to extract basic information from one handle.
+/// The default implementation supports `art::Handle` and `art::ValidHandle`.
+template <typename Handle, typename>
+class util::details::ProvenanceGetter {
+  
+  static art::Provenance const* provenance(Handle const& handle)
+    { return handle.provenance(); }
+  
+    public:
+  /// Returns the name of the class pointed by the handle.
+  static std::string productClass(Handle const& handle)
+    {
+      auto const* prov = provenance(handle);
+      return prov? prov->producedClassName(): "";
+    }
+  
+  /// Returns the C++ type of the handled data product.
+  static std::type_info const* productType()
+    { return &typeid(typename Handle::element_type); }
+  
+  /// Returns the C++ type of the handled data product.
+  static std::type_info const* productType(Handle const&)
+    { return productType(); }
+  
+  /// Returns the input tag of the handled data product.
+  /// Deferred implementation of `inputTag()`.
+  static art::InputTag inputTag(Handle const& handle)
+    {
+      auto const* prov = provenance(handle);
+      return prov? prov->inputTag(): art::InputTag{};
+    }
+  
+  
+}; // util::details::ProvenanceGetter
+
+
+template <typename Handle>
+std::string util::details::productClassOf(Handle const& handle)
+  { return ProvenanceGetter<Handle>::productClass(handle); }
+  
+template <typename Handle>
+std::type_info const* util::details::productTypeOf(Handle const& handle)
+  { return ProvenanceGetter<Handle>::productType(handle); }
+  
+template <typename Handle>
+art::InputTag util::details::inputTagOf(Handle const& handle)
+  { return ProvenanceGetter<Handle>::inputTag(handle); }
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Tracks _art_ handle objects.
+ * @tparam Handle type of handle being tracked
+ * 
+ * @note Due to my limited expertise with metaprogramming (and/or for C++
+ *       limitations?) I need one tracker per data type.
+ *       The `util::ArtHandleTrackerManager` class should mitigate the hassle
+ *       deriving from this limitation.
+ * 
+ */
+template <typename Event, typename Handle>
+class util::details::ArtHandleTracker: public ArtHandleTrackerInterface<Event> {
+  
+  Event const* fEvent = nullptr;
+  
+  Handle fHandle;
+  
+  // --- BEGIN -- Virtual method implementation --------------------------------
+  /// @name Virtual method implementation
+  /// @{
+  
+  /// Actually removes the cache.
+  virtual bool doRemoveCachedProduct() override
+    {
+      mf::LogDebug{ "ArtHandleTracker" } << "Removing cache for handle<"
+        << fHandle.provenance()->producedClassName()
+        << ">(" << fHandle.provenance()->inputTag().encode() << ").";
+      return fEvent->removeCachedProduct(fHandle);
+    }
+  
+  /// Returns a pointer to the managed handle, wrapped in `std::any`.
+  virtual std::any doHandlePtr() const override
+    { return { &handle() }; }
+  
+  /// Returns the name of the class pointed by the handle.
+  virtual std::string doProductClass() const override
+    { return productClassOf(fHandle); }
+  
+  /// Returns the C++ type of the handled data product.
+  virtual std::type_info const* doProductType() const override
+    { return ProvenanceGetter<Handle>::productType(); }
+  
+  /// Returns the input tag of the handled data product.
+  /// Deferred implementation of `inputTag()`.
+  virtual art::InputTag doInputTag() const override
+    { return inputTagOf(fHandle); }
+
+  /// @}
+  // --- END ---- Virtual method implementation --------------------------------
+  
+    public:
+  
+  /// Constructor: records all the needed information.
+  ArtHandleTracker(Event const& event, Handle handle)
+    : fEvent(&event), fHandle(std::move(handle)) {}
+  
+  /// Returns the tracked handle.
+  Handle const& handle() const { return fHandle; }
+  
+  /// Returns the provenance information of the handle.
+  art::Provenance const* provenance() const { return fHandle.provenance(); }
+  
+}; // util::details::ArtHandleTracker<>
+
+
+// -----------------------------------------------------------------------------
+// --- util::ArtHandleTrackerManager
+// -----------------------------------------------------------------------------
+template <typename Event>
+util::ArtHandleTrackerManager<Event>::ArtHandleTrackerManager
+  (Config_t config /* = {} */)
+  : fConfig{ std::move(config) }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+util::ArtHandleTrackerManager<Event>::ArtHandleTrackerManager
+  (Event_t const& event, Config_t config /* = {} */)
+  : fEvent{ &event }, fConfig{ std::move(config) }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+void util::ArtHandleTrackerManager<Event>::useEvent(Event_t const& event) {
+  
+  if (nTrackedHandles() > 0) {
+    // since fEvent might be invalid, we don't attempt to figure out which ID
+    // that event might have had
+    throw art::Exception{ art::errors::LogicError }
+      << "ArtHandleTrackerManager attempted to change event to "
+      << event.id() << " when " << nTrackedHandles()
+      << " handles are still tracked.\n";
+  }
+  
+  fEvent = &event;
+  
+} // util::ArtHandleTrackerManager<Event>::useEvent()
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename T, typename... Args>
+art::Handle<T> util::ArtHandleTrackerManager<Event>::getHandle
+  (Args&&... args)
+{
+  canOperate("getHandle()");
+  return registerHandle
+    (fEvent->template getHandle<T>(std::forward<Args>(args)...));
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename T, typename... Args>
+art::ValidHandle<T> util::ArtHandleTrackerManager<Event>::getValidHandle
+  (Args&&... args)
+{
+  canOperate("getValidHandle()");
+  return registerHandle
+    (fEvent->template getValidHandle<T>(std::forward<Args>(args)...));
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename Handle>
+auto util::ArtHandleTrackerManager<Event>::registerHandle
+  (Handle&& handle) -> decltype(auto)
+{
+  using util::details::ProvenanceGetter;
+  
+  using Handle_t = std::decay_t<Handle>;
+  
+  canOperate("registerHandle()");
+  
+  using Tracker_t = util::details::ArtHandleTracker<Event_t, Handle_t>;
+  
+  // if it's already registered, we don't want to have it again
+  if (auto ptr = findHandle(handle)) {
+    auto const& registeredHandle = *ptr;
+    mf::LogDebug msg { fConfig.logCategory };
+    msg
+      << "Handle<" << details::productClassOf(registeredHandle)
+      << ">(" << details::inputTagOf(registeredHandle).encode()
+      << ") was already registered";
+    if (typeid(registeredHandle) != typeid(Handle_t)) {
+      msg << " as a different handle type (" << typeid(registeredHandle).name()
+        << ", now " << typeid(Handle_t).name() << ")";
+    }
+    msg << ".";
+  }
+  else {
+    mf::LogDebug{ fConfig.logCategory }
+      << "Registering handle<" << details::productClassOf(handle)
+      << ">(" << details::inputTagOf(handle).encode()
+      << ") (handle type: " << typeid(Handle_t).name() << ")."
+      ;
+    
+    fTrackers.push_back(std::make_unique<Tracker_t>(*fEvent, handle));
+  }
+  
+  return std::forward<Handle>(handle);
+  
+} // util::ArtHandleTrackerManager<>::registerHandle()
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+unsigned int util::ArtHandleTrackerManager<Event>::nTrackedHandles() const
+  { return fTrackers.size(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+bool util::ArtHandleTrackerManager<Event>::hasEvent() const
+  { return fEvent; }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+unsigned int util::ArtHandleTrackerManager<Event>::removeCachedProducts() {
+  
+  // we remove cache in opposite order to registration: it's a C++ tradition.
+  unsigned int const nRemoved = std::count_if(
+    fTrackers.crbegin(), fTrackers.crend(),
+    [](auto const& tracker){ return tracker->removeCachedProduct(); }
+    );
+  
+  forgetAllHandles();
+  
+  return nRemoved;
+} // util::ArtHandleTrackerManager<Event>::removeCachedProducts()
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+void util::ArtHandleTrackerManager<Event>::forgetAllHandles()
+  { fTrackers.clear(); }
+
+  
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+unsigned int util::ArtHandleTrackerManager<Event>::doneWithEvent
+  (bool removeCache /* = true */, art::Event const* event /* = nullptr */)
+{
+  if (event && (fEvent != event)) return 0;
+  
+  unsigned int count = 0;
+  if (removeCache) count = removeCachedProducts();
+  else count = forgetAllHandles();
+  
+  fEvent = nullptr;
+  
+  return count;
+} // util::ArtHandleTrackerManager<Event>::doneWithEvent()
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename Handle>
+Handle const* util::ArtHandleTrackerManager<Event>::findHandle
+  (Handle const& like) const
+{
+  
+  // look for it, one by one
+  for (TrackerPtr const& tracker: fTrackers) {
+    
+    
+    
+    std::any anyHandlePtr = tracker->handlePtr();
+    Handle const** handlePtr = std::any_cast<Handle const*>(&anyHandlePtr);
+    if (!handlePtr) continue; // not the right type
+    
+    if ((*handlePtr)->provenance()->inputTag() != like.provenance()->inputTag())
+      continue; // different tag
+    
+    return *handlePtr;
+  } // for
+  
+  return nullptr; // failed
+  
+} // util::ArtHandleTrackerManager<Event>::findTracker()
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename Handle>
+bool util::ArtHandleTrackerManager<Event>::handleSameProduct
+  (TrackerPtr tracker, Handle const& handle)
+{
+  using util::details::ProvenanceGetter;
+  
+  if (!tracker) return false;
+  if (ProvenanceGetter<Handle>::productType() != tracker->productType())
+    return false;
+  if (ProvenanceGetter<Handle>::inputTag() != tracker->inputTag())
+    return false;
+  
+  return true;
+} // util::ArtHandleTrackerManager<>::handleSameProduct()
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+void util::ArtHandleTrackerManager<Event>::canOperate(const char* where) const {
+  
+  if (fEvent) return;
+  
+  throw art::Exception(art::errors::LogicError)
+    << "util::ArtHandleTrackerManager attempted an operation without a valid"
+      " event.\nThe operation was: " << where << "\n";
+  
+} // util::ArtHandleTrackerManager<Event>::canOperate()
+
+
+// -----------------------------------------------------------------------------
+// ---  util::LocalArtHandleTrackerManager
+// -----------------------------------------------------------------------------
+template <typename Event>
+util::LocalArtHandleTrackerManager<Event>::LocalArtHandleTrackerManager
+  (Event const& event, bool removeCache /* = true */)
+  : fManager{ event }, fRemoveCache{ removeCache }
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+util::LocalArtHandleTrackerManager<Event>::~LocalArtHandleTrackerManager()
+  { doneWithEvent(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+unsigned int util::LocalArtHandleTrackerManager<Event>::nTrackedHandles() const
+  {return fManager.nTrackedHandles(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+bool util::LocalArtHandleTrackerManager<Event>::willRemoveCachedProducts() const
+  { return fRemoveCache; }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename T, typename... Args>
+art::Handle<T> util::LocalArtHandleTrackerManager<Event>::getHandle
+  (Args&&... args)
+  { return fManager.template getHandle<T>(std::forward<Args>(args)...); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename T, typename... Args>
+art::ValidHandle<T> util::LocalArtHandleTrackerManager<Event>::getValidHandle
+  (Args&&... args)
+  { return fManager.template getValidHandle<T>(std::forward<Args>(args)...); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+template <typename Handle>
+auto util::LocalArtHandleTrackerManager<Event>::registerHandle
+  (Handle&& handle) -> decltype(auto)
+{
+  return fManager.template registerHandle<Handle>(std::forward<Handle>(handle)); 
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+void util::LocalArtHandleTrackerManager<Event>::setRemoveCachedProducts
+  (bool removeCache)
+  { fRemoveCache = removeCache; }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+unsigned int util::LocalArtHandleTrackerManager<Event>::removeCachedProducts()
+  { return fManager.removeCachedProducts(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+void util::LocalArtHandleTrackerManager<Event>::forgetAllHandles()
+  { return fManager.forgetAllHandles(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+unsigned int util::LocalArtHandleTrackerManager<Event>::doneWithEvent
+  (bool removeCache)
+{
+  assert(fManager.hasEvent());
+  
+  if (removeCache) return removeCachedProducts();
+  
+  forgetAllHandles();
+  return 0;
+} // util::LocalArtHandleTrackerManager<Event>::doneWithEvent()
+
+
+// -----------------------------------------------------------------------------
+template <typename Event>
+unsigned int util::LocalArtHandleTrackerManager<Event>::doneWithEvent()
+  { return doneWithEvent(willRemoveCachedProducts()); }
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCORE_UTILITIES_ARTHANDLETRACKERMANAGER_H

--- a/icaruscode/Utilities/StreamIndenter.h
+++ b/icaruscode/Utilities/StreamIndenter.h
@@ -1,0 +1,202 @@
+/**
+ * @file icaruscode/Utilities/StreamIndenter.h
+ * @brief Utility to have simple indentation in a stream.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date March 22, 2022
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_STREAMINDENTER_H
+#define ICARUSCODE_UTILITIES_STREAMINDENTER_H
+
+
+// C/C++ standard libraries
+#include <utility> // std::move(), std::forward()
+#include <sstream>
+#include <string>
+
+
+namespace util {
+  
+  /**
+   * @brief Stream modifier that makes it "indented".
+   * 
+   * The intended use of this class is to be "inserted" into an output stream
+   * object in order to gain a simple indentation:
+   *  * on the first insertion after this modifier, `firstIndent` will be used
+   *    to indent the stream;
+   *  * on the following insertions, `indent` will be used instead.
+   * 
+   * Example:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::cout << util::addIndent("> ", "") << "First line: not indented."
+   *   << "\nSecond line: indented by '> '."
+   *   << "\nThird line: indented by '> '."
+   *   ;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * 
+   * Technically, after the first insertion (`std::cout << addIndent(...)`)
+   * the returned object is not `std::cout` any more, but a wrapper around it
+   * which intercepts all the insertion operations (`operator<<`).
+   * 
+   * The wrapper is designed to steal the stream object if it is a temporary one
+   * (e.g. `std::ofstream{ "test.txt" } << addIndent("> ") << ...`) and to
+   * reference to it otherwise. Unless the wrapper object is somehow saved,
+   * it is destroyed (together with the stream if it was "stolen") as soon as
+   * the statement falls out of scope. Therefore, in this two-lines example:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::cout << util::addIndent("> ", "");
+   * std::cout << "First line: not indented."
+   *   << "\nSecond line: also not indented."
+   *   ;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * the first line does effectively nothing (the wrapper is created, ready to
+   * indent, but it is then immediately destroyed) while the second line
+   * performs normal `std::cout` output.
+   * 
+   * @note The "first line" is actually the first insertion into the wrapped
+   *       stream. For example,
+   *       `std::cout << "A!" << util::addIndent("> ", "$ ") << "First line.";`
+   *       will produce `A!$ First line.`.
+   * 
+   * 
+   * @note It is in principle possible to create modifiers with a special
+   *       behaviour to interact directly with the wrapper (for example, change
+   *       the indentation level or indentation string, reset to the first line
+   *       indentation, ...). Such modifiers are not implemented so far.
+   */
+  struct addIndent {
+    std::string firstIndent, indent;
+    
+    addIndent(std::string indent, std::string firstIndent)
+      : firstIndent{ std::move(firstIndent) }, indent{ std::move(indent) }
+      {}
+    addIndent(std::string const& indent)
+      : addIndent{ indent, indent } {}
+    
+  }; // addIndent
+  
+  
+  //@{
+  /**
+   * @brief Creates an indented stream wrapper.
+   * @tparam Stream the type of stream being wrapped
+   * @param out the stream to wrap
+   * @param indent string inserted at the beginning of each new line
+   * @param firstIndent string inserted at the beginning of the first line
+   * @return an indented stream wrapper
+   * @see `addIndent()`
+   * 
+   * The use of the wrapper stream is explained in `addIndent()`.
+   * 
+   * This function wraps a stream `out`, stealing it if it's a temporary,
+   * and returns the wrapping object. This object can be used for indented
+   * output to `out` until it is destroyed (if `out` is referenced as opposed
+   * to stolen, `out` itself needs to stay valid).
+   * 
+   * If not specified, `firstIndent` is assigned to be the same as `indent`.
+   * 
+   * The equivalent two-line example of `addIndent()` becomes:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * auto out = util::makeIndented(std::cout, "> ", "$ ");
+   * out << "First line: indented with '$ '."
+   *   << "\nSecond line: indented with '> '."
+   *   ;
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  template <typename Stream>
+  auto makeIndented(Stream&& out, std::string indent, std::string firstIndent);
+  
+  template <typename Stream>
+  auto makeIndented(Stream&& out, std::string const& indent);
+  //@}
+  
+  
+  /// Helper function for `addIndent` (@see `addIndent`).
+  template <typename Stream>
+  auto operator<< (Stream&& out, addIndent&& adder);
+  
+} // namespace util
+
+
+namespace util::details {
+
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Stream wapper.
+   */
+  template <typename Stream>
+  class IndentAdder {
+    
+    Stream&& fOut;
+    std::string const fFirstIndent;
+    std::string const fIndent;
+    
+    std::stringstream fSStr; // don't even try to be thread-safe
+    std::string const* fCurrentIndent { &fFirstIndent };
+    
+      public:
+    IndentAdder(Stream&& out, std::string indent, std::string firstIndent)
+      : fOut{ std::forward<Stream>(out) }
+      , fFirstIndent{ std::move(firstIndent) }, fIndent{ std::move(indent) }
+      {}
+    IndentAdder(Stream& out, std::string const& indent = "")
+      : IndentAdder{ std::forward<Stream>(out), indent, indent } {}
+    
+    template <typename T>
+    IndentAdder& operator<< (T&& value)
+      { fSStr << std::forward<T>(value); streamOut(); return *this; }
+    
+      private:
+    
+    void streamOut()
+      {
+        bool newLine = true;
+        char ch;
+        while(fSStr.get(ch)) {
+          if (newLine) { fOut << *fCurrentIndent; fCurrentIndent = &fIndent; }
+          fOut << ch;
+          newLine = (ch == '\n');
+        } // while
+        fSStr.clear();
+      }
+    
+  }; // class IndentAdder
+  
+  
+  // ---------------------------------------------------------------------------
+  
+} // namespace util::details
+
+
+// -----------------------------------------------------------------------------
+template <typename Stream>
+auto util::makeIndented
+  (Stream&& out, std::string indent, std::string firstIndent)
+{
+  return details::IndentAdder
+    { std::forward<Stream>(out), std::move(indent), std::move(firstIndent) };
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename Stream>
+auto util::makeIndented(Stream&& out, std::string const& indent)
+  { return makeIndented(out, indent, indent); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Stream>
+auto util::operator<< (Stream&& out, addIndent&& adder) {
+  return details::IndentAdder{
+    std::forward<Stream>(out),
+    std::move(adder.indent), std::move(adder.firstIndent)
+    };
+} // operator<< (Stream, addIndent)
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_UTILITIES_STREAMINDENTER_H


### PR DESCRIPTION
The most noticeable features of this pull request are:

1. Some helper for deleting from memory data products that _art_ had read from the input file (the ones produced in the current job don't abide); they are used in the TPC and PMT decoding to delete from memory the DAQ data fragments immediately after decoding; this should decrease by some hundred MB the amount of memory required by the job¹.
2. A `TriggerDumper` module (and a standard ICARUS job configuration) printing on screen the decoded information of the hardware trigger. This module requires as input an already decoded set of trigger data products.

This is part of a private branch with a lot of other commits. The branch itself was extensively used with data production-like jobs and I consider it well tested. The changed in this pull request are also involved in those jobs, but they have not been tested standalone.

--- 

¹ Unfortunately the CRT decoder uses a reading pattern that loads all data fragments anyway. I have discussed with @aaduszki and @wesketchum on how to proceed to avoid that, but I haven't implemented that change yet.
