### PR TITLE
Trigger decoder tool supporting both V2 and V3 data fragment versions

### DIFF
--- a/fcl/reco/Definitions/decoderdefs_icarus.fcl
+++ b/fcl/reco/Definitions/decoderdefs_icarus.fcl
@@ -71,6 +71,13 @@ decodeTriggerV3: {
                     FragmentsLabel:     "daq:ICARUSTriggerV3"
                     DecoderTool:        @local::TriggerDecoderV3Tool
 }
+
+decodeTriggerAutodetect: {
+                    module_type:        DaqDecoderICARUSTrigger
+                    FragmentsLabel:     ""
+                    DecoderTool:        @local::TriggerDecoderAutoTool
+}
+
 copyPMTonBeam: {
                     module_type:        CopyBeamTimePMTwaveforms
                     Waveforms:          @nil # must override

--- a/fcl/reco/Definitions/stage0_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs.fcl
@@ -37,6 +37,9 @@ icarus_stage0_analyzers:
 # set the name of our `extractPMTconfig` and `extractTriggerConfig` for our decoders
 decodeTriggerV2.DecoderTool.TrigConfigLabel: triggerconfig
 decodeTriggerV3.DecoderTool.TrigConfigLabel: triggerconfig
+decodeTriggerAutodetect.DecoderTool.Decoders[0].ToolConfig.TrigConfigLabel: triggerconfig
+decodeTriggerAutodetect.DecoderTool.Decoders[1].ToolConfig.TrigConfigLabel: triggerconfig
+decodeTriggerAutodetect.DecoderTool.Decoders[2].ToolConfig.TrigConfigLabel: triggerconfig
 decodePMT.PMTconfigTag: pmtconfig
 decodePMT.TriggerTag:   daqTrigger
 
@@ -464,7 +467,5 @@ icarus_stage0_producers.purityana1.PersistPurityInfo:                           
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
 icarus_stage0_producers.purityana1.PersistPurityInfo:                                          false
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
-
-icarus_stage0_producers.triggerconfig.TriggerFragmentType:				       ICARUSTriggerV3
 
 END_PROLOG

--- a/fcl/reco/Definitions/stage0_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs.fcl
@@ -60,7 +60,7 @@ icarus_stage0_producers:
 
   daqCRT:                         @local::crtdaq_icarus
 
-  daqTrigger:                     @local::decodeTriggerV3
+  daqTrigger:                     @local::decodeTriggerAutodetect
 
   ### calwire producers
   decon1droi:                     @local::icarus_decon1droi

--- a/fcl/reco/Stage0/Run2/partial/decodeTrigger_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/partial/decodeTrigger_icarus.fcl
@@ -21,7 +21,7 @@ physics: {
 //     pmtconfig:  @local::extractPMTconfig
     triggerconfig: @local::extractTriggerConfig
     
-    daqTrigger: @local::decodeTriggerV3
+    daqTrigger: @local::decodeTriggerAutodetect
     
 //     daqPMT:     @local::decodePMT
     
@@ -45,8 +45,10 @@ outputs: {
 } # outputs 
 
 
-physics.producers.triggerconfig.TriggerFragmentType: ICARUSTriggerV3
 physics.producers.daqTrigger.DecoderTool.TrigConfigLabel: triggerconfig
-physics.producers.daqTrigger.DecoderTool.DiagnosticOutput: true
-physics.producers.daqTrigger.DecoderTool.Debug: true
-
+physics.producers.daqTrigger.DecoderTool.Decoders[0].ToolConfig.DiagnosticOutput: true
+physics.producers.daqTrigger.DecoderTool.Decoders[0].ToolConfig.Debug:            true
+physics.producers.daqTrigger.DecoderTool.Decoders[1].ToolConfig.DiagnosticOutput: true
+physics.producers.daqTrigger.DecoderTool.Decoders[1].ToolConfig.Debug:            true
+physics.producers.daqTrigger.DecoderTool.Decoders[2].ToolConfig.DiagnosticOutput: true
+physics.producers.daqTrigger.DecoderTool.Decoders[2].ToolConfig.Debug:            true

--- a/icaruscode/Decode/DataProducts/TriggerConfiguration.cxx
+++ b/icaruscode/Decode/DataProducts/TriggerConfiguration.cxx
@@ -18,6 +18,9 @@
 static_assert(icarus::TriggerConfiguration::DefaultDumpVerbosity <= icarus::TriggerConfiguration::MaxDumpVerbosity);
 
 //------------------------------------------------------------------------------
+std::string const icarus::TriggerConfiguration::UnknwonGenerator { "<unknown>" };
+
+//------------------------------------------------------------------------------
 void icarus::TriggerConfiguration::dumpGateConfig
   (std::ostream& out, icarus::TriggerConfiguration::GateConfig const& gateConfig, std::string const& indent) const
 {
@@ -84,8 +87,11 @@ void icarus::TriggerConfiguration::dump(std::ostream& out,
     // --- verbosity: 0+ -------------------------------------------------------
     out << firstIndent
       << "Basic trigger configuration:";
-      outnl() << " Use WR time:    " << std::boolalpha << useWrTime << std::noboolalpha;
-      outnl() << " WR time offset: " << wrTimeOffset << " ns";
+    outnl() << " Generator name: ";
+    if (generator == UnknwonGenerator) out << "unknown";
+    else out << "'" << generator << "'";
+    outnl() << " Use WR time:    " << std::boolalpha << useWrTime << std::noboolalpha;
+    outnl() << " WR time offset: " << wrTimeOffset << " ns";
     
     if (++level > verbosity) break;
     // --- verbosity: 1+ -------------------------------------------------------

--- a/icaruscode/Decode/DataProducts/TriggerConfiguration.h
+++ b/icaruscode/Decode/DataProducts/TriggerConfiguration.h
@@ -29,7 +29,10 @@ namespace icarus {
 
 
 struct icarus::TriggerConfiguration {
-
+  
+  /// Label used for unknown DAQ generator.
+  static std::string const UnknwonGenerator;
+  
   struct CryoConfig {
 
     /// Majority Level for in-time activity
@@ -130,11 +133,14 @@ struct icarus::TriggerConfiguration {
   /// Force the run to be fully a MinBias, if runType=="MinBias". If runType=="Majority" does a majority run with some prescaled minbias triggers depending on the gate selection in use
   std::string runType;
 
-  /// TPCTriggerDelay: distance between the Global trigger time and the output for the TPC. NB: It is in units of 400 ns 
+  /// TPCTriggerDelay: distance between the Global trigger time and the output for the TPC. NB: It is in units of 400 ns.
   unsigned int tpcTriggerDelay = 0;
 
-  /// Gate Configuration 
+  /// Gate Configuration.
   std::array<GateConfig, icarus::trigger::kNTriggerSource> gateConfig;
+  
+  /// Name of the trigger fragment DAQ generator.
+  std::string generator = UnknwonGenerator;
 
   // --- END ---- Data members -------------------------------------------------
 

--- a/icaruscode/Decode/DataProducts/classes_def.xml
+++ b/icaruscode/Decode/DataProducts/classes_def.xml
@@ -17,7 +17,8 @@
 <lcgdict>
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->  
 
-     <class name="icarus::TriggerConfiguration" ClassVersion="11" >
+     <class name="icarus::TriggerConfiguration" ClassVersion="12" >
+      <version ClassVersion="12" checksum="2609357722"/>
       <version ClassVersion="11" checksum="2294188438"/>
    <version ClassVersion="10" checksum="3222464842"/>
      </class>

--- a/icaruscode/Decode/DecoderTools/CMakeLists.txt
+++ b/icaruscode/Decode/DecoderTools/CMakeLists.txt
@@ -64,6 +64,7 @@ cet_build_plugin(TPCNoiseFilterCanny art::tool LIBRARIES ${TOOL_LIBRARIES})
 cet_build_plugin(TriggerDecoder art::tool LIBRARIES ${TOOL_LIBRARIES})
 cet_build_plugin(TriggerDecoderV2 art::tool LIBRARIES ${TOOL_LIBRARIES})
 cet_build_plugin(TriggerDecoderV3 art::tool LIBRARIES ${TOOL_LIBRARIES})
+cet_build_plugin(TriggerDecoderDispatcher art::tool LIBRARIES ${TOOL_LIBRARIES})
 
 
 

--- a/icaruscode/Decode/DecoderTools/IDecoder.h
+++ b/icaruscode/Decode/DecoderTools/IDecoder.h
@@ -65,6 +65,15 @@ public:
     virtual void setupRun(art::Run const& run) {}
 
     /**
+     *  @brief Returns the tag of the input fragment, if known (empty otherwise).
+     *
+     *  The steering module can optionally use this tag for choosing or
+     *  overriding the input fragment.
+     */
+    virtual std::optional<art::InputTag> preferredInput() const
+        { return std::nullopt; }
+
+    /**
      *  @brief Preparation to process a new event.
      *
      *  To be called on every _art_ event transition.

--- a/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
+++ b/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
@@ -304,6 +304,8 @@ auto icarus::TriggerConfigurationExtractor::extractTriggerConfiguration
     = parsePrescaleString( prescaleMinBiasCalibration, icarus::trigger::kCalibration );
   rc.gateConfig[icarus::trigger::kCalibration].period 
     = spexiParams.get<unsigned int>("ZeroBiasFreq.value"); //it is actually a period 
+  
+  rc.generator = triggerParams.get<std::string>("generator");
 
   return rc;
 

--- a/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
+++ b/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.cxx
@@ -145,7 +145,7 @@ icarus::TriggerConfiguration icarus::TriggerConfigurationExtractor::extract
   if (!config) {
     throw cet::exception{ "TriggerConfigurationExtractor" }
       << "No trigger configuration found (fragment type: '"
-      << fExpectedFragmentType << "').\n";
+      << fExpectedFragmentTypeSpec << "').\n";
   }
   
   return *config;
@@ -330,7 +330,7 @@ icarus::TriggerConfigurationExtractor::readTriggerConfig
     std::string fragmentType;
     if (!boardPSet.get_if_present("daq.fragment_receiver.generator", fragmentType))
       break;
-    if (fragmentType != fExpectedFragmentType) break;
+    if (!std::regex_match(fragmentType, fExpectedFragmentType)) break;
     
     config.emplace(std::move(boardPSet)); // success
   } while (false);

--- a/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.h
+++ b/icaruscode/Decode/DecoderTools/TriggerConfigurationExtractor.h
@@ -302,7 +302,9 @@ class icarus::TriggerConfigurationExtractorBase {
  * 
  * The extractor identifies the correct configuration by the
  * `daq.fragment_receiver.generator` configuration key (in the above example,
- * it is `ICARUSTriggerUDP`).
+ * it is `ICARUSTriggerUDP`). The key is specified as a regular expression
+ * pattern that must match the whole string (as in `std::regex_match()` with
+ * standard format).
  * 
  */
 class icarus::TriggerConfigurationExtractor
@@ -313,8 +315,9 @@ class icarus::TriggerConfigurationExtractor
   
   /// Learns the name of the trigger fragment type.
   TriggerConfigurationExtractor
-    (std::string const& expectedFragmentType = "ICARUSTriggerUDP")
-    : fExpectedFragmentType{ expectedFragmentType }
+    (std::string expectedFragmentType = "ICARUSTrigger.*")
+    : fExpectedFragmentTypeSpec{ std::move(expectedFragmentType) }
+    , fExpectedFragmentType{ fExpectedFragmentTypeSpec }
     {}
 
   // --- BEGIN -- Interface ----------------------------------------------------
@@ -345,7 +348,11 @@ class icarus::TriggerConfigurationExtractor
   
     private:
   
-  std::string const fExpectedFragmentType;
+  /// Specification of the trigger type name pattern.
+  std::string const fExpectedFragmentTypeSpec;
+  
+  /// Regular expression pattern for trigger type name.
+  std::regex const fExpectedFragmentType;
   
   /// Regular expressions matching all names of supported Trigger configurations.
   static std::vector<std::regex> const ConfigurationNames;

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderDispatcher_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderDispatcher_tool.cc
@@ -1,0 +1,485 @@
+/**
+ * @file   icaruscode/Decode/DecodeTools/TriggerDecoderDispatched_tool.cc
+ * @brief  Trigger decoder detecting which version of decoding to use.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu), Jacob Zettlemoyer
+ * 
+ * 
+ */
+
+// ICARUS libraries
+#include "icaruscode/Decode/DecoderTools/IDecoder.h"
+#include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
+#include "icaruscode/Decode/DataProducts/TriggerConfiguration.h"
+
+// LArSoft and artDAQ libraries
+#include "lardataobj/RawData/ExternalTrigger.h"
+#include "lardataobj/RawData/TriggerData.h" // raw::Trigger
+#include "lardataobj/Simulation/BeamGateInfo.h"
+#include "artdaq-core/Data/Fragment.hh"
+
+// framework libraries
+#include "art/Framework/Core/ConsumesCollector.h"
+#include "art/Framework/Core/ProducesCollector.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Utilities/make_tool.h"
+#include "art/Utilities/ToolConfigTable.h"
+#include "art/Utilities/ToolMacros.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/ParameterSet.h"
+
+// C/C++ standard libraries
+#include <memory> // std::unique_ptr
+#include <regex>
+#include <string>
+#include <optional>
+#include <vector>
+
+
+// -----------------------------------------------------------------------------
+namespace daq { class TriggerDecoderDispatched; }
+/**
+ * @brief Trigger decoding tool supporting multiple trigger versions.
+ * 
+ * This class delegates trigger decoding to another, single-purpose tool.
+ * Which tool is chosen depends on the trigger configuration, and it may change
+ * on each run (i.e. no access to any trigger data fragment is allowed to make
+ * that choice).
+ * 
+ * A fragment generator is a part of the DAQ code that serves a hardware
+ * component and generates data fragments out of it.
+ * The trigger configuration contains the name of the generator used to create
+ * the trigger fragment. That name is used to determine the configuration of the
+ * trigger decoding tool ("worker" tool) that will be actually used. If there is
+ * no configuration for that generator, an exception is typically thrown.
+ * 
+ * 
+ * Configuration
+ * --------------
+ * 
+ * * `TrigConfigLabel` (input tag, mandatory): the data product with the trigger
+ *   configuration
+ * * `Decoders` (list of generator configurations): each entry in this list is
+ *   a generator configuration table structured as follows:
+ *     * `Generator` (regular expression, mandatory): name of the generator this
+ *       configuration deals with. It is a regular expression matched with
+ *       `std::regex_match()`, but it can be specified as a simple name.
+ *     * `FragmentsLabel` (input tag, mandatory): name of the data product with
+ *       the trigger data fragment.
+ *     * `ToolConfig` (configuration table): the configuration for the trigger
+ *       decoder tool that can decode the data fragments written by the
+ *       `Generator`.
+ * * `LogCategory` (string, default: `"TriggerDecoderDispatched"`): name of
+ *   the message facility stream where messages of this tool are sent to.
+ * 
+ * 
+ * Input
+ * ------
+ * 
+ * In addition to the input required by the delegated trigger decoder tools,
+ * this tool also uses:
+ * 
+ * * `icarus::TriggerConfiguration` (`TrigConfigLabel`): configuration of
+ *   trigger hardware
+ *   (extracted e.g. by `icarus::TriggerConfigurationExtraction` module).
+ * * `std::vector<artdaq::Fragment>` (`FragmentsLabel` of the worker tool(s)
+ *   that is actually used).
+ * 
+ * 
+ * Output
+ * -------
+ * 
+ * This tool requires that each worker tool produces all (and only) the
+ * following data products:
+ * 
+ * * `std::vector<raw::ExternalTrigger>` (empty instance name)
+ * * `std::vector<raw::ExternalTrigger>` (instance name `"previous"`)
+ * * `std::vector<raw::Trigger>`
+ * * `std::vector<sim::BeamGateInfo>`
+ * * `sbn::ExtraTriggerInfo`
+ * 
+ * The specifics of these data products should be described by the worker tools.
+ * 
+ * 
+ * The `IDecoder` protocol
+ * ------------------------
+ * 
+ * This object does not fully implement the `daq::IDecoder` protocol, nor it
+ * supports all its functionalities.
+ * 
+ * The `preferredInput()` call will return the input data product tag for the
+ * raw trigger data fragment. This is directly learnt from the tool
+ * configuration (`FragmentsLabel`).
+ * 
+ * The `configure()` hook does not work and will throw an exception if invoked.
+ * This tool only accepts configuration at construction time.
+ * 
+ * The `consumes()` functionality is not very robust. It must be invoked at
+ * construction time, when it's not yet known which trigger generator(s) will
+ * be encountered, and therefore which tools will be used. 
+ * As a fallback, because the tool configurations in this module must include
+ * the input tag of the data fragment they need, we can declare that all of them
+ * _might_ be consumed, which is what this tool does. Most likely, all but one
+ * of those declarations will not be confirmed.
+ * 
+ * Similarly, `produces()` is troublesome. This is not an optional protocol,
+ * but at least the produce of the tools is well defined by LArSoft/ICARUS
+ * conventions. So we stick to it and require that all worker tools we use will
+ * honour that convention (documented in the `Outputs` section above).
+ * 
+ * 
+ * ### Support for different triggers in the same job
+ * 
+ * The design of this tool should allow for the use of different trigger tools
+ * in the same job. A limitation in the implementation in `icaruscode`
+ * `v09_63_00` comes from the fact that the trigger decoding tools have all
+ * the same fully qualified name, which likely makes it troublesome to load
+ * more than one of them at the same time. This can be easily addressed by
+ * renaming the tool C++ class names; since the tools are never called by name
+ * in external code, this should have no effect in the big picture.
+ * 
+ * 
+ * 
+ */
+class daq::TriggerDecoderDispatched: public daq::IDecoder {
+  
+    public:
+  
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    struct DecoderConfig {
+      
+      fhicl::Atom<std::string> Generator{
+        Name{ "Generator" },
+        Comment{ "the name of the trigger fragment generator (regex)" }
+        };
+      
+      fhicl::Atom<art::InputTag> FragmentsLabel{
+        Name{ "FragmentsLabel" },
+        Comment{ "the trigger fragment input tag" }
+        };
+      
+      fhicl::DelegatedParameter ToolConfig{
+        Name{ "ToolConfig" },
+        Comment{ "configuration of the tool for this generator" }
+        };
+      
+    }; // DecoderConfig
+    
+    
+    fhicl::Atom<art::InputTag> TrigConfigLabel{
+      Name{ "TrigConfigLabel" },
+      Comment{ "data product with the trigger hardware configuration" }
+      };
+    
+    fhicl::Sequence<fhicl::Table<DecoderConfig>> Decoders{
+      Name{ "Decoders" },
+      Comment{ "Configurations of all supported decoders" }
+      };
+    
+    fhicl::Atom<std::string> LogCategory{
+      Name{ "LogCategory" },
+      Comment{ "name of stream for messages of this tool" },
+      "TriggerDecoderDispatched"
+      };
+    
+  }; // Config
+  
+  using Parameters = art::ToolConfigTable<Config>;
+  
+  explicit TriggerDecoderDispatched(Parameters const& params);
+  
+  /// Optionally declares which data products to read.
+  virtual void consumes(art::ConsumesCollector& collector) override;
+  
+  /// Registers all the data products we promise to produce.
+  virtual void produces(art::ProducesCollector& collector) override;
+  
+  virtual void configure(const fhicl::ParameterSet&) override;
+  
+  /// Delegates data product initialization to the current trigger decoder.
+  virtual void initializeDataProducts() override;
+  
+  /// Constructs and prepares the tool according to the trigger in the run.
+  virtual void setupRun(art::Run const& run) override;
+  
+  virtual std::optional<art::InputTag> preferredInput() const override;
+  
+  /// Delegates the fragment processing to the current trigger decoder.
+  virtual void process_fragment(const artdaq::Fragment &fragment) override;
+  
+  /// Delegates data product output to the current trigger decoder.
+  virtual void outputDataProducts(art::Event &event) override;
+  
+  
+    private:
+  
+  /// Configuration of a single generator and tool to decode it.
+  struct GeneratorParams_t {
+    std::string generatorName; ///< Name of the generator (pattern text).
+    std::regex generatorPattern; ///< Regular expression for generator name.
+    art::InputTag fragmentTag; ///< Tag for the trigger input fragment.
+    fhicl::ParameterSet toolConfig; ///< Configuration for the tool.
+  };
+  
+  /// Standard name for data products referring to the current event.
+  static std::string const CurrentTriggerInstanceName;
+  
+  /// Standard name for data products referring to the previous event.
+  static std::string const PreviousTriggerInstanceName;
+  
+  
+  // --- BEGIN -- Configuration ------------------------------------------------
+  
+  /// Data product with trigger hardware configuration.
+  art::InputTag const fTriggerConfigTag;
+  
+  /// Configuration for each and all supported generators.
+  std::vector<GeneratorParams_t> const fGenParams;
+  
+  std::string const fLogCategory; ///< Message facility stream for this tool.
+  
+  // --- END ---- Configuration ------------------------------------------------
+  
+  
+  // --- BEGIN -- Current decoder ----------------------------------------------
+  
+  /// Pointer to the current generator and tool parameters.
+  GeneratorParams_t const* fCurrentGenParam = nullptr;
+  
+  std::string fCurrentGenerator; ///< Name of the current generator.
+  
+  std::unique_ptr<IDecoder> fDecoder; ///< The decoder for the current run.
+  
+  // --- END ---- Current decoder ----------------------------------------------
+  
+  /// Sets up the object for the decoder for the specified `generator`.
+  /// Throws exceptions if the setup fails.
+  void createDecoder(std::string const& generator);
+  
+  /// Converts `DecoderConfig` into `GeneratorParams_t`.
+  static std::vector<GeneratorParams_t> makeGeneratorParams
+    (std::vector<Config::DecoderConfig> const& genConfigs);
+  
+}; // class daq::TriggerDecoderDispatched
+
+
+// -----------------------------------------------------------------------------
+// ---  Implementation
+// -----------------------------------------------------------------------------
+std::string const daq::TriggerDecoderDispatched::CurrentTriggerInstanceName {};
+std::string const daq::TriggerDecoderDispatched::PreviousTriggerInstanceName
+  { "previous" };
+
+// -----------------------------------------------------------------------------
+daq::TriggerDecoderDispatched::TriggerDecoderDispatched
+  (Parameters const& params)
+    // configuration
+  : fTriggerConfigTag{ params().TrigConfigLabel() }
+  , fGenParams{ makeGeneratorParams(params().Decoders()) }
+  , fLogCategory{ params().LogCategory() }
+    // caches
+{
+  
+  //
+  // configuration checks
+  //
+  if (fGenParams.empty()) {
+    throw art::Exception{ art::errors::Configuration }
+      << "No tool configured for the trigger decoder ('"
+      << params().Decoders.name() << "').\n";
+  }
+  
+  //
+  // configuration dump on screen
+  //
+  {
+    mf::LogInfo log{ fLogCategory };
+    log << "Trigger decoder dispatcher supports " << fGenParams.size()
+      << " trigger generators:";
+    for (GeneratorParams_t const& genParam: fGenParams) {
+      log << "\n - '" << genParam.generatorName << "': ";
+      if (genParam.toolConfig.is_key_to_atom("tool_type")) {
+        log << " tool '" << genParam.toolConfig.get<std::string>("tool_type")
+          << "' reading '" << genParam.fragmentTag.encode() << "'";
+      }
+      else {
+        log << "not a tool?!";
+      }
+    } // for
+    log << "\nTrigger generator is read from '" << fTriggerConfigTag.encode()
+      << "'";
+  }
+  
+} // daq::TriggerDecoderDispatched::TriggerDecoderDispatched()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::consumes(art::ConsumesCollector& collector)
+{
+  
+  collector.consumes<icarus::TriggerConfiguration>(fTriggerConfigTag);
+  
+  // we don't ask the tools what they will/would consume, but rather have
+  // a simple guess
+  for (GeneratorParams_t const& genParam: fGenParams)
+    collector.mayConsume<artdaq::Fragments>(genParam.fragmentTag);
+  
+} // daq::TriggerDecoderDispatched::consumes()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::produces(art::ProducesCollector& collector)
+{
+  collector.produces<std::vector<raw::ExternalTrigger>>
+    (CurrentTriggerInstanceName);
+  collector.produces<std::vector<raw::ExternalTrigger>>
+    (PreviousTriggerInstanceName);
+  collector.produces<std::vector<raw::Trigger>>
+    (CurrentTriggerInstanceName);
+  collector.produces<std::vector<sim::BeamGateInfo>>
+    (CurrentTriggerInstanceName);
+  collector.produces<sbn::ExtraTriggerInfo>
+    (CurrentTriggerInstanceName);
+} // daq::TriggerDecoderDispatched::produces()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::configure(const fhicl::ParameterSet&) {
+  
+  throw art::Exception{ art::errors::LogicError }
+    << "TriggerDecoderDispatched tool does not support the `configure()` call:"
+    " all configuration happened in the constructor already.\n";
+  // ... delegated tools will be configured at construction time in setupRun()
+  
+} // daq::TriggerDecoderDispatched::configure()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::setupRun(art::Run const& run) {
+  
+  // determine the generator
+  auto const& trigConfig
+    = run.getProduct<icarus::TriggerConfiguration>(fTriggerConfigTag);
+  if (fCurrentGenerator != trigConfig.generator)
+    createDecoder(trigConfig.generator);
+
+  // set up the tool for the run (delegated setup)
+  fDecoder->setupRun(run);
+  
+} // daq::TriggerDecoderDispatched::setupRun()
+
+
+// -----------------------------------------------------------------------------
+std::optional<art::InputTag> daq::TriggerDecoderDispatched::preferredInput()
+  const
+{
+  return fCurrentGenParam
+    ? std::optional{ fCurrentGenParam->fragmentTag }: std::nullopt;
+} // daq::TriggerDecoderDispatched::preferredInput()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::initializeDataProducts() {
+  
+  if (!fDecoder) {
+    throw art::Exception{ art::errors::LogicError }
+      << "No decoder tool configured when initializing the data product!\n";
+  }
+  
+  fDecoder->initializeDataProducts();
+  
+} // daq::TriggerDecoderDispatched::initializeDataProducts()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::process_fragment
+  (const artdaq::Fragment &fragment)
+{
+  
+  if (!fDecoder) {
+    throw art::Exception{ art::errors::LogicError }
+      << "No decoder tool configured when processing the fragment!\n";
+  }
+  
+  fDecoder->process_fragment(fragment);
+  
+} // daq::TriggerDecoderDispatched::process_fragment()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::outputDataProducts(art::Event &event) {
+  
+  if (!fDecoder) {
+    throw art::Exception{ art::errors::LogicError }
+      << "No decoder tool configured when outputting data products!\n";
+  }
+  
+  fDecoder->outputDataProducts(event);
+  
+} // daq::TriggerDecoderDispatched::outputDataProducts()
+
+
+// -----------------------------------------------------------------------------
+void daq::TriggerDecoderDispatched::createDecoder(std::string const& generator)
+{
+  
+  // determine the tool
+  GeneratorParams_t const* newGenParam = nullptr;
+  for (GeneratorParams_t const& genParam: fGenParams) {
+    if (!std::regex_match(generator, genParam.generatorPattern)) continue;
+    newGenParam = &genParam;
+    break;
+  } // for
+  
+  if (!newGenParam) {
+    art::Exception e{ art::errors::NotFound };
+    e << "Generator '" << generator << "' not supported (supported: ";
+    auto itGenParam = fGenParams.cbegin();
+    auto gend = fGenParams.cend();
+    e << "'" << itGenParam->generatorName << "'";
+    while (++itGenParam != gend) e << ", '" << itGenParam->generatorName << "'";
+    e << ").\n";
+    throw e;
+  }
+  
+  // construct a new tool (only if not the same as the current one)
+  fCurrentGenerator = generator;
+  fCurrentGenParam = newGenParam;
+  fDecoder = art::make_tool<IDecoder>(fCurrentGenParam->toolConfig);
+  
+  mf::LogDebug{ fLogCategory }
+    << "Generator '" << fCurrentGenerator << "' matches '"
+    << fCurrentGenParam->generatorName << "' tool configuration.";
+  
+} // daq::TriggerDecoderDispatched::createDecoder()
+
+
+// -----------------------------------------------------------------------------
+auto daq::TriggerDecoderDispatched::makeGeneratorParams
+  (std::vector<Config::DecoderConfig> const& genConfigs)
+  -> std::vector<GeneratorParams_t>
+{
+  std::vector<GeneratorParams_t> params;
+  params.reserve(genConfigs.size());
+  for (Config::DecoderConfig const& config: genConfigs) {
+    params.push_back({ // C++20: use named elements
+        config.Generator()                            // generatorName
+      , std::regex{ config.Generator() }              // generatorPattern
+      , config.FragmentsLabel()                       // fragmentTag
+      , config.ToolConfig.get<fhicl::ParameterSet>()  // toolConfig
+      });
+  } // for
+  return params;
+} // daq::TriggerDecoderDispatched::makeGeneratorParams()
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(daq::TriggerDecoderDispatched)
+
+
+// -----------------------------------------------------------------------------

--- a/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
+++ b/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
@@ -103,13 +103,34 @@ TriggerDecoderTool: {
 
 TriggerDecoderV2Tool: {
    tool_type:          TriggerDecoderV2
-   TriggerConfigLabel: @nil # must override
+   TrigConfigLabel:    triggerconfig  # may need override
 }
 
 TriggerDecoderV3Tool: {
-   tool_type:	      TriggerDecoderV3
-   TriggerConfigLabel: @nil # must override		      
+   tool_type:          TriggerDecoderV3
+   TrigConfigLabel:    triggerconfig  # may need override
 }
 
+TriggerDecoderAutoTool: {
+   tool_type:          TriggerDecoderDispatcher
+   TrigConfigLabel:    triggerconfig  # may need override
+   Decoders: [
+      {
+         Generator:      "ICARUSTriggerUDP"
+         FragmentsLabel: "daq:ICARUSTriggerUDP"
+         ToolConfig:     @local::TriggerDecoderTool
+      },
+      {
+         Generator:      "ICARUSTriggerV2"
+         FragmentsLabel: "daq:ICARUSTriggerV2"
+         ToolConfig:     @local::TriggerDecoderV2Tool
+      },
+      {
+         Generator:      "ICARUSTriggerV3"
+         FragmentsLabel: "daq:ICARUSTriggerV3"
+         ToolConfig:     @local::TriggerDecoderV3Tool
+      }
+   ]
+}
 
 END_PROLOG

--- a/icaruscode/Decode/TriggerConfigurationExtraction_module.cc
+++ b/icaruscode/Decode/TriggerConfigurationExtraction_module.cc
@@ -61,7 +61,7 @@ namespace icarus { class TriggerConfigurationExtraction; }
  * 
  * The following configuration parameters are supported:
  * 
- * * **TriggerFragmentType** (string, default: `ICARUSTriggerV2`):
+ * * **TriggerFragmentType** (string, default: `ICARUSTrigger.*`):
  *     name of the type of trigger fragment, used to identify the configuration
  *     of the trigger.
  * * **Verbose** (flag, default: `false`): if set to `true`, it will print in
@@ -101,8 +101,8 @@ class icarus::TriggerConfigurationExtraction: public art::EDProducer {
     
     fhicl::Atom<std::string> TriggerFragmentType {
       fhicl::Name("TriggerFragmentType"),
-      fhicl::Comment("the name of the type of trigger fragment from DAQ"),
-      "ICARUSTriggerV2" // default
+      fhicl::Comment("the name of the trigger generator in DAQ"),
+      "ICARUSTrigger.*" // default
       };
     
     fhicl::Atom<bool> Verbose {


### PR DESCRIPTION
This branch introduces and enables in the standard workflow a trigger decoding tool which is able to process trigger data fragments both from V2 (Run 1) and from V3 (Run 2).
Mixing the two is untested and may cryptically fail.

The new tool is actually just a dispatcher which will read from the run which version is being saved in the input file and will instantiate and utilise the proper single-version existing trigger decoder tool for processing.
In addition, the trigger configuration data product and extractor have been extended to discover and store which DAQ "generator" was used in the run, which then allows the new decoder tool to take the proper action.

Because ultimately the existing decoders are used for the actual processing, it is expected that no breaking change happens. The old tools still work stand-alone, as the old configurations should.

This is a request for merge into `develop`. The commits in this branch should also work with the production branch, which is matter of pull request #503.

### Testing

The configurations `decodeTrigger_icarus.fcl` and `stage0_run2_icarus.fcl` were tested with a Run 1 and a Run 2 file, while `stage0_run1_icarus.fcl` was tested with a Run1 file.

### Reviewers

I suggest @jzettle as the author of all the actual decoders this one delegates to, and @SFBayLaser to check the changes in the workflow.