### PR TITLE
PMT readout simulation

### DIFF
--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -70,7 +70,7 @@ namespace daq
    *     * `TriggerCount()`: the trigger count from the beginning of the run.
    *     * `TriggerBits()`: includes the beam(s) with an open gate when the
    *         trigger happened (currently only one beam gate per trigger);
-   *         definitions are in `sbn::beamType` namespace.
+   *         definitions are in `sbn::bits::triggerSource` enumerator.
    * 
    *     It always includes a single entry (zero _might_ be supported).
    * * `std::vector<sim::BeamGateInfo>` containing information on the "main"

--- a/icaruscode/IcarusObj/OpDetWaveformMeta.h
+++ b/icaruscode/IcarusObj/OpDetWaveformMeta.h
@@ -135,6 +135,9 @@ struct sbn::OpDetWaveformMeta {
   /// @}
   
   
+  /// Returns whether the specified time is contained in the waveform interval.
+  bool includes(double time) const; // inline
+  
 }; // sbn::OpDetWaveformMeta
 
 
@@ -156,6 +159,12 @@ inline bool sbn::OpDetWaveformMeta::withTrigger() const {
 
 inline bool sbn::OpDetWaveformMeta::withoutTrigger() const {
   return flags.isDefined(bits::WithTrigger) && flags.isUnset(bits::WithTrigger);
+}
+
+
+// -----------------------------------------------------------------------------
+inline bool sbn::OpDetWaveformMeta::includes(double time) const {
+  return (time >= startTime) && (time < endTime);
 }
 
 

--- a/icaruscode/PMT/Algorithms/ConstantPedestalGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/ConstantPedestalGeneratorAlg.h
@@ -1,0 +1,273 @@
+/**
+ * @file   icaruscode/PMT/Algorithms/ConstantPedestalGeneratorAlg.h
+ * @brief  A pedestal generation algorithm using a single constant baseline.
+ * @date   November 17, 2022
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    icaruscode/PMT/Algorithms/PMTnoiseGenerator.h
+ */
+
+#ifndef ICARUSCODE_PMT_ALGORITHMS_CONSTANTPEDESTALGENERATORALG_H
+#define ICARUSCODE_PMT_ALGORITHMS_CONSTANTPEDESTALGENERATORALG_H
+
+// LArSoft/ICARUS libraries
+#include "icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h"
+#include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
+#include "icaruscode/Utilities/quantities_utils.h" // util::...::value()
+#include "lardataalg/Utilities/quantities_fhicl.h" // counts_f from FHiCL
+
+// framework libraries
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <algorithm> // std::fill_n()
+#include <memory> // std::unique_ptr<>
+#include <utility> // std::move()
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <typename ADCT = double> class ConstantPedestalGeneratorAlg;
+}
+/**
+ * @brief Constant pedestal generator algorithm for PMT electronics simulation.
+ * @param ADCT type of the ADC count this interface treats with.
+ * 
+ * This generator produces a constant pedestal, with the addition of the noise
+ * from the configured noise generator.
+ * 
+ */
+template <typename ADCT /* = double */>
+class icarus::opdet::ConstantPedestalGeneratorAlg
+  : public icarus::opdet::PedestalGeneratorAlg<ADCT>
+{
+  ///< Base class alias.
+  using Base_t = icarus::opdet::PedestalGeneratorAlg<ADCT>;
+  
+    public:
+  
+  using ADCcount_t = typename Base_t::ADCcount_t;
+  using Timestamp_t = typename Base_t::Timestamp_t;
+  
+  /// Underlying fundamental type of `ADCcount_t`, e.g. `float`.
+  using ADCvalue_t = util::value_t<typename Base_t::ADCcount_t>;
+  
+  /// Type of the noise generator algorithm interface.
+  using NoiseGenerator_t = icarus::opdet::NoiseGeneratorAlg<ADCcount_t>;
+  
+  
+  // --- BEGIN -- Configuration ------------------------------------------------
+  /// Algorithm configuration parameters.
+  struct Params_t {
+    ADCcount_t level; ///< Pedestal level.
+  };
+  
+  
+  /// Configuration parameters.
+  struct Config {
+
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Atom<ADCvalue_t> Pedestal{
+      Name{ "Pedestal" },
+      Comment{ "level of the pedestal" }
+      // mandatory
+      };
+    
+  }; // struct Config
+  
+  
+  // --- END ---- Configuration ------------------------------------------------
+  
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters
+   * @param noiseGen noise generation algorithm (will be acquired and owned)
+   */
+  ConstantPedestalGeneratorAlg
+    (Params_t params, std::unique_ptr<NoiseGenerator_t>&& noiseGen);
+  
+  
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters in FHiCL format
+   * @param noiseGen noise generation algorithm (will be acquired and owned)
+   */
+  ConstantPedestalGeneratorAlg
+    (Config const& config, std::unique_ptr<NoiseGenerator_t>&& noiseGen);
+
+  
+  
+    protected:
+  
+  // --- BEGIN -- Configuration parameters -------------------------------------
+  
+  Params_t const fParams; ///< All configuration parameters.
+  
+  // --- END ---- Configuration parameters -------------------------------------
+  
+  
+  std::unique_ptr<NoiseGenerator_t> fNoiseGen; ///< Noise generator algorithm.
+  
+  
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  virtual ADCcount_t doPedestalLevel
+    (raw::Channel_t channel, Timestamp_t time) const override;
+  
+  
+  /**
+   * @brief Adds pedestal (with noise) to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with pedestal
+   * @param n number of samples to add pedestal to
+   * @return the number of samples actually added pedestal
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   * 
+   * The pedestal is added _before_ the noise is added (that may be relevant
+   * if the noise level depends on the value of the sample).
+   */
+  virtual std::size_t doAdd(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with pedestal plus noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with pedestal
+   * @param n number of samples to fill with pedestal
+   * @return the number of samples actually overwritten with pedestal
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   * 
+   * The pedestal is set _before_ the noise is added (that may be relevant
+   * if the noise level depends on the value of the sample).
+   */
+  virtual std::size_t doFill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Prints into the stream the parameters of this algorithm.
+   * @param out the C++ output stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   */
+  virtual void doDump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const override;
+  
+  // --- END ---- Virtual interface --------------------------------------------
+  
+  
+  /// Extracts the configuration parameters from a FHiCL configuration.
+  static Params_t convert(Config const& config);
+  
+  
+}; // icarus::opdet::ConstantPedestalGeneratorAlg
+
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::ConstantPedestalGeneratorAlg<ADCT>::ConstantPedestalGeneratorAlg
+  (Params_t params, std::unique_ptr<NoiseGenerator_t>&& noiseGen)
+  : fParams{ std::move(params) }
+  , fNoiseGen{ std::move(noiseGen) }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::ConstantPedestalGeneratorAlg<ADCT>::ConstantPedestalGeneratorAlg
+  (Config const& config, std::unique_ptr<NoiseGenerator_t>&& noiseGen)
+  : ConstantPedestalGeneratorAlg{ convert(config), std::move(noiseGen) }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::ConstantPedestalGeneratorAlg<ADCT>::doPedestalLevel
+  (raw::Channel_t channel, Timestamp_t time) const -> ADCcount_t
+{
+  return fParams.level;
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::ConstantPedestalGeneratorAlg<ADCT>::doAdd(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  if (fNoiseGen) n = fNoiseGen->add(channel, time, begin, n);
+  ADCcount_t* const end = begin + n;
+  while (begin != end) *(begin++) += fParams.level;
+  return n;
+} // icarus::opdet::ConstantPedestalGeneratorAlg<>::doAdd()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::ConstantPedestalGeneratorAlg<ADCT>::doFill(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  std::fill_n(begin, n, fParams.level);
+  return fNoiseGen? fNoiseGen->add(channel, time, begin, n): n;
+} // icarus::opdet::ConstantPedestalGeneratorAlg<>::doFill()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::ConstantPedestalGeneratorAlg<ADCT>::doDump(
+  std::ostream& out,
+  std::string const& indent, std::string const& firstIndent
+) const {
+  out << firstIndent
+    << "Constant pedestal generator algorithm (ConstantPedestalGeneratorAlg):"
+    << "\n" << indent << "  level: " << fParams.level
+    << "\n" << indent << "  noise: ";
+  if (fNoiseGen) fNoiseGen->dump(out, indent + "  ", "");
+  else out << "none";
+} // icarus::opdet::ConstantPedestalGeneratorAlg<>::doDump()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::ConstantPedestalGeneratorAlg<ADCT>::convert
+  (Config const& config) -> Params_t
+{
+  return {
+    ADCcount_t{ config.Pedestal() } // level
+    };
+}
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_ALGORITHMS_CONSTANTPEDESTALGENERATORALG_H
+
+

--- a/icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.cxx
+++ b/icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.cxx
@@ -9,6 +9,9 @@
 
 // library header
 #include "icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.h"
+
+// ICARUS libraries
+#include "icaruscode/Utilities/quantities_utils.h" // util::...::abs()
 #include "icarusalg/Utilities/WaveformOperations.h"
 
 // framework libraries
@@ -88,8 +91,9 @@ bool icarus::opdet::DiscretePhotoelectronPulse::checkRange
   auto const high
     = *(fSampledShape.subsample(fSampledShape.nSubsamples() - 1).rbegin());
 
-  bool const bLowOk = (low.abs() < limit);
-  bool const bHighOk = (high.abs() < limit);
+  using std::abs;
+  bool const bLowOk = (abs(low) < limit);
+  bool const bHighOk = (abs(high) < limit);
   if (bLowOk && bHighOk) return true;
   if (!outputCat.empty()) {
     mf::LogWarning log(outputCat);

--- a/icaruscode/PMT/Algorithms/FastGaussianNoiseGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/FastGaussianNoiseGeneratorAlg.h
@@ -1,0 +1,285 @@
+/**
+ * @file   icaruscode/PMT/Algorithms/FastGaussianNoiseGeneratorAlg.h
+ * @brief  A (faster?) Gaussian noise generation algorithm.
+ * @date   November 17, 2022
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    icaruscode/PMT/Algorithms/PMTnoiseGenerator.h
+ */
+
+#ifndef ICARUSCODE_PMT_ALGORITHMS_FASTGAUSSIANNOISEGENERATORALG_H
+#define ICARUSCODE_PMT_ALGORITHMS_FASTGAUSSIANNOISEGENERATORALG_H
+
+// ICARUS libraries
+#include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
+#include "icaruscode/Utilities/quantities_utils.h" // util::...::value()
+#include "icarusalg/Utilities/FastAndPoorGauss.h"
+
+// CLHEP libraries
+#include "CLHEP/Random/RandEngine.h" // CLHEP::HepRandomEngine
+
+// C/C++ standard libraries
+#include <vector>
+#include <utility> // std::move()
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <typename ADCT = double> class FastGaussianNoiseGeneratorAlg;
+}
+/**
+ * @brief Gaussian noise generator algorithm for PMT electronics simulation.
+ * @param ADCT type of the ADC count this interface treats with.
+ * 
+ * This noise generator produces a random Gaussian-distributed noise with
+ * the specified RMS and no bias.
+ * 
+ * It requires a CLHEP random engine as input, and directly uses a custom
+ * adapter.
+ * 
+ * Generating for any type `ADCT` other that the CLHEP-native `double` requires
+ * a conversion and slows down the generation.
+ * 
+ * Compared to GaussianNoiseGeneratorAlg(), we use a somehow faster random
+ * generator; to squeeze the CPU cycles, we avoid the CLHEP interface as much as
+ * possible; the random number from the engine is immediately converted
+ * to single precision, and the rest of the math happens in there as well.
+ * No virtual interfaces nor indirection is involved within this function
+ * (except for CLHEP random engine and the call to `add()`/`fill()`). We
+ * generate a normal variable _z_ (standard deviation 1, mean 0) and we just
+ * scale it to the desired standard deviation, not bothering to add the mean
+ * offset of 0.
+ * 
+ * Note that unless the random engine is multi-thread safe, this function
+ * won't gain anything from multi-threading.
+ * 
+ * @note Despite the name, the generator limits to generate one sample per call.
+ *       It may be possible, if this proved to be a limitation, to extend
+ *       `util::FastAndPoorGauss` to generate an array of numbers, in the hope
+ *       that the compiler lets vectorization kick in.
+ */
+template <typename ADCT /* = double */>
+class icarus::opdet::FastGaussianNoiseGeneratorAlg
+  : public icarus::opdet::NoiseGeneratorAlg<ADCT>
+{
+  using Base_t = icarus::opdet::NoiseGeneratorAlg<ADCT>; ///< Base class alias.
+  
+    public:
+  
+  using ADCcount_t = typename Base_t::ADCcount_t;
+  using Timestamp_t = typename Base_t::Timestamp_t;
+  
+  /// Underlying fundamental type of `ADCcount_t`, e.g. `float`.
+  using ADCvalue_t = util::value_t<typename Base_t::ADCcount_t>;
+  
+  
+  // --- BEGIN -- Configuration ------------------------------------------------
+  /// Algorithm configuration parameters.
+  struct Params_t {
+    ADCcount_t RMS; ///< Gaussian sigma parameter for the noise.
+  };
+  
+  
+  /// Configuration parameters.
+  struct Config {
+
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Atom<ADCvalue_t> RMS{
+      Name{ "RMS" },
+      Comment{ "RMS of the Gaussian noise" }
+      // mandatory
+      };
+    
+  }; // struct Config
+  
+  
+  // --- END ---- Configuration ------------------------------------------------
+  
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters
+   * @param engine random engines
+   */
+  FastGaussianNoiseGeneratorAlg(Params_t params, CLHEP::HepRandomEngine& engine);
+  
+  
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters in FHiCL format
+   * @param engine random engines
+   */
+  FastGaussianNoiseGeneratorAlg
+    (Config const& config, CLHEP::HepRandomEngine& engine);
+  
+  
+    private:
+  
+  using GaussAdapter_t = util::FastAndPoorGauss<32768U, ADCvalue_t>;
+  
+  // --- BEGIN -- Configuration parameters -------------------------------------
+  
+  Params_t const fParams; ///< All configuration parameters.
+  
+  // --- END ---- Configuration parameters -------------------------------------
+  
+  
+  /// Random engine used by this algorithm.
+  CLHEP::HepRandomEngine& fRandomEngine;
+  
+  
+  /// Random adapter.
+  static GaussAdapter_t const FastGauss;
+  
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /**
+   * @brief Adds noise to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with noise
+   * @param n number of samples to add noise to
+   * @return the number of samples actually added noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doAdd(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with noise
+   * @param n number of samples to fill with noise
+   * @return the number of samples actually overwritten with noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doFill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Prints into the stream the parameters of this algorithm.
+   * @param out the C++ output stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   */
+  virtual void doDump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const override;
+  
+  // --- END ---- Virtual interface --------------------------------------------
+  
+  
+  /// Extracts the configuration parameters from a FHiCL configuration.
+  static Params_t convert(Config const& config);
+  
+  
+}; // icarus::opdet::FastGaussianNoiseGeneratorAlg
+
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+typename icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::GaussAdapter_t
+const icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::FastGauss;
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::FastGaussianNoiseGeneratorAlg
+  (Params_t params, CLHEP::HepRandomEngine& engine)
+  : fParams{ std::move(params) }
+  , fRandomEngine{ engine }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::FastGaussianNoiseGeneratorAlg
+  (Config const& config, CLHEP::HepRandomEngine& engine)
+  : FastGaussianNoiseGeneratorAlg{ convert(config), engine }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::doAdd(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  ADCcount_t* const end = begin + n;
+  while (begin != end) {
+    *(begin++)
+      += static_cast<ADCcount_t>(fParams.RMS*FastGauss(fRandomEngine.flat()));
+  }
+  return n;
+} // icarus::opdet::FastGaussianNoiseGeneratorAlg<>::doAdd()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::doFill(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  ADCcount_t* const end = begin + n;
+  while (begin != end) {
+    *(begin++)
+      = static_cast<ADCcount_t>(fParams.RMS*FastGauss(fRandomEngine.flat()));
+  }
+  return n;
+} // icarus::opdet::FastGaussianNoiseGeneratorAlg<>::doFill()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::doDump(
+  std::ostream& out,
+  std::string const& indent, std::string const& firstIndent
+) const {
+  out << firstIndent
+    << "Gaussian noise generator algorithm (FastGaussianNoiseGeneratorAlg with "
+    << GaussAdapter_t::NPoints << " precomputed values):"
+    << "\n" << indent << "  RMS: " << fParams.RMS;
+} // icarus::opdet::FastGaussianNoiseGeneratorAlg<>::doDump()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::FastGaussianNoiseGeneratorAlg<ADCT>::convert
+  (Config const& config) -> Params_t
+{
+  return {
+    ADCcount_t{ config.RMS() } // RMS
+    };
+}
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_ALGORITHMS_FASTGAUSSIANNOISEGENERATORALG_H
+
+

--- a/icaruscode/PMT/Algorithms/GaussianNoiseGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/GaussianNoiseGeneratorAlg.h
@@ -1,0 +1,270 @@
+/**
+ * @file   icaruscode/PMT/Algorithms/GaussianNoiseGeneratorAlg.h
+ * @brief  A Gaussian noise generation algorithm.
+ * @date   November 17, 2022
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    icaruscode/PMT/Algorithms/PMTnoiseGenerator.h
+ */
+
+#ifndef ICARUSCODE_PMT_ALGORITHMS_GAUSSIANNOISEGENERATORALG_H
+#define ICARUSCODE_PMT_ALGORITHMS_GAUSSIANNOISEGENERATORALG_H
+
+// LArSoft/ICARUS libraries
+#include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
+#include "icaruscode/Utilities/quantities_utils.h" // util::...::value()
+#include "lardataalg/Utilities/quantities_fhicl.h" // count_f from FHiCL
+
+// framework libraries
+#include "fhiclcpp/types/Atom.h"
+
+// CLHEP libraries
+#include "CLHEP/Random/RandEngine.h" // CLHEP::HepRandomEngine
+#include "CLHEP/Random/RandGaussQ.h"
+
+// C/C++ standard libraries
+#include <vector>
+#include <utility> // std::move()
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <typename ADCT = double> class GaussianNoiseGeneratorAlg;
+}
+/**
+ * @brief Gaussian noise generator algorithm for PMT electronics simulation.
+ * @param ADCT type of the ADC count this interface treats with.
+ * 
+ * This noise generator produces a random Gaussian-distributed noise with
+ * the specified RMS and no bias.
+ * 
+ * It requires a CLHEP random engine as input, and directly uses
+ * `CLHEP::RandGaussQ` adaptor on it.
+ * 
+ * Generating for any type `ADCT` other that the CLHEP-native `double` requires
+ * a conversion and slows down the generation.
+ * 
+ */
+template <typename ADCT /* = double */>
+class icarus::opdet::GaussianNoiseGeneratorAlg
+  : public icarus::opdet::NoiseGeneratorAlg<ADCT>
+{
+  using Base_t = icarus::opdet::NoiseGeneratorAlg<ADCT>; ///< Base class alias.
+  
+    public:
+  
+  using ADCcount_t = typename Base_t::ADCcount_t;
+  using Timestamp_t = typename Base_t::Timestamp_t;
+  
+  /// Underlying fundamental type of `ADCcount_t`, e.g. `float`.
+  using ADCvalue_t = util::value_t<typename Base_t::ADCcount_t>;
+  
+  
+  // --- BEGIN -- Configuration ------------------------------------------------
+  /// Algorithm configuration parameters.
+  struct Params_t {
+    ADCcount_t RMS; ///< Gaussian sigma parameter for the noise.
+  };
+  
+  
+  /// Configuration parameters.
+  struct Config {
+
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Atom<ADCvalue_t> RMS{
+      Name{ "RMS" },
+      Comment{ "RMS of the Gaussian noise" }
+      // mandatory
+      };
+    
+  }; // struct Config
+  
+  
+  // --- END ---- Configuration ------------------------------------------------
+  
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters
+   * @param engine random engines
+   */
+  GaussianNoiseGeneratorAlg(Params_t params, CLHEP::HepRandomEngine& engine);
+  
+  
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters in FHiCL format
+   * @param engine random engines
+   */
+  GaussianNoiseGeneratorAlg
+    (Config const& config, CLHEP::HepRandomEngine& engine);
+
+  
+  
+    protected:
+  
+  // --- BEGIN -- Configuration parameters -------------------------------------
+  
+  Params_t const fParams; ///< All configuration parameters.
+  
+  // --- END ---- Configuration parameters -------------------------------------
+  
+  
+  /// Random engine used by this algorithm.
+  CLHEP::HepRandomEngine& fRandomEngine;
+  
+  CLHEP::RandGaussQ fGausRandom; ///< Gaussian random extractor adapter.
+  
+  
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /**
+   * @brief Adds noise to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with noise
+   * @param n number of samples to add noise to
+   * @return the number of samples actually added noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doAdd(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with noise
+   * @param n number of samples to fill with noise
+   * @return the number of samples actually overwritten with noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doFill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Prints into the stream the parameters of this algorithm.
+   * @param out the C++ output stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   */
+  virtual void doDump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const override;
+  
+  // --- END ---- Virtual interface --------------------------------------------
+  
+  
+  /// Extracts the configuration parameters from a FHiCL configuration.
+  static Params_t convert(Config const& config);
+  
+  
+}; // icarus::opdet::GaussianNoiseGeneratorAlg
+
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::GaussianNoiseGeneratorAlg<ADCT>::GaussianNoiseGeneratorAlg
+  (Params_t params, CLHEP::HepRandomEngine& engine)
+  : fParams{ std::move(params) }
+  , fRandomEngine{ engine }
+  , fGausRandom{ fRandomEngine, 0.0, static_cast<double>(value(fParams.RMS)) }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::GaussianNoiseGeneratorAlg<ADCT>::GaussianNoiseGeneratorAlg
+  (Config const& config, CLHEP::HepRandomEngine& engine)
+  : GaussianNoiseGeneratorAlg{ convert(config), engine }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::GaussianNoiseGeneratorAlg<ADCT>::doAdd(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  std::vector<double> noise(n);
+  fGausRandom.fireArray(static_cast<int>(n), noise.data());
+  for (double const sample: noise)
+    *(begin++) += static_cast<ADCcount_t>(sample);
+  return n;
+} // icarus::opdet::GaussianNoiseGeneratorAlg<>::doAdd()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::GaussianNoiseGeneratorAlg<ADCT>::doFill(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  // if destination type is the same as generator natively uses,
+  // we avoid conversions
+  if constexpr(std::is_same_v<ADCcount_t, double>) {
+    fGausRandom.fireArray(static_cast<int>(n), begin);
+    return n;
+  }
+  else {
+    std::vector<double> noise(n);
+    fGausRandom.fireArray(static_cast<int>(n), noise.data());
+    for (double const sample: noise)
+      *(begin++) = static_cast<ADCcount_t>(sample);
+    return n;
+  }
+} // icarus::opdet::GaussianNoiseGeneratorAlg<>::doFill()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::GaussianNoiseGeneratorAlg<ADCT>::doDump(
+  std::ostream& out,
+  std::string const& indent, std::string const& firstIndent
+) const {
+  out << firstIndent
+    << "Gaussian noise generator algorithm (GaussianNoiseGeneratorAlg):"
+    << "\n" << indent << "  RMS: " << fParams.RMS;
+} // icarus::opdet::GaussianNoiseGeneratorAlg<>::doDump()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::GaussianNoiseGeneratorAlg<ADCT>::convert
+  (Config const& config) -> Params_t
+{
+  return {
+    ADCcount_t{ config.RMS() } // RMS
+    };
+}
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_ALGORITHMS_GAUSSIANNOISEGENERATORALG_H
+
+

--- a/icaruscode/PMT/Algorithms/NoNoiseGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/NoNoiseGeneratorAlg.h
@@ -1,0 +1,220 @@
+/**
+ * @file   icaruscode/PMT/Algorithms/NoNoiseGeneratorAlg.h
+ * @brief  A (faster?) Gaussian noise generation algorithm.
+ * @date   November 17, 2022
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    icaruscode/PMT/Algorithms/PMTnoiseGenerator.h
+ */
+
+#ifndef ICARUSCODE_PMT_ALGORITHMS_NONOISEGENERATORALG_H
+#define ICARUSCODE_PMT_ALGORITHMS_NONOISEGENERATORALG_H
+
+// ICARUS libraries
+#include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
+#include "icaruscode/Utilities/quantities_utils.h" // util::...::value()
+
+// C/C++ standard libraries
+#include <algorithm>
+#include <vector>
+#include <utility> // std::move()
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <typename ADCT = double> class NoNoiseGeneratorAlg;
+}
+/**
+ * @brief No-noise generator algorithm for PMT electronics simulation.
+ * @param ADCT type of the ADC count this interface treats with.
+ * 
+ * This noise generator always emits no noise (`0`).
+ * 
+ * The CLHEP random engine passed in the configuration is ignored.
+ */
+template <typename ADCT /* = double */>
+class icarus::opdet::NoNoiseGeneratorAlg
+  : public icarus::opdet::NoiseGeneratorAlg<ADCT>
+{
+  using Base_t = icarus::opdet::NoiseGeneratorAlg<ADCT>; ///< Base class alias.
+  
+    public:
+  
+  using ADCcount_t = typename Base_t::ADCcount_t;
+  using Timestamp_t = typename Base_t::Timestamp_t;
+  
+  /// Underlying fundamental type of `ADCcount_t`, e.g. `float`.
+  using ADCvalue_t = util::value_t<typename Base_t::ADCcount_t>;
+  
+  
+  // --- BEGIN -- Configuration ------------------------------------------------
+  /// Algorithm configuration parameters.
+  struct Params_t {
+    // empty
+  };
+  
+  
+  /// Configuration parameters.
+  struct Config {
+
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    // empty
+    
+  }; // struct Config
+  
+  
+  // --- END ---- Configuration ------------------------------------------------
+  
+  
+  // ---------------------------------------------------------------------------
+  /// Default constructor.
+  NoNoiseGeneratorAlg() = default;
+  
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters
+   * @param engine _ignored_
+   */
+  NoNoiseGeneratorAlg(Params_t params, CLHEP::HepRandomEngine& engine);
+  
+  
+  /**
+   * @brief Constructor: acquires configuration parameters as data structure.
+   * @param params configuration parameters in FHiCL format
+   * @param engine _ignored_
+   */
+  NoNoiseGeneratorAlg(Config const& config, CLHEP::HepRandomEngine& engine);
+  
+  
+    private:
+  
+  Params_t const fParams; ///< Configuration parameters.
+  
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /**
+   * @brief Adds noise to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with noise
+   * @param n number of samples to add noise to
+   * @return the number of samples actually added noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doAdd(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with noise
+   * @param n number of samples to fill with noise
+   * @return the number of samples actually overwritten with noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doFill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) override;
+  
+  /**
+   * @brief Prints into the stream the parameters of this algorithm.
+   * @param out the C++ output stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   */
+  virtual void doDump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const override;
+  
+  // --- END ---- Virtual interface --------------------------------------------
+  
+  
+  /// Extracts the configuration parameters from a FHiCL configuration.
+  static Params_t convert(Config const& config);
+  
+  
+}; // icarus::opdet::NoNoiseGeneratorAlg
+
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::NoNoiseGeneratorAlg<ADCT>::NoNoiseGeneratorAlg
+  (Params_t params, CLHEP::HepRandomEngine&)
+  : fParams{ std::move(params) }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+icarus::opdet::NoNoiseGeneratorAlg<ADCT>::NoNoiseGeneratorAlg
+  (Config const& config, CLHEP::HepRandomEngine& engine)
+  : NoNoiseGeneratorAlg{ convert(config), engine }
+{}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoNoiseGeneratorAlg<ADCT>::doAdd
+  (raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t n)
+{
+  return n;
+} // icarus::opdet::NoNoiseGeneratorAlg<ADCT>::doAdd()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoNoiseGeneratorAlg<ADCT>::doFill
+  (raw::Channel_t, Timestamp_t, ADCcount_t* begin, std::size_t n)
+{
+  std::fill_n(begin, n, ADCcount_t{ 0 });
+  return n;
+} // icarus::opdet::NoNoiseGeneratorAlg<ADCT>::doFill()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::NoNoiseGeneratorAlg<ADCT>::doDump(
+  std::ostream& out,
+  std::string const& indent, std::string const& firstIndent
+) const {
+  out << firstIndent << "No-noise generator algorithm (NoNoiseGeneratorAlg).";
+} // icarus::opdet::NoNoiseGeneratorAlg<ADCT>::doDump()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::NoNoiseGeneratorAlg<ADCT>::convert
+  (Config const& config) -> Params_t
+{
+  return {};
+}
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_ALGORITHMS_NONOISEGENERATORALG_H
+
+

