### PR TITLE
ICARUS configurations for new tool-based interface for CAF selections.

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -277,6 +277,26 @@ caf_preprocess_sce_evtw_sequence: [@sequence::caf_preprocess_sce_sequence, rns, 
 # CAFMaker config
 cafmaker: @local::standard_cafmaker
 
+caf_prescaled_selection: {
+  tool_type: CAFSelectionBlinded
+  PreScale: 10
+  Extension: ".Prescaled.OKTOLOOK.root"
+}
+
+caf_blinded_selection: {
+  tool_type: CAFSelectionBlindEnergy
+  Extension: ".Blind.OKTOLOOK.root"
+}
+
+# setup the ICARUS blinding scheme
+cafmaker.SelectionTools: [
+  @local::caf_prescaled_selection,
+  @local::caf_blinded_selection
+]
+
+# set the base file extension to warn about blinding
+cafmaker.BaseFileExtension: ".Unblind.DONOTLOOK.root"
+
 # Set the labels to ICARUS
 cafmaker.PandoraTagSuffixes: ["CryoE", "CryoW"]
 cafmaker.G4Label: "largeant"

--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -288,10 +288,16 @@ caf_blinded_selection: {
   Extension: ".Blind.OKTOLOOK.root"
 }
 
+caf_3trk1proton_selection: {
+  tool_type: CAFSelectionNtrkNproton
+  Extension: ".3t1p.root"
+}
+
 # setup the ICARUS blinding scheme
 cafmaker.SelectionTools: [
   @local::caf_prescaled_selection,
-  @local::caf_blinded_selection
+  @local::caf_blinded_selection,
+  @local::caf_3trk1proton_selection
 ]
 
 # set the base file extension to warn about blinding

--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -48,5 +48,5 @@ physics:
 }
 
 # Blinding not needed for MC
-cafmaker.SelectionTools: []
-cafmaker.BaseFileExtension: ".root"
+physics.producers.cafmaker.SelectionTools: []
+physics.producers.cafmaker.BaseFileExtension: ".root"

--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -48,4 +48,5 @@ physics:
 }
 
 # Blinding not needed for MC
-physics.producers.cafmaker.CreateBlindedCAF: false
+cafmaker.SelectionTools: []
+cafmaker.BaseFileExtension: ".root"


### PR DESCRIPTION
Note -- this is not needed for the upcoming MCP. Depends on https://github.com/SBNSoftware/sbncode/pull/336.