### PR TITLE
Stage0 configuration only keeps waveforms at beam gate time [SBN2022B]

### DIFF
--- a/fcl/reco/Definitions/stage0_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs.fcl
@@ -102,6 +102,8 @@ icarus_stage0_producers:
   opflashCryoE:                   @local::ICARUSSimpleFlashDataCryoE
   opflashCryoW:                   @local::ICARUSSimpleFlashDataCryoW
 
+  daqPMTonbeam:                   @local::copyPMTonBeam
+
   ### Purity monitoring
   purityana0:                     { module_type: "ICARUSPurityDQM" }
   purityana1:                     { module_type: "ICARUSPurityDQM" }
@@ -229,7 +231,8 @@ icarus_stage0_PMT:                  [ triggerconfig,
                                       ophituncorrected,
                                       ophit,
                                       opflashCryoE,
-                                      opflashCryoW
+                                      opflashCryoW,
+                                      daqPMTonbeam
                                     ]
 
 icarus_stage0_PMT_BNB:              [ @sequence::icarus_stage0_PMT,
@@ -467,5 +470,7 @@ icarus_stage0_producers.purityana1.PersistPurityInfo:                           
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
 icarus_stage0_producers.purityana1.PersistPurityInfo:                                          false
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
+
+icarus_stage0_producers.daqPMTonbeam.Waveforms: daqPMT
 
 END_PROLOG

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus.fcl
@@ -18,11 +18,14 @@ physics.end_paths:     [ outana, streamROOT ]
 # Drop all output from the TPC decoder stage
 # Drop all output from the 1D deconvolution stage
 # Drop the recob::Wire output from the roifinder (but keep the ChannelROIs)
+# Drop the reconstructed optical hits before the timing correction
+# Drop the PMT waveforms (will keep the ones from daqPMTonbeam)
 # Keep the Trigger fragment
 outputs.rootOutput.outputCommands: [
     "keep *_*_*_*", 
     "drop *_*_*_DAQ*",
     "drop *_ophituncorrected_*_*",
+    "drop raw::OpDetWaveforms_daqPMT__*",
     "drop *_daqTPCROI_*_*", 
     "drop *_decon1droi_*_*", 
     "drop recob::Wire*_roifinder_*_*",

--- a/fcl/reco/Stage0/Run2/stage0_run2_raw_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_raw_icarus.fcl
@@ -8,6 +8,7 @@ process_name: stage0
 
 ## Define the path we'll execute
 physics.path:     [ @sequence::icarus_stage0_data ]
+physics.producers.daqPMTonbeam.module_type: DummyProducer # replaced with a no-op
 
 ## boiler plate...
 physics.outana:        [ purityinfoana0, purityinfoana1 ]


### PR DESCRIPTION
This is the twin request of #504, but for production branch.
See PR #504 for the details.
