### PR TITLE
Fixed CAF making jobs with generator systematics

### DIFF
--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -2,7 +2,6 @@
 #include "channelmapping_icarus.fcl"
 
 #include "correctionservices_icarus.fcl"
-#include "seedservice.fcl"
 #include "particleinventoryservice.fcl"
 #include "backtrackerservice.fcl"
 #include "photonbacktrackerservice.fcl"
@@ -17,6 +16,7 @@ services:
   ParticleInventoryService:  @local::standard_particleinventoryservice
   BackTrackerService:        @local::standard_backtrackerservice
   @table::icarus_wirecalibration_minimum_services
+  @table::icarus_random_services  # from services_common_icarus.fcl
 
   SpaceChargeService: @local::icarus_spacecharge
 }

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -9,7 +9,8 @@ process_name: CAFmaker
 
 services:
 {
-  @table::icarus_wirecalibration_services
+  @table::icarus_wirecalibration_minimum_services
+  @table::icarus_random_services  # from services_common_icarus.fcl
 
   SpaceChargeService: @local::icarus_spacecharge
 }

--- a/fcl/caf/cafmakerjob_icarus_evtw.fcl
+++ b/fcl/caf/cafmakerjob_icarus_evtw.fcl
@@ -1,5 +1,3 @@
 #include "cafmakerjob_icarus.fcl"
 
-services.RandomNumberGenerator: {}
-
 physics.runprod: [@sequence::caf_preprocess_evtw_sequence, cafmaker]

--- a/fcl/caf/cafmakerjob_icarus_sce_genie.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie.fcl
@@ -1,6 +1,9 @@
 #include "cafmakerjob_icarus_sce.fcl"
 
-services.RandomNumberGenerator: {}
+services: {
+  @table::services
+  @table::icarus_random_services  # from services_common_icarus.fcl
+}
 
 physics.runprod: [ @sequence::caf_preprocess_sce_sequence, rns, genieweight, cafmaker ]
 

--- a/fcl/caf/cafmakerjob_icarus_sce_genie.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie.fcl
@@ -1,10 +1,5 @@
 #include "cafmakerjob_icarus_sce.fcl"
 
-services: {
-  @table::services
-  @table::icarus_random_services  # from services_common_icarus.fcl
-}
-
 physics.runprod: [ @sequence::caf_preprocess_sce_sequence, rns, genieweight, cafmaker ]
 
 physics.producers.cafmaker.SystWeightLabels: ["genieweight"]

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -1,6 +1,9 @@
 #include "cafmakerjob_icarus_sce.fcl"
 
-services.RandomNumberGenerator: {}
+services: {
+  @table::services
+  @table::icarus_random_services  # from services_common_icarus.fcl
+}
 
 physics.runprod: [ @sequence::caf_preprocess_sce_evtw_sequence, cafmaker ]
 

--- a/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_sce_genie_and_fluxwgt.fcl
@@ -1,10 +1,5 @@
 #include "cafmakerjob_icarus_sce.fcl"
 
-services: {
-  @table::services
-  @table::icarus_random_services  # from services_common_icarus.fcl
-}
-
 physics.runprod: [ @sequence::caf_preprocess_sce_evtw_sequence, cafmaker ]
 
 physics.producers.cafmaker.SystWeightLabels: ["genieweight","fluxweight"]


### PR DESCRIPTION
Recently I reworked the random number service configuration and at the same time removed the configuration of the random services from the places where it is not supposed to belong.
CAF making is one of them, since it's about translation of data from one format to another.
Unfortunately CAF making currently does more than just translation, and in particular for simulation input it runs a generation-class process, the stochastic extraction of generation parameters and the computation of the weights bridging the extracted parameters to the ones chosen by the experiment as the best ones. These jobs were broken by my changes.

This pull request simply adds the configuration of the required services to the two CAF making jobs including weight generation that I could find.
It is a non-breaking bug fix.