### PR TITLE
Fixing CRTT0Matching_module

### DIFF
--- a/icaruscode/CRT/CRTT0MatchingAna_module.cc
+++ b/icaruscode/CRT/CRTT0MatchingAna_module.cc
@@ -338,7 +338,7 @@ namespace icarus {
 	  //std::cout << "closest match " << closest.t0 << std::endl;
 	  //std::cout << "closest dca " << closest.dca << " ,tagger: "<< closest.thishit.tagger << " , sin angele: \t" << closest.dca/closest.extrapLen << std::endl;
 	  double sin_angle = -99999;
-	  if(closest.dca != -99999){ 
+	  if(closest.dca != DBL_MIN){ 
 	    hDCA[closest.thishit.tagger]->Fill(closest.dca);
 	    //hDCA["All"]->Fill(closest.dca);
 	    sin_angle = closest.dca/closest.extrapLen;
@@ -379,19 +379,19 @@ namespace icarus {
 		hEffDCATotal[tagger]->Fill(DCAcut);
 		
 		// If closest hit is below limit and track matches any hits then fill efficiency
-		if(closest.dca < DCAcut && closest.dca != -99999){
+		if(closest.dca < DCAcut && closest.dca != DBL_MIN){
 		  hEffDCAReco[tagger]->Fill(DCAcut);
 		}
 	      }
 	      // Fill total efficiency histograms
 	      // hEffDCATotal["All"]->Fill(DCAcut);
-	      if(closest.dca < DCAcut && closest.dca != -99999){
+	      if(closest.dca < DCAcut && closest.dca != DBL_MIN){
 		// hEffDCAReco["All"]->Fill(DCAcut);
 	      }
 	    }
 	    
 	    // Fill total purity histogram with each cut if closest hit is below limit
-	    if(closest.dca < DCAcut && closest.dca != -99999){
+	    if(closest.dca < DCAcut && closest.dca != DBL_MIN){
 	      hPurityDCATotal[closest.thishit.tagger]->Fill(DCAcut);
 	      // hPurityDCATotal["All"]->Fill(DCAcut);
 	      
@@ -418,19 +418,19 @@ namespace icarus {
 		hEffDoLTotal[tagger]->Fill(DCAcut);
 		
 		// If closest hit is below limit and track matches any hits then fill efficiency
-		if(sin_angle < DCAcut && closest.dca != -99999){
+		if(sin_angle < DCAcut && closest.dca != DBL_MIN){
 		  hEffDoLReco[tagger]->Fill(DCAcut);
 		}
 	      }
 	      // Fill total efficiency histograms
 	      //  hEffDoLTotal["All"]->Fill(DCAcut);
-	      if(sin_angle < DCAcut && closest.dca != -99999){
+	      if(sin_angle < DCAcut && closest.dca != DBL_MIN){
 		// hEffDoLReco["All"]->Fill(DCAcut);
 	      }
 	    }
 	    
 	    // Fill total purity histogram with each cut if closest hit is below limit
-	    if(sin_angle < DCAcut && closest.dca != -99999){
+	    if(sin_angle < DCAcut && closest.dca != DBL_MIN){
 	      hPurityDoLTotal[closest.thishit.tagger]->Fill(DCAcut);
 	      // hPurityDoLTotal["All"]->Fill(DCAcut);
 	      

--- a/icaruscode/CRT/CRTT0Matching_module.cc
+++ b/icaruscode/CRT/CRTT0Matching_module.cc
@@ -332,7 +332,7 @@ namespace icarus {
 	  // std::vector <matchCand> closestvec = t0Alg.GetClosestCRTHit(detProp, *trackList[track_i], crtHits, event);
 	  // matchCand closest = closestvec.back();	  
 
-	  if(closest.dca >=0 ){
+	  if(closest.dca !=DBL_MIN ){
 	    mf::LogInfo("CRTT0Matching")
 	      <<"Matched time = "<<closest.t0<<" [us] to track "<<trackList[track_i]->ID()<<" with DCA = "<<closest.dca;
 	    T0col->push_back(anab::T0(closest.t0*1e3, trackList[track_i]->ID(),  closest.thishit.plane, (int)closest.extrapLen, closest.dca));
@@ -340,7 +340,7 @@ namespace icarus {
 	    
 	    //std::cout << "---------------------- line #156 "  << std::endl;
 	    double sin_angle = -99999;
-	    if(closest.dca != -99999){
+//	    if(closest.dca != -99999){
 	      auto start = trackList[track_i]->Vertex<TVector3>();
 	      //auto end   = trackList[track_i]->End<TVector3>();
 	      hDCA[closest.thishit.tagger]->Fill(closest.dca);
@@ -362,7 +362,7 @@ namespace icarus {
 	      fcrtz.push_back(closest.thishit.z_pos);
 	      // fCrtRegion.push_back(closest.thishit.tagger);
 	      fCrtRegion.push_back(fCrtutils->AuxDetRegionNameToNum(closest.thishit.tagger));	    
-	    }
+//	    }
 	      //find this CRThit in the collection
 	    // note this does not work (both the loop and the assoc !!)
 	    unsigned CRThitIndex = std::numeric_limits<unsigned>::max();


### PR DESCRIPTION
Replaces a now-faulty if statement to correctly search for the default value of DCA for the closest CRT Hit and skip if that default is found, which is a sign no match was found and thus will return null pointers that have caused seg faults.