### PR TITLE
Generation Configurations for ALP model in ICARUS

### DIFF
--- a/fcl/gen/mevprtl/CMakeLists.txt
+++ b/fcl/gen/mevprtl/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(higgs)
 add_subdirectory(hnl)
+add_subdirectory(alp)
+

--- a/fcl/gen/mevprtl/alp/CMakeLists.txt
+++ b/fcl/gen/mevprtl/alp/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()

--- a/fcl/gen/mevprtl/alp/alp_corsika_p_gen_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_corsika_p_gen_icarus.fcl
@@ -1,0 +1,6 @@
+#include "corsika_icarus.fcl"
+#include "alp_gen_icarus.fcl"
+
+physics.producers.cosmgen: @local::icarus_corsika_p
+physics.runprod: [@sequence::physics.runprod, cosmgen]
+

--- a/fcl/gen/mevprtl/alp/alp_em_gen_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_em_gen_icarus.fcl
@@ -1,0 +1,42 @@
+#include "alp.fcl"
+# service configuration
+#
+#include "services_icarus_simulation.fcl"
+
+
+process_name: ALPTree
+
+services:
+{
+  @table::icarus_basic_services
+  TFileService: { fileName: "alp_icarus.root" }
+  IFDH: {}
+}
+
+source: {
+  module_type: EmptyEvent
+}
+
+physics:
+{
+  producers: {
+    alp: @local::alp
+  }
+ 
+  ana:  [ alp ]
+ 
+  trigger_paths: [ana] 
+  end_paths:     [ ] 
+  
+} # physics
+
+# Set muon coupling to 0
+physics.producers.alp.Flux.cAl: 0
+physics.producers.alp.Decay.ReferenceALPcAl: 0
+physics.producers.alp.Decay.AllowEMDecay: true
+
+# Make art ROOT file
+physics.producers.alp.Produce: true
+physics.producers.alp.AnaOutput: false
+
+services.NuRandomService.policy: "random"

