### PR TITLE
PMT baseline estimation added to Stage0

### DIFF
--- a/fcl/reco/Definitions/stage0_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs.fcl
@@ -95,6 +95,7 @@ icarus_stage0_producers:
   pmtthr:                         @local::icarus_pmtdiscriminatethr
   
   ### Optical hit finder
+  pmtbaselines:                   @local::icarus_opreco_pedestal_fromchannel_data  # from icarus_ophitfinder.fcl
   ophituncorrected:               @local::icarus_ophit_data
   ophit:                          @local::icarus_ophit_timing_correction
   ophitfulluncorrected:           @local::icarus_ophitdebugger_data
@@ -228,6 +229,7 @@ icarus_stage0_PMT:                  [ triggerconfig,
                                       daqPMT,
                                       pmtconfigbaselines,
                                       pmtthr,
+                                      pmtbaselines,
                                       ophituncorrected,
                                       ophit,
                                       opflashCryoE,

--- a/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
@@ -30,6 +30,7 @@ icarus_stage0_mc_producers:
 
     @table::icarus_standard_triggersim.producers  # from trigger_emulation_icarus.fcl
     
+    pmtbaselines:      @local::icarus_opreco_pedestal_fromchannel_MC  # from icarus_ophitfinder.fcl
     ophit:             @local::icarus_ophit_data
     mcophit:           @local::ICARUSMCOpHit
 
@@ -47,6 +48,7 @@ icarus_stage0_mc_trigger: [
 
 icarus_stage0_mc_PMT:  [
                          @sequence::icarus_stage0_mc_trigger,
+                         pmtbaselines,
                          ophit,
                          mcophit,
                          opflashCryoE,

--- a/icaruscode/PMT/OpReco/fcl/icarus_ophitfinder.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_ophitfinder.fcl
@@ -4,6 +4,59 @@ BEGIN_PROLOG
 # ==============================================================================
 #  Pedestal estimation algorithms
 # ==============================================================================
+icarus_opreco_pedestal_fromchannel_data: {
+  # this is not by itself a pedestal algorithm in the optical hit reconstruction
+  # mini-framework; it extracts the baseline from multiple waveforms on the same
+  # channel (which the mini-framework does not support) and writes the result in
+  # a data product; a heavily hacked pedestal algorithm in the mini-framework
+  # can plug the baselines from that data product into the hit reconstruction.
+  module_type: PMTWaveformBaselinesFromChannelData
+
+  # data configuration
+  OpticalWaveforms: daqPMT
+  PMTconfigurationTag: pmtconfig
+
+  # use half the pre-trigger buffer (ICARUS 2022 configuration: 750 samples)
+  PretriggerBufferFractionForBaseline: 0.5
+
+  # waveform on beam gate is the most likely to have signal from its start;
+  # systematically exclude it if there are enough other waveforms available:
+  ExcludeSpillTimeIfMoreThan: 8
+
+  AlgoParams: {
+    
+    # if a waveform has 4 or more samples farther than 5 RMS from the median,
+    # do not use it (still, RMS estimation is biassed by those samples too)
+    AcceptedSampleRangeRMS: 5.0
+    ExcessSampleLimit: 4
+    
+  }
+
+  PlotBaselines: false
+  
+} # icarus_opreco_pedestal_fromchannel_data
+
+icarus_opreco_pedestal_fromchannel_MC: {
+  # configuration to apply to the waveforms without PMT readout simulation
+  # (thus, very low threshold, which makes the algorithm more reliable)
+  @table::icarus_opreco_pedestal_fromchannel_data
+  
+  OpticalWaveforms: opdaq
+  PMTconfigurationTag: @erase
+  PretriggerBufferSize: 500 # samples: (ReadoutWindowSize x PreTrigFraction) from pmtsimulation_icarus.fcl, 
+  
+} # icarus_opreco_pedestal_fromchannel_MC
+
+icarus_opreco_pedestal_fromchannel_MC_readout: {
+  # configuration to apply to the waveforms with PMT readout simulation
+  # (very similar to data, but we don't make up the pmtconfig)
+  @table::icarus_opreco_pedestal_fromchannel_data
+  
+  PretriggerBufferSize: 1500 # samples, from PMT readout hardware configuration
+  
+} # icarus_opreco_pedestal_fromchannel_MC_readout
+
+
 icarus_opreco_pedestal_edges: {
   @table::standard_algo_pedestal_edges
   NumSampleFront:  3

--- a/icaruscode/PMT/extractpmtchannelbaseline_icarus.fcl
+++ b/icaruscode/PMT/extractpmtchannelbaseline_icarus.fcl
@@ -40,8 +40,8 @@
 
 # ------------------------------------------------------------------------------
 #include "services_common_icarus.fcl"
+#include "icarus_ophitfinder.fcl"
 #include "rootoutput_icarus.fcl"
-
 
 # ------------------------------------------------------------------------------
 process_name: PMTbline

--- a/icaruscode/PMT/extractpmtchannelbaseline_icarus.fcl
+++ b/icaruscode/PMT/extractpmtchannelbaseline_icarus.fcl
@@ -1,0 +1,83 @@
+#
+# File:    extractpmtchannelbaseline_icarus.fcl
+# Purpose: writes PMT waveform baseline into a data product.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    February 4, 2023
+#
+# This job configuration applies the `opdet::SharedWaveformBaseline` algorithm
+# to the input data, and stores the result into a data product.
+# 
+# The algorithm attempts to extract a common baseline from all the PMT waveforms
+# recorded on the same channel and event using the starting part of the
+# waveforms. More details are in the algorithm class documentation.
+# 
+# The job is set up for data-like waveforms, and in particular:
+#  * the input data product tag matches the standard one from ICARUS stage0
+#  * PMT readout configuration information is required
+# 
+# 
+# Input
+# ------
+# 
+# Standard Stage0 and decodePMT output files contain the needed information
+# (Stage1 files may not contain it any more!):
+# 
+# * `daqPMT` (`std::vector<raw::OpDetWaveform>`): the PMT recorded waveforms
+# * `pmtconfig` (`sbn::PMTConfiguration`, run data product): the PMT readout
+#     configuration settings
+# 
+# Output
+# -------
+# 
+# A replica out the input file, with in addition:
+#  * `std::vector<icarus::WaveformBaseline>` (`pmtbaselines`): baselines per channel
+#  * `std::vector<icarus::WaveformRMS>` (`pmtbaselines`): baseline RMS per channel
+# 
+# Baseline plots are produced in the `pmtbaselines` directory of the
+# supplemental ROOT file.
+#
+#
+
+# ------------------------------------------------------------------------------
+#include "services_common_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+
+
+# ------------------------------------------------------------------------------
+process_name: PMTbline
+
+
+# ------------------------------------------------------------------------------
+services: @local::icarus_minimum_services
+
+
+# ------------------------------------------------------------------------------
+physics: {
+  producers: {
+    pmtbaselines: {
+
+      @table::icarus_opreco_pedestal_fromchannel_data
+      
+      # enable plots
+      PlotBaselines: true
+      BaselineTimeAverage: 600.0 # seconds
+      
+    } # pmtbaselines
+  } # producers
+  
+  
+  reco:    [ pmtbaselines ]
+  
+  streams: [ rootoutput ]
+  
+} # physics
+
+
+# ------------------------------------------------------------------------------
+outputs.rootoutput: @local::icarus_rootoutput  # from rootoutput_icarus.fcl
+
+
+# ------------------------------------------------------------------------------
+outputs.rootoutput.outputCommands: [ "drop *", "keep *_*_*_PMTbline" ]
+
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
A standalone algorithm, not directly used (yet) for optical reconstruction, computes the PMT waveform baselines based on all the recorded activity on a channel during a  single event. It requires all waveforms to be available, so it needs to be run before they are dropped, i.e. during Stage0.
The algorithm was already in `icaruscode` (and PR #525 is moving it to `icarusalg`). It is described in [`icarus::PMTWaveformBaselinesFromChannelData` class documentation](https://icarus-exp.fnal.gov/at_work/software/doc/icaruscode/latest/classicarus_1_1PMTWaveformBaselinesFromChannelData.html).

This pull request queues the execution of this algorithm in `Stage0` (Run 2 only).
Unfortunately it's not a fast algorithm, but the 0.2 second/event it adds do not significantly impact the 100 s/event overall processing.

This is the `develop` pull request. A sibling one, #527, targets the production branch.

Reviewers:
* @SFBayLaser as the maintainer of the Stage0 queues
* @mvicenzi as a person informed on the PMT reconstruction
