### PR TITLE
Update WC parameters to match ICARUS simulation configuration

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/params.jsonnet
@@ -86,7 +86,9 @@ base {
 
     elec: super.elec {
         type: "WarmElecResponse",
-        gain: 17.8075*wc.mV/wc.fC, // 0.027 fC/(ADC*us)
+        // gain: 17.8075*wc.mV/wc.fC, // 0.027 fC/(ADC*us)
+        // Set gain to (roughly) match data ADC values (docdb 25161)
+        gain: 14.9654*wc.mV/wc.fC, // 0.0321 fC/(ADC*us)
         shaping: 1.3*wc.us,
         postgain: 1.0,
         start: 0,

--- a/icaruscode/TPC/ICARUSWireCell/icarus/simparams.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/simparams.jsonnet
@@ -10,9 +10,9 @@ base {
     // Transverse diffusion constant
     DT :  8.8 * wc.cm2/wc.s,
     // Electron lifetime
-    lifetime : 9.6*wc.ms,
+    lifetime : 3.5*wc.ms,
     // Electron drift speed, assumes a certain applied E-field
-    drift_speed : 1.6*wc.mm/wc.us, // at 500 V/cm
+    drift_speed : 0.15756*wc.mm/wc.us, // at 500 V/cm
   },
   daq: super.daq {
 

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-omit-noise.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-omit-noise.jsonnet
@@ -152,10 +152,20 @@ local wcls_simchannel_sink = g.pnode({
     u_to_rp: 100 * wc.mm,
     v_to_rp: 100 * wc.mm,
     y_to_rp: 100 * wc.mm,
-    u_time_offset: 0.0 * wc.us,
-    v_time_offset: 0.0 * wc.us,
-    y_time_offset: 0.0 * wc.us,
-    g4_ref_time: -1150 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
+
+    // GP: The shaping time of the electronics response (2.2us) shifts the peak
+    //     of the field response time. Eyeballing simulation times, it does this
+    //     by a bit less than the 2.2us.
+    //
+    //     N.B. for future: there is likely an additional offset on the two induction
+    //     planes due to where the deconvolution precisely defines where the "peak"
+    //     of the pulse is. One may want to refine these parameters to account for that.
+    //     This perturbation shouldn't be more than a tick or two.
+    u_time_offset: 2.0 * wc.us,
+    v_time_offset: 2.0 * wc.us,
+    y_time_offset: 2.0 * wc.us,
+
+    g4_ref_time: -1500 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
     use_energy: true,
   },
 }, nin=1, nout=1, uses=tools.anodes);

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet
@@ -156,10 +156,20 @@ local wcls_simchannel_sink = g.pnode({
     u_to_rp: 100 * wc.mm,
     v_to_rp: 100 * wc.mm,
     y_to_rp: 100 * wc.mm,
-    u_time_offset: 0.0 * wc.us,
-    v_time_offset: 0.0 * wc.us,
-    y_time_offset: 0.0 * wc.us,
-    g4_ref_time: -1150 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
+
+    // GP: The shaping time of the electronics response (2.2us) shifts the peak
+    //     of the field response time. Eyeballing simulation times, it does this
+    //     by a bit less than the 2.2us.
+    //
+    //     N.B. for future: there is likely an additional offset on the two induction
+    //     planes due to where the deconvolution precisely defines where the "peak"
+    //     of the pulse is. One may want to refine these parameters to account for that.
+    //     This perturbation shouldn't be more than a tick or two.
+    u_time_offset: 2.0 * wc.us,
+    v_time_offset: 2.0 * wc.us,
+    y_time_offset: 2.0 * wc.us,
+
+    g4_ref_time: -1500 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
     use_energy: true,
   },
 }, nin=1, nout=1, uses=tools.anodes);

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-sim-drift-simchannel.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-sim-drift-simchannel.jsonnet
@@ -127,10 +127,20 @@ local wcls_simchannel_sink = g.pnode({
     u_to_rp: 100 * wc.mm,
     v_to_rp: 100 * wc.mm,
     y_to_rp: 100 * wc.mm,
-    u_time_offset: 0.0 * wc.us,
-    v_time_offset: 0.0 * wc.us,
-    y_time_offset: 0.0 * wc.us,
-    g4_ref_time: -1150 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
+
+    // GP: The shaping time of the electronics response (2.2us) shifts the peak
+    //     of the field response time. Eyeballing simulation times, it does this
+    //     by a bit less than the 2.2us.
+    //
+    //     N.B. for future: there is likely an additional offset on the two induction
+    //     planes due to where the deconvolution precisely defines where the "peak"
+    //     of the pulse is. One may want to refine these parameters to account for that.
+    //     This perturbation shouldn't be more than a tick or two.
+    u_time_offset: 2.0 * wc.us,
+    v_time_offset: 2.0 * wc.us,
+    y_time_offset: 2.0 * wc.us,
+
+    g4_ref_time: -1500 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
     use_energy: true,
   },
 }, nin=1, nout=1, uses=tools.anodes);


### PR DESCRIPTION
Updates a few parameters:

-G4RefTime is set to the correct value
-A delta to the "time_offsets"'s is added to account for electronics shaping time
-The gain is set to match data (see https://github.com/SBNSoftware/icaruscode/pull/356)
-The drift velocity is set to the more precise value found in data

