### PR TITLE
Random seed policy moved back to per-event

### DIFF
--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -19,7 +19,6 @@ services:
   @table::icarus_wirecalibration_minimum_services
 
   SpaceChargeService: @local::icarus_spacecharge
-  NuRandomService: @local::per_event_NuRandomService
 }
 
 

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -2,7 +2,6 @@
 #include "channelmapping_icarus.fcl"
 
 #include "correctionservices_icarus.fcl"
-#include "seedservice.fcl"
 
 #include "cafmaker_defs.fcl"
 
@@ -10,10 +9,9 @@ process_name: CAFmaker
 
 services:
 {
-  @table::icarus_wirecalibration_minimum_services
+  @table::icarus_wirecalibration_services
 
   SpaceChargeService: @local::icarus_spacecharge
-  NuRandomService: @local::per_event_NuRandomService
 }
 
 physics:

--- a/fcl/gen/background/prodbackground_Ar39_icarus.fcl
+++ b/fcl/gen/background/prodbackground_Ar39_icarus.fcl
@@ -21,7 +21,6 @@ process_name: BackgroundGen
 services: {
   
                    @table::icarus_common_services # from services_common_icarus.fcl
-  NuRandomService: @local::per_event_NuRandomService  
   
 } # services
 

--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
@@ -45,7 +45,6 @@ services:
   #FileCatalogMetadata:  @local::art_file_catalog_mc
   @table::icarus_gen_services
   @table::icarus_g4_services 
-  NuRandomService: @local::random_NuRandomService
 }
 
 #Start each new event with an empty event.

--- a/fcl/gen/cosmics/simulation_cosmics_icarus_common.fcl
+++ b/fcl/gen/cosmics/simulation_cosmics_icarus_common.fcl
@@ -17,7 +17,7 @@ services:
   TFileService: { fileName: "simulation_cosmics_icarus.root" }
   #FileCatalogMetadata:  @local::art_file_catalog_mc
   @table::icarus_gen_services
-  NuRandomService: @local::per_event_NuRandomService
+  NuRandomService: @local::icarus_default_NuRandomService
 }
 
 services.Geometry.SurfaceY:  560 # This value has been introduced because at the moment using 690 cry provides an error... maybe related to Geometry.. to be fixed!

--- a/fcl/gen/mevprtl/higgs/dissonant_higgs_gen.fcl
+++ b/fcl/gen/mevprtl/higgs/dissonant_higgs_gen.fcl
@@ -51,5 +51,4 @@ outputs: {
 
 }
 
-services.NuRandomService.policy: "random"
 outputs.out.fileName: "simulation_higgs_icarus_numi_%tc-%p.root"

--- a/fcl/gen/mevprtl/higgs/dissonant_higgs_tree_icarus.fcl
+++ b/fcl/gen/mevprtl/higgs/dissonant_higgs_tree_icarus.fcl
@@ -32,4 +32,3 @@ physics:
 
 physics.producers.disshiggs.RayTrace: @local::wgtraytrace
 
-services.NuRandomService.policy: "random"

--- a/fcl/gen/mevprtl/hnl/hnl_icarus_gen.fcl
+++ b/fcl/gen/mevprtl/hnl/hnl_icarus_gen.fcl
@@ -51,4 +51,3 @@ outputs: {
 
 }
 
-services.NuRandomService.policy: "random"

--- a/fcl/gen/mevprtl/hnl/hnl_testray_icarus.fcl
+++ b/fcl/gen/mevprtl/hnl/hnl_testray_icarus.fcl
@@ -32,4 +32,3 @@ physics:
   
 } # physics
 
-services.NuRandomService.policy: "random"

--- a/fcl/gen/mevprtl/hnl/hnl_tree_icarus.fcl
+++ b/fcl/gen/mevprtl/hnl/hnl_tree_icarus.fcl
@@ -32,4 +32,3 @@ physics:
 
 phyiscs.producers.hnl.RayTrace: @local::wgtraytrace
 
-services.NuRandomService.policy: "random"

--- a/fcl/gen/single/prodsingle_common_icarus.fcl
+++ b/fcl/gen/single/prodsingle_common_icarus.fcl
@@ -9,7 +9,7 @@ services:
   TFileService: { fileName: "Supplemental-prodsingle_common_icarus_%tc-%p.root" }
   #FileCatalogMetadata:  @local::art_file_catalog_mc
   @table::icarus_gen_services
-  NuRandomService: @local::per_event_NuRandomService
+  NuRandomService: @local::icarus_default_NuRandomService
 }
 
 #Start each new event with an empty event.

