### PR TITLE
Updates to trigger efficiency branch

### DIFF
--- a/fcl/detsim/standard_detsim_icarus.fcl
+++ b/fcl/detsim/standard_detsim_icarus.fcl
@@ -55,7 +55,7 @@ physics:
     
     
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    opdaq:  @local::icarus_simpmt_nonoise # turn off the noise so it runs more quickly
+    opdaq:  @local::icarus_simpmt
     
     
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -92,6 +92,8 @@ namespace daq
    *         `sbn::triggerSource` (equivalent to `raw::Trigger::TriggerBits()`,
    *         but in the form of an enumerator rather than a bit mask).
    *         Also called gate type.
+   *     * `triggerType`: the type of trigger logic applied, a value from
+   *         `sbn::triggerType`, e.g. minimum bias or majority.
    *     * `triggerTimestamp`: same as `raw::ExternalTrigger::GetTrigTime()`
    *         (nanoseconds from the Epoch, Coordinated Universal Time).
    *     * `beamGateTimestamp`: absolute time of the beam gate opening as
@@ -596,6 +598,7 @@ namespace daq
     } // switch gate type
     
     fTriggerExtra->sourceType = beamGateBit;
+    fTriggerExtra->triggerType = static_cast<sbn::triggerType>(datastream_info.trigger_type);
     fTriggerExtra->triggerTimestamp = artdaq_ts;
     fTriggerExtra->beamGateTimestamp = beamgate_ts;
     fTriggerExtra->enableGateTimestamp = enablegate_ts;

--- a/icaruscode/Decode/fcl/stage0_multiTPC_icarus_MC.fcl
+++ b/icaruscode/Decode/fcl/stage0_multiTPC_icarus_MC.fcl
@@ -32,7 +32,8 @@ outputs.outBNB.dataTier: "reconstructed"
 outputs.outBNB.outputCommands: ["keep *_*_*_*", "drop *_MCDecodeTPCROI_*_*", "drop *_decon1droi_*_*","drop raw::RawDigits_*_*_*" ]
 
 # Set the expected input for ophit
-physics.producers.ophit.InputModule: "opdaq"
+physics.producers.ophit:     @local::icarus_ophit_MC
+physics.producers.ophitfull: @local::icarus_ophitdebugger_MC
 
 # Set up for the single module mutliple TPC mode...
 physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq3:PHYSCRATEDATATPCWW","daq2:PHYSCRATEDATATPCWE","daq1:PHYSCRATEDATATPCEW","daq0:PHYSCRATEDATATPCEE"]

--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -49,7 +49,7 @@ BEGIN_PROLOG
 
 icarus_settings_opdet: {
   
-  nominalPMTgain: 7.0e6  # PMT multiplication gain factor
+  nominalPMTgain: 9.7e6  # PMT multiplication gain factor
   
 } # icarus_settings_opdet
 
@@ -158,7 +158,7 @@ icarus_photoelectronresponse_customexample: {
 #
 # pick one
 #
-icarus_photoelectronresponse_standard: @local::icarus_photoelectronresponse_exponentials
+icarus_photoelectronresponse_standard: @local::icarus_photoelectronresponse_202202
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -331,7 +331,7 @@ icarus_pmtsimulationalg_2018_nonoise: {
 #
 # Includes noise.
 #
-icarus_pmtsimulationalg_standard: @local::icarus_pmtsimulationalg_2018_nonoise
+icarus_pmtsimulationalg_standard: @local::icarus_pmtsimulationalg_202202
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/icaruscode/PMT/CMakeLists.txt
+++ b/icaruscode/PMT/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(Trigger)
 
 simple_plugin(SimPMTIcarus "module"
   icaruscode_PMT_Algorithms
+  icaruscode_Utilities
   lardataobj_RawData
   lardataobj_Simulation
   nurandom_RandomUtils_NuRandomService_service

--- a/icaruscode/PMT/OpReco/fcl/icarus_flashcalib.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_flashcalib.fcl
@@ -27,7 +27,7 @@ icarus_pmt_calibration.Calib202203: {
 
 
 # ------------------------------------------------------------------------------
-icarus_pmt_calibration.CalibStandard: @local::icarus_pmt_calibration.Calib202203
+icarus_pmt_calibration.CalibStandard: @local::icarus_pmt_calibration.NoCalib
 
 
 

--- a/icaruscode/PMT/OpReco/fcl/icarus_ophitfinder.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_ophitfinder.fcl
@@ -147,7 +147,7 @@ icarus_ophit: # some basic configuration
    UseStartTime:   true  # record pulse start time rather than peak (max) time
    reco_man:       @local::standard_preco_manager
    HitAlgoPset:    @local::icarus_opreco_hit_slidingwindow_201910
-   PedAlgoPset:    @local::icarus_opreco_pedestal_MC_DocDB24969
+   PedAlgoPset:    @local::icarus_opreco_pedestal_DocDB24969
 }
 
 icarus_ophitdebugger: @local::icarus_ophit
@@ -158,6 +158,7 @@ icarus_ophitdebugger.OutputFile:  "ophit_debug.root"
 # this is the "standard" ICARUS configuration for MC optical hit reconstruction:
 icarus_ophit_MC: {
   @table::icarus_ophit
+  PedAlgoPset:    @local::icarus_opreco_pedestal_MC_DocDB24969
   InputModule: "opdaq"
 }
 

--- a/icaruscode/PMT/OpReco/fcl/icarus_spe.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_spe.fcl
@@ -13,6 +13,6 @@ SPE202202: {  # amplitude set to 4 mV, gain 9.7x10^6 with R = 50 ohm
   Shift: 0.
 }
 
-SPE: @local::SPEorig
+SPE: @local::SPE202202
 
 END_PROLOG

--- a/icaruscode/TPC/Simulation/DetSim/CMakeLists.txt
+++ b/icaruscode/TPC/Simulation/DetSim/CMakeLists.txt
@@ -12,7 +12,7 @@ art_make(
                            larevt_Filters
                            lardataobj_RawData
                            icaruscode_TPC_Utilities_SignalShapingICARUSService_service
-		           larevt_CalibrationDBI_Providers
+                           larevt_CalibrationDBI_Providers
                            nurandom_RandomUtils_NuRandomService_service
                            ${ART_FRAMEWORK_CORE}
                            ${ART_FRAMEWORK_PRINCIPAL}
@@ -23,7 +23,7 @@ art_make(
                            art_Persistency_Common
                            art_Persistency_Provenance
                            art_Utilities
-			   canvas
+                           canvas
                            ${MF_MESSAGELOGGER}
                            ${MF_UTILITIES}
                            ${FHICLCPP}
@@ -36,6 +36,7 @@ art_make(
         )
 
 simple_plugin(SimWireICARUS "module"
+                           icaruscode_Utilities
                            larcorealg_Geometry
                            larcore_Geometry_Geometry_service
                            larsim_Simulation 
@@ -56,7 +57,7 @@ simple_plugin(SimWireICARUS "module"
                            art_Persistency_Common
                            art_Persistency_Provenance
                            art_Utilities
-	                   canvas
+                           canvas
                            ${MF_MESSAGELOGGER}
                            ${MF_UTILITIES}
                            ${FHICLCPP}


### PR DESCRIPTION
*Note*: this pull request is toward a branch managed by @jzettle, it should not be managed by the ICARUS release team.

----

* use the optical hit updated reconstruction by default (will also go in the 2022B production release, #457)
* use the PMT updated simulation by default (will also go in the 2022B production release, also #457)
* correctly decode trigger type (#455)
* a minor update to potentially save memory in some workflows (although it does not seem to do much)