### PR TITLE
Stage0 configuration only keeps waveforms at beam gate time

### DIFF
--- a/fcl/reco/Definitions/decoderdefs_icarus.fcl
+++ b/fcl/reco/Definitions/decoderdefs_icarus.fcl
@@ -71,6 +71,7 @@ decodeTriggerV3: {
                     FragmentsLabel:     "daq:ICARUSTriggerV3"
                     DecoderTool:        @local::TriggerDecoderV3Tool
 }
+
 copyPMTonBeam: {
                     module_type:        CopyBeamTimePMTwaveforms
                     Waveforms:          @nil # must override

--- a/fcl/reco/Definitions/stage0_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs.fcl
@@ -99,6 +99,8 @@ icarus_stage0_producers:
   opflashCryoE:                   @local::ICARUSSimpleFlashDataCryoE
   opflashCryoW:                   @local::ICARUSSimpleFlashDataCryoW
 
+  daqPMTonbeam:                   @local::copyPMTonBeam
+
   ### Purity monitoring
   purityana0:                     { module_type: "ICARUSPurityDQM" }
   purityana1:                     { module_type: "ICARUSPurityDQM" }
@@ -226,7 +228,8 @@ icarus_stage0_PMT:                  [ triggerconfig,
                                       ophituncorrected,
                                       ophit,
                                       opflashCryoE,
-                                      opflashCryoW
+                                      opflashCryoW,
+                                      daqPMTonbeam
                                     ]
 
 icarus_stage0_PMT_BNB:              [ @sequence::icarus_stage0_PMT,
@@ -466,5 +469,7 @@ icarus_stage0_producers.purityana1.PersistPurityInfo:                           
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
 
 icarus_stage0_producers.triggerconfig.TriggerFragmentType:				       ICARUSTriggerV3
+
+icarus_stage0_producers.daqPMTonbeam.Waveforms: daqPMT
 
 END_PROLOG

--- a/fcl/reco/Definitions/stage0_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs.fcl
@@ -471,8 +471,6 @@ icarus_stage0_producers.purityana1.FillAnaTuple:                                
 icarus_stage0_producers.purityana1.PersistPurityInfo:                                          false
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
 
-icarus_stage0_producers.triggerconfig.TriggerFragmentType:				       ICARUSTriggerV3
-
 icarus_stage0_producers.daqPMTonbeam.Waveforms: daqPMT
 
 END_PROLOG

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus.fcl
@@ -18,11 +18,14 @@ physics.end_paths:     [ outana, streamROOT ]
 # Drop all output from the TPC decoder stage
 # Drop all output from the 1D deconvolution stage
 # Drop the recob::Wire output from the roifinder (but keep the ChannelROIs)
+# Drop the reconstructed optical hits before the timing correction
+# Drop the PMT waveforms (will keep the ones from daqPMTonbeam)
 # Keep the Trigger fragment
 outputs.rootOutput.outputCommands: [
     "keep *_*_*_*", 
     "drop *_*_*_DAQ*",
     "drop *_ophituncorrected_*_*",
+    "drop raw::OpDetWaveforms_daqPMT__*",
     "drop *_daqTPCROI_*_*", 
     "drop *_decon1droi_*_*", 
     "drop recob::Wire*_roifinder_*_*",

--- a/fcl/reco/Stage0/Run2/stage0_run2_raw_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_raw_icarus.fcl
@@ -8,6 +8,7 @@ process_name: stage0
 
 ## Define the path we'll execute
 physics.path:     [ @sequence::icarus_stage0_data ]
+physics.producers.daqPMTonbeam.module_type: DummyProducer # replaced with a no-op
 
 ## boiler plate...
 physics.outana:        [ purityinfoana0, purityinfoana1 ]


### PR DESCRIPTION
Following PR #478, this pull request enables retaining only the waveforms including the beam gate.

Technically, all PMT decoding and reconstruction proceeds through the data product `daqPMT` as before, but a module is appended that copies the regular waveforms containing the regular beam gate opening time from `daqPMT` into `daqPMTonbeam`. Then the regular PMT waveforms from `daqPMT` are all dropped.
Note that this affects only the "regular" waveforms, i.e. the ones associated with a PMT. The waveforms on the other readout channels (the "16th channel") are in different data products and are retained.
This behaviour has been encoded in the default `Stage0` Run 2 job configuration `stage0_run2_icarus.fcl`.

The job configuration `stage0_run2_raw_icarus.fcl` has been modified not to run the waveform duplication and not to drop any PMT waveform.

Implementation-wise:
1. the _default_ workflow definitions have changed to include also the copy of the gates;
2. the standard `Stage0` configuration has been modified to drop the optical waveforms from the decoder;
3. the "raw" configuration has been modified to run a dummy producer instead of the one copying the gates.

Because of this, any other configuration using the default workflow will have the duplicated waveforms, and possibly also the original ones if they were not dropped. If this is not acceptable, a different implementation is needed.

**Note**: because the waveforms on the beam gate are duplicated, the job memory usage is going to increase accordingly (the data product is 360×26 µs = 9.36 MB large).

This is a request for the `develop` branch. A twin request will be opened for the production branch.

### Reviewers

* @SFBayLaser to check the workflow changes