--- a/fcl/services/seedservice_icarus.fcl
+++ b/fcl/services/seedservice_icarus.fcl
@@ -1,0 +1,60 @@
+#
+# File:    seedservice_icarus.fcl
+# Purpose: preset configurations for random number generator seeds in ICARUS.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    September 9, 2022
+#
+# A "standard" configuration for ICARUS random number generators is defined:
+#     
+#     services.NuRandomService: @local::icarus_default_NuRandomService
+#     
+# includes it in a job configuration.
+#
+# This configuration file includes all the presets from LArSoft, and it adds
+# one with per-event seed policy but with a fallback policy as described in
+# LArSoft Redmine issue #26116 and icaruscode issues #243.
+# 
+# This configuration should be good enough for all applications.
+#
+
+#include "seedservice.fcl"
+
+BEGIN_PROLOG
+#-------------------------------------------------------------------------------
+
+## # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Per-event with random fallback
+#
+# This policy guarantees reproducibility for all random numbers used while
+# processing an event, just like the perEvent policy does.
+# In addition, it explicitly assigns an unreproducible random number sequence
+# for use before the first event is encountered (as for example in a generator
+# randomly selecting before the job starts which pools to extract pre-generated
+# events from, like the CORSIKA implementation in LArSoft does).
+# 
+# In practice, there may be some way to reproduce also the "unreproducible"
+# random sequence by setting the master seed to the value printed by the job;
+# although the success of this process also depends on providing the exact input
+# data file sequence to the job, which can't be guaranteed when SAM is feeding
+# the input.
+#
+per_event_with_random_fallback_NuRandomService: {
+  
+  @table::per_event_NuRandomService
+  
+  initSeedPolicy: { policy: "random" }
+  
+} # per_event_with_random_fallback_NuRandomService
+
+
+## # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# ICARUS "default" seed configuration
+#
+# If there are no specific needs, this is the configuration that should be used.
+#
+
+icarus_default_NuRandomService: @local::per_event_with_random_fallback_NuRandomService
+
+
+#-------------------------------------------------------------------------------
+END_PROLOG

--- a/fcl/services/services_common_icarus.fcl
+++ b/fcl/services/services_common_icarus.fcl
@@ -38,7 +38,7 @@
 #
 #
 
-#include "seedservice.fcl"
+#include "seedservice_icarus.fcl"
 #include "magfield_larsoft.fcl"
 
 #include "services_basic_icarus.fcl"
@@ -95,7 +95,7 @@ icarus_art_services: {
 icarus_random_services:
 {
     RandomNumberGenerator:               {}
-    NuRandomService:                     @local::random_NuRandomService
+    NuRandomService:                     @local::icarus_default_NuRandomService  # seedservice_icarus.fcl
 
 } # icarus_random_services
 
@@ -168,7 +168,6 @@ icarus_wirecalibration_services: {
                      @table::icarus_wirecalibration_minimum_services
 
                      @table::icarus_random_services
-    NuRandomService: @local::per_event_NuRandomService
 
 } # icarus_wirecalibration_services
 

--- a/fcl/services/services_icarus_simulation.fcl
+++ b/fcl/services/services_icarus_simulation.fcl
@@ -59,8 +59,6 @@ icarus_simulation_basic_services: {
   
                                            @table::icarus_common_services
 
-    NuRandomService:                       @local::per_event_NuRandomService
-
     LArG4Parameters:                       @local::icarus_largeantparameters
     LArVoxelCalculator:                    @local::icarus_larvoxelcalculator
     SpaceChargeService:                    @local::icarus_spacecharge


### PR DESCRIPTION
The policy now uses `random` as fallback policy for per-event seeds.

This addresses issue #243.

The background: LArSoft provides a policy for providing seeds to the random number generators which ensures that the same event will always receive the same seeds, guaranteeing job reproducibility. Unfortunately that policy does not define what happens when seeds are required outside the event boundaries; a typical case is the LArSoft implementation of CORSIKA interface, `CORSIKAGen`, which _at beginning of the job_ decides randomly which pool of pre-generated events to use in the job. This choice happens at a time when no event is being processed (no input file, in fact, has been opened yet). The undefined behaviour of the per-event policy was in fact to always use `0` as a seed, which would cause the same pool of cosmic ray events to be used for every job.

While LArSoft offers no real solution to this issue, it now provide a workaround in allowing to control which seeds are provided at that time. My choice here is to use a `random` policy, which does not guarantee reproducibility (e.g. rerunning a job on a certain input will pick a different CORSIKA event pool) but at least behaves as a random generator.

This pull request defines this new configuration, defines also an alias `icarus_default_NuRandomService` supposed to define the "default" random seed service configuration for ICARUS, and then it uses the latter wherever there is the need to configure that service.

This may be a breaking change for the simulation, since different random streams may be generated for some of the modules, but it will likely not be noticed by the integration tests, which fix the random seeds overriding the standard configuration settings.

This pull request has been tested running the unit tests, a `prodcorsika_genie_standard_icarus.fcl` job, a `standard_g4_icarus.fcl` job and a `standard_detsim_icarus.fcl` job.
