### PR TITLE
Turn off blinding in for MC cafmaker

### DIFF
--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -46,3 +46,6 @@ physics:
   trigger_paths: [ runprod ] 
   end_paths:     [ stream1 ]
 }
+
+# Blinding not needed for MC
+physics.producers.cafmaker.CreateBlindedCAF: false


### PR DESCRIPTION
Turn off newly added blinding code in cafmaker for MC since it's only needed for data. Added to cafmakerjob_icarus.fcl which should propagate to other MC cafmaker fcls.