### PR TITLE
Speed optimisation for `GnocchiCalorimetry` tools

### DIFF
--- a/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
+++ b/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
@@ -82,7 +82,7 @@ private:
   std::map<uint64_t, ScaleInfo> fScaleInfos;
 
   // Helpers
-  const ScaleInfo GetScaleInfo(uint64_t timestamp);
+  const ScaleInfo& GetScaleInfo(uint64_t timestamp);
 };
 
 DEFINE_ART_CLASS_TOOL(NormalizeYZSQL)
@@ -153,7 +153,7 @@ icarus::calo::NormalizeYZSQL::NormalizeYZSQL(fhicl::ParameterSet const &pset):
 
 void icarus::calo::NormalizeYZSQL::configure(const fhicl::ParameterSet& pset) {}
 
-const icarus::calo::NormalizeYZSQL::ScaleInfo icarus::calo::NormalizeYZSQL::GetScaleInfo(uint64_t timestamp) {
+const icarus::calo::NormalizeYZSQL::ScaleInfo& icarus::calo::NormalizeYZSQL::GetScaleInfo(uint64_t timestamp) {
   // check the cache
   if (fScaleInfos.count(timestamp)) {
     return fScaleInfos.at(timestamp);
@@ -207,16 +207,14 @@ const icarus::calo::NormalizeYZSQL::ScaleInfo icarus::calo::NormalizeYZSQL::GetS
   std::sort(thisscale.bins.begin(), thisscale.bins.end());
 
   // Set the cache
-  fScaleInfos[timestamp] = thisscale;
+  return fScaleInfos[timestamp] = std::move(thisscale);
 
-  return thisscale;
 }
 
 double icarus::calo::NormalizeYZSQL::Normalize(double dQdx, const art::Event &e, 
     const recob::Hit &hit, const geo::Point_t &location, const geo::Vector_t &direction, double t0) {
   // Get the info
-  ScaleInfo i = GetScaleInfo(e.time().timeHigh());
-
+  ScaleInfo const& i = GetScaleInfo(e.time().timeHigh());
 
   // compute itpc
   int cryo = hit.WireID().Cryostat;


### PR DESCRIPTION
I propose here three optimisations to speed up the normalising tools used in `GnocchiCalorimetry` module (copy setup data only once per event, avoid data structure copies, use faster lookup algorithm).
One of the three optimisations requires an interface change, which is the subject of pull request LArSoft/larreco#54 to `larana`.
The bottlenecks have been identified with ForgeTools Map profiler.

Overall in my test I observe a conspicuous speedup (larger than ×20), with an event being processed in 0.15" (compared to 5" before the changes). This makes a big difference in a workflow I am running.

I haven't provided a branch for production. If this is needed, a patch release of `larreco` will also be needed, unless we give up the optimisation that requires it or a different approach is used (possible, but less elegant).

Testing
------------

I have tested the two more complicate optimisations by running a version of both codes at the same time and comparing the result (exception thrown if discrepant). I tested that on 50 data events from run `8650`.


Reviewers
-----------------

* @gputnam: original author of the code
