### PR TITLE
Get CaloSkimmer Working for MC Digits

### DIFF
--- a/fcl/reco/Definitions/stage1_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage1_icarus_defs.fcl
@@ -81,8 +81,8 @@ icarus_stage1_filters:
 
 icarus_stage1_analyzers:
 {
-  caloskimE: @local::caloskim_cryoe_nodigits_goldentracks
-  caloskimW: @local::caloskim_cryow_nodigits_goldentracks
+  caloskimE: @local::caloskim_cryoe_goldentracks_not0
+  caloskimW: @local::caloskim_cryow_goldentracks_not0
   simpleLightAna: @local::ICARUSFlashAssAna
   CRTDataAnalysis: 
    {
@@ -99,9 +99,11 @@ icarus_stage1_analyzers:
 
 icarus_stage1_analyzers.caloskimE.SelectEvents: [reco]
 icarus_stage1_analyzers.caloskimE.CALOproducer: caloskimCalorimetryCryoE 
+icarus_stage1_analyzers.caloskimE.SilenceMissingDataProducts: true
 
 icarus_stage1_analyzers.caloskimW.SelectEvents: [reco]
 icarus_stage1_analyzers.caloskimW.CALOproducer: caloskimCalorimetryCryoW 
+icarus_stage1_analyzers.caloskimW.SilenceMissingDataProducts: true
 
 ### Below are a list of convenient sequences that can be used for production/typical users. ###
 

--- a/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
@@ -40,8 +40,10 @@ physics.reco: [
 # Turn on truth-info for track skimmer 
 physics.analyzers.caloskimE.G4producer: "largeant"
 physics.analyzers.caloskimE.SimChannelproducer: "largeant"
+physics.analyzers.caloskimE.RawDigitproducers: ["MCDecodeTPCROI:PHYSCRATEDATATPCEW", "MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 physics.analyzers.caloskimW.G4producer: "largeant"
 physics.analyzers.caloskimW.SimChannelproducer: "largeant"
+physics.analyzers.caloskimW.RawDigitproducers: ["MCDecodeTPCROI:PHYSCRATEDATATPCWW", "MCDecodeTPCROI:PHYSCRATEDATATPCWE"]
 
 physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
 physics.trigger_paths:     [ reco ]


### PR DESCRIPTION
Switch default caloskim behavior to include tracks w/out a T0. Specify name of MC RawDigit product. Silence missing data products (to automatically handle case where RawDigits are not present).

Depends on https://github.com/SBNSoftware/sbncode/pull/315.