### PR TITLE
add kdif-only fcls for higgs portal generator

### DIFF
--- a/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M050.fcl
+++ b/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M050.fcl
@@ -1,0 +1,8 @@
+#include "dissonant_higgs_corsika_p_gen.fcl"
+
+higgsM: 0.05
+physics.producers.generator.Flux.KDIFandBeamline: true
+physics.producers.generator.Decay.ReferenceHiggsMixing: 2e-4
+physics.producers.generator.Flux.MixingAngle: 2e-4
+
+#include "set_higgsM.fcl"

--- a/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M100.fcl
+++ b/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M100.fcl
@@ -1,0 +1,8 @@
+#include "dissonant_higgs_corsika_p_gen.fcl"
+
+higgsM: 0.10
+physics.producers.generator.Flux.KDIFandBeamline: true
+physics.producers.generator.Decay.ReferenceHiggsMixing: 2e-4
+physics.producers.generator.Flux.MixingAngle: 2e-4
+
+#include "set_higgsM.fcl"

--- a/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M150.fcl
+++ b/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M150.fcl
@@ -1,0 +1,8 @@
+#include "dissonant_higgs_corsika_p_gen.fcl"
+
+higgsM: 0.15
+physics.producers.generator.Flux.KDIFandBeamline: true
+physics.producers.generator.Decay.ReferenceHiggsMixing: 2e-4
+physics.producers.generator.Flux.MixingAngle: 2e-4
+
+#include "set_higgsM.fcl"

--- a/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M200.fcl
+++ b/fcl/gen/mevprtl/higgs/dissH_corsikap_kdif_M200.fcl
@@ -1,0 +1,8 @@
+#include "dissonant_higgs_corsika_p_gen.fcl"
+
+higgsM: 0.20
+physics.producers.generator.Flux.KDIFandBeamline: true
+physics.producers.generator.Decay.ReferenceHiggsMixing: 2e-4
+physics.producers.generator.Flux.MixingAngle: 2e-4
+
+#include "set_higgsM.fcl"


### PR DESCRIPTION
These fcl files were added to a production branch of icaruscode (v09_37) in March 2022, and I would like them in develop also so that they continue to be accessible in later code releases.