### PR TITLE
Fixed trigger configuration module configuration

### DIFF
--- a/fcl/reco/Definitions/decoderdefs_icarus.fcl
+++ b/fcl/reco/Definitions/decoderdefs_icarus.fcl
@@ -4,6 +4,7 @@ BEGIN_PROLOG
 
 extractTriggerConfig: { 
                     module_type:        TriggerConfigurationExtraction
+                    DataFragmentType:   ICARUSTriggerV3
 }
 
 extractPMTconfig: {

--- a/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
@@ -51,6 +51,7 @@ decodeTriggerV2.DecoderTool.TrigConfigLabel: triggerconfig
 decodeTriggerV3.DecoderTool.TrigConfigLabel: triggerconfig
 decodePMT.PMTconfigTag: pmtconfig
 decodePMT.TriggerTag:   daqTrigger
+extractTriggerConfig.DataFragmentType: ICARUSTriggerV2
 
 ### This is the complete list of all producers! ###
 icarus_stage0_producers:


### PR DESCRIPTION
Unfortunately I am not in the conditions to even test these changes.
There is an issue with the name configured in `triggerconfig` module label for Run2, and this solution sets the "default" to the latest version and overrides the legacy Run1 configuration.

**The same fix must be applied to the production branch.**