### PR TITLE
GENIE event generator list set back to Default

### DIFF
--- a/fcl/gen/genie/genie_icarus_bnb.fcl
+++ b/fcl/gen/genie/genie_icarus_bnb.fcl
@@ -54,8 +54,7 @@ icarus_genie_BNB_base: {
 # TopVolume:            "volTPCActive"
 # TopVolume:            "volCryostat"
   BeamName:             "booster"
-  EventGeneratorList:   "Default+CCMEC+NCMEC"
-# EventGeneratorList:   "Default"
+  EventGeneratorList:   "Default"
 # FluxCopyMethod:       "IFDH"
   FluxSearchPaths:      "/pnfs/icarus/persistent/bnb_gsimple/fluxes_Oct2017/"
   FluxFiles:            ["converted_beammc_icarus_*.root"]


### PR DESCRIPTION
Tune (chosen with the UPS qualifier of `genie`, currently `G1810a0211a:e1000:k250`) in GENIE v3 includes MEC, and the old event list should not be used any more.

Many thanks to @mmrosenberg, @sjgardiner and Stephen Dolan for the support.