### PR TITLE
Setting CRTSimT0Offset to 1.6ms in MC CAFMaker

### DIFF
--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -6,6 +6,7 @@
 #include "backtrackerservice.fcl"
 #include "photonbacktrackerservice.fcl"
 #include "mccheatermodules.fcl"
+#include "crtsimmodules_icarus.fcl"
 
 #include "cafmaker_defs.fcl"
 
@@ -50,6 +51,6 @@ physics:
 # MCT0Offset for MC ()
 # ref1 : https://github.com/SBNSoftware/icaruscode/blob/v09_37_02_01/icaruscode/CRT/crtsimmodules_icarus.fcl#L11
 # ref2 : https://github.com/SBNSoftware/icaruscode/blob/v09_64_01/icaruscode/CRT/crttruehitproducer.fcl#L8
-physics.producers.cafmaker.CRTSimT0Offset: 1600000
+physics.producers.cafmaker.CRTSimT0Offset: @local::standard_icarus_crtsimalg.GlobalT0Offset
 # Blinding not needed for MC
 physics.producers.cafmaker.CreateBlindedCAF: false

--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -47,5 +47,9 @@ physics:
   end_paths:     [ stream1 ]
 }
 
+# MCT0Offset for MC ()
+# ref1 : https://github.com/SBNSoftware/icaruscode/blob/v09_37_02_01/icaruscode/CRT/crtsimmodules_icarus.fcl#L11
+# ref2 : https://github.com/SBNSoftware/icaruscode/blob/v09_64_01/icaruscode/CRT/crttruehitproducer.fcl#L8
+physics.producers.cafmaker.CRTSimT0Offset: 1600000
 # Blinding not needed for MC
 physics.producers.cafmaker.CreateBlindedCAF: false


### PR DESCRIPTION
This feature was introduced in https://github.com/SBNSoftware/icaruscode/pull/384 to [release/SBN2022A](https://github.com/SBNSoftware/icaruscode/tree/release/SBN2022A), but never been propagated to develop branch. This is to incorporate with the intrinsic "shift" in CRT simhit timimgs; They all starts from "0", but those zeros represents -1.6ms before the beam gate. I put two references where this value is defined.