### PR TITLE
Trigger simulation in production workflow

### DIFF
--- a/fcl/configurations/beamgates_icarus.fcl
+++ b/fcl/configurations/beamgates_icarus.fcl
@@ -1,0 +1,147 @@
+#
+# File:    beamgates_icarus.fcl
+# Purpose: Module configurations to ensure the presence of `sim::BeamGateInfo`.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 22, 2022
+# Version: 1.0
+#
+# This is a collection of simple module configurations to help simulation
+# workflows (generation stage) to ensure the presence of a beam gate information
+# data product with a standard name.
+# 
+# Three main scenarios may be present:
+# 1. the generator module(s) does generate the proper beam gate data product,
+#    but with a non-standard name;
+# 2. the generator module does generate a beam gate data product, but it needs;
+#    adjustment;
+# 3. no generator module generates a beam data data product.
+# 
+# The workflow should rely on a standard beam gate data product name which is
+# not a standard generator name, to support the case (3) where one of those
+# generators is run with the standard generator name.
+# 
+# Thus, I propose here also a standard beam gate definition name, "beamgate",
+# which modules looking for a beam gate data product can confidently refer to:
+#     
+#     BeamGateTag: @local::icarus_standardbeamgate_tag
+#     
+# For the rest, this configuration file supports two of the cases above:
+# 
+# 1. `icarus_standardbeamgate_copy` can "rename" the data product; the label of
+#    the generator module creating the original beam gate can be overridden in
+#    the `BeamGateTag` parameter, and its default value is the standard
+#    "generator" (for example ICARUS GENIE configurations usually use that one).
+#    Example:
+#        
+#      physics.producers: {
+#        
+#        beamgate: @local::icarus_standardbeamgate_copy
+#        
+#        # ...
+#        
+#      }
+# 
+# 2. This case should use `FixBeamGateInfo`, but no preset is provided because
+#    no specific use case is known.
+# 
+# 3. The workflow must decide which beam gate to use. Options prepackaged here
+#    are:
+#    
+#    * BNB:
+#          
+#          physics.producers: {
+#            
+#            beamgate: @local::icarus_standardbeamgate_BNB
+#            
+#            # ...
+#          }
+#          
+#    * NuMI:
+#          
+#          physics.producers: {
+#            
+#            beamgate: @local::icarus_standardbeamgate_NuMI
+#            
+#            # ...
+#          }
+#          
+#    
+#    In doubt, it is suggested that the longer one (i.e. NuMI) is used, because
+#    usually downstream to take into account the effect of a reduced beam gate 
+#    is easier than with an too narrow one.
+# 
+# 
+# Changes:
+# 20221122 (petrillo@slac.stanford.edu) [v1.0]
+#   original version
+# 
+#
+
+#include "trigger_icarus.fcl"
+
+BEGIN_PROLOG
+
+# ------------------------------------------------------------------------------
+#
+# This is the name that downstream workflows should expect for the beam gate
+# data product.
+#
+icarus_standardbeamgate_tag: beamgate
+
+
+# ------------------------------------------------------------------------------
+# 
+# these two configurations create a beam gate data product with strictly the
+# nominal beam specifications. They are intended for use in the workflow of
+# event generators that do not generate beam gate information.
+#
+icarus_standardbeamgate_BNB: {
+
+  module_type: WriteBeamGateInfo
+  
+  BeamGates: [
+    {
+      Duration: @local::BNB_settings.spill_duration  # from trigger_icarus.fcl
+      Type: BNB
+    }
+  ]
+
+} # icarus_standardbeamgate_BNB
+
+
+icarus_standardbeamgate_NuMI: {
+
+  module_type: WriteBeamGateInfo
+  
+  BeamGates: [
+    {
+      Duration: @local::NuMI_settings.spill_duration  # from trigger_icarus.fcl
+      Type: NuMI
+    }
+  ]
+
+} # icarus_standardbeamgate_NuMI
+
+
+# ------------------------------------------------------------------------------
+#
+# This configuration is copying an existing beam gate data product (by default,
+# with `generator` tag) into a new one with the same characteristics.
+# The net effect is of "renaming" the beam gate, that is a useful trick for
+# workflows.
+# Any association is lost (the code may be extended to copy them too).
+#
+icarus_standardbeamgate_copy: {
+
+  module_type: FixBeamGateInfo
+  
+  BeamGateTag: generator
+  
+  Changes: [ {} ]  # no changes
+  
+} # icarus_standardbeamgate_copy
+
+
+# ------------------------------------------------------------------------------
+
+END_PROLOG

