### PR TITLE
Add CRT ntuple creation module to MC

### DIFF
--- a/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
@@ -43,7 +43,7 @@ physics.analyzers.caloskimE.SimChannelproducer: "largeant"
 physics.analyzers.caloskimW.G4producer: "largeant"
 physics.analyzers.caloskimW.SimChannelproducer: "largeant"
 
-physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
 physics.trigger_paths:     [ reco ]
 physics.end_paths:         [ outana, stream1 ]
 outputs.out1.fileName:     "%ifb_%tc-%p.root"

--- a/fcl/reco/Stage1/Run2/stage1_run2_wc_icarus_MC.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_wc_icarus_MC.fcl
@@ -43,7 +43,7 @@ physics.analyzers.caloskimE.SimChannelproducer: "largeant"
 physics.analyzers.caloskimW.G4producer: "largeant"
 physics.analyzers.caloskimW.SimChannelproducer: "largeant"
 
-physics.outana:            [ caloskimE, caloskimW, simpleLightAna]
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
 physics.trigger_paths:     [ reco ]
 physics.end_paths:         [ outana, stream1 ]
 outputs.out1.fileName:     "%ifb_%tc-%p.root"


### PR DESCRIPTION
Add CRT ntuple creator module to MC. This simply runs the same module that is run on the data to fill the ntuples. The reconstructed HitTree is filled and the module runs. Tested on what I understand is recent MC produced for testing WireCell, which is unrelated except for it was produced with a recent icaruscode version so this runs on the right MC for merging here. 