### PR TITLE
Decoder now updates trigger type (minimum bias, majority)

### DIFF
--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -92,6 +92,8 @@ namespace daq
    *         `sbn::triggerSource` (equivalent to `raw::Trigger::TriggerBits()`,
    *         but in the form of an enumerator rather than a bit mask).
    *         Also called gate type.
+   *     * `triggerType`: the type of trigger logic applied, a value from
+   *         `sbn::triggerType`, e.g. minimum bias or majority.
    *     * `triggerTimestamp`: same as `raw::ExternalTrigger::GetTrigTime()`
    *         (nanoseconds from the Epoch, Coordinated Universal Time).
    *     * `beamGateTimestamp`: absolute time of the beam gate opening as
@@ -596,6 +598,7 @@ namespace daq
     } // switch gate type
     
     fTriggerExtra->sourceType = beamGateBit;
+    fTriggerExtra->triggerType = static_cast<sbn::triggerType>(datastream_info.trigger_type);
     fTriggerExtra->triggerTimestamp = artdaq_ts;
     fTriggerExtra->beamGateTimestamp = beamgate_ts;
     fTriggerExtra->enableGateTimestamp = enablegate_ts;


### PR DESCRIPTION
The field of `sbn::ExtraTriggerInfo` in charge of recording which type of trigger logic is applied (minimum bias, majority) is now correctly set from the decoded information.
Plain and simple, this bit had escaped us.

The PMT decoder tree now also stores that information.

We might also consider to set a bit in `raw::Trigger` with whether the trigger is minimum bias or not... but that is not for this time.