--- a/icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h
@@ -1,0 +1,557 @@
+/**
+ * @file   icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h
+ * @brief  Interface for a noise generating algorithm.
+ * @date   November 17, 2022
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ */
+
+#ifndef ICARUSCODE_PMT_ALGORITHMS_NOISEGENERATORALG_H
+#define ICARUSCODE_PMT_ALGORITHMS_NOISEGENERATORALG_H
+
+// LArSoft libraries
+#include "lardataobj/RawData/OpDetWaveform.h" // raw::Channel_t
+
+// C/C++ standard libraries
+#include <ostream>
+#include <sstream>
+#include <algorithm>
+#include <vector>
+#include <cstdint> // std::uint64_t
+#include <cstddef> // std::size_t
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <typename ADCT> class NoiseGeneratorAlg; 
+  template <typename Stream, typename ADCT>
+  Stream& operator<< (Stream&& out, NoiseGeneratorAlg<ADCT> const& gen);
+} // namespace icarus::opdet
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Interface for a PMT electronics noise generator algorithm.
+ * @param ADCT type of the ADC count this interface deals with.
+ * 
+ * A noise generator is an algorithm able to fill digitization samples with
+ * some proper noise.
+ * The interface allows to specify the channel that the noise will apply to and
+ * the absolute time at which the noise is produced. Neither is an essential
+ * parameter.
+ * 
+ * The configuration of the generator is expected to be performed on
+ * construction, and it is therefore out of the interface.
+ * Configuration and all additional setup elements must be passed through the
+ * constructor; that includes any random engine that is likely needed.
+ * 
+ * Currently the interface expects to know ahead how many noise samples are
+ * going to be extracted by each call.
+ * 
+ * 
+ * Implementer notes
+ * ==================
+ * 
+ * The interface methods are deliberately marked non-`const`, with the
+ * expectation that random engines will be used and that the implementers will
+ * not be forced to use mutable state: as a baseline, the implementations of
+ * this interface should be treated as thread-unsafe.
+ * 
+ * The interface currently demands the definition of two functions, one to fill
+ * (overwrite) a buffer, the other to add to it. The rationale is that the
+ * implementer can choose the ones which is more efficient to implement (also
+ * depending on the expected most common use), and it is expected that most
+ * implementations will have either of the two call the other.
+ * 
+ * The other overrideable function is a configuration dump that is convenient
+ * for the log files but does not affect the noise generation.
+ * 
+ * Although the constructor is in principle not bound to any particular
+ * signature from the point of view of C++ inheritance, because these objects
+ * are going to be created via a factory written in C++, it is still demanded
+ * (by the factory interface or by the callers of the factory) that the
+ * constructor signature be standardized. To make these objects work with _art_
+ * tool infrastructure, they need to be wrapped into a class which exposes a
+ * constructor whose sole argument can be initialized from a
+ * `fhicl::ParameterSet`.
+ * 
+ */
+template <typename ADCT>
+class icarus::opdet::NoiseGeneratorAlg {
+  
+    public:
+  
+  using ADCcount_t = ADCT; ///< Type of the sample value.
+  
+  using Timestamp_t = std::uint64_t; ///< Type of timestamp.
+  
+  // --- BEGIN -- Noise addition -----------------------------------------------
+  /// @name Noise addition
+  /// @{
+  
+  /**
+   * @brief Adds noise to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with noise
+   * @param n number of samples to add noise to
+   * @return the number of samples actually added noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  std::size_t add(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  /**
+   * @brief Adds noise to the samples from `begin` up to `end` (excluded).
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added noise
+   * @param end pointer past the last sample to be added noise
+   * @return pointer to the first sample not added noise
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same considerations apply as expressed in
+   * `add(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`,
+   * with the difference that the expected return value is `end` unless the
+   * generator was unable to fully fulfill the request.
+   */
+  ADCcount_t* add(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, ADCcount_t* end
+    );
+  
+  /**
+   * @brief Adds noise to all the `samples`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param samples container of the samples to be added noise to
+   * @return number of samples actually added noise
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same general considerations apply as expressed in
+   * `add(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`.
+   * 
+   * In addition, the buffer (`samples`) is now automatically guaranteed to be
+   * valid and _all_ its samples are added noise. The size of the buffer is
+   * never resized.
+   * The expected return value is `samples.size()` unless the generator was
+   * unable to fully fulfill the request.
+   */
+  std::size_t add(
+    raw::Channel_t channel, Timestamp_t time,
+    std::vector<ADCcount_t>& samples
+    );
+  
+  /// @}
+  // --- END ---- Noise addition -----------------------------------------------
+  
+  
+  // --- BEGIN -- Noise overwrite ----------------------------------------------
+  /// @name Noise overwrite
+  /// @{
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with noise
+   * @param n number of samples to fill with noise
+   * @return the number of samples actually overwritten with noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  std::size_t fill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  /**
+   * @brief Overwrites samples from `begin` to `end` with noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with noise
+   * @param end pointer past the last sample to be overwritten with noise
+   * @return pointer to the first sample not overwritten with noise
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same considerations apply as expressed in
+   * `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`,
+   * with the difference that the expected return value is `end` unless the
+   * generator was unable to fully fulfill the request.
+   */
+  ADCcount_t* fill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, ADCcount_t* end
+    );
+  
+  /**
+   * @brief Overwrites all the `samples` with noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param samples container of the samples to be overwritten
+   * @return number of samples actually overwritten with noise
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same general considerations apply as expressed in
+   * `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`.
+   * 
+   * In addition, the buffer (`samples`) is now automatically guaranteed to be
+   * valid and _all_ its samples are overwritten with noise. The size of the
+   * buffer is never resized.
+   * The expected return value is `samples.size()` unless the generator was
+   * unable to fully fulfill the request.
+   */
+  std::size_t fill(
+    raw::Channel_t channel, Timestamp_t time,
+    std::vector<ADCcount_t>& samples
+    );
+  
+  
+  /**
+   * @brief Adds to the end of `samples` additional `n` noise samples.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param samples container of the samples to be expanded
+   * @param n number of noise samples to be added
+   * @return number of samples actually overwritten with noise
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same general considerations apply as expressed in
+   * `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`.
+   * 
+   * In addition, the buffer (`samples`) is automatically expanded with `n`
+   * more elements, which are assigned noise values.
+   * The expected return value is `n` unless the generator was unable to fully
+   * fulfill the request. In that case, the sample is resized to include only
+   * up to the samples actually added with noise (the actually allocated
+   * memory, `capacity()`, may exceed that though, and the buffer does not
+   * `shrink_to_fit()`).
+   */
+  std::size_t append(
+    raw::Channel_t channel, Timestamp_t time,
+    std::vector<ADCcount_t>& samples, std::size_t n
+    );
+  
+  /// @}
+  // --- END ---- Noise overwrite ----------------------------------------------
+  
+  
+  // --- BEGIN -- Dump configuration on screen ---------------------------------
+  /// @name Dump configuration on screen
+  /// @{
+  
+  //@{
+  /**
+   * @brief Prints on stream the configuration parameters.
+   * @param out the stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   */
+  void dump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const;
+  void dump(std::ostream&& out, std::string const& indent = "") const;
+  //@}
+
+
+  //@{
+  /**
+   * @brief Returns the configuration parameter description.
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   * @return a string with the parameters of this shape
+   */
+  std::string toString
+    (std::string const& indent, std::string const& firstIndent) const;
+  std::string toString(std::string const& indent = "") const;
+  //@}
+  
+  /// @}
+  // --- END ---- Dump configuration on screen ---------------------------------
+  
+  
+    protected:
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /**
+   * @brief Adds noise to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with noise
+   * @param n number of samples to add noise to
+   * @return the number of samples actually added noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doAdd(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) = 0;
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with noise.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with noise
+   * @param n number of samples to fill with noise
+   * @return the number of samples actually overwritten with noise
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doFill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) = 0;
+  
+  /**
+   * @brief Prints into the stream the parameters of this algorithm.
+   * @param out the C++ output stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   * 
+   * Sends a complete description of the configuration of the algorithm to the
+   * `out` stream. The output starts on the current line of the stream, which
+   * is added a `firstIndent` indentation string. All following new lines are
+   * started with an indentation string `indent`. The last line is not ended
+   * with a newline character.
+   * 
+   * The default implementation prints nothing (also no indentation).
+   * Custom implementations may choose to add line breaks in addition to the
+   * ones described above.
+   */
+  virtual void doDump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const {}
+  
+  // --- END ---- Virtual interface --------------------------------------------
+  
+  
+  // --- BEGIN -- Convenience implementation functions -------------------------
+  
+  /**
+   * Implementation helper: implements `doFill()` based on `doAdd()`.
+   * 
+   * This implementation is trivial: the buffer is first zeroed, and then noise
+   * is added.
+   * 
+   * The definition of `doFill()` becomes:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::size_t doFill(
+   *   raw::Channel_t channel, Timestamp_t time,
+   *   ADCcount_t* begin, std::size_t n
+   *   ) override
+   *   { return _fillByAdding(channel, time, begin, n); }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  std::size_t _fillByAdding(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  /**
+   * Implementation helper: implements `doAdd()` based on `doFill()`.
+   * 
+   * This implementation is trivial: the noise is first generated in a new
+   * buffer, and then it's added to the existing one.
+   * 
+   * The definition of `doAdd()` becomes:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::size_t doAdd(
+   *   raw::Channel_t channel, Timestamp_t time,
+   *   ADCcount_t* begin, std::size_t n
+   *   ) override
+   *   { return _addByFilling(channel, time, begin, n); }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  std::size_t _addByFilling(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  // --- END ---- Convenience implementation functions -------------------------
+  
+}; // icarus::opdet::NoiseGeneratorAlg
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::add(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  return doAdd(channel, time, begin, n);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::NoiseGeneratorAlg<ADCT>::add(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, ADCcount_t* end
+) -> ADCcount_t* {
+  std::size_t const n = add(channel, time, begin, end - begin);
+  return begin + n;
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::add(
+  raw::Channel_t channel, Timestamp_t time,
+  std::vector<ADCcount_t>& samples
+) {
+  return add(channel, time, samples.data(), samples.size());
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::fill(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  return doFill(channel, time, begin, n);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::NoiseGeneratorAlg<ADCT>::fill(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, ADCcount_t* end
+) -> ADCcount_t* {
+  std::size_t const n = fill(channel, time, begin, end - begin);
+  return begin + n;
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::fill(
+  raw::Channel_t channel, Timestamp_t time,
+  std::vector<ADCcount_t>& samples
+) {
+  return fill(channel, time, samples.data(), samples.size());
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::append(
+  raw::Channel_t channel, Timestamp_t time,
+  std::vector<ADCcount_t>& samples, std::size_t n
+) {
+  std::size_t const oldSize = samples.size();
+  samples.resize(oldSize + n);
+  std::size_t const nAdded = fill(channel, time, samples.data() + oldSize, n);
+  samples.resize(oldSize + nAdded); // no-op if nAdded is equal to n
+  return nAdded;
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::NoiseGeneratorAlg<ADCT>::dump(
+  std::ostream& out, std::string const& indent, std::string const& firstIndent
+) const {
+  doDump(out, indent, firstIndent);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::NoiseGeneratorAlg<ADCT>::dump
+  (std::ostream&& out, std::string const& indent /* = "" */) const
+  { dump(out, indent, indent); }
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::string icarus::opdet::NoiseGeneratorAlg<ADCT>::toString
+  (std::string const& indent, std::string const& firstIndent) const
+{
+  std::ostringstream sstr;
+  dump(sstr, indent, firstIndent);
+  return std::move(sstr).str();
+} // icarus::opdet::NoiseGeneratorAlg<>::toString()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::string icarus::opdet::NoiseGeneratorAlg<ADCT>::toString
+  (std::string const& indent /* = "" */) const
+  { return toString(indent, indent); }
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::_fillByAdding(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  std::fill_n(begin, n, ADCcount_t{ 0 });
+  return doAdd(channel, time, begin, n);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::_addByFilling(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  std::vector<ADCcount_t> noise(n);
+  std::size_t const nSamples = fill(channel, time, noise);
+  assert(nSamples <= n);
+  
+  auto it = noise.cbegin();
+  auto const nend = it + nSamples;
+  while (it != nend) *(begin++) += *it++;
+  
+  return nSamples;
+} // icarus::opdet::NoiseGeneratorAlg::_addByFilling()
+
+
+// -----------------------------------------------------------------------------
+// --- free function implementation
+// -----------------------------------------------------------------------------
+template <typename Stream, typename ADCT>
+Stream& icarus::opdet::operator<<
+  (Stream&& out, icarus::opdet::NoiseGeneratorAlg<ADCT> const& gen)
+  { out << gen.toString(); return out; }
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_ALGORITHMS_NOISEGENERATORALG_H
+
+

--- a/icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h
@@ -24,8 +24,9 @@
 // -----------------------------------------------------------------------------
 namespace icarus::opdet {
   template <typename ADCT> class NoiseGeneratorAlg; 
-  template <typename Stream, typename ADCT>
-  Stream& operator<< (Stream&& out, NoiseGeneratorAlg<ADCT> const& gen);
+  template <typename ADCT>
+  std::ostream& operator<<
+    (std::ostream& out, NoiseGeneratorAlg<ADCT> const& gen);
 } // namespace icarus::opdet
 
 // -----------------------------------------------------------------------------
@@ -83,6 +84,10 @@ class icarus::opdet::NoiseGeneratorAlg {
   using ADCcount_t = ADCT; ///< Type of the sample value.
   
   using Timestamp_t = std::uint64_t; ///< Type of timestamp.
+  
+  
+  virtual ~NoiseGeneratorAlg() = default;
+  
   
   // --- BEGIN -- Noise addition -----------------------------------------------
   /// @name Noise addition
@@ -544,9 +549,9 @@ std::size_t icarus::opdet::NoiseGeneratorAlg<ADCT>::_addByFilling(
 // -----------------------------------------------------------------------------
 // --- free function implementation
 // -----------------------------------------------------------------------------
-template <typename Stream, typename ADCT>
-Stream& icarus::opdet::operator<<
-  (Stream&& out, icarus::opdet::NoiseGeneratorAlg<ADCT> const& gen)
+template <typename ADCT>
+std::ostream& icarus::opdet::operator<<
+  (std::ostream& out, icarus::opdet::NoiseGeneratorAlg<ADCT> const& gen)
   { out << gen.toString(); return out; }
 
 

--- a/icaruscode/PMT/Algorithms/PMTReadoutWindowMaker.h
+++ b/icaruscode/PMT/Algorithms/PMTReadoutWindowMaker.h
@@ -1,0 +1,217 @@
+/**
+ * @file   icaruscode/PMT/Algorithms/PMTReadoutWindowMaker.h
+ * @brief  Algorithm turning readout seeds into a list of readout windows.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   December 9, 2022
+ * 
+ * This library is header-only.
+ */
+
+#ifndef ICARUSCODE_PMT_ALGORITHMS_PMTREADOUTWINDOWMAKER_H
+#define ICARUSCODE_PMT_ALGORITHMS_PMTREADOUTWINDOWMAKER_H
+
+// ICARUS libraries
+#include "icarusalg/Utilities/mfLoggingClass.h"
+
+// C/C++ standard library
+#include <ostream>
+#include <vector>
+#include <utility> // std::pair, std::move()
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <typename Time, typename Interval = typename Time::interval_t>
+  class PMTReadoutWindowMaker;
+}
+/**
+ * @brief Algorithm turning readout seeds into a list of readout windows.
+ * @tparam Time type of the time point of the primitives
+ * @tparam Interval type of the interval between time points
+ * 
+ * Given a definition of readout window in the configuration, this algorithm
+ * builds a list of readout windows around "seeds".
+ * A seed is a time when the trigger of the readout window happens, and each
+ * readout window will include a pre-trigger buffer (`preBuffer()`) before
+ * that time and a post-trigger buffer (`postBuffer()`) after it.
+ * 
+ * This class is designed to work with LArSoft timescale data types like
+ * `detinfo::timescales::electronics_time`, but it can also be used with simple
+ * data types (like `double`), provided that the `Interval` template parameter
+ * is correctly set.
+ */
+template <typename Time, typename Interval /* = typename Time::interval_t */>
+class icarus::opdet::PMTReadoutWindowMaker
+  : public icarus::ns::util::mfLoggingClass
+{
+  
+    public:
+  
+  using TimePoint_t = Time; ///< Type of time used.
+  using TimeInterval_t = Interval; ///< Type of time interval used.
+  
+  /// A single contiguous readout window.
+  struct Window_t: std::pair<TimePoint_t, TimePoint_t> {
+    using Base_t = std::pair<TimePoint_t, TimePoint_t>;
+    
+    using Base_t::Base_t;
+    
+    constexpr TimePoint_t start() const noexcept { return Base_t::first; }
+    constexpr TimePoint_t stop() const noexcept { return Base_t::second; }
+    constexpr auto width() const noexcept { return stop() - start(); }
+    
+    constexpr bool empty() const noexcept { return start() >= stop(); }
+    
+    constexpr bool includes(TimePoint_t t) const noexcept
+      { return (t >= start()) && (t < stop()); }
+    
+    /// Sets the start of this interval to `start`.
+    void setStart(TimePoint_t start) { Base_t::first = start; }
+    
+    /// Sets the end of this interval to `stop`.
+    void setStop(TimePoint_t stop) { Base_t::second = stop; }
+    
+    
+    friend std::ostream& operator<< (std::ostream& out, Window_t const& w)
+      {
+        return
+          out << w.start() << " -- " << w.stop() << " (" << w.width() << ")";
+      }
+    
+  }; // Window_t
+  
+  
+  /**
+   * @brief Constructor: specifies all the algorithm parameters.
+   * @param readoutWindow the total time of the readout window
+   * @param preTriggerWindow the time of the window preceding a readout seed
+   * @param logCategory name of the stream to send console messages to
+   */
+  PMTReadoutWindowMaker(
+    TimeInterval_t readoutWindow, TimeInterval_t preTriggerWindow,
+    std::string logCategory = "PMTReadoutWindowMaker"
+    );
+  
+  // --- BEGIN -- Configuration query ------------------------------------------
+  /// @name Configuration query
+  /// @{
+  
+  /// Returns the total time of a readout buffer.
+  TimeInterval_t buffer() const { return preBuffer() + postBuffer(); }
+  
+  /// Returns the time of the readout buffer before its seed.
+  TimeInterval_t preBuffer() const { return fPreBuffer; }
+  
+  /// Returns the time of the readout buffer after its seed.
+  TimeInterval_t postBuffer() const { return fPostBuffer; }
+  
+  /// @}
+  // --- END ---- Configuration query ------------------------------------------
+  
+  
+  // --- BEGIN -- Algorithm operations -----------------------------------------
+  /// @name Algorithm operations
+  /// @{
+  
+  //@{
+  /**
+   * @brief Returns a list of readout windows from the specified seeds.
+   * @param seeds the list of seeds to be considered
+   * @return a list of readout windows
+   * 
+   * Each seed generates a readout window with the size specified by the
+   * algorithm configuration (`buffer()`) for each of the time seeds specified
+   * in the list.
+   *
+   * Overlapping windows are merged.
+   * 
+   * The seeds are expected to be sorted in increasing time.
+   */
+  std::vector<Window_t> makeWindows
+    (std::vector<TimePoint_t> const& seeds) const;
+  
+  std::vector<Window_t> operator()
+    (std::vector<TimePoint_t> const& seeds) const { return makeWindows(seeds); }
+  
+  //@}
+  
+  /// @}
+  // --- END ---- Algorithm operations -----------------------------------------
+  
+    private:
+  
+  /// Extension of readout buffer before trigger.
+  TimeInterval_t const fPreBuffer;
+  
+  /// Extension of readout buffer after trigger.
+  TimeInterval_t const fPostBuffer;
+  
+}; // icarus::opdet::PMTReadoutWindowMaker
+
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <typename Time, typename Interval>
+icarus::opdet::PMTReadoutWindowMaker<Time, Interval>::PMTReadoutWindowMaker(
+  TimeInterval_t readoutWindow, TimeInterval_t preTriggerWindow,
+  std::string logCategory /* = "PMTReadoutWindowMaker" */
+)
+  : icarus::ns::util::mfLoggingClass{ std::move(logCategory) }
+  , fPreBuffer{ preTriggerWindow }
+  , fPostBuffer{ readoutWindow - fPreBuffer }
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <typename Time, typename Interval>
+auto icarus::opdet::PMTReadoutWindowMaker<Time, Interval>::makeWindows
+  (std::vector<TimePoint_t> const& seeds) const
+  -> std::vector<Window_t>
+{
+  std::vector<Window_t> windows;
+  if (seeds.empty()) return windows;
+  
+  auto itSeed = seeds.begin();
+  auto const send = seeds.end();
+  
+  windows.emplace_back(*itSeed - fPreBuffer, *itSeed + fPostBuffer);
+  Window_t* lastWindow = &(windows.back());
+  
+  mfLogTrace() << "Processing " << seeds.size() << " readout seeds."
+    << "\nFirst window from t=" << *itSeed << ": " << *lastWindow;
+  
+  while (++itSeed != send) {
+    
+    TimePoint_t const time = *itSeed;
+    
+    TimePoint_t const start = time - fPreBuffer;
+    TimePoint_t const stop = time + fPostBuffer;
+    
+    mfLogTrace() << "Seed at: " << time << " (starts at " << start << ")";
+    if (start <= lastWindow->stop()) { // merge
+      assert(lastWindow->start() <= start);
+      lastWindow->setStop(stop);
+      
+      mfLogTrace()
+        << "  starts within last window: extended, now " << *lastWindow;
+      
+    }
+    else { // new
+      windows.emplace_back(start, stop);
+      lastWindow = &(windows.back());
+      mfLogTrace() << "  new window: " << *lastWindow;
+    }
+    
+  } // while
+  
+  return windows;
+  
+} // icarus::opdet::PMTReadoutWindowMaker<>::makeWindows()
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_ALGORITHMS_PMTREADOUTWINDOWMAKER_H

--- a/icaruscode/PMT/Algorithms/PMTsimulationAlg.h
+++ b/icaruscode/PMT/Algorithms/PMTsimulationAlg.h
@@ -18,14 +18,16 @@
 // ICARUS libraries
 #include "icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.h"
 #include "icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h"
+#include "icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h"
+#include "icaruscode/Utilities/quantities_utils.h" // util::value_t
 #include "icarusalg/Utilities/SampledFunction.h"
-#include "icarusalg/Utilities/FastAndPoorGauss.h"
 
 // LArSoft libraries
 #include "lardataobj/RawData/OpDetWaveform.h"
 #include "lardataobj/Simulation/SimPhotons.h"
 #include "lardataalg/DetectorInfo/LArProperties.h"
 #include "lardataalg/DetectorInfo/DetectorClocksData.h"
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/DetectorInfo/DetectorTimingTypes.h"
 #include "lardataalg/Utilities/quantities_fhicl.h" // microsecond from FHiCL
 #include "lardataalg/Utilities/quantities/spacetime.h" // microsecond, ...
@@ -66,6 +68,10 @@ namespace icarus::opdet {
   /// Type for single photon response shape function: nanosecond -> ADC counts.
   using SinglePhotonResponseFunc_t
     = DiscretePhotoelectronPulse::PulseFunction_t;
+  
+  /// Type of electronics noise generator algorithm.
+  using PedestalGenerator_t
+    = icarus::opdet::PedestalGeneratorAlg<DiscretePhotoelectronPulse::ADCcount>;
 
   template <typename SampleType> class OpDetWaveformMakerClass;
   
@@ -247,9 +253,15 @@ class icarus::opdet::OpDetWaveformMakerClass {
  * Electronics noise
  * ------------------
  *
- * Electronics noise is described by Gaussian fluctuations of a given
- * standard deviation, controlled by the configuration parameter `AmpNoise`.
- * No noise correlation is simulated neither in time nor in space.
+ * Electronics noise generation is delegated to an algorithm that also sets the
+ * waveform baseline and which can actually either add noise or transform the
+ * signal.
+ * Currently the "standard" noise model is Gaussian fluctuations of a given
+ * standard deviation, from tools `PMTgausNoiseGeneratorTool` or
+ * `PMTfastGausNoiseGeneratorTool`, with no noise correlation either in time
+ * or in space, while the standard pedestal model is a fixed value
+ * (`PMTconstantPedestalGeneratorTool`).
+ * Noise can be disabled by using the `PMTnoNoiseGeneratorTool`.
  *
  *
  * Configuration
@@ -341,8 +353,8 @@ class icarus::opdet::OpDetWaveformMakerClass {
 class icarus::opdet::PMTsimulationAlg {
 
     public:
-  using microseconds = util::quantities::microsecond;
-  using nanoseconds = util::quantities::nanosecond;
+  using microsecond = util::quantities::microsecond;
+  using nanosecond = util::quantities::nanosecond;
   using hertz = util::quantities::hertz;
   using megahertz = util::quantities::megahertz;
   using picocoulomb = util::quantities::picocoulomb;
@@ -422,20 +434,17 @@ class icarus::opdet::PMTsimulationAlg {
     float  pretrigFraction;       ///< Fraction of window size to be before "trigger"
     ADCcount thresholdADC; ///< ADC Threshold for self-triggered readout
     int    pulsePolarity;         ///< Pulse polarity (=1 for positive, =-1 for negative)
-    microseconds triggerOffsetPMT; ///< Time relative to trigger when PMT readout starts TODO make it a `trigger_time` point
+    microsecond triggerOffsetPMT; ///< Time relative to trigger when PMT readout starts TODO make it a `trigger_time` point
 
-    microseconds readoutEnablePeriod;  ///< Time (us) for which pmt readout is enabled
+    microsecond readoutEnablePeriod;  ///< Time (us) for which pmt readout is enabled
 
     bool createBeamGateTriggers; ///< Option to create unbiased readout around beam spill
-    microseconds beamGateTriggerRepPeriod; ///< Repetition Period (us) for BeamGateTriggers TODO make this a time_interval
+    microsecond beamGateTriggerRepPeriod; ///< Repetition Period (us) for BeamGateTriggers TODO make this a time_interval
     size_t beamGateTriggerNReps; ///< Number of beamgate trigger reps to produce
 
     unsigned int pulseSubsamples = 1U; ///< Number of tick subsamples.
 
     unsigned int ADCbits = 14U; ///< Number of bits of the digitizer.
-    ADCcount baseline; //waveform baseline
-    ADCcount ampNoise; //amplitude of gaussian noise
-    bool useFastElectronicsNoise; ///< Whether to use fast generator for electronics noise.
     hertz darkNoiseRate;
     float saturation; //equivalent to the number of p.e. that saturates the electronic signal
     PMTspecs_t PMTspecs; ///< PMT specifications.
@@ -445,13 +454,22 @@ class icarus::opdet::PMTsimulationAlg {
     /// @{
     /// @name Setup parameters
 
+    /// Beam gate opening time [UTC, ns]
+    std::uint64_t beamGateTimestamp = 0;
 
     detinfo::LArProperties const* larProp = nullptr; ///< LarProperties service provider.
 
     detinfo::DetectorClocksData const* clockData = nullptr;
+    
+    // detTimings is not really "optional" but it needs delayed construction.
+    /// Detector clocks data wrapper.
+    std::optional<detinfo::DetectorTimings> detTimings;
 
     /// Single photon response function.
     SinglePhotonResponseFunc_t const* pulseFunction;
+    
+    /// Pedestal and electronics noise generator algorithm.
+    PedestalGenerator_t* pedestalGen;
 
     /// Main random stream engine.
     CLHEP::HepRandomEngine* randomEngine = nullptr;
@@ -522,14 +540,12 @@ class icarus::opdet::PMTsimulationAlg {
   
   /// Type internally used for storing waveforms.
   using Waveform_t = OpDetWaveformMaker_t::WaveformData_t;
-  using WaveformValue_t = ADCcount::value_t; ///< Numeric type in waveforms.
+  /// Numeric type in waveforms.
+  using WaveformValue_t = util::value_t<ADCcount>;
 
   /// Type of sampled pulse shape: sequence of samples, one per tick.
   using PulseSampling_t = DiscretePhotoelectronPulse::Subsample_t;
-
-  /// Type of member function to add electronics noise.
-  using NoiseAdderFunc_t = void (PMTsimulationAlg::*)(Waveform_t&) const;
-
+  
 
   // --- BEGIN -- Helper functors ----------------------------------------------
   /// Functor to convert tick point into a tick number and a subsample index.
@@ -583,11 +599,10 @@ class icarus::opdet::PMTsimulationAlg {
   
   DiscretePhotoelectronPulse wsp; /// Single photon pulse (sampled).
 
-  NoiseAdderFunc_t const fNoiseAdder; ///< Selected electronics noise method.
-
-  ///< Transformation uniform to Gaussian for electronics noise.
-  static util::FastAndPoorGauss<32768U, float> const fFastGauss;
-
+  /// Pedestal and electronics noise generator algorithm.
+  PedestalGenerator_t* fPedestalGen = nullptr;
+  
+  
   /**
    * @brief Creates `raw::OpDetWaveform` objects from simulated photoelectrons.
    * @param photons the simulated list of photoelectrons
@@ -712,9 +727,10 @@ class icarus::opdet::PMTsimulationAlg {
     ) const;
   
   
-  void AddNoise(Waveform_t& wave) const; //add noise to baseline
-  /// Same as `AddNoise()` but using an alternative generator.
-  void AddNoise_faster(Waveform_t& wave) const;
+  /// Add the pedestal, including electronics noise.
+  void AddPedestal
+    (raw::Channel_t channel, std::uint64_t time, Waveform_t& wave) const;
+
   // Add "dark" noise to baseline.
   void AddDarkNoise(Waveform_t& wave) const;
   
@@ -741,7 +757,8 @@ class icarus::opdet::PMTsimulationAlg {
    * additional interest points that are added independently of whether there
    * is actual interesting activity in there.
    */
-  std::vector<optical_tick> FindTriggers(Waveform_t const& wvfm) const;
+  std::vector<optical_tick> FindTriggers
+    (Waveform_t const& wvfm, ADCcount baseline) const;
   
   
   /**
@@ -768,19 +785,23 @@ class icarus::opdet::PMTsimulationAlg {
   bool KicksPhotoelectron() const;
   
   /// Returns the ADC range allowed for photoelectron saturation.
-  std::pair<ADCcount, ADCcount> saturationRange() const;
+  std::pair<ADCcount, ADCcount> saturationRange(ADCcount baseline) const;
   
   /// Applies the configured photoelectron saturation on the `waveform`,
   /// only if the saturation is cutting into the digitisation `range`.
-  void ApplySaturation
-    (Waveform_t& waveform, std::pair<ADCcount, ADCcount> const& range) const;
+  void ApplySaturation(
+    Waveform_t& waveform, ADCcount baseline,
+    std::pair<ADCcount, ADCcount> const& range
+    ) const;
   
   /// Applies the configured photoelectron saturation on the `waveform`.
-  void ApplySaturation(Waveform_t& waveform) const;
+  void ApplySaturation(Waveform_t& waveform, ADCcount baseline) const;
   
   /// Forces `waveform` ADC within the `min` to `max` range (`max` included).
   static void ClipWaveform(Waveform_t& waveform, ADCcount min, ADCcount max);
   
+  /// Returns the timestamp matching the start of the full waveforms [UTC, ns]
+  std::uint64_t waveformStartTimestamp() const;
   
 }; // class PMTsimulationAlg
 
@@ -791,11 +812,11 @@ class icarus::opdet::PMTsimulationAlg {
 class icarus::opdet::PMTsimulationAlgMaker {
 
      public:
-  using microseconds = util::quantities::microsecond;
-  using nanoseconds = util::quantities::nanosecond;
+  using microsecond = util::quantities::microsecond;
+  using nanosecond = util::quantities::nanosecond;
   using hertz = util::quantities::hertz;
   using picocoulomb = util::quantities::picocoulomb;
-
+  
   struct PMTspecConfig {
     using Name = fhicl::Name;
     using Comment = fhicl::Comment;
@@ -828,7 +849,7 @@ class icarus::opdet::PMTsimulationAlgMaker {
     //
     // readout settings
     //
-    fhicl::Atom<microseconds> ReadoutEnablePeriod {
+    fhicl::Atom<microsecond> ReadoutEnablePeriod {
       Name("ReadoutEnablePeriod"),
       Comment("Time for which PMT readout is enabled [us]")
       // mandatory
@@ -843,11 +864,6 @@ class icarus::opdet::PMTsimulationAlgMaker {
       Name("ADCBits"),
       Comment("number of bits of the Analog-to-Digital Converter"),
       14U
-      };
-    fhicl::Atom<float> Baseline {
-      Name("Baseline"),
-      Comment("Waveform baseline (may be fractional) [ADC]")
-      // mandatory
       };
     fhicl::Atom<int> PulsePolarity {
       Name("PulsePolarity"),
@@ -902,21 +918,6 @@ class icarus::opdet::PMTsimulationAlgMaker {
       };
 
     //
-    // electronics noise
-    //
-    fhicl::Atom<double> AmpNoise {
-      Name("AmpNoise"),
-      Comment("RMS of the electronics noise fluctuations [ADC counts]")
-      // mandatory
-      };
-    fhicl::Atom<bool> FastElectronicsNoise {
-      Name("FastElectronicsNoise"),
-      Comment
-        ("use an approximate and faster random generator for electronics noise"),
-      true
-      };
-
-    //
     // trigger
     //
     fhicl::Atom<float> ThresholdADC {
@@ -929,7 +930,7 @@ class icarus::opdet::PMTsimulationAlgMaker {
       Comment("Whether to create unbiased readout trigger at beam spill")
       // mandatory
       };
-    fhicl::Atom<microseconds> BeamGateTriggerRepPeriod {
+    fhicl::Atom<microsecond> BeamGateTriggerRepPeriod {
       Name("BeamGateTriggerRepPeriod"),
       Comment("Repetition period for beam gate generated readout triggers [us]")
       // mandatory
@@ -939,7 +940,7 @@ class icarus::opdet::PMTsimulationAlgMaker {
       Comment("Number of beam gate readout triggers to generate")
       // mandatory
       };
-    fhicl::Atom<microseconds> TriggerOffsetPMT {
+    fhicl::Atom<microsecond> TriggerOffsetPMT {
       Name("TriggerOffsetPMT"),
       Comment("Time  when readout begins, relative to readout trigger [us]")
       // mandatory
@@ -954,9 +955,11 @@ class icarus::opdet::PMTsimulationAlgMaker {
 
   /**
    * @brief Creates and returns a new algorithm instance.
+   * @param beamGateTimestamp the time of beam gate opening, in UTC [ns]
    * @param larProp instance of `detinfo::LArProperties` to be used
    * @param detClocks instance of `detinfo::DetectorClocks` to be used
    * @param SPRfunction function to use for the single photon response
+   * @param pedestalGenerator algorithm generating the pedestal plus noise
    * @param mainRandomEngine main random engine (quantum efficiency, etc.)
    * @param darkNoiseRandomEngine random engine for dark noise simulation
    * @param elecNoiseRandomEngine random engine for electronics noise simulation
@@ -967,9 +970,11 @@ class icarus::opdet::PMTsimulationAlgMaker {
    * configuration disabled noise simulation.
    */
   std::unique_ptr<PMTsimulationAlg> operator()(
+    std::uint64_t beamGateTimestamp,
     detinfo::LArProperties const& larProp,
     detinfo::DetectorClocksData const& detClocks,
     SinglePhotonResponseFunc_t const& SPRfunction,
+    PedestalGenerator_t& pedestalGenerator,
     CLHEP::HepRandomEngine& mainRandomEngine,
     CLHEP::HepRandomEngine& darkNoiseRandomEngine,
     CLHEP::HepRandomEngine& elecNoiseRandomEngine,
@@ -978,9 +983,11 @@ class icarus::opdet::PMTsimulationAlgMaker {
 
   /**
    * @brief Returns a data structure to construct the algorithm.
+   * @param beamGateTimestamp the time of beam gate opening, in UTC [ns]
    * @param larProp instance of `detinfo::LArProperties` to be used
    * @param detClocks instance of `detinfo::DetectorClocks` to be used
    * @param SPRfunction function to use for the single photon response
+   * @param pedestalGenerator algorithm generating the pedestal plus noise
    * @param mainRandomEngine main random engine (quantum efficiency, etc.)
    * @param darkNoiseRandomEngine random engine for dark noise simulation
    * @param elecNoiseRandomEngine random engine for electronics noise simulation
@@ -993,9 +1000,11 @@ class icarus::opdet::PMTsimulationAlgMaker {
    * configuration disabled noise simulation.
    */
   PMTsimulationAlg::ConfigurationParameters_t makeParams(
+    std::uint64_t beamGateTimestamp,
     detinfo::LArProperties const& larProp,
     detinfo::DetectorClocksData const& clockData,
     SinglePhotonResponseFunc_t const& SPRfunction,
+    PedestalGenerator_t& pedestalGenerator,
     CLHEP::HepRandomEngine& mainRandomEngine,
     CLHEP::HepRandomEngine& darkNoiseRandomEngine,
     CLHEP::HepRandomEngine& elecNoiseRandomEngine,
@@ -1069,7 +1078,6 @@ void icarus::opdet::PMTsimulationAlg::printConfiguration
             << indent << "ADC bits:            " << fParams.ADCbits
       << " (" << fParams.ADCrange().first << " -- " << fParams.ADCrange().second
       << ")"
-    << '\n' << indent << "Baseline:            " << fParams.baseline
     << '\n' << indent << "ReadoutWindowSize:   " << fParams.readoutWindowSize << " ticks"
     << '\n' << indent << "PreTrigFraction:     " << fParams.pretrigFraction
     << '\n' << indent << "ThresholdADC:        " << fParams.thresholdADC
@@ -1085,12 +1093,7 @@ void icarus::opdet::PMTsimulationAlg::printConfiguration
     << '\n' << indent << "Gain at first stage: " << fParams.PMTspecs.firstStageGain()
     ;
 
-  out << '\n' << indent << "Electronics noise:   ";
-  if (fParams.ampNoise > 0_ADCf) {
-    out << fParams.ampNoise << " RMS ("
-      << (fParams.useFastElectronicsNoise? "faster": "slower") << " algorithm)";
-  }
-  else out << "none";
+  out << '\n' << indent << "Pedestal:          " << fPedestalGen->toString(indent + "  ", "");
 
   if (fParams.createBeamGateTriggers) {
     out << '\n' << indent << "Create " << fParams.beamGateTriggerNReps

--- a/icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h
@@ -1,0 +1,603 @@
+/**
+ * @file   icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h
+ * @brief  Interface for a pedestal generating algorithm.
+ * @date   November 19, 2022
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ */
+
+#ifndef ICARUSCODE_PMT_ALGORITHMS_PEDESTALGENERATORALG_H
+#define ICARUSCODE_PMT_ALGORITHMS_PEDESTALGENERATORALG_H
+
+// LArSoft libraries
+#include "lardataobj/RawData/OpDetWaveform.h" // raw::Channel_t
+
+// C/C++ standard libraries
+#include <ostream>
+#include <sstream>
+#include <algorithm>
+#include <vector>
+#include <limits> // std::numeric_limits
+#include <cstdint> // std::uint64_t
+#include <cstddef> // std::size_t
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <typename ADCT> class PedestalGeneratorAlg; 
+  template <typename Stream, typename ADCT>
+  Stream& operator<< (Stream&& out, PedestalGeneratorAlg<ADCT> const& gen);
+} // namespace icarus::opdet
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Interface for a PMT electronics pedestal generator algorithm.
+ * @param ADCT type of the ADC count this interface deals with.
+ * 
+ * A pedestal generator is an algorithm able to fill digitization samples with
+ * a pedestal. In the ideal case, the pedestal is constant. In any realistic
+ * case, the pedestal is at least affected by some electronics noise.
+ * The interface allows to specify the channel that the pedestal will pertain to
+ * and the absolute time at which the pedestal is produced. Neither is an
+ * essential parameter.
+ * 
+ * Because it's such a common requirement, the interface also explicitly allows
+ * a noise generator algorithm to be specified; typically the noise algorithm
+ * object will become owned by the pedestal generator.
+ * 
+ * The configuration of the generator is expected to be performed on
+ * construction, and it is therefore out of the interface.
+ * Configuration and all additional setup elements must be passed through the
+ * constructor; that includes the noise generator algorithm.
+ * 
+ * Currently the interface expects to know ahead how many noise samples are
+ * going to be extracted by each call.
+ * 
+ * 
+ * Implementer notes
+ * ==================
+ * 
+ * The interface methods are deliberately marked non-`const`, with the
+ * expectation that random engines will be used and that the implementers will
+ * not be forced to use mutable state: as a baseline, the implementations of
+ * this interface should be treated as thread-unsafe.
+ * 
+  * The interface currently demands the definition of two functions, one to fill
+ * (overwrite) a buffer, the other to add to it. The rationale is that the
+ * implementer can choose the ones which is more efficient to implement (also
+ * depending on the expected most common use), and it is expected that most
+ * implementations will have either of the two call the other.
+ * 
+ * The other overrideable function is a configuration dump that is convenient
+ * for the log files but does not affect the noise generation.
+ * 
+ * Although the constructor is in principle not bound to any particular
+ * signature from the point of view of C++ inheritance, because these objects
+ * are going to be created via a factory written in C++, it is still demanded
+ * (by the factory interface or by the callers of the factory) that the
+ * constructor signature be standardized. To make these objects work with _art_
+ * tool infrastructure, they need to be wrapped into a class which exposes a
+ * constructor whose sole argument can be initialized from a
+ * `fhicl::ParameterSet`.
+ * 
+ */
+template <typename ADCT>
+class icarus::opdet::PedestalGeneratorAlg {
+  
+    public:
+  
+  using ADCcount_t = ADCT; ///< Type of the sample value.
+  
+  using Timestamp_t = std::uint64_t; ///< Type of timestamp.
+  
+  
+  /// Special pedestal value to express no knowledge of the pedestal.
+  static constexpr ADCcount_t NoPedestalLevel
+    = std::numeric_limits<ADCcount_t>::max();
+  
+  
+  /**
+   * @brief Returns the pedestal level at a certain `channel` and `time`.
+   * @param channel channel the pedestal belongs to
+   * @param time absolute time at which to query the pedestal level [UTC, ns]
+   * @return the average level at the specific channel and time
+   * 
+   * If the tool does not support this concept, this function will return the
+   * value `NoPedestalLevel`.
+   */
+  ADCcount_t pedestalLevel(raw::Channel_t channel, Timestamp_t time) const;
+
+  
+  // --- BEGIN -- Pedestal addition --------------------------------------------
+  /// @name Pedestal addition
+  /// @{
+  
+  /**
+   * @brief Adds pedestal to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with pedestal
+   * @param n number of samples to add pedestal to
+   * @return the number of samples actually added pedestal
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  std::size_t add(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  /**
+   * @brief Adds pedestal to the samples from `begin` up to `end` (excluded).
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added pedestal
+   * @param end pointer past the last sample to be added pedestal
+   * @return pointer to the first sample not added pedestal
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same considerations apply as expressed in
+   * `add(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`,
+   * with the difference that the expected return value is `end` unless the
+   * generator was unable to fully fulfill the request.
+   */
+  ADCcount_t* add(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, ADCcount_t* end
+    );
+  
+  /**
+   * @brief Adds pedestal to all the `samples`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param samples container of the samples to be added pedestal to
+   * @return number of samples actually added pedestal
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same general considerations apply as expressed in
+   * `add(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`.
+   * 
+   * In addition, the buffer (`samples`) is now automatically guaranteed to be
+   * valid and _all_ its samples are added pedestal. The size of the buffer is
+   * never resized.
+   * The expected return value is `samples.size()` unless the generator was
+   * unable to fully fulfill the request.
+   */
+  std::size_t add(
+    raw::Channel_t channel, Timestamp_t time,
+    std::vector<ADCcount_t>& samples
+    );
+  
+  /// @}
+  // --- END ---- Pedestal addition --------------------------------------------
+  
+  
+  // --- BEGIN -- Pedestal overwrite -------------------------------------------
+  /// @name Pedestal overwrite
+  /// @{
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with pedestal.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with pedestal
+   * @param n number of samples to fill with pedestal
+   * @return the number of samples actually overwritten with pedestal
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  std::size_t fill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  /**
+   * @brief Overwrites samples from `begin` to `end` with pedestal.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with pedestal
+   * @param end pointer past the last sample to be overwritten with pedestal
+   * @return pointer to the first sample not overwritten with pedestal
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same considerations apply as expressed in
+   * `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`,
+   * with the difference that the expected return value is `end` unless the
+   * generator was unable to fully fulfill the request.
+   */
+  ADCcount_t* fill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, ADCcount_t* end
+    );
+  
+  /**
+   * @brief Overwrites all the `samples` with pedestal.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param samples container of the samples to be overwritten
+   * @return number of samples actually overwritten with pedestal
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same general considerations apply as expressed in
+   * `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`.
+   * 
+   * In addition, the buffer (`samples`) is now automatically guaranteed to be
+   * valid and _all_ its samples are overwritten with pedestal. The size of the
+   * buffer is never resized.
+   * The expected return value is `samples.size()` unless the generator was
+   * unable to fully fulfill the request.
+   */
+  std::size_t fill(
+    raw::Channel_t channel, Timestamp_t time,
+    std::vector<ADCcount_t>& samples
+    );
+  
+  
+  /**
+   * @brief Adds to the end of `samples` additional `n` pedestal samples.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param samples container of the samples to be expanded
+   * @param n number of pedestal samples to be added
+   * @return number of samples actually overwritten with pedestal
+   * @see `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`
+   * 
+   * The same general considerations apply as expressed in
+   * `fill(raw::Channel_t, Timestamp_t, ADCcount_t*, std::size_t)`.
+   * 
+   * In addition, the buffer (`samples`) is automatically expanded with `n`
+   * more elements, which are assigned pedestal values.
+   * The expected return value is `n` unless the generator was unable to fully
+   * fulfill the request. In that case, the sample is resized to include only
+   * up to the samples actually added with pedestal (the actually allocated
+   * memory, `capacity()`, may exceed that though, and the buffer does not
+   * `shrink_to_fit()`).
+   */
+  std::size_t append(
+    raw::Channel_t channel, Timestamp_t time,
+    std::vector<ADCcount_t>& samples, std::size_t n
+    );
+  
+  /// @}
+  // --- END ---- Pedestal overwrite -------------------------------------------
+  
+  
+  // --- BEGIN -- Dump configuration on screen ---------------------------------
+  /// @name Dump configuration on screen
+  /// @{
+  
+  //@{
+  /**
+   * @brief Prints on stream the configuration parameters.
+   * @param out the stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   */
+  void dump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const;
+  void dump(std::ostream&& out, std::string const& indent = "") const;
+  //@}
+
+
+  //@{
+  /**
+   * @brief Returns the configuration parameter description.
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   * @return a string with the parameters of this shape
+   */
+  std::string toString
+    (std::string const& indent, std::string const& firstIndent) const;
+  std::string toString(std::string const& indent = "") const;
+  //@}
+  
+  /// @}
+  // --- END ---- Dump configuration on screen ---------------------------------
+  
+  
+    protected:
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /**
+   * @brief Returns the pedestal level at a certain `channel` and `time`.
+   * @param channel channel the pedestal belongs to
+   * @param time absolute time at which to query the pedestal level [UTC, ns]
+   * @return the average level at the specific channel and time
+   * 
+   * If the tool does not support this concept, this function will return the
+   * value `NoPedestalLevel`.
+   */
+  virtual ADCcount_t doPedestalLevel
+    (raw::Channel_t channel, Timestamp_t time) const = 0;
+  
+  
+  /**
+   * @brief Adds pedestal to `n` samples starting at `begin`.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be added with pedestal
+   * @param n number of samples to add pedestal to
+   * @return the number of samples actually added pedestal
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * It is guaranteed that no more than `n` samples are changed, in the
+   * contiguous sequence after `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doAdd(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) = 0;
+  
+  /**
+   * @brief Overwrites `n` samples starting at `begin` with pedestal.
+   * @param channel ID of the readout channel the samples are from
+   * @param time the absolute time of the first sample being filled [UTC, ns]
+   * @param begin pointer to the first sample to be overwritten with pedestal
+   * @param n number of samples to fill with pedestal
+   * @return the number of samples actually overwritten with pedestal
+   * 
+   * No check is performed on the validity of the destination buffer.
+   * Old values are typically completely overwritten. It is guaranteed that no
+   * more than `n` samples are overwritten, in the contiguous sequence after
+   * `begin`.
+   * 
+   * The return value should be `n` unless the generator was unable to fully
+   * fulfill the request.
+   */
+  virtual std::size_t doFill(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    ) = 0;
+  
+  /**
+   * @brief Prints into the stream the parameters of this algorithm.
+   * @param out the C++ output stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   * 
+   * Sends a complete description of the configuration of the algorithm to the
+   * `out` stream. The output starts on the current line of the stream, which
+   * is added a `firstIndent` indentation string. All following new lines are
+   * started with an indentation string `indent`. The last line is not ended
+   * with a newline character.
+   * 
+   * The default implementation prints nothing (also no indentation).
+   * Custom implementations may choose to add line breaks in addition to the
+   * ones described above.
+   */
+  virtual void doDump(
+    std::ostream& out,
+    std::string const& indent, std::string const& firstIndent
+    ) const {}
+  
+  // --- END ---- Virtual interface --------------------------------------------
+  
+  
+  // --- BEGIN -- Convenience implementation functions -------------------------
+  
+  /**
+   * @brief Implementation helper: implements `doFill()` based on `doAdd()`.
+   * 
+   * This implementation is trivial: the buffer is first zeroed, and then
+   * pedestal is added.
+   * 
+   * The definition of `doFill()` becomes:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::size_t doFill(
+   *   raw::Channel_t channel, Timestamp_t time,
+   *   ADCcount_t* begin, std::size_t n
+   *   ) override
+   *   { return _fillByAdding(channel, time, begin, n); }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  std::size_t _fillByAdding(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  /**
+   * @brief Implementation helper: implements `doAdd()` based on `doFill()`.
+   * 
+   * This implementation is trivial: the pedestal is first generated in a new
+   * buffer, and then it's added to the existing one.
+   * 
+   * The definition of `doAdd()` becomes:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::size_t doAdd(
+   *   raw::Channel_t channel, Timestamp_t time,
+   *   ADCcount_t* begin, std::size_t n
+   *   ) override
+   *   { return _addByFilling(channel, time, begin, n); }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  std::size_t _addByFilling(
+    raw::Channel_t channel, Timestamp_t time,
+    ADCcount_t* begin, std::size_t n
+    );
+  
+  // --- END ---- Convenience implementation functions -------------------------
+  
+}; // icarus::opdet::PedestalGeneratorAlg
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::PedestalGeneratorAlg<ADCT>::pedestalLevel
+  (raw::Channel_t channel, Timestamp_t time) const -> ADCcount_t
+{
+  return doPedestalLevel(channel, time);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::add(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  return doAdd(channel, time, begin, n);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::PedestalGeneratorAlg<ADCT>::add(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, ADCcount_t* end
+) -> ADCcount_t* {
+  std::size_t const n = add(channel, time, begin, end - begin);
+  return begin + n;
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::add(
+  raw::Channel_t channel, Timestamp_t time,
+  std::vector<ADCcount_t>& samples
+) {
+  return add(channel, time, samples.data(), samples.size());
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::fill(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  return doFill(channel, time, begin, n);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+auto icarus::opdet::PedestalGeneratorAlg<ADCT>::fill(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, ADCcount_t* end
+) -> ADCcount_t* {
+  std::size_t const n = fill(channel, time, begin, end - begin);
+  return begin + n;
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::fill(
+  raw::Channel_t channel, Timestamp_t time,
+  std::vector<ADCcount_t>& samples
+) {
+  return fill(channel, time, samples.data(), samples.size());
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::append(
+  raw::Channel_t channel, Timestamp_t time,
+  std::vector<ADCcount_t>& samples, std::size_t n
+) {
+  std::size_t const oldSize = samples.size();
+  samples.resize(oldSize + n);
+  std::size_t const nAdded = fill(channel, time, samples.data() + oldSize, n);
+  samples.resize(oldSize + nAdded); // no-op if nAdded is equal to n
+  return nAdded;
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::PedestalGeneratorAlg<ADCT>::dump(
+  std::ostream& out, std::string const& indent, std::string const& firstIndent
+) const {
+  doDump(out, indent, firstIndent);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+void icarus::opdet::PedestalGeneratorAlg<ADCT>::dump
+  (std::ostream&& out, std::string const& indent /* = "" */) const
+  { dump(out, indent, indent); }
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::string icarus::opdet::PedestalGeneratorAlg<ADCT>::toString
+  (std::string const& indent, std::string const& firstIndent) const
+{
+  std::ostringstream sstr;
+  dump(sstr, indent, firstIndent);
+  return std::move(sstr).str();
+} // icarus::opdet::PedestalGeneratorAlg<>::toString()
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::string icarus::opdet::PedestalGeneratorAlg<ADCT>::toString
+  (std::string const& indent /* = "" */) const
+  { return toString(indent, indent); }
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::_fillByAdding(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  std::fill_n(begin, n, ADCcount_t{ 0 });
+  return doAdd(channel, time, begin, n);
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename ADCT>
+std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::_addByFilling(
+  raw::Channel_t channel, Timestamp_t time,
+  ADCcount_t* begin, std::size_t n
+) {
+  std::vector<ADCcount_t> noise(n);
+  std::size_t const nSamples = fill(channel, time, noise);
+  assert(nSamples <= n);
+  
+  auto it = noise.cbegin();
+  auto const nend = it + nSamples;
+  while (it != nend) *(begin++) += *it++;
+  
+  return nSamples;
+} // icarus::opdet::PedestalGeneratorAlg::_addByFilling()
+
+
+// -----------------------------------------------------------------------------
+// --- free function implementation
+// -----------------------------------------------------------------------------
+template <typename Stream, typename ADCT>
+Stream& icarus::opdet::operator<<
+  (Stream&& out, icarus::opdet::PedestalGeneratorAlg<ADCT> const& gen)
+  { out << gen.toString(); return out; }
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_ALGORITHMS_PEDESTALGENERATORALG_H
+
+

--- a/icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h
+++ b/icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h
@@ -25,8 +25,9 @@
 // -----------------------------------------------------------------------------
 namespace icarus::opdet {
   template <typename ADCT> class PedestalGeneratorAlg; 
-  template <typename Stream, typename ADCT>
-  Stream& operator<< (Stream&& out, PedestalGeneratorAlg<ADCT> const& gen);
+  template <typename ADCT>
+  std::ostream& operator<<
+    (std::ostream& out, PedestalGeneratorAlg<ADCT> const& gen);
 } // namespace icarus::opdet
 
 // -----------------------------------------------------------------------------
@@ -94,6 +95,9 @@ class icarus::opdet::PedestalGeneratorAlg {
   /// Special pedestal value to express no knowledge of the pedestal.
   static constexpr ADCcount_t NoPedestalLevel
     = std::numeric_limits<ADCcount_t>::max();
+  
+  
+  virtual ~PedestalGeneratorAlg() = default;
   
   
   /**
@@ -590,9 +594,9 @@ std::size_t icarus::opdet::PedestalGeneratorAlg<ADCT>::_addByFilling(
 // -----------------------------------------------------------------------------
 // --- free function implementation
 // -----------------------------------------------------------------------------
-template <typename Stream, typename ADCT>
-Stream& icarus::opdet::operator<<
-  (Stream&& out, icarus::opdet::PedestalGeneratorAlg<ADCT> const& gen)
+template <typename ADCT>
+std::ostream& icarus::opdet::operator<<
+  (std::ostream& out, icarus::opdet::PedestalGeneratorAlg<ADCT> const& gen)
   { out << gen.toString(); return out; }
 
 

--- a/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
+++ b/icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h
@@ -78,11 +78,11 @@ class icarus::opdet::PhotoelectronPulseFunction {
 
   // @{
   /**
-    * @brief Prints on stream the parameters of this shape.
-    * @param out the stream to write into
-    * @param indent indentation string, prepended to all lines except first
-    * @param indentFirst indentation string prepended to the first line
-    */
+   * @brief Prints on stream the parameters of this shape.
+   * @param out the stream to write into
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   */
   void dump(
     std::ostream& out,
     std::string const& indent, std::string const& firstIndent
@@ -95,11 +95,11 @@ class icarus::opdet::PhotoelectronPulseFunction {
 
   // @{
   /**
-    * @brief Returns the parameters of this shape as a descriptive string.
-    * @param indent indentation string, prepended to all lines except first
-    * @param indentFirst indentation string prepended to the first line
-    * @return a string with the parameters of this shape
-    */
+   * @brief Returns the parameters of this shape as a descriptive string.
+   * @param indent indentation string, prepended to all lines except first
+   * @param firstIndent indentation string prepended to the first line
+   * @return a string with the parameters of this shape
+   */
   std::string toString
     (std::string const& indent, std::string const& firstIndent) const;
   std::string toString(std::string const& indent = "") const
@@ -142,7 +142,7 @@ class icarus::opdet::PhotoelectronPulseFunction {
    * @brief Prints into the stream the parameters of this shape.
    * @param out the C++ output stream to write into
    * @param indent indentation string, prepended to all lines except first
-   * @param indentFirst indentation string prepended to the first line
+   * @param firstIndent indentation string prepended to the first line
    */
   virtual void doDump(
     std::ostream& out,

--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -51,6 +51,13 @@ icarus_settings_opdet: {
   
   nominalPMTgain: 9.7e6  # PMT multiplication gain factor
   
+  # the actual readout window size for each "trigger" on the readout electronics
+  readoutWindowSize:         5000   # ticks (2 ns each --> 10 us)
+
+  # fraction of readout window size that should come before the "trigger" in the
+  # readout electronics
+  readoutPreTrigFraction:   0.3   # fraction (3+7 us)
+  
 } # icarus_settings_opdet
 
 

--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -58,6 +58,10 @@ icarus_settings_opdet: {
   # readout electronics
   readoutPreTrigFraction:   0.3   # fraction (3+7 us)
   
+  NoiseRMS:                 3.0   # in ADC#; "temporary" value, see SBN DocDB 19187
+  
+  NominalPedestal:      14999.5   # in ADC#; try to balance rounding errors
+  
 } # icarus_settings_opdet
 
 
@@ -173,7 +177,7 @@ icarus_photoelectronresponse_standard: @local::icarus_photoelectronresponse_2022
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 icarus_pmt_electronicsnoise_gauss: {
   tool_type: PMTgausNoiseGeneratorTool
-  RMS:       3.0  # in ADC#; "temporary" value, see SBN DocDB 19187
+  RMS:       @local::icarus_settings_opdet.NoiseRMS
 }
 
 icarus_pmt_electronicsnoise_gauss_fast: {
@@ -191,10 +195,10 @@ icarus_pmt_electronicsnoise_standard: @local::icarus_pmt_electronicsnoise_gauss_
 
 icarus_pmt_pedestal_gaussnoise: {
   tool_type: PMTconstantPedestalGeneratorTool
-  Pedestal:       14999.5        # in ADC; try to distribute rounding errors
+  Pedestal:       @local::icarus_settings_opdet.NominalPedestal
   NoiseGenerator: {
     tool_type:      PMTgausNoiseGeneratorTool
-    RMS:            3.0  # in ADC#; "temporary" value, see SBN DocDB 19187
+    RMS:            @local::icarus_settings_opdet.NoiseRMS
   }
 } # icarus_pmt_pedestal_gaussnoise
 
@@ -213,6 +217,7 @@ icarus_pmt_pedestal_nonoise: {
   }
 } # icarus_pmt_pedestal_nonoise
 
+icarus_pmt_pedestal_standard: @local::icarus_pmt_pedestal_fastgaussnoise
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -263,7 +268,7 @@ icarus_pmtsimulation.disable_noise: {
 
 icarus_pmtsimulationalg_202202_noise: {
 
-  Pedestal:                  @local::icarus_pmt_pedestal_fastgaussnoise
+  Pedestal:                  @local::icarus_pmt_pedestal_standard
   
   SinglePhotonResponse:      @local::icarus_photoelectronresponse_standard
   
@@ -319,7 +324,13 @@ icarus_pmtsimulationalg_202202: @local::icarus_pmtsimulationalg_202202_noise
 ###
 icarus_pmtsimulationalg_2018: {
 
-  Pedestal:                  @local::icarus_pmt_pedestal_fastgaussnoise
+  Pedestal: {
+    Pedestal:                  14999.5
+    NoiseGenerator: {
+      tool_type:                 PMTfastGausNoiseGeneratorTool
+      RMS:                       3.0
+    }
+  } # Pedestal
   
   SinglePhotonResponse:      @local::icarus_photoelectronresponse_standard
   

--- a/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
+++ b/icaruscode/PMT/Algorithms/pmtsimulation_icarus.fcl
@@ -168,13 +168,60 @@ icarus_photoelectronresponse_customexample: {
 icarus_photoelectronresponse_standard: @local::icarus_photoelectronresponse_202202
 
 
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Electronics noise configurations
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+icarus_pmt_electronicsnoise_gauss: {
+  tool_type: PMTgausNoiseGeneratorTool
+  RMS:       3.0  # in ADC#; "temporary" value, see SBN DocDB 19187
+}
+
+icarus_pmt_electronicsnoise_gauss_fast: {
+  tool_type: PMTfastGausNoiseGeneratorTool
+  RMS:       @local::icarus_pmt_electronicsnoise_gauss.RMS
+}
+
+icarus_pmt_electronicsnoise_nonoise: {
+  tool_type: PMTnoNoiseGeneratorTool
+}
+
+# icarus_pmt_electronicsnoise_standard is always the current favourite
+icarus_pmt_electronicsnoise_standard: @local::icarus_pmt_electronicsnoise_gauss_fast
+
+
+icarus_pmt_pedestal_gaussnoise: {
+  tool_type: PMTconstantPedestalGeneratorTool
+  Pedestal:       14999.5        # in ADC; try to distribute rounding errors
+  NoiseGenerator: {
+    tool_type:      PMTgausNoiseGeneratorTool
+    RMS:            3.0  # in ADC#; "temporary" value, see SBN DocDB 19187
+  }
+} # icarus_pmt_pedestal_gaussnoise
+
+icarus_pmt_pedestal_fastgaussnoise: {
+  @table::icarus_pmt_pedestal_gaussnoise
+  NoiseGenerator: {
+    tool_type:      PMTfastGausNoiseGeneratorTool
+    RMS:            @local::icarus_pmt_electronicsnoise_gauss.RMS
+  }
+} # icarus_pmt_pedestal_fastgaussnoise
+
+icarus_pmt_pedestal_nonoise: {
+  @table::icarus_pmt_pedestal_gaussnoise
+  NoiseGenerator: {
+    tool_type:      NoNoiseGeneratorTool
+  }
+} # icarus_pmt_pedestal_nonoise
+
+
+
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ###
 ### Configuration preset components
 ###
 icarus_pmtsimulation.disable_noise: {
-  AmpNoise:      0.0     # RMS in ADC counts
-  DarkNoiseRate: "0 kHz"
+  Pedestal:                  @local::icarus_pmt_pedestal_nonoise
+  DarkNoiseRate:             "0 kHz"
 } # icarus_pmtsimulation.disable_noise
 
 
@@ -216,11 +263,10 @@ icarus_pmtsimulation.disable_noise: {
 
 icarus_pmtsimulationalg_202202_noise: {
 
-  Baseline:                  14999.5        # in ADC; try to distribute rounding errors
+  Pedestal:                  @local::icarus_pmt_pedestal_fastgaussnoise
   
-  SinglePhotonResponse: @local::icarus_photoelectronresponse_standard
+  SinglePhotonResponse:      @local::icarus_photoelectronresponse_standard
   
-  AmpNoise:                  3.0            # in ADC; temporary value, see SBN DocDB 19187
   DarkNoiseRate:             "1.6 kHz"      # per channel, from CERN test stand measurement
 
   ## This is the readout window size for each "trigger" on the electronics
@@ -230,7 +276,7 @@ icarus_pmtsimulationalg_202202_noise: {
   PreTrigFraction:           0.25           # fraction (1+3 us)
 
   ##Threshold in ADC counts for a PMT self-trigger.
-  # 15 ADC = 5x 3 ADC (RMS, see AmpNoise above),~45% of standard SPR (4 mV, 33 ADC);
+  # 15 ADC = 5x 3 ADC (RMS, see ElectronicsNoise above),~45% of standard SPR (4 mV, 33 ADC);
   # number of noise samples above 15 ADC: ~206 samples for 2 ms x 360 channels (300 Hz)
   # number of noise samples above 18 ADC: ~0.36 samples for 2 ms x 360 channels (0.5 Hz)
   ##NOTE this is assumed to be positive-going and ABOVE BASELINE! Pulse polarity is corrected before determining trigger.
@@ -273,11 +319,10 @@ icarus_pmtsimulationalg_202202: @local::icarus_pmtsimulationalg_202202_noise
 ###
 icarus_pmtsimulationalg_2018: {
 
-  Baseline:                  14999.5         #in ADC
+  Pedestal:                  @local::icarus_pmt_pedestal_fastgaussnoise
   
-  SinglePhotonResponse: @local::icarus_photoelectronresponse_standard
+  SinglePhotonResponse:      @local::icarus_photoelectronresponse_standard
   
-  AmpNoise:                  3.0            # in ADC; temporary value, see SBN DocDB 19187
   DarkNoiseRate:             "1.6 kHz"      # from CERN test stand measurement
 
   ##This is the readout window size for each "trigger" on the electronics
@@ -287,7 +332,7 @@ icarus_pmtsimulationalg_2018: {
   PreTrigFraction:           0.25           # fraction
 
   ##Threshold in ADC counts for a PMT self-trigger.
-  # 18 ADC = 6x 3 ADC (RMS, see AmpNoise above),~35% of standard SPR (55 ADC);
+  # 18 ADC = 6x 3 ADC (RMS, see ElectronicsNoise above),~35% of standard SPR (55 ADC);
   # number of noise samples above 18 ADC: ~0.35 samples for 2 ms x 360 channels
   ##NOTE this is assumed to be positive-going and ABOVE BASELINE! Pulse polarity is corrected before determining trigger.
   ThresholdADC:              18             # ADC counts

--- a/icaruscode/PMT/CMakeLists.txt
+++ b/icaruscode/PMT/CMakeLists.txt
@@ -107,6 +107,7 @@ cet_build_plugin(SampledWaveformFunctionTool art::tool
 	icaruscode_Decode_DecoderTools
   )
 
+<<<<<<< HEAD
 cet_build_plugin(CustomPulseFunctionTool art::tool
         LIBRARIES
 	icaruscode_PMT_Algorithms
@@ -120,9 +121,31 @@ cet_build_plugin(CopyBeamTimePMTwaveforms art::module
     lardataobj::RawData
   )
 
+cet_build_plugin(SimPMTreadout art::module
+  LIBRARIES
+    icaruscode::PMT_Algorithms
+    lardata::DetectorInfoServices
+    lardataalg::DetectorInfo
+    lardataobj::RawData
+    lardataalg::Utilities
+    lardataobj::Simulation
+    larcore::Geometry_Geometry_service
+    larcorealg::Geometry
+    nurandom::RandomUtils_NuRandomService_service
+    art::Framework_Services_Registry
+    art::Framework_Services_Optional_RandomNumberGenerator_service
+  )
+
+cet_build_plugin(OpDetWaveformMetaMaker art::module
+  icaruscode::PMT_Algorithms
+  lardataalg::DetectorInfo
+  lardataobj::RawData
+  )
+
 art_make_library(
   EXCLUDE
     "SimPMTIcarus_module.cc"
+    "SimPMTreadout_module.cc"
     "OpDetWaveformMetaMaker_module.cc"
     "CopyBeamTimePMTwaveforms_module.cc"
     "PMTWaveformBaselines_module.cc"

--- a/icaruscode/PMT/CMakeLists.txt
+++ b/icaruscode/PMT/CMakeLists.txt
@@ -107,7 +107,6 @@ cet_build_plugin(SampledWaveformFunctionTool art::tool
 	icaruscode_Decode_DecoderTools
   )
 
-<<<<<<< HEAD
 cet_build_plugin(CustomPulseFunctionTool art::tool
         LIBRARIES
 	icaruscode_PMT_Algorithms

--- a/icaruscode/PMT/CMakeLists.txt
+++ b/icaruscode/PMT/CMakeLists.txt
@@ -36,7 +36,7 @@ cet_build_plugin(SimPMTIcarus art::module
 
 cet_build_plugin(OpDetWaveformMetaMaker art::module
                     LIBRARIES
-			icaruscode_PMT_Algorithms
+			icaruscode::PMT_Algorithms
 			lardataalg::DetectorInfo
 			lardataobj::RawData
 			lardata::Utilities
@@ -113,6 +113,38 @@ cet_build_plugin(CustomPulseFunctionTool art::tool
 	ROOT::Hist
 	)
 
+cet_build_plugin(PMTconstantPedestalGeneratorTool art::tool
+  LIBRARIES
+    icaruscode::PMT_Algorithms
+    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardataalg::DetectorInfo
+    lardataobj::RawData
+  )
+
+cet_build_plugin(PMTgausNoiseGeneratorTool art::tool
+  LIBRARIES
+    icaruscode::PMT_Algorithms
+    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardataalg::DetectorInfo
+    lardataobj::RawData
+  )
+
+cet_build_plugin(PMTfastGausNoiseGeneratorTool art::tool
+  LIBRARIES
+    icaruscode::PMT_Algorithms
+    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardataalg::DetectorInfo
+    lardataobj::RawData
+  )
+
+cet_build_plugin(PMTnoNoiseGeneratorTool art::tool
+  LIBRARIES
+    icaruscode::PMT_Algorithms
+    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardataalg::DetectorInfo
+    lardataobj::RawData
+  )
+
 cet_build_plugin(CopyBeamTimePMTwaveforms art::module
   LIBRARIES
     lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
@@ -123,22 +155,14 @@ cet_build_plugin(CopyBeamTimePMTwaveforms art::module
 cet_build_plugin(SimPMTreadout art::module
   LIBRARIES
     icaruscode::PMT_Algorithms
-    lardata::DetectorInfoServices
     lardataalg::DetectorInfo
     lardataobj::RawData
-    lardataalg::Utilities
     lardataobj::Simulation
     larcore::Geometry_Geometry_service
     larcorealg::Geometry
     nurandom::RandomUtils_NuRandomService_service
     art::Framework_Services_Registry
     art::Framework_Services_Optional_RandomNumberGenerator_service
-  )
-
-cet_build_plugin(OpDetWaveformMetaMaker art::module
-  icaruscode::PMT_Algorithms
-  lardataalg::DetectorInfo
-  lardataobj::RawData
   )
 
 art_make_library(
@@ -150,9 +174,19 @@ art_make_library(
     "PMTWaveformBaselines_module.cc"
     "PMTWaveformBaselinesFromReadoutConfiguration_module.cc"
     "PMTWaveformBaselinesFromChannelData_module.cc"
+    "OpHitFinderICARUS_module.cc"
+    "PMTStartCalibTime_module.cc"
+    "PMTcoordinates_module.cc"
+    "PhotonPropogationICARUS_module.cc"
+    "TrigInfo_module.cc"
+    "wvfAnaicarus_module.cc"
     "AsymGaussPulseFunctionTool_tool.cc"
     "AsymExpPulseFunctionTool_tool.cc"
     "SampledWaveformFunctionTool_tool.cc"
+    "PMTconstantPedestalGeneratorTool_tool.cc"
+    "PMTgausNoiseGeneratorTool_tool.cc"
+    "PMTfastGausNoiseGeneratorTool_tool.cc"
+    "PMTnoNoiseGeneratorTool_tool.cc"
     "CustomPulseFunctionTool_tool.cc"
           LIBRARIES
             lardataobj::RawData

--- a/icaruscode/PMT/PMTconstantPedestalGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTconstantPedestalGeneratorTool_tool.cc
@@ -43,7 +43,7 @@ namespace icarus::opdet { struct PMTconstantPedestalGeneratorTool; }
  * the configuration of the noise generator tool within.
  * 
  */
-class icarus::opdet::PMTconstantPedestalGeneratorTool
+struct icarus::opdet::PMTconstantPedestalGeneratorTool
   : public icarus::opdet::PMTpedestalGeneratorToolBase<ConstantPedestalGeneratorAlg>
 {
   using Base_t

--- a/icaruscode/PMT/PMTconstantPedestalGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTconstantPedestalGeneratorTool_tool.cc
@@ -1,0 +1,62 @@
+/**
+ * @file   icaruscode/PMT/PMTconstantPedestalGeneratorTool_tool.cc
+ * @brief  Toolization of `icarus::opdet::ConstantPedestalGeneratorAlg<counts_f>`.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 17, 2020
+ * @see    `icaruscode/PMT/Algorithms/PMTconstantPedestalGenerator.h`
+ * 
+ * This is an implementation of tool interface
+ * `icarus::opdet::PMTpedestalGeneratorTool`.
+ */
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/PMTpedestalGeneratorToolBase.h"
+#include "icaruscode/PMT/Algorithms/ConstantPedestalGeneratorAlg.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet { struct PMTconstantPedestalGeneratorTool; }
+/**
+ * @brief Creates a `icarus::opdet::ConstantPedestalGeneratorAlg` algorithm.
+ * @see `icarus::opdet::ConstantPedestalGeneratorAlg`
+ * 
+ * This tool creates a `icarus::opdet::ConstantPedestalGeneratorAlg<counts_f>`
+ * pedestal generator algorithm, armed with the noise generator specified in
+ * the configuration.
+ * 
+ * The usage pattern of this algorithm is the standard one documented in
+ * `icarus::opdet::PMTpedestalGeneratorToolBase`.
+ * 
+ * 
+ * Configuration
+ * --------------
+ * 
+ * Run `lar --print-description PMTconstantPedestalGeneratorTool` for a
+ * short explanation of the meaning of the parameters; or read
+ * `icarus::opdet::ConstantPedestalGeneratorAlg::Config` data structure, or
+ * check the documentation of `icarus::opdet::ConstantPedestalGeneratorAlg`,
+ * plus the one in `icarus::opdet::PMTpedestalGeneratorToolBase` which explain
+ * the configuration of the noise generator tool within.
+ * 
+ */
+class icarus::opdet::PMTconstantPedestalGeneratorTool
+  : public icarus::opdet::PMTpedestalGeneratorToolBase<ConstantPedestalGeneratorAlg>
+{
+  using Base_t
+    = icarus::opdet::PMTpedestalGeneratorToolBase<ConstantPedestalGeneratorAlg>;
+  
+  using Base_t::Base_t;
+  
+}; // icarus::opdet::PMTconstantPedestalGeneratorTool
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(icarus::opdet::PMTconstantPedestalGeneratorTool)
+
+
+//------------------------------------------------------------------------------
+

--- a/icaruscode/PMT/PMTfastGausNoiseGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTfastGausNoiseGeneratorTool_tool.cc
@@ -1,0 +1,59 @@
+/**
+ * @file   icaruscode/PMT/PMTfastGausNoiseGeneratorTool_tool.cc
+ * @brief  Toolization of `icarus::opdet::FastGaussianNoiseGeneratorAlg<counts_f>`.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 17, 2020
+ * @see    `icaruscode/PMT/Algorithms/GastGaussianNoiseGenerator.h`
+ * 
+ * This is an implementation of tool interface
+ * `icarus::opdet::PMTnoiseGeneratorTool`.
+ */
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/PMTnoiseGeneratorToolBase.h"
+#include "icaruscode/PMT/Algorithms/FastGaussianNoiseGeneratorAlg.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet { struct PMTfastGausNoiseGeneratorTool; }
+/**
+ * @brief Creates a `icarus::opdet::FastGaussianNoiseGeneratorAlg` algorithm.
+ * @see `icarus::opdet::FastGaussianNoiseGeneratorAlg`
+ * 
+ * This tool creates a `icarus::opdet::FastGaussianNoiseGeneratorAlg<counts_f>`
+ * noise generator algorithm.
+ * 
+ * The usage pattern of this algorithm is the standard one documented in
+ * `icarus::opdet::PMTnoiseGeneratorToolBase`.
+ * 
+ * 
+ * Configuration
+ * --------------
+ * 
+ * Run `lar --print-description PMTgausNoiseGeneratorTool` (or read
+ * `icarus::opdet::FastGaussianNoiseGeneratorAlg::Config` data structure) for a
+ * short explanation of the meaning of the parameters, or check the
+ * documentation of `icarus::opdet::FastGaussianNoiseGeneratorAlg`.
+ * 
+ */
+class icarus::opdet::PMTfastGausNoiseGeneratorTool
+  : public icarus::opdet::PMTnoiseGeneratorToolBase<FastGaussianNoiseGeneratorAlg>
+{
+  using Base_t
+    = icarus::opdet::PMTnoiseGeneratorToolBase<FastGaussianNoiseGeneratorAlg>;
+  
+  using Base_t::Base_t;
+  
+}; // icarus::opdet::PMTfastGausNoiseGeneratorTool
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(icarus::opdet::PMTfastGausNoiseGeneratorTool)
+
+
+//------------------------------------------------------------------------------
+

--- a/icaruscode/PMT/PMTfastGausNoiseGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTfastGausNoiseGeneratorTool_tool.cc
@@ -40,7 +40,7 @@ namespace icarus::opdet { struct PMTfastGausNoiseGeneratorTool; }
  * documentation of `icarus::opdet::FastGaussianNoiseGeneratorAlg`.
  * 
  */
-class icarus::opdet::PMTfastGausNoiseGeneratorTool
+struct icarus::opdet::PMTfastGausNoiseGeneratorTool
   : public icarus::opdet::PMTnoiseGeneratorToolBase<FastGaussianNoiseGeneratorAlg>
 {
   using Base_t

--- a/icaruscode/PMT/PMTgausNoiseGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTgausNoiseGeneratorTool_tool.cc
@@ -40,7 +40,7 @@ namespace icarus::opdet { struct PMTgausNoiseGeneratorTool; }
  * documentation of `icarus::opdet::GaussianNoiseGeneratorAlg`.
  * 
  */
-class icarus::opdet::PMTgausNoiseGeneratorTool
+struct icarus::opdet::PMTgausNoiseGeneratorTool
   : public icarus::opdet::PMTnoiseGeneratorToolBase<GaussianNoiseGeneratorAlg>
 {
   using Base_t

--- a/icaruscode/PMT/PMTgausNoiseGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTgausNoiseGeneratorTool_tool.cc
@@ -1,0 +1,59 @@
+/**
+ * @file   icaruscode/PMT/PMTgausNoiseGeneratorTool_tool.cc
+ * @brief  Toolization of `icarus::opdet::GaussianNoiseGeneratorAlg<counts_f>`.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 17, 2020
+ * @see    `icaruscode/PMT/Algorithms/GaussianNoiseGenerator.h`
+ * 
+ * This is an implementation of tool interface
+ * `icarus::opdet::PMTnoiseGeneratorTool`.
+ */
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/PMTnoiseGeneratorToolBase.h"
+#include "icaruscode/PMT/Algorithms/GaussianNoiseGeneratorAlg.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet { struct PMTgausNoiseGeneratorTool; }
+/**
+ * @brief Creates a `icarus::opdet::GaussianNoiseGeneratorAlg` algorithm.
+ * @see `icarus::opdet::GaussianNoiseGeneratorAlg`
+ * 
+ * This tool creates a `icarus::opdet::GaussianNoiseGeneratorAlg<counts_f>`
+ * noise generator algorithm.
+ * 
+ * The usage pattern of this algorithm is the standard one documented in
+ * `icarus::opdet::PMTnoiseGeneratorToolBase`.
+ * 
+ * 
+ * Configuration
+ * --------------
+ * 
+ * Run `lar --print-description PMTgausNoiseGeneratorTool` (or read
+ * `icarus::opdet::GaussianNoiseGeneratorAlg::Config` data structure) for a
+ * short explanation of the meaning of the parameters, or check the
+ * documentation of `icarus::opdet::GaussianNoiseGeneratorAlg`.
+ * 
+ */
+class icarus::opdet::PMTgausNoiseGeneratorTool
+  : public icarus::opdet::PMTnoiseGeneratorToolBase<GaussianNoiseGeneratorAlg>
+{
+  using Base_t
+    = icarus::opdet::PMTnoiseGeneratorToolBase<GaussianNoiseGeneratorAlg>;
+  
+  using Base_t::Base_t;
+  
+}; // icarus::opdet::PMTgausNoiseGeneratorTool
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(icarus::opdet::PMTgausNoiseGeneratorTool)
+
+
+//------------------------------------------------------------------------------
+

--- a/icaruscode/PMT/PMTnoNoiseGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTnoNoiseGeneratorTool_tool.cc
@@ -40,7 +40,7 @@ namespace icarus::opdet { struct PMTnoNoiseGeneratorTool; }
  * documentation of `icarus::opdet::NoNoiseGeneratorAlg`.
  * 
  */
-class icarus::opdet::PMTnoNoiseGeneratorTool
+struct icarus::opdet::PMTnoNoiseGeneratorTool
   : public icarus::opdet::PMTnoiseGeneratorToolBase<NoNoiseGeneratorAlg>
 {
   using Base_t

--- a/icaruscode/PMT/PMTnoNoiseGeneratorTool_tool.cc
+++ b/icaruscode/PMT/PMTnoNoiseGeneratorTool_tool.cc
@@ -1,0 +1,59 @@
+/**
+ * @file   icaruscode/PMT/PMTnoNoiseGeneratorTool_tool.cc
+ * @brief  Toolization of `icarus::opdet::NoNoiseGeneratorAlg<counts_f>`.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 17, 2020
+ * @see    `icaruscode/PMT/Algorithms/PMTgausNoiseGenerator.h`
+ * 
+ * This is an implementation of tool interface
+ * `icarus::opdet::PMTnoiseGeneratorTool`.
+ */
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/PMTnoiseGeneratorToolBase.h"
+#include "icaruscode/PMT/Algorithms/NoNoiseGeneratorAlg.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet { struct PMTnoNoiseGeneratorTool; }
+/**
+ * @brief Creates a `icarus::opdet::NoNoiseGeneratorAlg` algorithm.
+ * @see `icarus::opdet::NoNoiseGeneratorAlg`
+ * 
+ * This tool creates a `icarus::opdet::NoNoiseGeneratorAlg<counts_f>`
+ * "noise" generator algorithm.
+ * 
+ * The usage pattern of this algorithm is the standard one documented in
+ * `icarus::opdet::PMTnoiseGeneratorToolBase`.
+ * 
+ * 
+ * Configuration
+ * --------------
+ * 
+ * Run `lar --print-description PMTgausNoiseGeneratorTool` (or read
+ * `icarus::opdet::NoNoiseGeneratorAlg::Config` data structure) for a
+ * short explanation of the meaning of the parameters, or check the
+ * documentation of `icarus::opdet::NoNoiseGeneratorAlg`.
+ * 
+ */
+class icarus::opdet::PMTnoNoiseGeneratorTool
+  : public icarus::opdet::PMTnoiseGeneratorToolBase<NoNoiseGeneratorAlg>
+{
+  using Base_t
+    = icarus::opdet::PMTnoiseGeneratorToolBase<NoNoiseGeneratorAlg>;
+  
+  using Base_t::Base_t;
+  
+}; // icarus::opdet::PMTnoNoiseGeneratorTool
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(icarus::opdet::PMTnoNoiseGeneratorTool)
+
+
+//------------------------------------------------------------------------------
+

--- a/icaruscode/PMT/PMTnoiseGeneratorTool.h
+++ b/icaruscode/PMT/PMTnoiseGeneratorTool.h
@@ -1,0 +1,110 @@
+/**
+ * @file   icaruscode/PMT/PMTnoiseGeneratorTool.h
+ * @brief  Tool to create a PMT noise generator.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 17, 2022
+ * @see    `icaruscode/PMT/Algorithms/PMTnoiseGenerator.h`
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCODE_PMT_PMTNOISEGENERATORTOOL_H
+#define ICARUSCODE_PMT_PMTNOISEGENERATORTOOL_H
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
+
+// LArSoft libraries
+#include "lardataalg/Utilities/quantities/electronics.h" // counts_f
+
+// CLHEP libraries
+#include "CLHEP/Random/RandEngine.h" // CLHEP::HepRandomEngine
+
+// C/C++ standard libraries
+#include <memory> // std::unique_ptr()
+#include <utility> // std::move()
+#include <cassert>
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet { struct PMTnoiseGeneratorTool; }
+/**
+ * @brief Creates a `PMTnoiseGenerator` algorithm object.
+ * 
+ * Implementations of this tool create an algorithm to emit PMT readout
+ * electronics noise, as an object derived from
+ * `icarus::opdet::PMTnoiseGenerator<util::quantities::counts_f>`
+ * (the template parameter is the same used by the single photoelectron
+ * response, but it's not programmatically tied to it to avoid entangling
+ * dependencies).
+ * 
+ * The tool object is just a wrapper factory that creates the actual generator,
+ * which is owned and can be returned for use.
+ * 
+ * The signature of the tool constructor should be compatible with:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * PMTnoiseGeneratorTool(fhicl::ParameterSet const&)
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * in order to be compatible with `art::make_tool()`.
+ * 
+ * 
+ */
+struct icarus::opdet::PMTnoiseGeneratorTool {
+  
+  using ADCcount_t = util::quantities::counts_f; ///< Type of ADC count used.
+  
+  /// Type of function returned.
+  using Generator_t = icarus::opdet::NoiseGeneratorAlg<ADCcount_t>;
+  
+  
+  virtual ~PMTnoiseGeneratorTool() = default;
+  
+  /**
+   * @brief Returns an instance of the noise generator.
+   * @param engine the random engine to be used by the generator.
+   * 
+   * This function is guaranteed to return a valid generator only once.
+   * The return value on following calls is undefined, but it is considered
+   * an error to return a null pointer.
+   */
+  std::unique_ptr<Generator_t> makeGenerator(CLHEP::HepRandomEngine& engine);
+  
+  
+    private:
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /**
+   * @brief Returns an instance of the noise generator.
+   * @param engine the random engine to be used by the generator.
+   * 
+   * Only the first call is guaranteed to return a non-null pointer.
+   * 
+   */
+  virtual std::unique_ptr<Generator_t> doMakeGenerator
+    (CLHEP::HepRandomEngine& engine) = 0;
+
+  
+  // --- END -- Virtual interface ----------------------------------------------
+  
+  
+}; // icarus::opdet::PMTnoiseGeneratorTool
+
+
+//------------------------------------------------------------------------------
+//--- icarus::opdet::PMTnoiseGeneratorTool implementation
+//------------------------------------------------------------------------------
+inline auto icarus::opdet::PMTnoiseGeneratorTool::makeGenerator
+  (CLHEP::HepRandomEngine& engine) -> std::unique_ptr<Generator_t>
+{
+  std::unique_ptr<Generator_t> ptr = doMakeGenerator(engine);
+  assert(ptr);
+  return ptr;
+} // icarus::opdet::PMTnoiseGeneratorTool::makeGenerator()
+
+
+//------------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_PMT_PMTNOISEGENERATORTOOL_H

--- a/icaruscode/PMT/PMTnoiseGeneratorToolBase.h
+++ b/icaruscode/PMT/PMTnoiseGeneratorToolBase.h
@@ -1,0 +1,153 @@
+/**
+ * @file   icaruscode/PMT/PMTnoiseGeneratorToolBase.h
+ * @brief  Standard base for implementation of tools of PMT noise generators.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 17, 2022
+ * @see    `icaruscode/PMT/Algorithms/PMTgausNoiseGenerator.h`
+ */
+
+#ifndef ICARUSCODE_PMT_PMTNOISEGENERATORTOOLBASE_H
+#define ICARUSCODE_PMT_PMTNOISEGENERATORTOOLBASE_H
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/PMTnoiseGeneratorTool.h"
+
+// LArSoft libraries
+#include "lardataalg/Utilities/quantities_fhicl.h" // quantities from FHiCL
+
+// framework libraries
+#include "art/Utilities/ToolConfigTable.h" // for the derived classes
+#include "art/Utilities/ToolMacros.h" // for the derived classes
+#include "canvas/Utilities/Exception.h"
+
+// CLHEP libraries
+#include "CLHEP/Random/RandEngine.h" // CLHEP::HepRandomEngine
+
+// C/C++ standard libraries
+#include <memory> // std::unique_ptr()
+#include <string>
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <template <typename> class ProvidedGenerator>
+  struct PMTnoiseGeneratorToolBase;
+}
+/**
+ * @brief Base class for a standard tool wrapper for noise generator algorithms.
+ * @see `icarus::opdet::PMTnoiseGeneratorTool`
+ * 
+ * This is a base class aimed to make the addition of tools for PMT noise
+ * generators faster by implementing most of the boilerplate code, at the price
+ * of a loss of flexibility.
+ * 
+ * 
+ * Usage pattern
+ * --------------
+ * 
+ * To have a tool serving the algorithm `GenAlg`, a new class must be defined
+ * and declared a tool:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * class icarus::opdet::PMTGenAlgTool
+ *   : public icarus::opdet::PMTnoiseGeneratorToolBase<GenAlg>
+ * {
+ *   using Base_t = icarus::opdet::PMTnoiseGeneratorToolBase<GenAlg>;
+ *   
+ *   using Base_t::Base_t;
+ *   
+ * }; // icarus::opdet::PMTGenAlgTool
+ * 
+ * DEFINE_ART_CLASS_TOOL(icarus::opdet::PMTGenAlgTool)
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * To use this tool, given the necessity of specifying more than just the FHiCL
+ * configuration (in particular, the random generator engine is needed), a
+ * two-step procedure is necessary:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * std::unique_ptr<icarus::opdet::PMTnoiseGeneratorTool> genTool
+ *   = art::make_tool<icarus::opdet::PMTnoiseGeneratorTool>(config);
+ * std::unique_ptr<icarus::opdet::NoiseGeneratorAlg<util::quantities::counts_f>> genAlg
+ *   = genTool->makeGenerator(engine);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * where `config` is better served as a `fhicl::DelegatedParameter` object.
+ * The tool can be destroyed after the algorithm is created, as the ownership
+ * of the algorithm is given to the caller.
+ * Of course, to initialize a member variable in the initialization list of a
+ * constructor the two steps may be merged, provided that the `engine` is
+ * already available:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * : fGenAlg{
+ *     art::make_tool<icarus::opdet::PMTnoiseGeneratorTool>(params().GenAlgo())
+ *       ->makeGenerator(engine)
+ *     }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * 
+ * Configuration
+ * --------------
+ * 
+ * The configuration is specific to the featured algorithm.
+ * Run `lar --print-description` on the tool or read the algorithm `Config` data
+ * structure for a short explanation of the meaning of the parameters, or check
+ * the documentation of the generator algorithms.
+ * 
+ * 
+ * 
+ * Requirements
+ * =============
+ * 
+ * Generator algorithm:
+ *  * `Config` data structure with FHiCL configuration;
+ *  * construction from a configuration table and a CLHEP random engine
+ * 
+ * 
+ * Implementations:
+ *  * (optional) override the name of the tool (`toolName()`)
+ * 
+ */
+template <template <typename ADCT> class ProvidedGenerator>
+struct icarus::opdet::PMTnoiseGeneratorToolBase
+  : public icarus::opdet::PMTnoiseGeneratorTool
+{
+  
+  /// Type of generator actually being provided.
+  using ProvidedGenerator_t = ProvidedGenerator<ADCcount_t>;
+  
+  /// Tool parameter configuration.
+  using Parameters = art::ToolConfigTable<typename ProvidedGenerator_t::Config>;
+  
+  /// Constructor: sets the configuration.
+  PMTnoiseGeneratorToolBase(Parameters const& params)
+    : fConfigParams(std::move(params))
+    {}
+  
+  
+    protected:
+  
+  /// Returns the name of this tool for error messages.
+  virtual std::string toolName() const
+    { return fConfigParams.get_PSet().template get<std::string>("tool_type"); }
+  
+  
+    private:
+  
+  Parameters const fConfigParams; ///< Configuration parameters.
+  
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /// Creates a generator with the stored configuration and the specified random
+  /// `engine`.
+  virtual std::unique_ptr<Generator_t> doMakeGenerator
+    (CLHEP::HepRandomEngine& engine) override
+    { return std::make_unique<ProvidedGenerator_t>(fConfigParams(), engine); }
+  
+  // --- END -- Virtual interface ----------------------------------------------
+  
+}; // icarus::opdet::PMTgausNoiseGeneratorTool
+
+
+//------------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_PMTNOISEGENERATORTOOLBASE_H

--- a/icaruscode/PMT/PMTpedestalGeneratorTool.h
+++ b/icaruscode/PMT/PMTpedestalGeneratorTool.h
@@ -1,0 +1,159 @@
+/**
+ * @file   icaruscode/PMT/PMTpedestalGeneratorTool.h
+ * @brief  Tool to create a PMT pedestal generator.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 19, 2022
+ * @see    `icaruscode/PMT/Algorithms/PMTpedestalGenerator.h`
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCODE_PMT_PMTPEDESTALGENERATORTOOL_H
+#define ICARUSCODE_PMT_PMTPEDESTALGENERATORTOOL_H
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h"
+#include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
+
+// LArSoft libraries
+#include "lardataalg/Utilities/quantities/electronics.h" // counts_f
+
+// CLHEP libraries
+#include "CLHEP/Random/RandEngine.h" // CLHEP::HepRandomEngine
+
+// C/C++ standard libraries
+#include <memory> // std::unique_ptr()
+#include <utility> // std::move()
+#include <cassert>
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet { struct PMTpedestalGeneratorTool; }
+/**
+ * @brief Creates a `PMTpedestalGenerator` algorithm object.
+ * 
+ * Implementations of this tool create an algorithm to emit PMT readout
+ * electronics pedestal, as an object derived from
+ * `icarus::opdet::PMTpedestalGenerator<util::quantities::counts_f>`
+ * (the template parameter is the same used by the single photoelectron
+ * response, but it's not programmatically tied to it to avoid entangling
+ * dependencies).
+ * 
+ * The tool object is just a wrapper factory that creates the actual generator,
+ * which is owned and can be returned for use.
+ * 
+ * The signature of the tool constructor should be compatible with:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * PMTpedestalGeneratorTool(fhicl::ParameterSet const&)
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * in order to be compatible with `art::make_tool()`.
+ * 
+ * The only purpose of the tool itself is to create and return the pedestal
+ * generation algorithm. This may be done by calling `makeGenerator()` either
+ * with the noise generator to be used or with the random engine to use to
+ * create a new noise generator (the latter functionality is not guaranteed for
+ * all tool implementations).
+ * 
+ */
+struct icarus::opdet::PMTpedestalGeneratorTool {
+  
+  using ADCcount_t = util::quantities::counts_f; ///< Type of ADC count used.
+  
+  /// Base type of algorithm returned.
+  using Generator_t = icarus::opdet::PedestalGeneratorAlg<ADCcount_t>;
+  
+  /// Type of noise generation algorithm passed to the pedestal generator.
+  using NoiseGenerator_t = icarus::opdet::NoiseGeneratorAlg<ADCcount_t>;
+  
+  
+  virtual ~PMTpedestalGeneratorTool() = default;
+  
+  /**
+   * @brief Returns an instance of the pedestal generator.
+   * @param noiseGen noise generation algorithm (will be acquired and owned)
+   * 
+   * This function is guaranteed to return a valid pulse function only once.
+   * The return value on following calls is undefined, but it is considered
+   * an error to return a null pointer.
+   */
+  std::unique_ptr<Generator_t> makeGenerator
+    (std::unique_ptr<NoiseGenerator_t>&& noiseGen);
+  
+  /**
+   * @brief Returns an instance of the pedestal generator.
+   * @param engine the random engine used for the noise generation algorithm
+   * 
+   * This function will attempt to create the proper noise generation algorithm
+   * from the configuration, using the specified random `engine`, and then
+   * proceed to the creation of the pedestal generation algorithm utilizing
+   * the noise generator just created.
+   * 
+   * It is possible that the creation of a certain generator with this procedure
+   * is not possible, in which case an exception should be expected.
+   * This function is guaranteed to return a valid pulse function only once.
+   * The return value on following calls is undefined, but it is considered
+   * an error to return a null pointer.
+   */
+  std::unique_ptr<Generator_t> makeGenerator
+    (CLHEP::HepRandomEngine& engine);
+  
+  
+    private:
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /**
+   * @brief Returns an instance of the pedestal generator
+   * @param noiseGen noise generation algorithm (will be acquired and owned)
+   * 
+   * Only the first call is guaranteed to return a non-null pointer.
+   * 
+   */
+  virtual std::unique_ptr<Generator_t> doMakeGenerator
+    (std::unique_ptr<NoiseGenerator_t>&& noiseGen) = 0;
+  
+  
+  /**
+   * @brief Returns an instance of the pedestal generator
+   * @param engine the random engine used for the noise generation algorithm
+   * 
+   * Only the first call is guaranteed to return a non-null pointer.
+   */
+  virtual std::unique_ptr<Generator_t> doMakeGenerator
+    (CLHEP::HepRandomEngine& engine) = 0;
+
+
+  
+  // --- END -- Virtual interface ----------------------------------------------
+  
+  
+}; // icarus::opdet::PMTpedestalGeneratorTool
+
+
+//------------------------------------------------------------------------------
+//--- icarus::opdet::PMTpedestalGeneratorTool implementation
+//------------------------------------------------------------------------------
+inline auto icarus::opdet::PMTpedestalGeneratorTool::makeGenerator
+  (std::unique_ptr<NoiseGenerator_t>&& noiseGen) -> std::unique_ptr<Generator_t>
+{
+  std::unique_ptr<Generator_t> ptr = doMakeGenerator(std::move(noiseGen));
+  assert(ptr);
+  return ptr;
+} // icarus::opdet::PMTpedestalGeneratorTool::makeGenerator()
+
+
+//------------------------------------------------------------------------------
+inline auto icarus::opdet::PMTpedestalGeneratorTool::makeGenerator
+  (CLHEP::HepRandomEngine& engine) -> std::unique_ptr<Generator_t>
+{
+  std::unique_ptr<Generator_t> ptr = doMakeGenerator(engine);
+  assert(ptr);
+  return ptr;
+} // icarus::opdet::PMTpedestalGeneratorTool::makeGenerator()
+
+
+//------------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_PMT_PMTPEDESTALGENERATORTOOL_H

--- a/icaruscode/PMT/PMTpedestalGeneratorToolBase.h
+++ b/icaruscode/PMT/PMTpedestalGeneratorToolBase.h
@@ -1,0 +1,220 @@
+/**
+ * @file   icaruscode/PMT/PMTpedestalGeneratorToolBase.h
+ * @brief  Standard base for implementation of tools of PMT pedestal generators.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 19, 2022
+ * @see    `icaruscode/PMT/Algorithms/PMTgausPedestalGenerator.h`
+ */
+
+#ifndef ICARUSCODE_PMT_PMTNOISEGENERATORTOOLBASE_H
+#define ICARUSCODE_PMT_PMTNOISEGENERATORTOOLBASE_H
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/PMTpedestalGeneratorTool.h"
+#include "icaruscode/PMT/PMTnoiseGeneratorTool.h"
+#include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
+
+// LArSoft libraries
+#include "lardataalg/Utilities/quantities/electronics.h" // counts_f
+#include "lardataalg/Utilities/quantities_fhicl.h" // quantities from FHiCL
+
+// framework libraries
+#include "art/Utilities/make_tool.h"
+#include "art/Utilities/ToolConfigTable.h" // for the derived classes
+#include "art/Utilities/ToolMacros.h" // for the derived classes
+#include "canvas/Utilities/Exception.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/types/TableFragment.h"
+#include "fhiclcpp/ParameterSet.h"
+
+// CLHEP libraries
+#include "CLHEP/Random/RandEngine.h" // CLHEP::HepRandomEngine
+
+// C/C++ standard libraries
+#include <memory> // std::unique_ptr
+#include <utility> // std::move()
+#include <string>
+
+
+//------------------------------------------------------------------------------
+namespace icarus::opdet {
+  template <template <typename> class ProvidedGenerator>
+  struct PMTpedestalGeneratorToolBase;
+}
+/**
+ * @brief Base for a standard tool wrapper for pedestal generator algorithms.
+ * @see `icarus::opdet::PMTpedestalGeneratorTool`
+ * 
+ * This is a base class aimed to make the addition of tools for PMT pedestal
+ * generators faster by implementing most of the boilerplate code, at the price
+ * of a loss of flexibility.
+ * 
+ * 
+ * Usage pattern
+ * --------------
+ * 
+ * To have a tool serving the algorithm `GenAlg`, a new class must be defined
+ * and declared a tool:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * class icarus::opdet::PMTGenAlgTool
+ *   : public icarus::opdet::PMTpedestalGeneratorToolBase<GenAlg>
+ * {
+ *   using Base_t = icarus::opdet::PMTpedestalGeneratorToolBase<GenAlg>;
+ *   
+ *   using Base_t::Base_t;
+ *   
+ * }; // icarus::opdet::PMTGenAlgTool
+ * 
+ * DEFINE_ART_CLASS_TOOL(icarus::opdet::PMTGenAlgTool)
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * To use this tool, given the necessity of specifying more than just the FHiCL
+ * configuration (in particular, a random number engine for the noise generator
+ * algorithm is needed), a two-step procedure is necessary:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * std::unique_ptr<icarus::opdet::PMTpedestalGeneratorTool> genTool
+ *   = art::make_tool<icarus::opdet::PMTpedestalGeneratorTool>(config);
+ * std::unique_ptr<icarus::opdet::PedestalGeneratorAlg<util::quantities::counts_f>> genAlg
+ *   = genTool->makeGenerator(engine);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * where `config` is better served as a `fhicl::DelegatedParameter` object.
+ * The tool can be destroyed after the algorithm is created, as the ownership
+ * of the algorithm is given to the caller.
+ * Of course, to initialize a member variable in the initialization list of a
+ * constructor the two steps may be merged, provided that the `engine` is
+ * already available:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * : fGenAlg{
+ *     art::make_tool<icarus::opdet::PMTpedestalGeneratorTool>(params().GenAlgo())
+ *       ->makeGenerator(engine)
+ *     }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * 
+ * Configuration
+ * --------------
+ * 
+ * The configuration is specific to the featured algorithm.
+ * Run `lar --print-description` on the tool or read the algorithm `Config` data
+ * structure for a short explanation of the meaning of the parameters, or check
+ * the documentation of the generator algorithms.
+ * It is expected, though, that the configuration contains a `NoiseGenerator`
+ * table for the configuration of the noise generation algorithm and tool.
+ * If that mandatory table is empty, no noise generator algorithm will be
+ * provided (which the pedestal generator may or may not be happy with).
+ * 
+ * 
+ * Requirements
+ * =============
+ * 
+ * Generator algorithm:
+ *  * `Config` data structure with FHiCL configuration;
+ *  * construction from a configuration table and a `std::unique_ptr` to a
+ *    noise generator algorithm.
+ * 
+ * Implementations:
+ *  * (optional) override the name of the tool (`toolName()`)
+ * 
+ */
+template <template <typename ADCT> class ProvidedGenerator>
+struct icarus::opdet::PMTpedestalGeneratorToolBase
+  : public icarus::opdet::PMTpedestalGeneratorTool
+{
+  
+  /// Type of generator actually being provided.
+  using ProvidedGenerator_t = ProvidedGenerator<ADCcount_t>;
+  
+  /// FHiCL configuration of the provided generator.
+  using ProvidedGeneratorConfig_t = typename ProvidedGenerator_t::Config;
+  
+  /// Configuration class for pedestal generation tools.
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::TableFragment<ProvidedGeneratorConfig_t> PedestalConfig;
+    fhicl::DelegatedParameter NoiseGenerator{
+      Name{ "NoiseGenerator" },
+      Comment{
+        "Configuration of the noise generation tool"
+        " (from PMTnoiseGenerationTool)"
+        }
+      };
+    
+  }; // Config
+  
+  /// Tool parameter configuration.
+  using Parameters = art::ToolConfigTable<Config>;
+  
+  /// Constructor: sets the configuration.
+  PMTpedestalGeneratorToolBase(Parameters const& params)
+    : fConfigParams(std::move(params))
+    {}
+  
+  
+    protected:
+  
+  /// Returns the name of this tool for error messages.
+  virtual std::string toolName() const
+    { return fConfigParams.get_PSet().template get<std::string>("tool_type"); }
+  
+  
+    private:
+  
+  Parameters const fConfigParams; ///< Configuration parameters.
+  
+  
+  // --- BEGIN -- Virtual interface --------------------------------------------
+  
+  /// Creates a generator with the stored configuration and the specified noise
+  /// generator.
+  virtual std::unique_ptr<Generator_t> doMakeGenerator
+    (std::unique_ptr<NoiseGenerator_t>&& noiseGen) override;
+  
+  /// Creates a generator with the stored configuration and the specified random
+  /// `engine`.
+  virtual std::unique_ptr<Generator_t> doMakeGenerator
+    (CLHEP::HepRandomEngine& engine) override;
+  
+  // --- END -- Virtual interface ----------------------------------------------
+  
+}; // icarus::opdet::PMTgausPedestalGeneratorTool
+
+
+//------------------------------------------------------------------------------
+//---  Template implementation
+//------------------------------------------------------------------------------
+template <template <typename ADCT> class ProvidedGenerator>
+auto
+icarus::opdet::PMTpedestalGeneratorToolBase<ProvidedGenerator>::doMakeGenerator
+  (std::unique_ptr<NoiseGenerator_t>&& noiseGen) -> std::unique_ptr<Generator_t>
+{
+  return std::make_unique<ProvidedGenerator_t>
+    (fConfigParams().PedestalConfig(), std::move(noiseGen));
+} // icarus::opdet::PMTpedestalGeneratorToolBase::doMakeGenerator(noiseGen)
+
+
+//------------------------------------------------------------------------------
+template <template <typename ADCT> class ProvidedGenerator>
+auto
+icarus::opdet::PMTpedestalGeneratorToolBase<ProvidedGenerator>::doMakeGenerator
+  (CLHEP::HepRandomEngine& engine) -> std::unique_ptr<Generator_t>
+{
+  using NoiseGenerator_t
+    = icarus::opdet::NoiseGeneratorAlg<util::quantities::counts_f>;
+  
+  std::unique_ptr<NoiseGenerator_t> noiseGen;
+  fhicl::ParameterSet const& noiseConfig
+    = fConfigParams().NoiseGenerator.template get<fhicl::ParameterSet>();
+  if (!noiseConfig.is_empty()) {
+    noiseGen = art::make_tool<icarus::opdet::PMTnoiseGeneratorTool>(noiseConfig)
+      ->makeGenerator(engine);
+  }
+  return makeGenerator(std::move(noiseGen));
+} // icarus::opdet::PMTpedestalGeneratorToolBase::doMakeGenerator(engine)
+
+
+//------------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_PMTNOISEGENERATORTOOLBASE_H

--- a/icaruscode/PMT/SimPMTreadout_module.cc
+++ b/icaruscode/PMT/SimPMTreadout_module.cc
@@ -1122,7 +1122,7 @@ std::vector<raw::OpDetWaveform> icarus::opdet::SimPMTreadout::makeWaveforms(
   using microsecond = util::quantities::points::microsecond;
   
   auto const toTicks = [this](nanoseconds interval)
-    { return static_cast<int>(fDetTimings.toOpticalTicks(interval).value()); };
+    { return static_cast<int>(std::round(interval / fOpticalTick)); };
   auto const toTimestamp = [this,beamGateTimestamp](electronics_time t)
     {
       return beamGateTimestamp + static_cast<std::int64_t>

--- a/icaruscode/PMT/SimPMTreadout_module.cc
+++ b/icaruscode/PMT/SimPMTreadout_module.cc
@@ -1,0 +1,1281 @@
+/**
+ * @file   icaruscode/PMT/SimPMTreadout_module.cc
+ * @brief  Produces PMT waveforms reflecting ICARUS readout.
+ * @author Gianluca Petrillo
+ * @date   November 16, 2022
+ * 
+ */
+
+// ICARUS libraries
+#include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()
+
+// LArSoft libraries
+#include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/LArPropertiesService.h"
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
+#include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // electronics_time
+#include "lardataalg/Utilities/intervals_fhicl.h" // microseconds from FHiCL
+#include "lardataalg/Utilities/quantities/spacetime.h" // nanosecond
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "larcorealg/CoreUtils/counter.h"
+#include "lardataobj/RawData/OpDetWaveform.h"
+#include "lardataobj/RawData/TriggerData.h"
+#include "nurandom/RandomUtils/NuRandomService.h"
+
+// framework libraries
+#include "art/Framework/Core/SharedProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+// #include "art/Utilities/make_tool.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+// #include "fhiclcpp/types/DelegatedParameter.h"
+// #include "fhiclcpp/types/TableFragment.h"
+#include "fhiclcpp/types/TableAs.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/Atom.h"
+// #include "fhiclcpp/ParameterSet.h"
+
+// CLHEP libraries
+#include "CLHEP/Random/RandEngine.h" // CLHEP::HepRandomEngine
+
+// C/C++ standard library
+#include <vector>
+#include <algorithm> // std::min()
+#include <atomic> // std::atomic_flag
+#include <mutex> // std::mutex, std::lock_guard
+#include <memory> // std::make_unique()
+#include <utility> // std::move()
+#include <cmath> // std::round()
+#include <limits> // std::numeric_limits
+
+
+namespace icarus::opdet { class SimPMTreadout; }
+/**
+ * @brief Simulates the digitization of ICARUS PMT response including readout.
+ * 
+ * This module operates on top of already digitised PMT waveforms, with the
+ * purpose of simulating the effect of the selective readout of ICARUS PMT
+ * system.
+ * 
+ * In the detector, PMT signals are first digitised and discriminated in real
+ * time, then combined to determine trigger primitives. When a trigger
+ * primitive is formed, it causes the PMT readout board to actually save the
+ * PMT information.
+ * 
+ * In the simulation, this is done in steps:
+ * 
+ * 1. Digitization occurs first based on scintillation photons which converted
+ *    at the PMT surface; this is the task of `icarus::opdet::SimPMTIcarus`
+ *    module, which creates `raw::OpDetWaveform` with all scintillation signal
+ *    (except that a low threshold is used), including noise.
+ * 2. Trigger primitives are determined based on the waveforms from the
+ *    previous step. This task can be performed by the proper configuration of
+ *    `icarus::trigger::TriggerSimulationOnGates` module.
+ * 3. Finally, the trigger primitives are used to determine the time intervals
+ *    and the channels when and where the readout happens, and new waveforms
+ *    are created combining the samples from the waveforms in the first step.
+ * 
+ * 
+ * Readout details
+ * ================
+ * 
+ * The current implementation operates mimicking the ICARUS PMT and triger
+ * systems, although the delays are not simulated.
+ * 
+ * 1. Trigger primitives are expected to be generated with a time, precise at
+ *    the PMT sample (2 nanoseconds), and a location, precise at the cryostat
+ *    (conceivably it could be precise at the TPC, but currently the trigger
+ *    compbines the two TPC in a cryostat).
+ * 2. Optical detector waveforms used as input are expected to already contain
+ *    all the signal.
+ * 3. Readout parameters are learned from the module configuration, as well
+ *    as the noise parameters.
+ * 4. Artificial trigger primitives are added to reflect the ones sent by the
+ *    hardware to ensure coverage of the beam gate time
+ *    (see @ref SimPMTreadout_BeamGate "Readout during beam gate" below).
+ * 5. For each trigger primitive, all PMT in the primitive cryostat are read
+ *    out, with a time interval extending before the trigger primitive time
+ *    by the amount of configured pre-trigger buffer, and with a fixed
+ *    duration.
+ * 6. Contiguous buffers are merged in a single waveform.
+ * 
+ * 
+ * Waveform content creation
+ * --------------------------
+ * 
+ * The algorithm proceeds with the following steps:
+ * 
+ * 1. Read all the trigger primitives from input.
+ * 2. Generate additional, artificial trigger primitives as requested in the
+ *    configuration
+ *    (see @ref SimPMTreadout_BeamGate "Readout during beam gate" below)
+ * 3. Surround each trigger primitive with a readout buffer interval, and
+ *    determine the final readout intervals for all channels and waveforms.
+ *    A single channel will have multiple intervals, and each interval will
+ *    generate a waveform.
+ * 4. For each interval, the source waveform data is copied into the new one.
+ *    If there are times that are uncovered, the noise generator is tasked
+ *    to full the gaps.
+ * 
+ * It is assumed that the noise will not contribute to further trigger
+ * primitives. This is a solid assumption, considering that the noise is added
+ * only on top of the baseline (no signal present), and that the noise is two
+ * orders of magnitude smaller than the discrimination threshold the trigger
+ * primitives utilize.
+ * 
+ * 
+ * ### Readout during beam gate
+ * 
+ * @anchor SimPMTreadout_BeamGate
+ * 
+ * The trigger hardware is configured to always send a sequence of artificial
+ * trigger primitives at around the time the beam gate is expected.
+ * For example, in ICARUS Run1 three trigger primitives were sent to all the
+ * PMT readout boards (i.e. triggering the readout of all 360 channels) at
+ * the times of -4, +3 and +12 microseconds from the beam gate (which is also
+ * the time the trigger hardware opens the gate to form a global trigger).
+ * This, combined with a readout buffer of 10 microseconds, 3 before the
+ * trigger primitive signal and 7 after it, would ensure the coverage by the
+ * PMT of 26 microseconds, from -7 to +19 with respect to the beam gate, and
+ * therefore a coverage of 7 microseconds before any beam interaction to more
+ * than 9 microseconds after the latest of NuMI neutrino possible interaction.
+ * 
+ * In addition, a trigger primitive is still sent at the time of the global
+ * trigger; with the aforementioned configuration, though, this does not add
+ * any time coverage to the PMT.
+ * 
+ * 
+ * Configuration
+ * ==============
+ * 
+ * The configuration is also available with the usual
+ * `lar --print-description SimPMTreadout`.
+ * 
+ * * `WaveformTags` (list of input tags, mandatory): list of data products
+ *   with the waveform samples to be arranged in the new waveforms.
+ * * `PrimitiveTags` (list of input tags, mandatory): list of trigger
+ *   primitive data products to seed the PMT readout with.
+ * * `TriggerTags` (list of input tags, default: empty): list of global
+ *   triggers contributing additional trigger primitives to the whole
+ *   detector.
+ * * `FixedTriggerTimes` (list of times, optional): adds a global trigger (in
+ *   the same fashion as the ones from `TriggerTags` collections) to the times
+ *   specified in this list. Times here are relative to the beam gate opening
+ *   time.
+ * * `Readout` (table, mandatory): readout settings:
+ *     * `WindowSize` (integer, mandatory): the size of a readout buffer in
+ *       optical ticks.
+ *     * `PreTrigFraction` (real, mandatory): the fraction of the readout buffer
+ *       that is collected before the trigger primitive (e.g. a fraction `0.3`
+ *       over a buffer of `5000` samples will have `1500` samples before the
+ *       trigger primitive, and the remaining `3500` starting from the primitive
+ *       time on).
+ * * `CryostatFirstBit` (positive integer, mandatory): the trigger bit which is
+ *     set on triggers from cryostat 0; as many bits are expected as
+ *     there are cryostats in the detector (thus, 2 for ICARUS). The value `0`
+ *     represents the least significant bit.
+ * * `LogCategory` (string, default: `SimPMTreadout`): message facility
+ *   category to which the module messages are routed.
+ * 
+ * 
+ * Input
+ * ======
+ * 
+ * * `std::vector<raw::Trigger>` (`PrimitiveTags`): collection of trigger
+ *   primitives. Each object must encode the location of the primitive in its
+ *   trigger bits (see `CryostatFirstBit` configuration parameter).
+ * * `std::vector<raw::Trigger>` (optional, `TriggerTags`): collections of
+ *   global triggers; each global trigger will count as a trigger primitive
+ *   for each cryostat. All triggers in all data products are added.
+ * * `std::vector<raw::OpDetWaveform>` (`WaveformTags`): PMT waveforms already
+ *   digitized, source of the data for the new ones.
+ * 
+ * 
+ * Output
+ * =======
+ * 
+ * * `std::vector<raw::OpDetWaveform>` with the rearranged readout samples.
+ *   They are sorted by channel, then by time, like in the output of
+ *   `icarus::opdet::SimPMTIcarus` module.
+ * * `std::vector<sbn::OpDetWaveformMeta>` and associations with the optical
+ *   waveform data product, with "summary" informations about each waveform.
+ * 
+ * 
+ * Requirements
+ * =============
+ * 
+ * This module currently requires LArSoft services:
+ * * `DetectorClocksService` for timing conversions and settings
+ * 
+ * Three random streams are also used.
+ * 
+ * 
+ * 
+ */
+class icarus::opdet::SimPMTreadout: public art::SharedProducer {
+    
+  using electronics_time = detinfo::timescales::electronics_time;
+  
+  /// Type of trigger bits supported by `raw::Trigger`.
+  using TriggerBits_t = decltype(std::declval<raw::Trigger>().TriggerBits());
+  
+  /// Number of bits supported by `raw::Trigger`.
+  static constexpr std::size_t NTriggerBits = sizeof(TriggerBits_t) * 8U;
+  
+    public:
+  
+  using microseconds = util::quantities::intervals::microseconds; // alias
+  
+  /// Configuration parameters for PMT readout.
+  struct ReadoutParams_t {
+    
+    unsigned int bufferSize; ///< Size of the full readout buffer [samples]
+    unsigned int preSize; ///< Size of the buffer collected before trigger.
+    
+    unsigned int preTriggerSize() const { return preSize; }
+    unsigned int postTriggerSize() const { return bufferSize - preSize; }
+    
+  }; // ReadoutParams_t
+  
+  
+  /// Module configuration interface.
+  struct Config {
+    using Comment = fhicl::Comment;
+    using Name = fhicl::Name;
+    
+    struct ReadoutConfig {
+      
+      fhicl::Atom<unsigned int> WindowSize{
+        Name{ "WindowSize" },
+        Comment{ "readout window size in samples" }
+        };
+      
+      fhicl::Atom<float> PreTrigFraction {
+        Name{ "PreTrigFraction" },
+        Comment{ "fraction of readout coming before the trigger primitive" }
+        };
+      
+    }; // ReadoutConfig
+    
+    
+    fhicl::Sequence<art::InputTag> WaveformTags{
+      Name{ "WaveformTags" },
+      Comment{ "input PMT waveforms" }
+      };
+    
+    fhicl::Sequence<art::InputTag> PrimitiveTags{
+      Name{ "PrimitiveTags" },
+      Comment{ "input trigger primitives" }
+      };
+    
+    fhicl::Sequence<art::InputTag> TriggerTags{
+      Name{ "TriggerTags" },
+      Comment{ "additional global trigger(s) generating primitives" },
+      std::vector<art::InputTag>{}
+      };
+    
+    fhicl::Sequence<microseconds> FixedTriggerTimes{
+      Name{ "FixedTriggerTimes" },
+      Comment{ "additional global trigger(s) as time w.r.t. beam gate" },
+      std::vector<microseconds>{}
+      };
+    
+    fhicl::Atom<unsigned int> CryostatFirstBit{
+      Name("CryostatFirstBit"),
+      Comment(
+        "number of the trigger bit representing the first cryostat (< "
+        + std::to_string(NTriggerBits) + ")"),
+      NTriggerBits
+      };
+    
+    fhicl::Atom<std::string> LogCategory{
+      Name{ "LogCategory" },
+      Comment{ "category name for the message facility stream to be used" },
+      "SimPMTreadout"
+      };
+    
+    fhicl::TableAs<ReadoutParams_t, ReadoutConfig> Readout {
+      Name{ "Readout" },
+      Comment{ "Readout parameters" }
+      };
+      
+    
+    
+    // fhicl::DelegatedParameter SinglePhotonResponse {
+    //   fhicl::Name("SinglePhotonResponse"),
+    //   fhicl::Comment(
+    //     "parameters describing the single photon response"
+    //     " (SinglePhotonPulseFunctionTool tool)"
+    //     )
+    //   };
+    // 
+    // fhicl::TableFragment<icarus::opdet::PMTsimulationAlgMaker::Config> algoConfig;
+    
+//     rndm::SeedAtom DarkNoiseSeed {
+//       Name("DarkNoiseSeed"),
+//       Comment("fix the seed for stochastic dark noise generation")
+//       };
+//     
+//     rndm::SeedAtom ElectronicsNoiseSeed {
+//       Name("ElectronicsNoiseSeed"),
+//       Comment("fix the seed for stochastic electronics noise generation")
+//       };
+//     
+//     fhicl::Atom<std::string> electronicsNoiseRandomEngine {
+//         Name("ElectronicsNoiseRandomEngine"),
+//         Comment("type of random engine to use for electronics noise"),
+//         "HepJamesRandom"
+//     };
+// 
+//     fhicl::Atom<std::string> darkNoiseRandomEngine {
+//         Name("DarkNoiseRandomEngine"),
+//         Comment("type of random engine to use for dark noise"),
+//         "HepJamesRandom"
+//     };
+
+  }; // struct Config
+  
+  using Parameters = art::SharedProducer::Table<Config>;
+
+  
+  explicit SimPMTreadout
+    (Parameters const& config, art::ProcessingFrame const& frame);
+  
+  void produce(art::Event& event, art::ProcessingFrame const& frame) override;
+  
+  
+    private:
+  
+  using nanoseconds = util::quantities::intervals::nanoseconds; // alias
+  
+  /// Class to manage the input waveforms.
+  class WaveformManager {
+    
+    /// Pointers to the managed waveforms, sorted by channel.
+    std::vector<std::vector<raw::OpDetWaveform const*>> fByChannel;
+    
+      public:
+    
+    WaveformManager(unsigned int nChannels)
+      : fByChannel{ static_cast<std::size_t>(nChannels) }
+      {}
+    
+    /// Returns (pointers to) the waveforms in the specified `channel`.
+    std::vector<raw::OpDetWaveform const*> const& operator[]
+      (raw::Channel_t channel) const
+      { return fByChannel[static_cast<std::size_t>(channel)]; }
+    
+    /// Returns (pointers to) the waveforms in the specified `channel`.
+    std::vector<raw::OpDetWaveform const*> const& at
+      (raw::Channel_t channel) const
+      { return fByChannel.at(static_cast<std::size_t>(channel)); }
+    
+    /// Adds to the manager references to all `waveforms` (not sorted).
+    WaveformManager& add(std::vector<raw::OpDetWaveform> const& waveforms);
+    
+    /// Enforces order in increasing timestamp of all waveforms in each channel.
+    void sortInTime();
+    
+  }; // class WaveformManager
+
+  /// Tracks the required primitives per optical detector channel.
+  class PrimitiveManager {
+    
+    /// Cryostat ID of each PMT channel.
+    std::vector<geo::CryostatID> const fCryostatOf;
+    
+    /// Cached primitives per cryostat.
+    mutable std::vector<std::vector<electronics_time>> fPrimitives;
+    
+    /// Changes happened since last cache refresh.
+    mutable std::atomic_bool fModified{ false };
+    
+    mutable std::mutex fRefreshMutex; ///< Lock used while refreshing caches.
+    
+    void modify() { fModified = true; }
+    
+    /// Refreshes all caches. Note that this is a "const" method.
+    void refreshCaches(bool force = false) const;
+    
+    /// Creates a map of all PMT channels into cryostat ID.
+    static std::vector<geo::CryostatID> makeChannelMap
+      (geo::GeometryCore const& geom);
+    
+      public:
+    
+    PrimitiveManager(geo::GeometryCore const& geom);
+    
+    /// Returns all the readout windows for the specified channel.
+    std::vector<electronics_time> const& forChannel
+      (raw::Channel_t channel) const;
+    
+    /// Adds a primitive at the specified `time` for all channels in `cryo`.
+    void addPrimitiveForCryostat(electronics_time time, geo::CryostatID cryo);
+    
+    /// Adds a primitive at the specified `time` for all channels.
+    void addPrimitiveToAllChannels(electronics_time time);
+    
+    /// Prepares for queries; not essential, but add deterministic flow.
+    void prepare() { refreshCaches(); }
+    
+  }; // PrimitiveManager
+  
+  /// A single contiguous readout window.
+  struct Window_t: std::pair<electronics_time, electronics_time> {
+    using Base_t = std::pair<electronics_time, electronics_time>;
+    
+    using Base_t::Base_t;
+    
+    constexpr electronics_time start() const noexcept { return first; }
+    constexpr electronics_time stop() const noexcept { return second; }
+    constexpr auto width() const noexcept { return stop() - start(); }
+    
+    constexpr bool empty() const noexcept { return start() >= stop(); }
+    
+    void extendTo(electronics_time stop) { second = stop; }
+  }; // Window_t
+  
+  // --- BEGIN -- Configuration ------------------------------------------------
+  /// Input tags for already digitized waveforms.
+  std::vector<art::InputTag> const fWaveformTags;
+  
+  /// Input tags for trigger primitives.
+  std::vector<art::InputTag> const fPrimitiveTags;
+  
+  /// Input tags for additional global triggers.
+  std::vector<art::InputTag> const fTriggerTags;
+  
+  /// Time of the added, artificial global triggers.
+  std::vector<microseconds> const fFixedTriggerTimes;
+  
+  ReadoutParams_t const fReadoutParams; ///< PMT readout parameters.
+  
+  TriggerBits_t const fCryostatZeroMask; ///< Bit mask for cryostat `0`.
+  
+  std::string const fLogCategory; ///< Message facility category name.
+  
+  // --- END ---- Configuration ------------------------------------------------
+  
+  
+  // --- BEGIN -- Cached values ------------------------------------------------
+  
+  geo::GeometryCore const& fGeom; ///< Geometry service provider.
+  detinfo::DetectorTimings const fDetTimings; ///< Timing conversion utility.
+  
+  unsigned int const fNOpChannels; ///< Number of optical detector channels.
+  unsigned int const fNCryostats; ///< Number of cryostats in the detector.
+  
+  nanoseconds const fOpticalTick; ///< PMT digitization sampling time.
+  
+  // --- END ---- Cached values ------------------------------------------------
+  
+  
+  // CLHEP::HepRandomEngine&  fDarkNoiseEngine;
+  // CLHEP::HepRandomEngine&  fElectronicsNoiseEngine;
+  
+  /// Registers local primitives (affecting only part of the detector).
+  void addLocalPrimitives(
+    PrimitiveManager& manager,
+    std::vector<raw::Trigger> const& primitives
+    ) const;
+  
+  /// Registers global primitives (affecting the whole detector).
+  void addGlobalPrimitives(
+    PrimitiveManager& manager,
+    std::vector<raw::Trigger> const& primitives
+    ) const;
+  
+  /// Forms and merges the readout windows for the specified set of primitives.
+  std::vector<Window_t> extractReadoutWindows
+    (std::vector<electronics_time> const& primitives) const;
+  
+  /// Creates waveforms on a single channel, filling the specified readout
+  /// windows, from the samples in `source` waveforms.
+  std::vector<raw::OpDetWaveform> makeWaveforms(
+    raw::Channel_t channel,
+    std::vector<raw::OpDetWaveform const*> const& source,
+    std::vector<Window_t> const& readoutWindows
+    ) const;
+  
+  
+  /// Returns which cryostats the trigger belongs to (invalid if none/unknown).
+  std::vector<geo::CryostatID> cryostatsOf(raw::Trigger const& trigger) const;
+
+  
+  
+}; // class icarus::opdet::SimPMTreadout
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+namespace {
+  
+  // ---------------------------------------------------------------------------
+  template <typename T, typename=std::enable_if_t<std::is_rvalue_reference_v<T&&>>>
+  std::unique_ptr<T> moveToUniquePtr(T&& data)
+    { return std::make_unique<T>(std::move(data)); }
+  
+  
+  // ---------------------------------------------------------------------------
+  /// Moves the content of nested collection `src` flattening the outmost tier.
+  template <typename Coll, typename=std::enable_if_t<std::is_rvalue_reference_v<Coll&&>>>
+  std::vector<typename std::decay_t<Coll>::value_type::value_type> flatten
+    (Coll&& src)
+  {
+    
+    using SrcColl_t = typename std::decay_t<Coll>::value_type;
+    using value_type = typename SrcColl_t::value_type;
+    using DestColl_t = std::vector<value_type>;
+    
+    DestColl_t dest;
+    for (SrcColl_t& coll: src) {
+      for (value_type& value: coll) dest.push_back(std::move(value));
+    } // for src
+    
+    return dest;
+  } // flatten()
+  
+  
+  // ---------------------------------------------------------------------------
+  template <typename T>
+  constexpr T bitMask(std::size_t i) {
+    constexpr std::size_t nBits = sizeof(T) * 8;
+    return (i >= nBits)? T{ 0 }: T{ 1 } << i;
+  } // bitMask()
+  
+  
+  // ---------------------------------------------------------------------------
+  
+#if 0
+  /**
+   * 
+   * Example of usage:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * using detinfo::timescales::electronics_time;
+   * 
+   * electronics_time extendStop(
+   *   electronics_time prevStop,
+   *   electronics_time nextStart, electronics_time nextStop
+   * ) {
+   *   using util::quantities::time_literals;
+   *   TolerantComparer const T{ 0.1_ns };
+   *   return (T(prevStop) >= T(nextStart))? nextStop: prevStop;
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * (the comparison should work as `T(prevStop) >= nextStart` or
+   * `prevStop >= T(nextStart)` as well).
+   * 
+   * The design of this class is roughly the following:
+   * * `TolerantComparer` is a factory of operands
+   * * an operand is just a typed copy of a value
+   * * comparison between operands is performed by free-function operators.
+   * 
+   */
+  template <typename T>
+  class TolerantComparer {
+    
+    using Tolerance_t = T;
+    
+    Tolerance_t fTol; ///< Reference tolerance value.
+    
+      public:
+    
+    template <typename U>
+    struct Operand {
+      
+      using Comparer_t = TolerantComparer<Tolerance_t>;
+      
+      Tolerance_t tol;
+      U&& value;
+      
+      constexpr Operand(Tolerance_t tol, U&& value)
+        : tol(std::move(tol)), value(std::forward<U>(value)) {}
+      
+    }; // struct Operand
+    
+    
+    constexpr TolerantComparer(T const tol): fTol(tol) {}
+    
+    template <typename U>
+    constexpr Operand<U> operator() (U&& value) const
+      { return Operand<U>{ fTol, std::forward(value) }; }
+    
+    template <typename U>
+    static constexpr isZero(U const& value, T const& tol)
+      { T const v = static_cast<T>(value); return (v >= -tol) && (v <= tol); }
+    
+  }; // TolerantComparer
+  
+  
+  template <typename T, typename U, typename V>
+  constexpr bool operator==
+    (TolerantComparer<T>::Operand<U> const& a, V const& b)
+    { return TolerantComparer<T>::isZero(a.value - b, a.tol); }
+  template <typename T, typename U, typename V>
+  constexpr bool operator==
+    (V const& a, TolerantComparer<T>::Operand<U> const& b)
+    { return TolerantComparer<T>::isZero(a.value - b, a.tol); }
+  
+  template <typename T, typename U, typename V>
+  constexpr bool operator!=
+    (TolerantComparer<T>::Operand<U> const& a, V const& b)
+    { return !(a == b); }
+  
+  template <typename T, typename U, typename V>
+  bool operator< (TolerantComparer<T>::Operand<U> const& a, V const& b)
+    { return (a.value - a.tol) < b; }
+  
+  template <typename T, typename U, typename V>
+  bool operator<= (TolerantComparer<T>::Operand<U> const& a, V const& b)
+    { return (a.value + a.tol) <= b; }
+  
+  template <typename T, typename U, typename V>
+  bool operator> (TolerantComparer<T>::Operand<U> const& a, V const& b)
+    { return !(a <= b); }
+  
+  template <typename T, typename U, typename V>
+  bool operator>= (TolerantComparer<T>::Operand<U> const& a, V const& b)
+    { return !(a < b); }
+  
+#endif // 0
+  
+  // ---------------------------------------------------------------------------
+  
+} // local namespace
+
+
+// -----------------------------------------------------------------------------
+namespace icarus::opdet {
+  
+  SimPMTreadout::ReadoutParams_t convert
+    (icarus::opdet::SimPMTreadout::Config::ReadoutConfig const& config)
+  {
+    
+    return {
+        config.WindowSize()                                      // bufferSize
+      , static_cast<unsigned int>                                // preSize
+          (std::round(config.WindowSize() * config.PreTrigFraction()))
+      };
+    
+  } // convert(SimPMTreadout::Config::ReadoutConfig)
+  
+} // namespace icarus::opdet
+
+
+// -----------------------------------------------------------------------------
+// --- icarus::opdet::SimPMTreadout implementation
+// -----------------------------------------------------------------------------
+// --- icarus::opdet::SimPMTreadout::WaveformManager
+// -----------------------------------------------------------------------------
+auto icarus::opdet::SimPMTreadout::WaveformManager::add
+  (std::vector<raw::OpDetWaveform> const& waveforms) -> WaveformManager&
+{
+  
+  for (raw::OpDetWaveform const& waveform: waveforms)
+    fByChannel.at(waveform.ChannelNumber()).push_back(&waveform);
+  
+  sortInTime();
+  
+  return *this;
+} // icarus::opdet::SimPMTreadout::WaveformManager::add()
+
+
+// -----------------------------------------------------------------------------
+void icarus::opdet::SimPMTreadout::WaveformManager::sortInTime() {
+  
+  using std::begin, std::end;
+  
+  // standard ordering for waveforms goes channel first, then timestamp
+  for (std::vector<raw::OpDetWaveform const*>& waveforms: fByChannel) {
+    std::sort
+      (begin(waveforms), end(waveforms), [](auto a, auto b){ return *a < *b; });
+  }
+  
+} // icarus::opdet::SimPMTreadout::WaveformManager::sortInTime()
+
+
+// -----------------------------------------------------------------------------
+// --- icarus::opdet::SimPMTreadout::PrimitiveManager
+// -----------------------------------------------------------------------------
+void icarus::opdet::SimPMTreadout::PrimitiveManager::refreshCaches
+  (bool force /* = false */) const
+{
+  /*
+   * All in all, this class is still not thread-safe, because it would need
+   * explicit protection in the non-const methods.
+   * I am cheap and am only guaranteeing thread-safety for const ones.
+   */
+  if (!force && !fModified) return;
+  
+  std::lock_guard guard{ fRefreshMutex };
+  
+  if (!force && !fModified) return; // again. just in case something happened
+  
+  // for correct multithreading, this would need a lock
+  using std::begin, std::end;
+  for (std::vector<electronics_time>& primitives: fPrimitives)
+    std::sort(begin(primitives), end(primitives));
+  
+  fModified = false;
+  
+} // icarus::opdet::SimPMTreadout::PrimitiveManager::refreshCaches()
+
+
+// -----------------------------------------------------------------------------
+std::vector<geo::CryostatID>
+icarus::opdet::SimPMTreadout::PrimitiveManager::makeChannelMap
+  (geo::GeometryCore const& geom)
+{
+  std::vector<geo::CryostatID> cryos;
+  for (auto channel: util::counter(geom.NOpChannels()))
+    cryos.push_back(geom.OpDetGeoFromOpChannel(channel).ID());
+  return cryos;
+} // icarus::opdet::SimPMTreadout::PrimitiveManager::makeChannelMap()
+
+
+// -----------------------------------------------------------------------------
+icarus::opdet::SimPMTreadout::PrimitiveManager::PrimitiveManager
+  (geo::GeometryCore const& geom)
+  : fCryostatOf{ makeChannelMap(geom) }
+  , fPrimitives{ geom.Ncryostats() }
+  {}
+
+
+// -----------------------------------------------------------------------------
+auto icarus::opdet::SimPMTreadout::PrimitiveManager::forChannel
+  (raw::Channel_t channel) const -> std::vector<electronics_time> const&
+{
+  refreshCaches();
+  return fPrimitives[fCryostatOf.at(channel).Cryostat];
+} // icarus::opdet::SimPMTreadout::PrimitiveManager::forChannel()
+
+
+// -----------------------------------------------------------------------------
+void icarus::opdet::SimPMTreadout::PrimitiveManager::addPrimitiveForCryostat
+  (electronics_time time, geo::CryostatID cryo)
+{
+  if (!cryo) {
+    // this is probably coming from some misunderstanding with the trigger bits
+    // which made the cryostat extraction miserably fail
+    throw art::Exception{ art::errors::LogicError }
+      << "Added a trigger primitive to an invalid cryostat: " << cryo;
+  }
+  fPrimitives.at(cryo.Cryostat).push_back(time);
+  modify();
+} // icarus::opdet::SimPMTreadout::PrimitiveManager::addPrimitiveForCryostat()
+
+
+// -----------------------------------------------------------------------------
+void icarus::opdet::SimPMTreadout::PrimitiveManager::addPrimitiveToAllChannels
+  (electronics_time time)
+{
+  for (std::vector<electronics_time>& primitives: fPrimitives)
+    primitives.push_back(time);
+  modify();
+} // icarus::opdet::SimPMTreadout::PrimitiveManager::addPrimitiveToAllChannels()
+
+
+// -----------------------------------------------------------------------------
+// --- icarus::opdet::SimPMTreadout implementation
+// -----------------------------------------------------------------------------
+icarus::opdet::SimPMTreadout::SimPMTreadout
+  (Parameters const& config, art::ProcessingFrame const& frame)
+  : art::SharedProducer{ config }
+  // configuration
+  , fWaveformTags     { config().WaveformTags() }
+  , fPrimitiveTags    { config().PrimitiveTags() }
+  , fTriggerTags      { config().TriggerTags() }
+  , fFixedTriggerTimes{ config().FixedTriggerTimes() }
+  , fReadoutParams    { config().Readout() }
+  , fCryostatZeroMask { bitMask<TriggerBits_t>(config().CryostatFirstBit()) }
+  , fLogCategory      { config().LogCategory() }
+  // caches
+  , fGeom       { *(lar::providerFrom<geo::Geometry>()) }
+  , fDetTimings { icarus::ns::util::makeDetTimings() }
+  , fNOpChannels{ fGeom.NOpChannels() }
+  , fNCryostats { fGeom.Ncryostats() }
+  , fOpticalTick{ fDetTimings.OpticalClockPeriod() }
+{
+  
+  async<art::InEvent>();
+  
+  //
+  // configuration checks
+  //
+  if (config().CryostatFirstBit() + fNCryostats > NTriggerBits) {
+    throw art::Exception{ art::errors::Configuration }
+      << config().CryostatFirstBit.name()
+      << " must be small enough to accommodate all " << fNCryostats
+      << " cryostats in the " << fGeom.DetectorName()
+      << " detector, i.e. it must be no larger than "
+      << (NTriggerBits - fNCryostats) << "\n";
+  }
+  
+  //
+  // input data product declaration
+  //
+  for (art::InputTag const& tag: fWaveformTags)
+    consumes<std::vector<raw::OpDetWaveform>>(tag);
+  for (art::InputTag const& tag: fPrimitiveTags)
+    consumes<std::vector<raw::Trigger>>(tag);
+  for (art::InputTag const& tag: fTriggerTags)
+    consumes<std::vector<raw::Trigger>>(tag);
+  
+  //
+  // output data product declaration
+  //
+  produces<std::vector<raw::OpDetWaveform>>();
+  
+  
+  { // --- BEGIN -- configuration dump -----------------------------------------
+    
+    mf::LogInfo log{ fLogCategory };
+    log << "Configuration parameters:"
+      << "\n - waveforms:";
+    if (fWaveformTags.empty()) log << " none?!";
+    else {
+      auto iTag = fWaveformTags.cbegin(), tend = fWaveformTags.cend();
+      log << " " << iTag->encode();
+      while (++iTag != tend) log << ", " << iTag->encode();
+    }
+    log << "\n - trigger primitives:";
+    if (fPrimitiveTags.empty()) log << " none?!";
+    else {
+      auto iTag = fPrimitiveTags.cbegin(), tend = fPrimitiveTags.cend();
+      log << " " << iTag->encode();
+      while (++iTag != tend) log << ", " << iTag->encode();
+    }
+    if (!fTriggerTags.empty()) {
+      log << "\n - additional global triggers:";
+      auto iTag = fTriggerTags.cbegin(), tend = fTriggerTags.cend();
+      log << " " << iTag->encode();
+      while (++iTag != tend) log << ", " << iTag->encode();
+    }
+    
+    unsigned int const firstBit = config().CryostatFirstBit();
+    log
+      << "\n - readout buffer: " << fReadoutParams.bufferSize << " samples ("
+        << fReadoutParams.preTriggerSize() << " + "
+        << fReadoutParams.postTriggerSize() << ")"
+      << "\n - trigger bit for the first cryostat: #" << firstBit
+      ;
+    if (fNCryostats > 1) log << "-" << (firstBit + fNCryostats - 1);
+    log << " (0x" << std::hex << fCryostatZeroMask;
+    if (fNCryostats > 1)
+      log << "-0x" << (fCryostatZeroMask << (fNCryostats-1));
+    log << std::dec << ")";
+    
+    if (!fFixedTriggerTimes.empty()) {
+      auto itTime = fFixedTriggerTimes.begin();
+      auto const tend = fFixedTriggerTimes.end();
+      log << "\n - additional global triggers at time (w.r.t. beam gate): "
+        << *itTime;
+      while (++itTime != tend) log << ", " << *itTime;
+    }
+    
+  } // --- END ---- configuration dump -----------------------------------------
+  
+} // icarus::opdet::SimPMTreadout::SimPMTreadout()
+
+
+// -----------------------------------------------------------------------------
+void icarus::opdet::SimPMTreadout::produce
+  (art::Event& event, art::ProcessingFrame const& frame)
+{
+  
+  using detinfo::timescales::electronics_time;
+  
+  detinfo::DetectorTimings const detTimings
+    = icarus::ns::util::makeDetTimings(event);
+  
+  //
+  // determine the primitives and the channels they affect
+  //
+  PrimitiveManager primitives{ fGeom };
+  
+  // add the trigger primitives
+  for (art::InputTag const& tag: fPrimitiveTags) {
+    addLocalPrimitives
+      (primitives, event.getProduct<std::vector<raw::Trigger>>(tag));
+  }
+  
+  // add global triggers
+  for (art::InputTag const& tag: fTriggerTags) {
+    addGlobalPrimitives
+      (primitives, event.getProduct<std::vector<raw::Trigger>>(tag));
+  }
+  
+  // add artificial primitives
+  electronics_time const beamGateTime = detTimings.BeamGateTime();
+  for (microseconds const time: fFixedTriggerTimes)
+    primitives.addPrimitiveToAllChannels(beamGateTime + time);
+  
+  //
+  // read the input waveforms
+  //
+  WaveformManager simWaveforms{ fNOpChannels };
+  for (art::InputTag const& tag: fWaveformTags)
+    simWaveforms.add(event.getProduct<std::vector<raw::OpDetWaveform>>(tag));
+  
+  
+  //
+  // create the new waveforms
+  //
+  
+  std::vector<std::vector<raw::OpDetWaveform>> readoutWaveforms{ fNOpChannels };
+  for (auto const channel: util::counter<raw::Channel_t>(fNOpChannels)) {
+    
+    std::vector<Window_t> const readoutWindows
+      = extractReadoutWindows(primitives.forChannel(channel));
+    std::vector<raw::OpDetWaveform const*> const waveforms
+      = simWaveforms[channel];
+    
+    readoutWaveforms[channel]
+      = makeWaveforms(channel, waveforms, readoutWindows);
+    
+  } // for channels
+  
+  //
+  // sort the output and put it into the event
+  //
+  event.put(moveToUniquePtr(flatten(std::move(readoutWaveforms))));
+  
+} // icarus::opdet::SimPMTreadout::produce()
+
+
+// ---------------------------------------------------------------------------
+std::vector<geo::CryostatID> icarus::opdet::SimPMTreadout::cryostatsOf
+  (raw::Trigger const& trigger) const
+{
+  TriggerBits_t const bits = trigger.TriggerBits();
+  
+  std::vector<geo::CryostatID> cryostats;
+  TriggerBits_t cryoMask = fCryostatZeroMask;
+  for (auto const c: util::counter<unsigned int>(fNCryostats)) {
+    
+    if (bits & cryoMask) cryostats.emplace_back(c);
+    cryoMask <<= 1;
+    
+  } // for
+  
+  return cryostats;
+} // geo::CryostatID icarus::opdet::SimPMTreadout::cryostatOf()
+
+
+// ---------------------------------------------------------------------------
+void icarus::opdet::SimPMTreadout::addLocalPrimitives
+  (PrimitiveManager& manager, std::vector<raw::Trigger> const& primitives) const
+{
+  
+  using microsecond = util::quantities::points::microsecond;
+  
+  for (raw::Trigger const& trigger: primitives) {
+    
+    electronics_time const time = microsecond{ trigger.TriggerTime() };
+    
+    mf::LogTrace log{ fLogCategory };
+    log << "Adding trigger primitive at time " << time << " (bits: 0x"
+      << std::hex << trigger.TriggerBits() << std::dec << ")";
+    
+    for (geo::CryostatID const& cid: cryostatsOf(trigger)) {
+      log << " to " << cid;
+      manager.addPrimitiveForCryostat(time, cid);
+    }
+    
+  } // for
+  
+} // icarus::opdet::SimPMTreadout::addLocalPrimitives()
+
+
+// ---------------------------------------------------------------------------
+void icarus::opdet::SimPMTreadout::addGlobalPrimitives
+  (PrimitiveManager& manager, std::vector<raw::Trigger> const& primitives) const
+{
+  
+  using microsecond = util::quantities::points::microsecond;
+  
+  for (raw::Trigger const& trigger: primitives) {
+    
+    electronics_time const time = microsecond{ trigger.TriggerTime() };
+    
+    mf::LogTrace{ fLogCategory }
+      << "Adding global trigger primitive at time " << time << " (bits: 0x"
+      << std::hex << trigger.TriggerBits() << std::dec << ")";
+    
+    manager.addPrimitiveToAllChannels(time);
+    
+  } // for
+  
+} // icarus::opdet::SimPMTreadout::addGlobalPrimitives()
+
+
+// ---------------------------------------------------------------------------
+auto icarus::opdet::SimPMTreadout::extractReadoutWindows
+  (std::vector<electronics_time> const& primitives) const
+  -> std::vector<Window_t>
+{
+  std::vector<Window_t> windows;
+  if (primitives.empty()) return windows;
+  
+  auto const preBuffer = fReadoutParams.preTriggerSize() * fOpticalTick;
+  auto const postBuffer = fReadoutParams.postTriggerSize() * fOpticalTick;
+  
+  auto itPrimitive = primitives.begin();
+  auto const pend = primitives.end();
+  
+  windows.emplace_back(*itPrimitive - preBuffer, *itPrimitive + postBuffer);
+  Window_t* lastWindow = &(windows.back());
+  
+  // --- BEGIN DEBUG -----------------------------------------------------------
+  auto dumpWindow = [](Window_t const& w)
+    {
+      std::cout << w.start() << " -- " << w.stop() << " (" << w.width() << ")";
+      return "";
+    };
+  std::cout << "Processing " << primitives.size() << " primitives."
+    << "\nFirst window from t=" << *itPrimitive << ": "
+    << dumpWindow(*lastWindow) << std::endl;
+  // --- END   DEBUG -----------------------------------------------------------
+  
+  while (++itPrimitive != pend) {
+    
+    electronics_time const time = *itPrimitive;
+    
+    electronics_time const start = time - preBuffer;
+    electronics_time const stop = time + postBuffer;
+    // --- BEGIN DEBUG ---------------------------------------------------------
+    std::cout << "Primitive at: " << time << " (starts at " << start << ")"
+      << std::endl;
+    // --- END   DEBUG ---------------------------------------------------------
+    if (start <= lastWindow->stop()) { // merge
+      assert(lastWindow->start() <= start);
+      lastWindow->extendTo(stop);
+      // --- BEGIN DEBUG -------------------------------------------------------
+      std::cout << "  starts within last window: extended, now "
+        << dumpWindow(*lastWindow) << std::endl;
+      // --- END   DEBUG -------------------------------------------------------
+    }
+    else { // new
+      windows.emplace_back(start, stop);
+      lastWindow = &(windows.back());
+      // --- BEGIN DEBUG -------------------------------------------------------
+      std::cout << "  new window: " << dumpWindow(*lastWindow) << std::endl;
+      // --- END   DEBUG -------------------------------------------------------
+    }
+    
+  } // while
+  
+  return windows;
+  
+} // icarus::opdet::SimPMTreadout::extractReadoutWindows()
+
+
+// ---------------------------------------------------------------------------
+std::vector<raw::OpDetWaveform> icarus::opdet::SimPMTreadout::makeWaveforms(
+  raw::Channel_t channel,
+  std::vector<raw::OpDetWaveform const*> const& source,
+  std::vector<Window_t> const& readoutWindows
+) const {
+  
+  // assumption: source waveforms are sorted by timestamp
+  // assumption: readoutWindows sorted by timestamp and non-contiguous
+  
+  using microsecond = util::quantities::points::microsecond;
+  
+  auto const toTicks = [this](nanoseconds interval)
+    { return static_cast<int>(fDetTimings.toOpticalTicks(interval).value()); };
+  
+  std::vector<raw::OpDetWaveform> waveforms;
+  waveforms.reserve(readoutWindows.size());
+  
+  // --- BEGIN DEBUG -----------------------------------------------------------
+  std::cout << "makeWaveforms(channel=" << channel << ", { " << source.size()
+    << " waveforms }, { " << readoutWindows.size() << " windows })";
+  for (auto const& [ i, w ]: util::enumerate(source)) {
+    double const length = w->size() * fOpticalTick.value() / 1000.;
+    std::cout << "\n  [S" << i << "](" << ((void*) w)
+      << ") ch=" << w->ChannelNumber() << " t=" << w->TimeStamp()
+      << " -- " << (w->TimeStamp() + length) << " l=" << length
+      << " s=" << w->size();
+  } // for
+  for (auto const& [ i, r ]: util::enumerate(readoutWindows)) {
+    std::cout << "\n  [R" << i << "]"
+      << " " << r.start() << " -- " << r.stop() << " (" << r.width() << ")";
+  } // for
+  std::cout << std::endl;
+  // --- END   DEBUG -----------------------------------------------------------
+  
+  auto nextSource = source.begin();
+  auto const sourceEnd = source.end();
+  
+  for (Window_t const& window: readoutWindows) {
+    // --- BEGIN DEBUG ---------------------------------------------------------
+    std::cout << "Window: " << window.start() << " -- " << window.stop() << " ("
+      << window.width() << ")" << std::endl;
+    // --- END   DEBUG ---------------------------------------------------------
+    
+    if (window.empty()) continue;
+    
+    std::size_t const nSamples = toTicks(window.width());
+    std::vector<raw::ADC_Count_t> samples(nSamples); // allocated, uninitialized
+    auto itSample = samples.begin();
+    auto const send [[maybe_unused]] = samples.end();
+    
+    electronics_time neededTime = window.start();
+    
+    // --- BEGIN DEBUG ---------------------------------------------------------
+    auto sampleIndex = [&itSample,b=samples.begin()](){ return itSample - b; };
+    std::cout
+      << "Expected waveform with " << samples.size() << " samples;"
+      << " neededTime=" << neededTime << "  itSample=#" << sampleIndex()
+      << std::endl;
+    
+    // --- END   DEBUG ---------------------------------------------------------
+    while (neededTime < window.stop()) {
+      
+      // find the first waveform that might include the time we need
+      while (nextSource != sourceEnd) {
+        assert(*nextSource); // no null pointers please
+        electronics_time const srcStart
+          { microsecond{ (*nextSource)->TimeStamp() } };
+        electronics_time const srcStop
+          { srcStart + (*nextSource)->size() * fOpticalTick };
+        
+        // --- BEGIN DEBUG -----------------------------------------------------
+        std::cout << "Next source: " << ((void*) *nextSource)
+          << " t=" << srcStart << " -- " << srcStop << " s="
+          << (*nextSource)->size() << std::endl;
+        // --- END   DEBUG -----------------------------------------------------
+        
+        if (srcStop > neededTime) break;
+        ++nextSource;
+      } // while source available
+      
+      // start of the data of the next useful source waveform (may be never)
+      electronics_time const srcStart{
+        (nextSource == sourceEnd)
+        ? std::numeric_limits<microsecond>::max()
+        : microsecond{ (*nextSource)->TimeStamp() } 
+        };
+      
+      // --- BEGIN DEBUG -------------------------------------------------------
+      if (nextSource == sourceEnd) {
+        std::cout << "No source can help with neededTime=" << neededTime
+          << std::endl;
+      }
+      else {
+        std::cout << "Source might help with neededTime=" << neededTime
+          << " (srcStart=" << srcStart << ")" << std::endl;
+      }
+      // --- END   DEBUG -------------------------------------------------------
+      
+      if (neededTime < srcStart) {
+        // the data at needed time is not available: fill with noise
+        // --- BEGIN DEBUG -----------------------------------------------------
+        std::cout << "neededTime=" << neededTime
+          << " < srcStart=" << srcStart << ": noise time" << std::endl;
+        // --- END   DEBUG -----------------------------------------------------
+        electronics_time const noiseEnd = std::min(srcStart, window.stop());
+        std::size_t const nNoiseSamples = toTicks(noiseEnd - neededTime);
+        
+        // TODO add noise
+        std::advance(itSample, nNoiseSamples);
+        assert(itSample <= send);
+        
+        neededTime = noiseEnd;
+        // --- BEGIN DEBUG -----------------------------------------------------
+        std::cout << "Added " << nNoiseSamples
+          << " samples of noise, now neededTime=" << neededTime
+          << " itSample=#" << sampleIndex()
+          << "  window: " << window.start() << " -- " << window.stop()
+          << std::endl;
+        // --- END   DEBUG -----------------------------------------------------
+      } // if add noise
+      
+      if (neededTime < window.stop()) {
+        // adding noise (if any) was not enough: there must be some data to copy
+        // --- BEGIN DEBUG -----------------------------------------------------
+        std::cout << "neededTime=" << neededTime << "  window: "
+          << window.start() << "--" << window.stop() << ": copy!" << std::endl;
+        // --- END   DEBUG -----------------------------------------------------
+        assert(nextSource != sourceEnd);
+        electronics_time const srcStart
+          { microsecond{ (*nextSource)->TimeStamp() } };
+        electronics_time const srcStop
+          { srcStart + (*nextSource)->size() * fOpticalTick };
+        assert(neededTime < srcStop);
+        assert(neededTime >= srcStart);
+        
+        electronics_time const dataEndTime = std::min(srcStop, window.stop());
+        
+        auto const dbegin
+          = (*nextSource)->cbegin() + toTicks(neededTime - srcStart);
+        auto const dend = dbegin + toTicks(dataEndTime - neededTime);
+        
+        // --- BEGIN DEBUG -----------------------------------------------------
+        std::cout << "Copy data from " << srcStart << " (#"
+          << (dbegin - (*nextSource)->cbegin()) << ") to " << dataEndTime
+          << " (#" << (dend - (*nextSource)->cbegin()) << ")"
+          << " into itSample=#" << sampleIndex() << std::endl;
+        // --- END   DEBUG -----------------------------------------------------
+        
+        itSample = std::copy(dbegin, dend, itSample);
+        neededTime = dataEndTime;
+        
+        // --- BEGIN DEBUG -----------------------------------------------------
+        std::cout << "Copy is over, neededTime=" << neededTime
+          << " itSample=#" << sampleIndex() << std::endl;
+        // --- END   DEBUG -----------------------------------------------------
+        
+      } // if copy more data
+    
+      // --- BEGIN DEBUG -------------------------------------------------------
+      std::cout << "Done with this source+window, neededTime=" << neededTime
+        << "  window.stop()=" << window.stop() << std::endl;
+      // --- END   DEBUG -------------------------------------------------------
+    
+    } // while needed time
+    
+    // --- BEGIN DEBUG ---------------------------------------------------------
+    std::cout << "Now neededTime=" << neededTime << " window.stop()="
+      << window.stop() << " => done" << std::endl;
+    // --- END   DEBUG ---------------------------------------------------------
+    
+    assert(itSample == send);
+    
+    // add the new waveform (with a weird way dictated by a weird interface)
+    waveforms.emplace_back(window.start().value(), channel);
+    waveforms.back().Waveform() = std::move(samples);
+    
+    // --- BEGIN DEBUG ---------------------------------------------------------
+    {
+      raw::OpDetWaveform const& ow = waveforms.back();
+      double const length = ow.size() * fOpticalTick.value() / 1000.;
+      std::cout << "For window " << window.start() << " -- " << window.stop()
+        << " added ch=" << ow.ChannelNumber() << " t=" << ow.TimeStamp()
+        << " -- " << (ow.TimeStamp() + length) << " l=" << length
+        << " s=" << ow.size() << std::endl;
+    }
+    // --- END   DEBUG ---------------------------------------------------------
+    
+  } // for
+  
+  return waveforms;
+  
+} // icarus::opdet::SimPMTreadout::makeWaveforms()
+
+
+// ---------------------------------------------------------------------------
+DEFINE_ART_MODULE(icarus::opdet::SimPMTreadout)
+
+
+// ---------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/Algorithms/WindowChannelMap.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/WindowChannelMap.cxx
@@ -22,15 +22,20 @@
 void icarus::trigger::WindowChannelMap::WindowInfo_t::dump
   (std::ostream& out, std::string const& indent /* = "" */) const
 {
-  out << indent << "window #" << index << " at " << center << " cm";
-  if (hasCryostat()) out << " in " << cryoid;
+  
+  out << indent << "window #" << topology.index
+    << " at " << composition.center << " cm";
+  if (composition.hasCryostat()) out << " in " << composition.cryoid;
   else               out << " (cryostat undefined)";
-  out << " includes " << channels.size() << " channels";
-  if (!channels.empty())
-    out << " (" << icarus::makeIntegerRanges(channels) << ")";
-  if (hasOppositeWindow()) out << " opposite to [#" << opposite << "]";
-  if (hasUpstreamWindow()) out << " downstream of [#" << upstream << "]";
-  if (hasDownstreamWindow()) out << " upstream of [#" << downstream << "]";
+  out << " includes " << composition.channels.size() << " channels";
+  if (!composition.channels.empty())
+    out << " (" << icarus::makeIntegerRanges(composition.channels) << ")";
+  if (topology.hasOppositeWindow())
+    out << " opposite to [#" << topology.opposite << "]";
+  if (topology.hasUpstreamWindow())
+    out << " downstream of [#" << topology.upstream << "]";
+  if (topology.hasDownstreamWindow())
+    out << " upstream of [#" << topology.downstream << "]";
 } // icarus::trigger::WindowChannelMap::WindowInfo_t::dump()
 
 

--- a/icaruscode/PMT/Trigger/Algorithms/WindowChannelMap.h
+++ b/icaruscode/PMT/Trigger/Algorithms/WindowChannelMap.h
@@ -100,7 +100,7 @@ class icarus::trigger::WindowChannelMap {
   }; // struct WindowTopology_t
   
   /// Information of a single window.
-  struct WindowInfo_t: public WindowComposition_t, public WindowTopology_t {
+  struct WindowInfo_t {
     
     WindowComposition_t composition;
     

--- a/icaruscode/PMT/Trigger/Algorithms/WindowTopologyAlg.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/WindowTopologyAlg.cxx
@@ -182,11 +182,12 @@ auto icarus::trigger::WindowTopologyAlg::createWindowsFromCryostat(
   for (auto const& channels: windowChannels) {
     
     WindowChannelMap::WindowInfo_t wInfo;
+    WindowChannelMap::WindowComposition_t& wComp = wInfo.composition;
     
-    wInfo.index = iWindow++;
-    wInfo.channels = channels;
-    std::sort(wInfo.channels.begin(), wInfo.channels.end());
-    wInfo.cryoid = channels.empty()
+    wInfo.topology.index = iWindow++;
+    wComp.channels = channels;
+    std::sort(wComp.channels.begin(), wComp.channels.end());
+    wComp.cryoid = channels.empty()
       ? geo::CryostatID{}
       : geom.OpDetGeoFromOpChannel(channels.front()).ID().asCryostatID()
       ;
@@ -196,9 +197,9 @@ auto icarus::trigger::WindowTopologyAlg::createWindowsFromCryostat(
       // documentation of OpDetGeoFromOpChannel() does not say what on error...
       geo::OpDetGeo const& opDet = geom.OpDetGeoFromOpChannel(channel);
       middlePoint.add(opDet.GetCenter());
-      if (opDet.ID() != wInfo.cryoid) wInfo.cryoid = geo::CryostatID{};
+      if (opDet.ID() != wComp.cryoid) wComp.cryoid = geo::CryostatID{};
     } // for channel
-    wInfo.center = middlePoint.middlePoint();
+    wComp.center = middlePoint.middlePoint();
     
     windows.push_back(std::move(wInfo));
     cryoWindowInfo.push_back(&windows.back());
@@ -209,7 +210,7 @@ auto icarus::trigger::WindowTopologyAlg::createWindowsFromCryostat(
   // 2. sort the windows in drift plane (first cryostat TPC as reference)
   //
   auto const normalProjection = [&refTPC](auto const* info)
-    { return refTPC.DistanceFromReferencePlane(info->center); };
+    { return refTPC.DistanceFromReferencePlane(info->composition.center); };
   WindowInfoPtrs_t const windowsByNormal
     = util::sortCollBy(cryoWindowInfo, normalProjection);
   
@@ -219,7 +220,9 @@ auto icarus::trigger::WindowTopologyAlg::createWindowsFromCryostat(
   // split the list in two; there is a good deal of faith here
   auto const beamCoordinate
     = [&refPlane=refTPC.ReferencePlane()](auto const* info)
-      { return refPlane.PointWidthDepthProjection(info->center).X(); }
+      {
+        return refPlane.PointWidthDepthProjection(info->composition.center).X();
+      }
     ;
 
   //
@@ -248,14 +251,18 @@ auto icarus::trigger::WindowTopologyAlg::createWindowsFromCryostat(
       if (WindowChannelMap::WindowInfo_t const* closestOppositeWindow
         = findClosestWindow(otherPlaneWindows, windowInfo)
       ) {
-        windowInfo->opposite = closestOppositeWindow->index;
+        windowInfo->topology.opposite = closestOppositeWindow->topology.index;
       }
 
-      if (iPlaneWindow > 0U)
-        windowInfo->upstream = planeWindows[iPlaneWindow - 1U]->index;
+      if (iPlaneWindow > 0U) {
+        windowInfo->topology.upstream
+          = planeWindows[iPlaneWindow - 1U]->topology.index;
+      }
       
-      if (iPlaneWindow < iLastPlaneWindow)
-        windowInfo->downstream = planeWindows[iPlaneWindow + 1U]->index;
+      if (iPlaneWindow < iLastPlaneWindow) {
+        windowInfo->topology.downstream
+          = planeWindows[iPlaneWindow + 1U]->topology.index;
+      }
       
     } // for window in plane
   } // for planes
@@ -297,7 +304,8 @@ auto icarus::trigger::WindowTopologyAlg::findClosestWindow(
   for (auto const* window: windowList) {
     if (!window) continue;
     
-    double const d2 = (window->center - targetWindow->center).mag2();
+    double const d2
+      = (window->composition.center - targetWindow->composition.center).mag2();
     if (minDistance2 <= d2) continue;
     minDistance2 = d2;
     closest = window;
@@ -379,9 +387,10 @@ std::string icarus::trigger::WindowTopologyVerification::verifyGate
   
   WindowChannelMap::WindowInfo_t const& windowInfo = fWindowMap->info(iWindow);
   
-  auto const channelInWindow
-    = [begin=windowInfo.channels.cbegin(),end=windowInfo.channels.cend()]
-    (raw::Channel_t channel)
+  auto const channelInWindow = [
+      begin=windowInfo.composition.channels.cbegin(),
+      end=windowInfo.composition.channels.cend()
+    ](raw::Channel_t channel)
     { return std::binary_search(begin, end, channel); }
     ;
   
@@ -389,7 +398,7 @@ std::string icarus::trigger::WindowTopologyVerification::verifyGate
     if (channelInWindow(channel)) continue;
     if (errors.empty()) {
       errors =
-        "channels not in window #" + std::to_string(windowInfo.index)
+        "channels not in window #" + std::to_string(windowInfo.topology.index)
         + ":";
     } // if first error
     errors += " " + std::to_string(channel);

--- a/icaruscode/PMT/Trigger/SlidingWindowTriggerSimulation_module.cc
+++ b/icaruscode/PMT/Trigger/SlidingWindowTriggerSimulation_module.cc
@@ -3,6 +3,8 @@
  * @brief  Production of triggers data products based on PMT sliding windows.
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @date   March 27, 2021
+ * 
+ * @note This module is not being developed any more.
  */
 
 
@@ -248,6 +250,21 @@ namespace icarus::trigger { class SlidingWindowTriggerSimulation; }
  * configuration are defined in `icarus::trigger::WindowPattern` and
  * `icarus::trigger::ns::fhicl::WindowPatternConfig` respectively. Trigger
  * simulation is delegated to `icarus::trigger::SlidingWindowPatternAlg`.
+ * 
+ * 
+ * Discontinuation note
+ * =====================
+ * 
+ * @note This module is not being developed any more.
+ *       New features are currently being added to
+ *       `icarus::trigger::TriggerSimulationOnGates` module only.
+ *       The main things that are lost with the _deprecation_ of this module are
+ *       some plots and more in general the design oriented to a single beam
+ *       gate. This allowed for assumptions that in turn could result into a
+ *       rational choice of plots and (a bit more) rational treatment of
+ *       non-triggering events.
+ *       Nevertheless, adding features to both modules is becoming vexing, so
+ *       the author has opted to stick to the most versatile among the two.
  * 
  */
 class icarus::trigger::SlidingWindowTriggerSimulation

--- a/icaruscode/PMT/Trigger/simulate_trigger_primitives_icarus.fcl
+++ b/icaruscode/PMT/Trigger/simulate_trigger_primitives_icarus.fcl
@@ -58,7 +58,7 @@ triggerSimTemplate: {
 
   TriggerGatesTag: "pmttriggerwindows"
 
-  Thresholds: @local::icarus_triggergate_basic.ChannelThresholds # from trigger_icarus.fcl
+  Thresholds: [ @local::icarus_triggergate_basic.ChannelThresholds ] # from trigger_icarus.fcl
   
   ###
   ### requirement:

--- a/icaruscode/PMT/Trigger/simulate_trigger_primitives_icarus.fcl
+++ b/icaruscode/PMT/Trigger/simulate_trigger_primitives_icarus.fcl
@@ -1,0 +1,284 @@
+#
+# File:    simulate_trigger_primitives_icarus.fcl
+# Purpose: Executes emulation of physics-style trigger primitives on MC samples.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 10, 2022
+#
+# The job executes the simulation of the configured triggers, plus a special,
+# "standard" one that should most closely reflect the data trigger
+# configuration.
+#
+# This is a top-level configuration that can be run directly.
+# 
+# 
+# Simulation gate
+# ----------------
+# 
+# The trigger emulation is applied on a fixed time interval representing the
+# enable gate. The definition of the enable gate is stored in the trigger
+# configuration in data, while it is not included in LArSoft.
+# 
+# In this configuration we learn the enable gate from the simulation settings.
+# 
+# Required inputs
+# ----------------
+# 
+#  * `pmtthr`: discriminated signals (with threshold); must already contain all
+#      the discrimination thresholds needed for the simulation
+# 
+# 
+# Output
+# -------
+# 
+# Data products:
+#  * `emuTrigPrimS10:THR`, ...:
+#    `raw::Trigger` collections for simulation of a majority 10 trigger summing
+#    east and west TPC ("S5"); the instance name represents the discrimination
+#    threshold used for input.
+#  * `emuTrigPrim`: `raw::Trigger` collection for simulation of the selected
+#    trigger pattern and discrimination threshold.
+# 
+# Plots:
+#  * `emuTrigPrimS10`: basic trigger primitive response distributions for S10
+#    pattern
+#  * `emuTrigPrim`: basic trigger response distributions for selected trigger
+# 
+
+#include "trigger_emulation_icarus.fcl"
+#include "services_common_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+
+# ------------------------------------------------------------------------------
+BEGIN_PROLOG
+
+
+triggerSimTemplate: {
+
+  module_type: TriggerSimulationOnGates
+
+  TriggerGatesTag: "pmttriggerwindows"
+
+  Thresholds: @local::icarus_triggergate_basic.ChannelThresholds # from trigger_icarus.fcl
+  
+  ###
+  ### requirement:
+  ###
+  Pattern: @nil # need to replace
+
+  # Beam gate:
+  # duration (BNB: 1.6 us; NuMI: 9.5 us)
+  BeamGates: enablegate
+  
+  # we set the bits with a magic value
+  BeamBits: 0x1000000
+  
+  # do not produce "non-triggers" (triggers which did not fire)
+  EmitEmpty: false
+
+  # wait 200 ns before emitting another trigger primitive
+  DeadTime: "200 ns"
+  
+  # disable the retriggering bit, which won't make sense in a 2 ms gate
+  RetriggeringBit: 64
+  
+  # use bit 20 for triggers on cryostat 0, bit 21 for the ones on cryostat 1
+  CryostatFirstBit: 20
+  
+  # this should probably be 12 or 24 ns
+  TriggerTimeResolution: "8 ns"
+
+  # name of the category used for the output
+  LogCategory: "TriggerSim"
+
+} # triggerSimTemplate
+
+
+triggerSimTemplate_cryoE: {
+                    @table::triggerSimTemplate
+  TriggerGatesTag: "pmttriggerwindowsCryoE"
+}
+
+triggerSimTemplate_cryoW: {
+                    @table::triggerSimTemplate
+  TriggerGatesTag: "pmttriggerwindowsCryoW"
+}
+
+
+END_PROLOG
+
+
+# ------------------------------------------------------------------------------
+process_name: TrgPrimSim
+
+
+services: {
+  
+  # this provides: file service, random management (unused),
+  #                Geometry, detector properties and clocks
+  @table::icarus_common_services
+  
+  # currently unused (remove the line if they start mattering):
+  LArPropertiesService:      @erase
+  DetectorPropertiesService: @erase
+  
+} # services
+
+
+physics: {
+  
+  producers: {
+    
+    # --------------------------------------------------------------------------
+    pmtthr: @local::icarus_pmtdiscriminatethr_fixed_MC
+    
+    pmtlvdsgates: @local::icarus_lvdsgates
+    
+    pmttriggerwindowsCryoE: @local::icarus_trigslidewindow_cryoE
+    pmttriggerwindowsCryoW: @local::icarus_trigslidewindow_cryoW
+    
+    enablegate: @local::icarus_enablegate_sim  # from trigger_icarus.fcl
+    
+    # --------------------------------------------------------------------------
+    # all interesting triggers
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    emuTrigPrimS5cryoE: {
+    
+      @table::triggerSimTemplate_cryoE
+      
+      Pattern: @local::icarus_triggergate_basic.patterns.S5
+      
+    } # emuTrigPrimS5cryoE
+
+    emuTrigPrimS5cryoW: {
+    
+      @table::triggerSimTemplate_cryoW
+      
+      Pattern: @local::icarus_triggergate_basic.patterns.S5
+      
+    } # emuTrigPrimS5cryoW
+    
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    emuTrigPrimS8cryoE: {
+    
+      @table::triggerSimTemplate_cryoE
+      
+      Pattern: @local::icarus_triggergate_basic.patterns.S8
+      
+    } # emuTrigPrimS8cryoE
+
+    emuTrigPrimS8cryoW: {
+    
+      @table::triggerSimTemplate_cryoW
+      
+      Pattern: @local::icarus_triggergate_basic.patterns.S8
+      
+    } # emuTrigPrimS8cryoW
+    
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    emuTrigPrimS10cryoE: {
+    
+      @table::triggerSimTemplate_cryoE
+      
+      Pattern: @local::icarus_triggergate_basic.patterns.S10
+      
+    } # emuTrigPrimS10cryoE
+    
+    emuTrigPrimS10cryoW: {
+    
+      @table::triggerSimTemplate_cryoW
+      
+      Pattern: @local::icarus_triggergate_basic.patterns.S10
+      
+    } # emuTrigPrimS10cryoW
+    
+    
+    # --------------------------------------------------------------------------
+    # these are THE trigger primitives
+    
+    emuTrigPrimCryoE: {
+    
+      @table::triggerSimTemplate_cryoE
+      
+      Pattern: @local::icarus_triggergate_basic.SelectedPrimitivePattern  # from trigger_icarus.fcl
+      
+      Thresholds: [ @local::icarus_triggergate_basic.SelectedThreshold ]
+      
+    } # emuTrigPrimCryoE
+    
+    emuTrigPrimCryoW: {
+    
+      @table::triggerSimTemplate_cryoW
+      
+      Pattern: @local::icarus_triggergate_basic.SelectedPrimitivePattern  # from trigger_icarus.fcl
+      
+      Thresholds: [ @local::icarus_triggergate_basic.SelectedThreshold ]
+      
+    } # emuTrigPrimCryoW
+    
+    # --------------------------------------------------------------------------
+    
+  } # producers
+  
+  trigger: [
+      pmtthr  # TODO: comment out for stage0
+    , pmtlvdsgates, pmttriggerwindowsCryoE, pmttriggerwindowsCryoW
+    , enablegate
+#    , emuTrigPrimS5CryoE
+#    , emuTrigPrimS8CryoE
+#    , emuTrigPrimS10CryoE
+#    , emuTrigPrimS5CryoW
+#    , emuTrigPrimS8CryoW
+#    , emuTrigPrimS10CryoW
+    , emuTrigPrimCryoE
+    , emuTrigPrimCryoW
+    ]
+  output: [ rootoutput ]
+  
+  trigger_paths: [ trigger ]
+  end_paths: [ output ]
+  
+} # physics
+
+
+outputs.rootoutput: @local::icarus_rootoutput # from rootoutput_icarus.fcl
+outputs.rootoutput.outputCommands: [
+  "keep *"
+  , "drop longlonguinticarus::trigger::ReadoutTriggerGates_*_*_TrgPrimSim"
+  ]
+
+
+# ##############################################################################
+#
+# add debug output to its own file
+#
+services.message.destinations.TrigPrimSimLog: {
+  type:       file
+  filename:  "TrigPrimSim.log"
+  threshold:  DEBUG
+  categories: {
+    TriggerSim: { limit: -1 }
+    default:    { limit: 0 }
+  }
+} # services.messages.destinations.TrigPrimSimLog
+
+services.message.destinations.DebugLog: {
+  type:       file
+  filename:  "debug.log"
+  threshold:  DEBUG
+  categories: {
+    default:    { limit: -1 }
+  }
+} # services.messages.destinations.DebugLog
+
+#
+# FIXME for development, drop most data products
+#
+outputs.rootoutput.outputCommands: [
+  "drop *"
+  , "keep *_*_*_TrgPrimSim"
+  , "drop longlonguinticarus::trigger::ReadoutTriggerGates_*_*_TrgPrimSim"
+  ]
+

--- a/icaruscode/PMT/Trigger/simulate_triggers_icarus.fcl
+++ b/icaruscode/PMT/Trigger/simulate_triggers_icarus.fcl
@@ -76,6 +76,9 @@ triggerSimTemplate: {
   # we learn the bits from the beam gate type
   # (non a great deal... hope it doesn't matter(TM))
   # BeamBits: @local::BNB_settings.trigger_bits   # from trigger_icarus.fcl
+  
+  # write also a surrogate sbn::ExtraTriggerInfo data product
+  ExtraInfo: true
 
   # this should probably be 12 or 24 ns
   TriggerTimeResolution: "8 ns"

--- a/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
@@ -248,8 +248,8 @@ icarus_pmtdiscriminatethr_fixed_MC: {
 
   # PMT baseline (from standard simulation configuration)
   Baselines: @erase
-  Baseline: @local::icarus_pmtsimulationalg_standard.Baseline
-  
+  Baseline: @local::icarus_settings_opdet.NominalPedestal
+
 } # icarus_pmtdiscriminatethr_fixed_MC
 
 

--- a/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
@@ -318,6 +318,18 @@ icarus_trigslidewindow: {
 } # icarus_trigslidewindow
 
 
+icarus_trigslidewindow_cryoE: {
+                     @table::icarus_trigslidewindow
+  EnableOnlyWindows: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+} # icarus_trigslidewindow_cryoE
+
+
+icarus_trigslidewindow_cryoW: {
+                     @table::icarus_trigslidewindow
+  EnableOnlyWindows: [ 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+} # icarus_trigslidewindow_cryoW
+
+
 # ------------------------------------------------------------------------------
 # ---  workflow helpers
 # ------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/trigger_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_icarus.fcl
@@ -281,6 +281,31 @@ icarus_triggersimgates_Run1: {
 
 icarus_triggersimgates: @local::icarus_triggersimgates_Run1
 
+
+###
+### enable gate for the trigger primitives
+###
+
+#
+# this gate is read from the simulation settings
+#
+icarus_enablegate_sim: {
+
+  module_type: WriteBeamGateInfo
+  
+  BeamGates: [
+    {
+      Duration: @local::icarus_pmtsimulationalg_standard.ReadoutEnablePeriod  # from pmtsimulation_icarus.fcl
+      Start:    @local::icarus_pmtsimulationalg_standard.TriggerOffsetPMT  # from pmtsimulation_icarus.fcl
+    }
+  ]
+  
+} # icarus_enablegate_sim
+
+
+icarus_enablegate: @local::icarus_enablegate_sim
+
+
 ################################################################################
 ###  Legacy configurations
 ################################################################################
@@ -370,6 +395,7 @@ icarus_triggergate_basic.patterns.S10: {
 
 
 icarus_triggergate_basic.SelectedPattern: @local::icarus_triggergate_basic.patterns.S5
+icarus_triggergate_basic.SelectedPrimitivePattern: @local::icarus_triggergate_basic.patterns.S10
 
 
 

--- a/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
+++ b/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
@@ -152,7 +152,7 @@ physics: {
         PreTrigFraction: @local::icarus_settings_opdet.readoutPreTrigFraction  # from pmtsimulation_icarus.fcl
       }
       
-      NoiseGenerator:    @table::icarus_pmt_electronicsnoise_standard  # from "pmtsimulation_icarus.fcl"
+      Pedestal:          @local::icarus_pmt_pedestal_standard  # from "pmtsimulation_icarus.fcl"
       
       # pick the marking of the cryostat in the trigger from whom has put it in
       CryostatFirstBit:  @local::primTrigSimTemplate.CryostatFirstBit

--- a/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
+++ b/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
@@ -1,0 +1,221 @@
+#
+# File:    run_pmtreadoutsimulation_icarus.fcl
+# Purpose: Runs the simulation of ICARUS PMT readout.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    November 16, 2022
+# Version: 1.0
+#
+# This is a top-level configuration that can be run directly.
+#
+# This job reads the already digitized PMT waveforms, extracts the trigger
+# primitives using some standard ICARUS trigger settings and then reprocesses
+# the PMT waveforms, producing a waveform set comparable to the one from actual
+# ICARUS PMT readout.
+#
+#
+# Output
+# -------
+#
+# * `daqPMT` (`std::vector<raw::OpDetWaveform>`) the new waveforms
+# * `trigPrimitives (`std::vector<raw::Trigger>`) the trigger primitives
+#   discovered
+#
+#
+# Required inputs
+# ----------------
+#
+#  * simulated optical detector readout: `opdaq`
+#
+#
+# Required services
+# ------------------
+#
+#  * GeometryService
+#  * DetectorClocksService
+#
+#
+# Changes
+# --------
+# 
+# 20221116 (petrillo@slac.stanford.edu) [v1.0]
+# :   original version
+#
+
+#include "services_common_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+#include "trigger_emulation_icarus.fcl"
+#include "pmtsimulation_icarus.fcl"
+
+
+BEGIN_PROLOG
+
+primTrigSimTemplate: {
+
+  module_type: TriggerSimulationOnGates
+
+  TriggerGatesTag: "pmttriggerwindows"
+
+  Thresholds: [ @local::icarus_triggergate_basic.SelectedThreshold ]  # from trigger_icarus.fcl
+  
+  Pattern: @local::icarus_triggergate_basic.SelectedPrimitivePattern  # from trigger_icarus.fcl
+  
+  BeamGates: enablegate
+  
+  # we set the bits with a magic value
+  BeamBits: 0x1000000
+  
+  # do not produce "non-triggers" (triggers which did not fire)
+  EmitEmpty: false
+
+  # wait 200 ns before emitting another trigger primitive
+  DeadTime: "200 ns"
+  
+  # disable the retriggering bit, which won't make sense in a 2 ms gate
+  RetriggeringBit: 64
+  
+  # use bit 20 for triggers on cryostat 0, bit 21 for the ones on cryostat 1
+  CryostatFirstBit: 20
+  
+  # this should probably be 12 or 24 ns
+  TriggerTimeResolution: "8 ns"
+
+  # name of the category used for the output
+  LogCategory: "TrigPrimSim"
+
+} # primTrigSimTemplate
+
+
+primTrigSim_cryoE: {
+                    @table::primTrigSimTemplate
+  TriggerGatesTag: "pmttriggerwindowsCryoE"
+}
+
+primTrigSim_cryoW: {
+                    @table::primTrigSimTemplate
+  TriggerGatesTag: "pmttriggerwindowsCryoW"
+}
+
+END_PROLOG
+
+
+# ------------------------------------------------------------------------------
+process_name: PMTrout
+
+
+# ------------------------------------------------------------------------------
+process_name: TrgPrimSim
+
+
+services: {
+  
+  # this provides: file service, random management (unused),
+  #                Geometry, detector properties and clocks
+  @table::icarus_common_services
+  
+  # currently unused (remove the line if they start mattering):
+  LArPropertiesService:      @erase
+  DetectorPropertiesService: @erase
+  
+} # services
+
+
+physics: {
+  
+  producers: {
+    
+    # --------------------------------------------------------------------------
+    pmtthr: @local::icarus_pmtdiscriminatethr_fixed_MC
+    
+    pmtlvdsgates: @local::icarus_lvdsgates
+    
+    pmttriggerwindowsCryoE: @local::icarus_trigslidewindow_cryoE
+    pmttriggerwindowsCryoW: @local::icarus_trigslidewindow_cryoW
+    
+    enablegate: @local::icarus_enablegate_sim  # from trigger_icarus.fcl
+    
+    emuTrigPrimCryoE: @local::primTrigSim_cryoE
+    emuTrigPrimCryoW: @local::primTrigSim_cryoW
+    
+    daqPMT: {
+      module_type:    SimPMTreadout
+      
+      WaveformTags:  [ "opdaq" ]
+      
+      PrimitiveTags: [ "emuTrigPrimCryoE", "emuTrigPrimCryoW" ]
+      
+      TriggerTags:   []  # no extra global triggers so far
+      
+      FixedTriggerTimes: [ "-3 us", "4 us", "13 us" ]
+      
+      Readout: {
+        WindowSize:      @local::icarus_settings_opdet.readoutWindowSize  # pmtsimulation_icarus.fcl
+        PreTrigFraction: @local::icarus_settings_opdet.readoutPreTrigFraction  # pmtsimulation_icarus.fcl
+      }
+      
+      # pick the marking of the cryostat in the trigger from whom has put it in
+      CryostatFirstBit: @local::primTrigSimTemplate.CryostatFirstBit
+      
+      LogCategory:   "PMTreadoutSim"
+      
+    } # daqPMT
+    
+    # --------------------------------------------------------------------------
+    
+  } # producers
+  
+  trigger: [
+      pmtthr  # TODO: comment out for stage0
+    , pmtlvdsgates, pmttriggerwindowsCryoE, pmttriggerwindowsCryoW
+    , enablegate
+    , emuTrigPrimCryoE
+    , emuTrigPrimCryoW
+    , daqPMT
+    ]
+  output: [ rootoutput ]
+  
+  trigger_paths: [ trigger ]
+  end_paths: [ output ]
+  
+} # physics
+
+
+outputs.rootoutput: @local::icarus_rootoutput # from rootoutput_icarus.fcl
+outputs.rootoutput.outputCommands: [
+  "keep *"
+  , "drop longlonguinticarus::trigger::ReadoutTriggerGates_*_*_TrgPrimSim"
+  ]
+
+
+# ##############################################################################
+#
+# add debug output to its own file
+#
+services.message.destinations.TrigPrimSimLog: {
+  type:       file
+  filename:  "TrigPrimSim.log"
+  threshold:  DEBUG
+  categories: {
+    TrigPrimSim: { limit: -1 }
+    default:     { limit: 0 }
+  }
+} # services.messages.destinations.TrigPrimSimLog
+
+services.message.destinations.PMTreadoutSimLog: {
+  type:       file
+  filename:  "PMTreadoutSim.log"
+  threshold:  DEBUG
+  categories: {
+    PMTreadoutSim: { limit: -1 }
+    default:       { limit: 0 }
+  }
+} # services.messages.destinations.PMTreadoutSimLog
+
+services.message.destinations.DebugLog: {
+  type:       file
+  filename:  "debug.log"
+  threshold:  DEBUG
+  categories: {
+    default:    { limit: -1 }
+  }
+} # services.messages.destinations.DebugLog
+

--- a/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
+++ b/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
@@ -126,10 +126,20 @@ physics: {
     # --------------------------------------------------------------------------
     pmtthr: @local::icarus_pmtdiscriminatethr_fixed_MC
     
-    pmtlvdsgates: @local::icarus_lvdsgates
+    # the following modules are applied only on the preferred threshold for this application
+    pmtlvdsgates: {
+                    @table::icarus_lvdsgates                              # from trigger_emulation_icarus.fcl
+      Thresholds: [ @local::icarus_triggergate_basic.SelectedThreshold ]  # from trigger_icarus.fcl
+    }
     
-    pmttriggerwindowsCryoE: @local::icarus_trigslidewindow_cryoE
-    pmttriggerwindowsCryoW: @local::icarus_trigslidewindow_cryoW
+    pmttriggerwindowsCryoE: {
+                    @table::icarus_trigslidewindow_cryoE                  # from trigger_emulation_icarus.fcl
+      Thresholds: [ @local::icarus_triggergate_basic.SelectedThreshold ]  # from trigger_icarus.fcl
+    }
+    pmttriggerwindowsCryoW: {
+                    @table::icarus_trigslidewindow_cryoW                  # from trigger_emulation_icarus.fcl
+      Thresholds: [ @local::icarus_triggergate_basic.SelectedThreshold ]  # from trigger_icarus.fcl
+    }
     
     enablegate: @local::icarus_enablegate_sim  # from trigger_icarus.fcl
     

--- a/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
+++ b/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
@@ -137,25 +137,27 @@ physics: {
     emuTrigPrimCryoW: @local::primTrigSim_cryoW
     
     daqPMT: {
-      module_type:    SimPMTreadout
+      module_type:       SimPMTreadout
       
-      WaveformTags:  [ "opdaq" ]
+      WaveformTags:      [ "opdaq" ]
       
-      PrimitiveTags: [ "emuTrigPrimCryoE", "emuTrigPrimCryoW" ]
+      PrimitiveTags:     [ "emuTrigPrimCryoE", "emuTrigPrimCryoW" ]
       
-      TriggerTags:   []  # no extra global triggers so far
+      TriggerTags:       []  # no extra global triggers so far
       
       FixedTriggerTimes: [ "-3 us", "4 us", "13 us" ]
       
       Readout: {
-        WindowSize:      @local::icarus_settings_opdet.readoutWindowSize  # pmtsimulation_icarus.fcl
-        PreTrigFraction: @local::icarus_settings_opdet.readoutPreTrigFraction  # pmtsimulation_icarus.fcl
+        WindowSize:      @local::icarus_settings_opdet.readoutWindowSize  # from pmtsimulation_icarus.fcl
+        PreTrigFraction: @local::icarus_settings_opdet.readoutPreTrigFraction  # from pmtsimulation_icarus.fcl
       }
       
-      # pick the marking of the cryostat in the trigger from whom has put it in
-      CryostatFirstBit: @local::primTrigSimTemplate.CryostatFirstBit
+      NoiseGenerator:    @table::icarus_pmt_electronicsnoise_standard  # from "pmtsimulation_icarus.fcl"
       
-      LogCategory:   "PMTreadoutSim"
+      # pick the marking of the cryostat in the trigger from whom has put it in
+      CryostatFirstBit:  @local::primTrigSimTemplate.CryostatFirstBit
+      
+      LogCategory:       "PMTreadoutSim"
       
     } # daqPMT
     

--- a/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
+++ b/icaruscode/PMT/run_pmtreadoutsimulation_icarus.fcl
@@ -145,7 +145,7 @@ physics: {
       
       TriggerTags:       []  # no extra global triggers so far
       
-      FixedTriggerTimes: [ "-3 us", "4 us", "13 us" ]
+      FixedTriggerTimes: [ "-4 us", "3 us", "12 us" ]
       
       Readout: {
         WindowSize:      @local::icarus_settings_opdet.readoutWindowSize  # from pmtsimulation_icarus.fcl

--- a/icaruscode/Utilities/DetectorClocksHelpers.h
+++ b/icaruscode/Utilities/DetectorClocksHelpers.h
@@ -86,12 +86,12 @@ namespace icarus::ns::util {
   detinfo::DetectorTimings makeDetTimings(art::Event const* event)
     { return detinfo::DetectorTimings{ makeDetClockData(event) }; }
   
-  /// Returns detector clock data for the specified event.
+  /// Returns a `detinfo::DetectorTimings` for the specified event.
   /// @see `makeDetTimings(art::Event const*)`
   detinfo::DetectorTimings makeDetTimings(art::Event const& event)
     { return makeDetTimings(&event); }
   
-  /// Returns generic detector clock data for the job.
+  /// Returns a `detinfo::DetectorTimings` for the job.
   /// @see `makeDetTimings(art::Event const*)`
   detinfo::DetectorTimings makeDetTimings()
     { return makeDetTimings(nullptr); }

--- a/icaruscode/Utilities/intervals_utils.h
+++ b/icaruscode/Utilities/intervals_utils.h
@@ -1,0 +1,98 @@
+/**
+ * @file   icaruscode/Utilities/intervals_utils.h
+ * @brief  Utilities to make `util::Quantity` objects behave more like numbers.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 18, 2022
+ * 
+ * This library tries to provide utilities that a motivated developer may
+ * utilize to keep its code `util::quantities::concepts::Quantity`-friendly.
+ * 
+ * The quantities library is a likely too ambitious project, and although has
+ * proven useful at for some level convenient, for others it is a nightmare to
+ * use, especially when mixed to standard variables.
+ * These utilities are meant to make a syntax available that can be shared in
+ * generic code whether the variables involved are quantities or plain values.
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_INTERVALS_UTILS_H
+#define ICARUSCODE_UTILITIES_INTERVALS_UTILS_H
+
+// ICARUS libraries
+#include "icaruscode/Utilities/quantities_utils.h"
+
+// LArSoft libraries
+#include "lardataalg/Utilities/intervals.h"
+
+// C/C++ standard libraries
+#include <type_traits>
+
+
+namespace util::quantites::concepts { // same namespace where `Quantity` lives
+  
+  namespace details {
+    
+    template <typename IP>
+    using is_interval_or_point
+      = std::disjunction<is_interval<IP>, is_point<IP>>;
+    
+    template <typename IP>
+    constexpr bool is_interval_or_point_v = is_interval_or_point<IP>::value;
+    
+  } // namespace details
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Absolute value of a quantity.
+   * @tparam IP the `Interval` or `Point` type
+   * @param q interval or point to take absolute value of
+   * @return an object of type `IP` with its value made non-negative
+   * 
+   * The generic way to use this is:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * template <typename T>
+   * void f(T value) {
+   *   using std::abs;
+   *   T = abs(value);
+   *   // ...
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * 
+   */
+  template <
+    typename IP,
+    typename = std::enable_if_t<details::is_interval_or_point_v<IP>>
+    >
+  IP abs(IP q) { return q.abs(); }
+  
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Scalar value of a interval or point.
+   * @tparam IP the `Interval` or `Point` type
+   * @param q interval or point to be returned the value of
+   * @return a scalar value of the scalar type of `IP`
+   * 
+   * The generic way to use this is:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * template <typename T>
+   * float to_float(T v) {
+   *   using util::value;
+   *   return static_cast<float>(value(v));
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  template<
+    typename IP,
+    typename = std::enable_if_t<details::is_interval_or_point_v<IP>>
+    >
+  typename IP::value_t value(IP q) { return q.value(); }
+  
+  
+  // ---------------------------------------------------------------------------
+  
+} // namespace util
+
+
+#endif // ICARUSCODE_UTILITIES_INTERVALS_UTILS_H

--- a/icaruscode/Utilities/quantities_utils.h
+++ b/icaruscode/Utilities/quantities_utils.h
@@ -1,0 +1,110 @@
+/**
+ * @file   icaruscode/Utilities/quantities_utils.h
+ * @brief  Utilities to make `util::Quantity` objects behave more like numbers.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 18, 2022
+ * 
+ * This library tries to provide utilities that a motivated developer may
+ * utilize to keep its code `util::quantities::concepts::Quantity`-friendly.
+ * 
+ * The quantities library is a likely too ambitious project, and although has
+ * proven useful at for some level convenient, for others it is a nightmare to
+ * use, especially when mixed to standard variables.
+ * These utilities are meant to make a syntax available that can be shared in
+ * generic code whether the variables involved are quantities or plain values.
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_QUANTITIES_UTILS_H
+#define ICARUSCODE_UTILITIES_QUANTITIES_UTILS_H
+
+// LArSoft libraries
+#include "lardataalg/Utilities/quantities.h"
+
+// C/C++ standard libraries
+#include <type_traits>
+
+
+namespace util::quantities::concepts { // same namespace where `Quantity` lives
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Absolute value of a quantity.
+   * @tparam Q the `Quantity`-like type
+   * @param q quantity object to take absolute value of
+   * @return an object of type `T` with its value made non-negative
+   * 
+   * The generic way to use this is:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * template <typename T>
+   * void f(T value) {
+   *   using std::abs;
+   *   T const abs_value = abs(value);
+   *   // ...
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  template
+    <typename Q, typename = std::enable_if_t<details::is_quantity<Q>::value>>
+  Q abs(Q q) { return q.abs(); }
+  
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Scalar value of a quantity.
+   * @tparam Q the `Quantity`-like type
+   * @param v quantity to be returned the value of
+   * @return a scalar value of the scalar type of `Q`
+   * @see `util::value()`
+   * 
+   * The generic way to use this is:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * template <typename T>
+   * float to_float(T v) {
+   *   using util::value;
+   *   return static_cast<float>(value(v));
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  template
+    <typename Q, typename = std::enable_if_t<details::is_quantity<Q>::value>>
+  typename Q::value_t value(Q q) { return q.value(); }
+  
+  
+  // ---------------------------------------------------------------------------
+  
+} // namespace util::quantities::concepts
+
+
+// -----------------------------------------------------------------------------
+namespace util {
+  
+  /**
+   * @brief Scalar value of a scalar quantity.
+   * @tparam T the value type
+   * @param v value to be returned
+   * @return the value `v`
+   * 
+   * The generic way to use this is:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * template <typename T>
+   * float to_float(T v) {
+   *   using util::value;
+   *   return static_cast<float>(value(v));
+   * }
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   */
+  template
+    <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+  T value(T v) { return v; }
+  
+  /// The type returned by `util::value(T)`.
+  template <typename T>
+  using value_t = decltype(value(std::declval<T>()));
+  
+} // namespace util
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_UTILITIES_QUANTITIES_UTILS_H


### PR DESCRIPTION
This is the first implementation of the PMT readout simulation. With its 0-hour testing, it should not be considered production-ready.
This branch also contains a loosely related feature: trigger simulation now also outputs `sbn::ExtraTriggerInfo` data, which may be useful for CAF maker jobs.

The PMT readout simulation requires a trigger simulation, which requires PMT waveforms. Therefore, it is an additional step _after_ the PMT digitisation. This branch does not attempt to integrate it in a production workflow at this time.
The readout simulation happens in steps:
1. digitisation of PMT signals (good old `SimPMTIcarus`)
2. preparation for the trigger simulation: discrimination, combination in pairs, then in windows
3. application of a off-spill trigger logic (currently we are requiring 10 PMT pairs) to define trigger primitives
4. composition of the old waveform content plus noise filler into the waveforms that are supposed to be read out (new `SimPMTreadout` module).

This sequence is encoded in `run_pmtreadoutsimulation_icarus.fcl` job configuration file.
At the end, we are left with a new collection of `raw::OpDetWaveform` (called `daqPMT` in the job above) and the "metadata" collection (`sbn::OpDetWaveformMeta`).
The correct step would be to run the optical reconstruction on the newly created waveforms. A shortcut can be taken with some loss of correctness by using the hits that were already reconstructed on the full waveforms (`opdaq` waveforms, `ophit` hits in `Stage0` configurations) and keep only the ones at the times when readout was active (the metadata is a light-weight data product to obtain that information). Neither pattern is implemented in this branch, which only takes care of the simulation of waveforms.

Because the new module needs to create noise, and in the same way as the DetSim module did, I have detached the PMT noise generation from the core of `PMTsimulationAlg` module into a _art_ tool. This should make it easier to implement a data-driven noise generator in the future, and also can help with the tests by @brucehoward-physics to overlay simulated signals to background data.

The branch is updated to `develop` as of now.

----

Requesting the review of:
* @SFBayLaser especially for the choice of location of files
* @gputnam for the additional part of the trigger information for CAF
* ... not sure if any PMT reconstruction expert wants to comment (@Temigo, @amenegol, @JackSmedley): feel free to add your review if you like.
