### PR TITLE
Fix cmake and build errors found in standalone build of icaruscode SBN2022B

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,12 +90,6 @@ find_package(FFTW3f REQUIRED )
 find_package(FFTW3q REQUIRED )
 find_package(FFTW3l REQUIRED )
 
-find_package( PkgConfig REQUIRED )
-pkg_search_module(FFTW3F REQUIRED IMPORTED_TARGET GLOBAL fftw3f)
-pkg_search_module(FFTW3Q REQUIRED IMPORTED_TARGET GLOBAL fftw3q)
-pkg_search_module(FFTW3L REQUIRED IMPORTED_TARGET GLOBAL fftw3l)
-
-
 # macros for dictionary and simple_plugin
 include(ArtDictionary)
 include(ArtMake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,11 @@ find_package(FFTW3f REQUIRED )
 find_package(FFTW3q REQUIRED )
 find_package(FFTW3l REQUIRED )
 
+find_package( PkgConfig REQUIRED )
+pkg_search_module(FFTW3F REQUIRED IMPORTED_TARGET GLOBAL fftw3f)
+pkg_search_module(FFTW3Q REQUIRED IMPORTED_TARGET GLOBAL fftw3q)
+pkg_search_module(FFTW3L REQUIRED IMPORTED_TARGET GLOBAL fftw3l)
+
 
 # macros for dictionary and simple_plugin
 include(ArtDictionary)

--- a/icaruscode/Analysis/trigger/CMakeLists.txt
+++ b/icaruscode/Analysis/trigger/CMakeLists.txt
@@ -16,6 +16,7 @@ art_make_library(
 
 cet_build_plugin(TimedTrackSelector art::module
   LIBRARIES
+  icarusalg::Utilities
   lardataobj::AnalysisBase
   lardataobj::RecoBase
   messagefacility::MF_MessageLogger

--- a/icaruscode/Decode/CMakeLists.txt
+++ b/icaruscode/Decode/CMakeLists.txt
@@ -12,9 +12,8 @@ art_make_library(
 )
 
 set(          MODULE_LIBRARIES
-                        icarus_signal_processing
-                        icarus_signal_processing_Detection
-                        icarus_signal_processing_Filters
+                        icarus_signal_processing::Detection
+                        icarus_signal_processing::Filters
                         icaruscode_TPC_Utilities
                         sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_ICARUS
                         artdaq_core::artdaq-core_Utilities

--- a/icaruscode/TPC/Utilities/CMakeLists.txt
+++ b/icaruscode/TPC/Utilities/CMakeLists.txt
@@ -23,6 +23,7 @@ set(icarus_util_lib_list
 	art::Persistency_Provenance
 	icaruscode_IcarusObj
 	art_root_io::tfile_support ROOT::Core
+	art_root_io::RootDB
 	art::Framework_Services_Optional_RandomNumberGenerator_service
 	art_root_io::TFileService_service
 	art::Framework_Services_System_FileCatalogMetadata_service


### PR DESCRIPTION
Add missing pkg_search_module needed by icarus_signal_processing target. Add missing link targets for header includes.