--- a/fcl/gen/MultiVertex/multivertex_icarus.fcl
+++ b/fcl/gen/MultiVertex/multivertex_icarus.fcl
@@ -1,5 +1,6 @@
 #include "services_icarus_simulation.fcl"
 #include "multipartvertex_icarus.fcl"
+#include "beamgates_icarus.fcl"
 
 process_name: MultiVertexGen
 
@@ -34,12 +35,13 @@ physics:
  producers:
  {
    generator: @local::MultiPartVertex
+   beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator ]
+ simulate: [ rns, generator, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/background/prodbackground_Ar39_icarus.fcl
+++ b/fcl/gen/background/prodbackground_Ar39_icarus.fcl
@@ -15,6 +15,7 @@
 
 #include "services_common_icarus.fcl"
 #include "radiological_model_icarus.fcl"
+#include "beamgates_icarus.fcl"
 
 process_name: BackgroundGen
 
@@ -35,9 +36,10 @@ physics: {
   
   producers: {
     generator: @local::radiogen_Ar39_icarus # from radiological_model_icarus.fcl
+    beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
   }
   
-  simulate:      [ generator ]
+  simulate:      [ generator, beamgate ]
   
   stream1:       [ rootoutput ]
  

--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
@@ -34,6 +34,7 @@
 # do not pass the filtering in order to tune how many to generate
 
 #include "corsika_icarus.fcl"
+#include "beamgates_icarus.fcl"
 #include "services_common_icarus.fcl"
 #include "services_icarus_simulation.fcl"
 #include "largeantmodules_icarus.fcl"
@@ -67,6 +68,7 @@ physics:
  {
    generator: @local::icarus_corsika_p
    larg4intime: @local::icarus_largeant
+   beamgate:  @local::icarus_standardbeamgate_BNB  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
 
@@ -102,7 +104,7 @@ physics:
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below 
- simulate: [ rns, generator, GenInTimeSorter, larg4intime, timefilter ] 
+ simulate: [ rns, generator, GenInTimeSorter, larg4intime, beamgate, timefilter ] 
 
 
  #define the output stream, there could be more than one if using filters 

--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_numi.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_numi.fcl
@@ -88,6 +88,8 @@
 physics.filters.GenInTimeSorter.MaxT: 9600 # [ns]  9.5 us (NuMI beam) + 0.1 us (buffer)
 physics.filters.GenInTimeSorter.MinT: -200 # [ns]
 
+physics.producers.beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
+
 
 # ##############################################################################
 # time filter: events with at least this much scintillation energy detected

--- a/fcl/gen/corsika/prodcorsika_standard_icarus.fcl
+++ b/fcl/gen/corsika/prodcorsika_standard_icarus.fcl
@@ -1,4 +1,5 @@
 #include "corsika_icarus.fcl"
+#include "beamgates_icarus.fcl"
 #include "services_common_icarus.fcl"
 #include "services_icarus_simulation.fcl"
 
@@ -29,12 +30,13 @@ physics:
  producers:
  {
    generator: @local::icarus_corsika_cmc 
+   beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator ]
+ simulate: [ rns, generator, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/genie/prodcorsika_genie_standard_icarus.fcl
+++ b/fcl/gen/genie/prodcorsika_genie_standard_icarus.fcl
@@ -8,6 +8,7 @@
 #include "mcreco.fcl"
 #include "services_common_icarus.fcl"
 #include "genie_icarus_bnb.fcl"
+#include "beamgates_icarus.fcl"
 #include "services_icarus_simulation.fcl"
 
 process_name: GenGenieCorsika
@@ -45,12 +46,13 @@ physics:
  {
    generator: @local::icarus_genie_BNB # from `genie_icarus_bnb.fcl`
    cosmgen:   @local::icarus_corsika_cmc  
+   beamgate:  @local::icarus_standardbeamgate_BNB  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator, cosmgen ]
+ simulate: [ rns, generator, cosmgen, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/genie/simulation_genie_icarus_bnb.fcl
+++ b/fcl/gen/genie/simulation_genie_icarus_bnb.fcl
@@ -18,6 +18,7 @@
 
 #include "services_icarus_simulation.fcl"
 #include "genie_icarus_bnb.fcl"
+#include "beamgates_icarus.fcl"
 
 
 process_name: GenGenie
@@ -52,11 +53,12 @@ physics: {
     
     rns:       { module_type: "RandomNumberSaver" }
     generator: @local::icarus_genie_BNB # from `genie_icarus_bnb.fcl`
+    beamgate:  @local::icarus_standardbeamgate_BNB  # from beamgates_icarus.fcl
     
   } # producers
   
   
-  simulate:     [ rns, generator ]
+  simulate:     [ rns, generator, beamgate ]
   
   outputstream: [ rootoutput ]
   

--- a/fcl/gen/genie/simulation_genie_icarus_simple.fcl
+++ b/fcl/gen/genie/simulation_genie_icarus_simple.fcl
@@ -5,6 +5,7 @@
 
 #include "largeantmodules.fcl"
 #include "genie_icarus_bnb.fcl"
+#include "beamgates_icarus.fcl"
 #include "mcreco.fcl"
 #include "services_common_icarus.fcl"
 #include "services_icarus_simulation.fcl"
@@ -44,11 +45,12 @@ physics:
  {
    generator: @local::icarus_genie_BNB # from `genie_icarus_bnb.fcl`
    rns:       { module_type: "RandomNumberSaver" }
+   beamgate:  @local::icarus_standardbeamgate_BNB  # from beamgates_icarus.fcl
  }
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator ]
+ simulate: [ rns, generator, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/mevprtl/higgs/dissonant_higgs_gen.fcl
+++ b/fcl/gen/mevprtl/higgs/dissonant_higgs_gen.fcl
@@ -1,4 +1,5 @@
 #include "dissonant_higgs.fcl"
+#include "beamgates_icarus.fcl"
 # service configuration
 #
 #include "services_icarus_simulation.fcl"
@@ -25,6 +26,7 @@ physics:
 {
   producers:{
     generator: @local::dissonant_higgs_gen
+    beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
     rns:       { module_type: "RandomNumberSaver" }
   }
   filters:  {} 
@@ -32,7 +34,7 @@ physics:
     
   } # analyzers
  
-  runprod:  [ generator, rns ]
+  runprod:  [ generator, beamgate, rns ]
   stream: [out]
 
   trigger_paths: [ runprod ]

--- a/fcl/gen/mevprtl/hnl/hnl_icarus_gen.fcl
+++ b/fcl/gen/mevprtl/hnl/hnl_icarus_gen.fcl
@@ -1,4 +1,5 @@
 #include "hnl.fcl"
+#include "beamgates_icarus.fcl"
 # service configuration
 #
 #include "services_icarus_simulation.fcl"
@@ -25,6 +26,7 @@ physics:
 {
   producers:{
     generator: @local::hnl_gen
+    beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
     rns:       { module_type: "RandomNumberSaver" }
   }
   filters:  {} 
@@ -32,7 +34,7 @@ physics:
     
   } # analyzers
  
-  runprod:  [ generator, rns ]
+  runprod:  [ generator, beamgate, rns ]
   stream: [out]
 
   trigger_paths: [ runprod ]

--- a/fcl/gen/numi/simulation_genie_icarus_numi.fcl
+++ b/fcl/gen/numi/simulation_genie_icarus_numi.fcl
@@ -17,6 +17,7 @@
 
 #include "services_icarus_simulation.fcl"
 #include "genie_icarus_numioffaxis.fcl"
+#include "beamgates_icarus.fcl"
 
 
 process_name: GenGenie
@@ -51,11 +52,12 @@ physics: {
     
     rns:       { module_type: "RandomNumberSaver" }
     generator: @local::icarus_genie_NuMI # from `genie_icarus_numi.fcl`
+    beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
     
   } # producers
   
   
-  simulate:     [ rns, generator ]
+  simulate:     [ rns, generator, beamgate ]
   
   outputstream: [ rootoutput ]
   

--- a/fcl/gen/numi/simulation_numi.fcl
+++ b/fcl/gen/numi/simulation_numi.fcl
@@ -4,6 +4,7 @@
 #include "magfield_larsoft.fcl"
 #include "largeantmodules.fcl"
 #include "genie_icarus_numioffaxis.fcl"
+#include "beamgates_icarus.fcl"
 #include "mcreco.fcl"
 #include "services_common_icarus.fcl"
 #include "services_icarus_simulation.fcl"
@@ -38,11 +39,12 @@ physics:
  producers:
  {
    generator: @local::icarus_genienumi_simple   
+   beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator ]
+ simulate: [ rns, generator, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/numi/simulation_numi_nue.fcl
+++ b/fcl/gen/numi/simulation_numi_nue.fcl
@@ -4,6 +4,7 @@
 #include "magfield_larsoft.fcl"
 #include "largeantmodules.fcl"
 #include "genie_icarus_numioffaxis.fcl"
+#include "beamgates_icarus.fcl"
 #include "mcreco.fcl"
 #include "services_common_icarus.fcl"
 #include "services_icarus_simulation.fcl"
@@ -38,11 +39,12 @@ physics:
  producers:
  {
    generator: @local::icarus_genienumi_simple   
+   beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator ]
+ simulate: [ rns, generator, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/numi/simulation_numi_numu.fcl
+++ b/fcl/gen/numi/simulation_numi_numu.fcl
@@ -4,6 +4,7 @@
 #include "magfield_larsoft.fcl"
 #include "largeantmodules.fcl"
 #include "genie_icarus_numioffaxis.fcl"
+#include "beamgates_icarus.fcl"
 #include "mcreco.fcl"
 #include "services_common_icarus.fcl"
 #include "services_icarus_simulation.fcl"
@@ -38,11 +39,12 @@ physics:
  producers:
  {
    generator: @local::icarus_genienumi_simple   
+   beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator ]
+ simulate: [ rns, generator, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/overlay/prodoverlay_proton_sbnflux_icarus.fcl
+++ b/fcl/gen/overlay/prodoverlay_proton_sbnflux_icarus.fcl
@@ -8,6 +8,7 @@
 #include "mcreco.fcl"
 #include "services_common_icarus.fcl"
 #include "genie_icarus.fcl"
+#include "beamgates_icarus.fcl"
 #include "services_icarus_simulation.fcl"
 
 
@@ -48,13 +49,14 @@ physics:
  producers:
  {
    generator: @local::icarus_genie_simple
+   beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
    cosmgen:   @local::icarus_corsika_p
    rns:       { module_type: "RandomNumberSaver" }
  }
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator, cosmgen ]
+ simulate: [ rns, generator, cosmgen, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/single/prodsingle_common_icarus.fcl
+++ b/fcl/gen/single/prodsingle_common_icarus.fcl
@@ -1,5 +1,6 @@
 #include "services_icarus_simulation.fcl"
 #include "singles_icarus.fcl"
+#include "beamgates_icarus.fcl"
 
 process_name: SinglesGen
 
@@ -31,12 +32,13 @@ physics:
  producers:
  {
    generator: @local::icarus_singlep
+   beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
    rns:       { module_type: "RandomNumberSaver" }
  }
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- simulate: [ rns, generator ]
+ simulate: [ rns, generator, beamgate ]
 
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]

--- a/fcl/gen/text/prodtext_standard_icarus.fcl
+++ b/fcl/gen/text/prodtext_standard_icarus.fcl
@@ -59,6 +59,7 @@
 #include "geometry_icarus.fcl"
 #include "services_common_icarus.fcl"
 #include "rootoutput_icarus.fcl"
+#include "beamgates_icarus.fcl"
 
 
 # ------------------------------------------------------------------------------
@@ -98,9 +99,13 @@ physics: {
     
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     
+    beamgate:  @local::icarus_standardbeamgate_NuMI  # from beamgates_icarus.fcl
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
   } # producers
 
-  simulate: [ generator ]
+  simulate: [ generator, beamgate ]
 
   stream:   [ rootoutput ]
 

--- a/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
@@ -42,7 +42,7 @@ icarus_stage0_mc_producers:
 # make the following modifications to job flow for MC vs the data
 icarus_stage0_mc_trigger: [
                          pmtfixedthr
-#                        , @sequence::icarus_standard_triggersim.path
+                         , @sequence::icarus_standard_triggersim.path  # from trigger_emulation_icarus.fcl
                        ]
 
 icarus_stage0_mc_PMT:  [

--- a/icaruscode/PMT/Trigger/simulate_triggers_icarus.fcl
+++ b/icaruscode/PMT/Trigger/simulate_triggers_icarus.fcl
@@ -117,7 +117,7 @@ physics: {
     
     pmttriggerwindows: @local::icarus_trigslidewindow
     
-    triggersimgates: @local::icarus_triggersimgates
+    triggersimgates: @local::icarus_triggersimgates  # from trigger_icarus.fcl
     
     # --------------------------------------------------------------------------
     # all interesting triggers

--- a/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
@@ -339,7 +339,7 @@ icarus_standard_triggersim: {
       Thresholds: [ @local::icarus_triggergate_basic.SelectedThreshold ]
     }
     
-    triggersimgates: @local::icarus_triggersimgates
+    triggersimgates: @local::icarus_triggersimgates  # from trigger_icarus.fcl
     
     emuTrigger: {
       module_type:           TriggerSimulationOnGates

--- a/icaruscode/PMT/Trigger/trigger_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_icarus.fcl
@@ -4,7 +4,7 @@
 # Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
 # Date:    April 2, 2019
 #
-# Settings and paramteters are provided for algorithms related to triggering.
+# Settings and parameters are provided for algorithms related to triggering.
 # 
 # Current offer includes:
 # 
@@ -29,6 +29,8 @@ BEGIN_PROLOG
 ################################################################################
 
 BNB_settings: {
+
+  # also note the configuration `icarus_genie_BNB_base` in `genie_icarus_bnb.fcl`
 
   spill_duration: "1.6 us"
 
@@ -254,6 +256,11 @@ icarus_region_finder: {
 ################################################################################
 ###  Trigger evaluation gates
 # 
+# Preset configurations are available in `beamgates_icarus.fcl` to help the
+# workflow include the starting beam gate data product (there, its standard tag
+# is also defined, but we can't refer to it directly here because that
+# configuration file includes this one).
+#
 # this configuration takes the configured beam gate duration
 # and creates extended gates to be used for trigger evaluation;
 # [20221104] the amount of extension needs to be verified with Run2 data
@@ -262,7 +269,7 @@ icarus_triggersimgates_Run1: {
 
   module_type: FixBeamGateInfo
 
-  BeamGateTag: generator
+  BeamGateTag: beamgate
 
   Changes: [  # gates of type not included are left unchanged
     { # for BNB gates
@@ -279,7 +286,9 @@ icarus_triggersimgates_Run1: {
 
 } # icarus_triggersimgates_Run1
 
+
 icarus_triggersimgates: @local::icarus_triggersimgates_Run1
+
 
 ################################################################################
 ###  Legacy configurations


### PR DESCRIPTION
This pull request attempts to integrate trigger simulation in the standard production workflow, following PR #483 .

The general issue is that trigger emulation needs to know the beam gate, and it turns out that LArSoft generators do not fix a beam gate, except `GENIEGen` which fixes it wrong.

The strategy I propose adds to all generator jobs the creation of a beam gate with the module name `beamgate`. Downstream jobs will be able to learn the nominal beam gate by referring to that data product; trigger simulation does that (potentially it could also extend the gate to be closer to the hardware, but that's for a different pull request).

This pull request is made of two parts:

* reintroduction of trigger simulation in standard Stage0 MC workflow
* addition of a beam gate in pretty much all non-legacy generation configurations, with the following pattern:
    * neutrino generation: see below
    * neutrino interaction with cosmic overlay: follows the same pattern as the previous;
    * cosmic rays: using NuMI beam gate
    * in-time cosmic rays: using a beam gate matching the in-time definition (matching is manual, it can't easily be coded in the configuration)
    * radiogenic background: using NuMI beam gate
    * single particles: using NuMI beam gate
    * external particle list via text file: using NuMI beam gate
    * other physics (e.g. dissonant Higgs): using NuMI beam gate
    * other non-physics: using NuMI beam gate

The rationale of NuMI as the fallback gate is that it makes it easy to remove events whose trigger have fired after 1.6 µs to simulate a BNB beam instead.


Beam gates from `GENIEGen`
---------------------------

The module `GENIEGen` is pretty much the only one that can natively produce a beam gate data product (`std::vector<sim::BeamGateInfo>`). It does it by setting the beam type after decoding the name of the beam flux, the beam opening time from the global offset time and the beam width from the random offset interval (`RandomTimeOffset`). The latter in particular is used by `GENIEGen` to randomise the time of the event.
Unfortunately, that setting also interferes with the interaction time plugin that we do or could use to mirror the actual beam time structure; so when using the latter feature, `RandomTimeOffset` is set to `0`.

Therefore this pull request uses the "copy" option (i.e. create a copy of the GENIE beam gate `generator` which will be called `beamgate`) only if no time plugin is configured.
Otherwise, it sets a fixed beam gate reflecting the configuration job (BNB or NuMI).


Testing
========

I have tested a couple of these configurations to verify they do run and produce the new beam gate data product. I haven't tested the change in Stage0 because both the Monte Carlo configurations (Run1 and Run2) are currently broken for reasons apparently unrelated with this pull request.
I did run the unit tests, which include a grammar test for all the FHiCL configurations.


Reviewer notes
==============

I am asking the review of:
* @SFBayLaser for the general workflow and the modifications to `Stage0`
* @gputnam as author of the in-time and Higgs-like configurations
* @betan009 as a maintainer of the NuMI job configurations