--- a/fcl/gen/mevprtl/alp/alp_em_gen_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_em_gen_icarus.fcl
@@ -8,22 +8,28 @@ process_name: ALPTree
 
 services:
 {
-  @table::icarus_basic_services
+  @table::icarus_simulation_services
   TFileService: { fileName: "alp_icarus.root" }
   IFDH: {}
 }
 
 source: {
-  module_type: EmptyEvent
+  module_type: "EmptyEvent"
+  firstEvent: 1
+  firstRun: 1
+  timestampPlugin: {
+    plugin_type: "GeneratedEventTimestamp"
+  }
 }
 
 physics:
 {
   producers: {
     generator: @local::alp
+    rns:       { module_type: "RandomNumberSaver" }
   }
  
-  gen:  [ generator ]
+  gen:  [ generator, rns]
   stream: [out]
  
   trigger_paths: [gen] 

--- a/fcl/gen/mevprtl/alp/alp_em_tree_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_em_tree_icarus.fcl
@@ -1,0 +1,38 @@
+#include "alp.fcl"
+# service configuration
+#
+#include "services_icarus_simulation.fcl"
+
+
+process_name: ALPTree
+
+services:
+{
+  @table::icarus_basic_services
+  TFileService: { fileName: "alp_icarus.root" }
+  IFDH: {}
+}
+
+source: {
+  module_type: EmptyEvent
+}
+
+physics:
+{
+  producers: {
+    alp: @local::alp
+  }
+ 
+  ana:  [ alp ]
+ 
+  trigger_paths: [ana] 
+  end_paths:     [ ] 
+  
+} # physics
+
+# Set muon coupling to 0
+physics.producers.alp.Flux.cAl: 0
+physics.producers.alp.Decay.ReferenceALPcAl: 0
+physics.producers.alp.Decay.AllowEMDecay: true
+
+services.NuRandomService.policy: "random"

--- a/fcl/gen/mevprtl/alp/alp_gen_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_gen_icarus.fcl
@@ -8,25 +8,31 @@ process_name: ALPTree
 
 services:
 {
-  @table::icarus_basic_services
+  @table::icarus_simulation_services
   TFileService: { fileName: "alp_icarus.root" }
   IFDH: {}
 }
 
 source: {
-  module_type: EmptyEvent
+  module_type: "EmptyEvent"
+  firstEvent: 1
+  firstRun: 1
+  timestampPlugin: {
+    plugin_type: "GeneratedEventTimestamp"
+  }
 }
 
 physics:
 {
   producers: {
     generator: @local::alp
+    rns:       { module_type: "RandomNumberSaver" }
   }
  
-  gen:  [ generator ]
+  runprod:  [ generator, rns]
   stream: [out]
  
-  trigger_paths: [gen] 
+  trigger_paths: [runprod] 
   end_paths:     [stream] 
   
 } # physics

--- a/fcl/gen/mevprtl/alp/alp_gen_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_gen_icarus.fcl
@@ -44,12 +44,6 @@ outputs: {
 
 outputs.out.fileName: "simulation_higgs_icarus_numi_%tc-%p.root"
 
-
-# Set muon coupling to 0
-physics.producers.generator.Flux.cAl: 0
-physics.producers.generator.Decay.ReferenceALPcAl: 0
-physics.producers.generator.Decay.AllowEMDecay: true
-
 # Make art ROOT file
 physics.producers.generator.Produce: true
 physics.producers.generator.AnaOutput: false

--- a/fcl/gen/mevprtl/alp/alp_gen_icarus_M300.fcl
+++ b/fcl/gen/mevprtl/alp/alp_gen_icarus_M300.fcl
@@ -1,0 +1,4 @@
+#include "alp_corsika_p_gen_icarus.fcl"
+
+alpM: 0.3
+#include "set_alpM.fcl"

--- a/fcl/gen/mevprtl/alp/alp_gen_icarus_M500.fcl
+++ b/fcl/gen/mevprtl/alp/alp_gen_icarus_M500.fcl
@@ -1,0 +1,4 @@
+#include "alp_corsika_p_gen_icarus.fcl"
+
+alpM: 0.5
+#include "set_alpM.fcl"

--- a/fcl/gen/mevprtl/alp/alp_gen_icarus_M600.fcl
+++ b/fcl/gen/mevprtl/alp/alp_gen_icarus_M600.fcl
@@ -1,0 +1,6 @@
+#include "alp_corsika_p_gen_icarus.fcl"
+
+alpM: 0.6
+#include "set_alpM.fcl"
+alpfa: 1e6
+#include "set_alpfa.fcl"

--- a/fcl/gen/mevprtl/alp/alp_gen_icarus_M700.fcl
+++ b/fcl/gen/mevprtl/alp/alp_gen_icarus_M700.fcl
@@ -1,0 +1,6 @@
+#include "alp_corsika_p_gen_icarus.fcl"
+
+alpM: 0.7
+#include "set_alpM.fcl"
+alpfa: 1e6
+#include "set_alpfa.fcl"

--- a/fcl/gen/mevprtl/alp/alp_tree_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_tree_icarus.fcl
@@ -20,10 +20,10 @@ source: {
 physics:
 {
   producers: {
-    alp: @local::alp
+    generator: @local::alp
   }
  
-  ana:  [ alp ]
+  ana:  [ generator ]
  
   trigger_paths: [ana] 
   end_paths:     [ ] 

--- a/fcl/gen/mevprtl/alp/alp_tree_icarus.fcl
+++ b/fcl/gen/mevprtl/alp/alp_tree_icarus.fcl
@@ -1,0 +1,33 @@
+#include "alp.fcl"
+# service configuration
+#
+#include "services_icarus_simulation.fcl"
+
+
+process_name: ALPTree
+
+services:
+{
+  @table::icarus_basic_services
+  TFileService: { fileName: "alp_icarus.root" }
+  IFDH: {}
+}
+
+source: {
+  module_type: EmptyEvent
+}
+
+physics:
+{
+  producers: {
+    alp: @local::alp
+  }
+ 
+  ana:  [ alp ]
+ 
+  trigger_paths: [ana] 
+  end_paths:     [ ] 
+  
+} # physics
+
+services.NuRandomService.policy: "random"

--- a/fcl/gen/mevprtl/alp/alp_tree_icarus_M300.fcl
+++ b/fcl/gen/mevprtl/alp/alp_tree_icarus_M300.fcl
@@ -1,0 +1,4 @@
+#include "alp_tree_icarus.fcl"
+
+alpM: 0.3
+#include "set_alpM.fcl"

--- a/fcl/gen/mevprtl/alp/alp_tree_icarus_M500.fcl
+++ b/fcl/gen/mevprtl/alp/alp_tree_icarus_M500.fcl
@@ -1,0 +1,4 @@
+#include "alp_tree_icarus.fcl"
+
+alpM: 0.5
+#include "set_alpM.fcl"

--- a/fcl/gen/mevprtl/alp/alp_tree_icarus_M600.fcl
+++ b/fcl/gen/mevprtl/alp/alp_tree_icarus_M600.fcl
@@ -1,0 +1,4 @@
+#include "alp_tree_icarus.fcl"
+
+alpM: 0.6
+#include "set_alpM.fcl"

--- a/fcl/gen/mevprtl/alp/alp_tree_icarus_M700.fcl
+++ b/fcl/gen/mevprtl/alp/alp_tree_icarus_M700.fcl
@@ -1,0 +1,4 @@
+#include "alp_tree_icarus.fcl"
+
+alpM: 0.7
+#include "set_alpM.fcl"

--- a/fcl/gen/mevprtl/hnl/hnl_tau_tree_icarus.fcl
+++ b/fcl/gen/mevprtl/hnl/hnl_tau_tree_icarus.fcl
@@ -1,0 +1,33 @@
+#include "hnl.fcl"
+# service configuration
+#
+#include "services_icarus_simulation.fcl"
+
+
+process_name: HNLTree
+
+services:
+{
+  @table::icarus_basic_services
+  TFileService: { fileName: "hnl_icarus.root" }
+  IFDH: {}
+}
+
+source: {
+  module_type: EmptyEvent
+}
+
+physics:
+{
+  producers: {
+    hnl: @local::hnl_tau
+  }
+ 
+  ana:  [ hnl ]
+ 
+  trigger_paths: [ana] 
+  end_paths:     [ ] 
+  
+} # physics
+
+services.NuRandomService.policy: "random"


### PR DESCRIPTION
Depends on https://github.com/SBNSoftware/sbncode/pull/339.

This PR provides configurations to generate ALP and HNL decaysin ICARUS MC enabled by the corresponding update to sbncode.

NOTE: this is not needed for the upcoming MCP. It is intended to be merged once the corresponding sbncode PR is merged.