### PR TITLE
Memory footprint improvements related to CRT decoding

### DIFF
--- a/icaruscode/CRT/CRTDecoder/CMakeLists.txt
+++ b/icaruscode/CRT/CRTDecoder/CMakeLists.txt
@@ -170,6 +170,7 @@ simple_plugin( CRTEventProducer "module"
 )
 
 simple_plugin( DecoderICARUSCRT "module"
+  icaruscode_Utilities
   art_Framework_Services_Registry
   art_root_io_tfile_support
   art_root_io_TFileService_service

--- a/icaruscode/CRT/CRTDecoder/DecoderICARUSCRT_module.cc
+++ b/icaruscode/CRT/CRTDecoder/DecoderICARUSCRT_module.cc
@@ -30,6 +30,7 @@
 #include "sbndaq-artdaq-core/Overlays/FragmentType.hh"
 #include "sbndaq-artdaq-core/Overlays/Common/BernCRTTranslator.hh"
 
+#include "icaruscode/Utilities/ArtDataProductSelectors.h"
 #include "icaruscode/Decode/DecoderTools/IDecoder.h"
 #include "icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h"
 
@@ -51,6 +52,7 @@
 #include <iostream>
 #include<stdlib.h>
 #include <map>
+
 
 namespace crt {
   class DecoderICARUSCRT;
@@ -79,7 +81,10 @@ private:
 
   // Declare member data here.
   const icarusDB::IICARUSChannelMap* fChannelMap = nullptr;
-
+  
+  /// Selector object detecting all the suitable data products.
+  util::RegexDataProductSelector const fInputTagPatterns;
+  
   std::map<uint8_t, int32_t> FEB_delay_side; //<mac5, delay in ns>
   std::map<uint8_t, int32_t> FEB_delay_top;  //<mac5, delay in ns>
 };
@@ -87,9 +92,17 @@ private:
 
 crt::DecoderICARUSCRT::DecoderICARUSCRT(fhicl::ParameterSet const& p)
   : EDProducer{p}
+  , fInputTagPatterns{
+    util::RegexDataProductSelector::makePatterns(p.get(
+      "FragmentTagPatterns",
+      std::vector<std::string>{ "daq:(Container)?BERNCRT.*" }
+      ))
+    }
 {
   fChannelMap = art::ServiceHandle<icarusDB::IICARUSChannelMap const>{}.get();
   produces< std::vector<icarus::crt::CRTData> >();
+  
+  mayConsumeMany<artdaq::Fragments>();
 
   {
     std::vector<std::vector<int32_t> > delays =  p.get<std::vector<std::vector<int32_t> > >("FEB_delay_side");
@@ -156,11 +169,21 @@ uint64_t crt::DecoderICARUSCRT::CalculateTimestamp(icarus::crt::BernCRTTranslato
 void crt::DecoderICARUSCRT::produce(art::Event& evt)
 {
 
+  std::vector<art::Handle<artdaq::Fragments>> fragmentHandles
+     = evt.getMany<artdaq::Fragments>(fInputTagPatterns);
+  
+  {
+    mf::LogDebug log { "DecoderICARUSCRT" };
+    log << "Found " << fragmentHandles.size()
+      << " CRT fragment data product candidates:";
+    for (auto const& handle: fragmentHandles)
+      log << "\n - '" << handle.provenance()->inputTag().encode() << '"';
+  }
+  
   std::vector<icarus::crt::BernCRTTranslator> hit_vector;
 
-  auto fragmentHandles = evt.getMany<artdaq::Fragments>();
-  for (auto  handle : fragmentHandles) {
-    if (!handle.isValid() || handle->size() == 0)
+  for (auto const& handle : fragmentHandles) {
+    if (!handle.isValid() || handle->empty())
       continue;
 
     auto this_hit_vector = icarus::crt::BernCRTTranslator::getCRTData(*handle);

--- a/icaruscode/Utilities/ArtDataProductSelectors.cxx
+++ b/icaruscode/Utilities/ArtDataProductSelectors.cxx
@@ -1,0 +1,81 @@
+/**
+ * @file   icaruscode/Utilities/ArtDataProductSelectors.cxx
+ * @brief  Helpers to pass to `art::Event::getMany()` and similar (implement.).
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 30, 2022
+ * @see    icaruscode/Utilities/ArtDataProductSelectors.h
+ */
+
+// library header
+#include "icaruscode/Utilities/ArtDataProductSelectors.h"
+
+// framework libraries
+#include "canvas/Persistency/Provenance/BranchDescription.h"
+#include "canvas/Utilities/InputTag.h"
+
+// C/C++ standard libraries
+#include <regex>
+#include <string>
+#include <utility> // std::move()
+
+
+// -----------------------------------------------------------------------------
+util::RegexDataProductSelector::RegexDataProductSelector
+  (std::vector<ProductRegex> patterns)
+  : fPatterns(std::move(patterns))
+{}
+
+
+// -----------------------------------------------------------------------------
+auto util::RegexDataProductSelector::makePattern
+  (art::InputTag const& spec) -> ProductRegex
+{
+  
+  auto const regexIfNotEmpty = [](std::string const& ptn)
+    { return ptn.empty()? std::nullopt: std::optional{ std::regex{ ptn }}; };
+  
+  return {
+      regexIfNotEmpty(spec.process())   // process
+    , regexIfNotEmpty(spec.label())     // module
+    , regexIfNotEmpty(spec.instance())  // instance
+    };
+  
+} // util::RegexDataProductSelector::makePattern()
+
+
+// -----------------------------------------------------------------------------
+bool util::RegexDataProductSelector::doMatch
+  (art::BranchDescription const& brDescr) const
+{
+  art::InputTag const& tag = brDescr.inputTag();
+  for (ProductRegex const& pattern: fPatterns)
+    if (matchPattern(tag, pattern)) return true;
+  return false;
+} // util::RegexDataProductSelector::doMatch()
+
+
+// -----------------------------------------------------------------------------
+std::string util::RegexDataProductSelector::doPrint
+  (std::string const& indent) const
+{
+  return indent
+    + "any of " + std::to_string(fPatterns.size()) + " patterns";
+} // util::RegexDataProductSelector::doPrint()
+
+
+// -----------------------------------------------------------------------------
+bool util::RegexDataProductSelector::matchPattern
+  (art::InputTag const& tag, ProductRegex const& ptn) const
+{
+  if (ptn.process  && !std::regex_match(tag.process(),  *(ptn.process) ))
+    return false;
+  if (ptn.module   && !std::regex_match(tag.label(),    *(ptn.module)  ))
+    return false;
+  if (ptn.instance && !std::regex_match(tag.instance(), *(ptn.instance)))
+    return false;
+  return true;
+} // util::RegexDataProductSelector::matchPattern()
+
+
+// -----------------------------------------------------------------------------
+

--- a/icaruscode/Utilities/ArtDataProductSelectors.h
+++ b/icaruscode/Utilities/ArtDataProductSelectors.h
@@ -1,0 +1,120 @@
+/**
+ * @file   icaruscode/Utilities/ArtDataProductSelectors.h
+ * @brief  Helpers to pass to `art::Event::getMany()` and similar.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 30, 2022
+ */
+
+#ifndef ICARUSCODE_UTILITIES_ARTDATAPRODUCTSELECTORS_H
+#define ICARUSCODE_UTILITIES_ARTDATAPRODUCTSELECTORS_H
+
+// framework libraries
+#include "art/Framework/Principal/SelectorBase.h"
+
+// C/C++ standard libraries
+#include <regex>
+#include <vector>
+#include <optional>
+
+
+// -----------------------------------------------------------------------------
+namespace art { class InputTag; class BranchDescription; }
+
+// -----------------------------------------------------------------------------
+namespace util { class RegexDataProductSelector; }
+/**
+ * @brief Matches products by regex on process, module label and instance name.
+ * 
+ * A pattern is matched if all specified subpatterns (process, module, instance)
+ * match. Any component of the pattern may be unspecified.
+ * A product is selected if it matches any of the configured patterns.
+ * 
+ * Patterns are matched with `std::regex_match()`, i.e. the whole string must
+ * match.
+ * 
+ * The patterns may be created from one or a sequence of input-tag-like objects
+ * using `makePattern()` and `makePatterns()` static functions, respectively.
+ */
+class util::RegexDataProductSelector: public art::SelectorBase {
+    public:
+  
+  /// A pattern on a input tag (empty matches everything).
+  struct ProductRegex {
+    std::optional<std::regex> process;
+    std::optional<std::regex> module;
+    std::optional<std::regex> instance;
+  };
+  
+  /// Initializes the selector with all the supported patterns.
+  RegexDataProductSelector(std::vector<ProductRegex> patterns);
+  
+  
+  /**
+   * @brief Parses a input tag to create a single data product pattern.
+   * @param spec pattern specification
+   * @return a pattern object
+   * 
+   * A specification is in the form of an `art::InputTag`, but each element
+   * is a regex pattern rather than a standard name.
+   * 
+   * If the input tag is created from a string, in the usual form
+   * `<processName>:<moduleLabel>:<instanceName>` (with the usual omissions),
+   * each element can't contain a `:` character (no escaping is supported).
+   * 
+   * An empty `tag` matches everything.
+   */
+  static ProductRegex makePattern(art::InputTag const& spec);
+  
+  
+  /**
+   * @brief Parses a sequence of input tags to create data product patterns.
+   * @tparam SpecColl type of collection of specifications
+   * @param specs sequence of pattern specifications
+   * @return a sequence of pattern objects, one per input specification
+   * 
+   * Each specification in `specs` is converted into a pattern via
+   * `makePattern()`. The specification is explicitly converted into an input
+   * tag.
+   */
+  template <typename SpecColl>
+  static std::vector<ProductRegex> makePatterns(SpecColl const& specs);
+  
+    private:
+  
+  std::vector<ProductRegex> fPatterns; ///< All the selection patterns.
+  
+  
+  /// Returns whether data product described by `brDescr` matches.
+  virtual bool doMatch(art::BranchDescription const& brDescr) const override;
+  
+  /// Part of the message used when no data product matches.
+  virtual std::string doPrint(std::string const& indent) const override;
+  
+  
+  /// Returns whether the input `tag` matches the pattern `ptn`.
+  bool matchPattern(art::InputTag const& tag, ProductRegex const& ptn) const;
+  
+}; // class util::RegexDataProductSelector
+
+
+
+// -----------------------------------------------------------------------------
+// ---  Template implementation
+// -----------------------------------------------------------------------------
+template <typename SpecColl>
+auto util::RegexDataProductSelector::makePatterns
+  (SpecColl const& specs) -> std::vector<ProductRegex>
+{
+  using std::size;
+  std::vector<ProductRegex> ptns;
+  ptns.reserve(size(specs));
+  for (auto const& spec: specs)
+    ptns.push_back(makePattern(art::InputTag{ spec }));
+  return ptns;
+} // util::RegexDataProductSelector::makePatterns()
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_UTILITIES_ARTDATAPRODUCTSELECTORS_H

--- a/icaruscode/Utilities/CMakeLists.txt
+++ b/icaruscode/Utilities/CMakeLists.txt
@@ -7,6 +7,7 @@ art_make(
     "DuplicateEventTracker_service.cc"
   LIB_LIBRARIES
     ${ART_ROOT_IO_ROOTDB}
+    canvas::canvas
     SQLite::SQLite3
     cetlib_except
     cetlib


### PR DESCRIPTION
These two commits are intended to reduce the memory footprint of Stage0 job.
1. The first commit uses a "selector" to decide which data products to look for CRT data, instead of trying all of them. The previous pattern loaded all the artDAQ fragment in memory instead. The net effect of this alone is a dramatic speed up in jobs decoding only CRT data, but little to no gain is expected by full Stage0 jobs, where most data will be loaded by the other decoders anyway.
2. The second commit enables dropping the data products (CRT data fragments) from the memory after use. This is a feature _art_ provides on demand (and currently only for data products from the _input file_), and since nothing else is ever expected to use this CRT data, no reload will follow. This is also not particularly relevant in terms of memory gain, since CRT data is not that large. But it's easy to add.

So, the real deal is actually somewhere else: with the first commit, the CRT decoder avoids reloading the TPC and PMT data fragments after their respective decoders have dropped them (in the same way as the second commit here, since pull request #433). So the interplay of this first commit with the rest of the Stage0 workflow is what is supposed to buy us some memory footprint reduction.
A test with `stage0_run1_icarus.fcl` on 5 events of run `8650` showed a decrease in memory of 1 GB compared to disabling all the data product dropping. No way I am going to trust this figure. But I am selling it anyway.

This commit is supposed not to change anything in the output.

Reviewers:
* @aaduszki and I discussed about the possible approaches to be taken here, and he is the maintainer of the decoder.
* @SFBayLaser as workflow manager, for backup.
