### PR TITLE
Use corrected trigger time in trigger decoding

### DIFF
--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -688,7 +688,7 @@ namespace daq
     // absolute time trigger (raw::ExternalTrigger)
     //
     fTrigger->emplace_back
-      (fTriggerExtra->triggerID, artdaq_ts);//fTriggerExtra->triggerTimestamp);
+      (fTriggerExtra->triggerID, fTriggerExtra->triggerTimestamp);
     
     //
     // previous absolute time trigger (raw::ExternalTrigger)


### PR DESCRIPTION
This is an explicit way to address `icaruscode` issue #197.

The background as I understand it: the trigger decoder in `icaruscode` needs its timestamps in UTC; the hardware stamps in [TAI](https://en.wikipedia.org/wiki/International_Atomic_Time); their difference is some number of whole seconds.
The trigger decoder needs to correct all the timestamps from the hardware into UTC. Rather than doing the correction by itself, it acquires the corrected value from the online code (`icarus::ICARUSTriggerInfo::getNanoseconds_since_UTC_epoch()`) and it gets the correction offset by comparing it to the uncorrected timestamp; then it applies that correction offset to all timestamps it deals with.
Unfortunately the method `icarus::ICARUSTriggerInfo::getNanoseconds_since_UTC_epoch()` was affected by a bug (rounding error), so the trigger decoder needed to find a different way to do the correction. First, it did it locally, and at the same time issue #197 was opened.
Then, it moved to use the timestamp of the fragment, that the online code reset to match with the trigger time in UTC.

We may either choose to keep that way, relying on the convention by the online code, or to use now amended `icarus::ICARUSTriggerInfo::getNanoseconds_since_UTC_epoch()` as it originally was done.
Both are valid solutions, both do not charge the decoder with concocting the correction. 
This pull request implements the second option. The code currently in `develop` is an implementation of the first one.
The disadvantage of the fragment timestamp is that it relies on a convention that might in principle change. The disadvantage of using `icarus::ICARUSTriggerInfo::getNanoseconds_since_UTC_epoch()` is that the correction is computed a second time and it might differ from the one used in the online if different versions of the code are used; this may also be an advantage in case it is found that the online code applied the correction in a wrong way.

@jzettle is the author of both the board reader code and the trigger decoder; I am asking him to:
* review this change for correctness
* express his preference on which way to stick to

In case he chooses the way in this pull request, issue #197 should be closed as soon as this one is merged. If he prefers the way it is now, this pull request should be closed without merging, and issue #197 should be closed immediately.
