### PR TITLE
Cache requests to SQL database for TPC calibration

### DIFF
--- a/icaruscode/TPC/Calorimetry/NormalizeDriftSQLite_tool.cc
+++ b/icaruscode/TPC/Calorimetry/NormalizeDriftSQLite_tool.cc
@@ -53,6 +53,9 @@ private:
 
   // Helpers
   RunInfo GetRunInfo(uint64_t run);
+
+  // Cache run requests
+  std::map<uint32_t, RunInfo> fRunInfos;
 };
 
 DEFINE_ART_CLASS_TOOL(NormalizeDriftSQLite)
@@ -71,6 +74,11 @@ icarus::calo::NormalizeDriftSQLite::NormalizeDriftSQLite(fhicl::ParameterSet con
 void icarus::calo::NormalizeDriftSQLite::configure(const fhicl::ParameterSet& pset) {}
 
 icarus::calo::NormalizeDriftSQLite::RunInfo icarus::calo::NormalizeDriftSQLite::GetRunInfo(uint64_t run) {
+  // check the cache
+  if (fRunInfos.count(run)) {
+    return fRunInfos.at(run);
+  }
+
   // Look up the run
   //
   // Translate the run into a fake "timestamp"
@@ -93,7 +101,10 @@ icarus::calo::NormalizeDriftSQLite::RunInfo icarus::calo::NormalizeDriftSQLite::
   }
 
   if (fVerbose) std::cout << "NormalizeDriftSQLite Tool -- Lifetime Data:" << "\nTPC EE: " << thisrun.tau_EE << "\nTPC EW: " << thisrun.tau_EW << "\nTPC WE: " << thisrun.tau_WE << "\nTPC WW: " << thisrun.tau_WW << std::endl;
- 
+
+  // Set the cache
+  fRunInfos[run] = thisrun;
+
   return thisrun;
 }
 

--- a/icaruscode/TPC/Calorimetry/NormalizeTPCSQL_tool.cc
+++ b/icaruscode/TPC/Calorimetry/NormalizeTPCSQL_tool.cc
@@ -50,6 +50,9 @@ private:
 
   // Helpers
   ScaleInfo GetScaleInfo(uint64_t timestamp);
+
+  // Cache timestamp requests
+  std::map<uint64_t, ScaleInfo> fScaleInfos;
 };
 
 DEFINE_ART_CLASS_TOOL(NormalizeTPCSQL)
@@ -67,6 +70,11 @@ icarus::calo::NormalizeTPCSQL::NormalizeTPCSQL(fhicl::ParameterSet const &pset):
 void icarus::calo::NormalizeTPCSQL::configure(const fhicl::ParameterSet& pset) {}
 
 icarus::calo::NormalizeTPCSQL::ScaleInfo icarus::calo::NormalizeTPCSQL::GetScaleInfo(uint64_t timestamp) {
+  // check the cache
+  if (fScaleInfos.count(timestamp)) {
+    return fScaleInfos.at(timestamp);
+  }
+
   // Lookup the data
   fDB.UpdateData(timestamp*1e9);
 
@@ -80,6 +88,8 @@ icarus::calo::NormalizeTPCSQL::ScaleInfo icarus::calo::NormalizeTPCSQL::GetScale
 
     thisscale.scale[ch] = scale;
   }
+  // Set the cache
+  fScaleInfos[timestamp] = thisscale;
 
   return thisscale;
 }

--- a/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
+++ b/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
@@ -59,6 +59,8 @@ private:
     float tzero; // Earliest time that this scale info is valid
     std::vector<ScaleBin> bins;
   };
+  // Cache timestamp requests
+  std::map<uint64_t, ScaleInfo> fScaleInfos;
 
   // Helpers
   const ScaleInfo GetScaleInfo(uint64_t timestamp);
@@ -79,6 +81,11 @@ icarus::calo::NormalizeYZSQL::NormalizeYZSQL(fhicl::ParameterSet const &pset):
 void icarus::calo::NormalizeYZSQL::configure(const fhicl::ParameterSet& pset) {}
 
 const icarus::calo::NormalizeYZSQL::ScaleInfo icarus::calo::NormalizeYZSQL::GetScaleInfo(uint64_t timestamp) {
+  // check the cache
+  if (fScaleInfos.count(timestamp)) {
+    return fScaleInfos.at(timestamp);
+  }
+
   // Prep data
   fDB.UpdateData(timestamp*1e9);
 
@@ -123,6 +130,9 @@ const icarus::calo::NormalizeYZSQL::ScaleInfo icarus::calo::NormalizeYZSQL::GetS
 
     thisscale.bins.push_back(bin);
   }
+
+  // Set the cache
+  fScaleInfos[timestamp] = thisscale;
 
   return thisscale;
 }


### PR DESCRIPTION
Right now, running Calorimetry is really slow because access to the SQL database is slow. This speeds it up considerably.