### PR TITLE
Feature/howard duplicate hit filter tool v09 67

### DIFF
--- a/icaruscode/TPC/Tracking/ICARUSPandora/CMakeLists.txt
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/CMakeLists.txt
@@ -2,37 +2,12 @@
 # where should the scripts/..xml file be installed?  Perhaps in bin?
 
 set( TOOL_LIBRARIES
-	larpandora::LArPandora
-	larpandora::GeometryComponents
-	larpandoracontent::LArPandoraContent
-	lardata::AssociationUtil
-	lardata::Utilities
-	lardataobj::AnalysisBase
+	larpandora::LArPandoraInterface
 	lardataobj::RecoBase
-	lardataobj::Simulation
-	larcoreobj::SimpleTypesAndConstants
-	nusimdata::SimulationBase
-	art::Persistency_Common
 	canvas::canvas
-	PandoraPFA::PandoraSDK
-	larpandora::GetDetectorType
-	larreco::ClusterFinder
-	larreco::ClusterParamsImportWrapper
-	larreco::RecoAlg_ClusterRecoUtil
-	larevt::ChannelStatusProvider
-	larevt::ChannelStatusService
-	larsim::MCCheater_ParticleInventoryService_service
-	lardata::DetectorClocksService
-	lardata::DetectorPropertiesService
-	larcore::Geometry_Geometry_service
-	larcorealg::Geometry
-	art_root_io::TFileService_service
 	art::Framework_Principal
-	art::Framework_Services_Registry
 	messagefacility::MF_MessageLogger
 	cetlib::cetlib
-	cetlib_except::cetlib_except
-	PandoraPFA::PandoraSDK
 )
 
 cet_build_plugin(LArPandoraHitCollectionToolICARUS art::tool LIBRARIES ${TOOL_LIBRARIES})

--- a/icaruscode/TPC/Tracking/ICARUSPandora/CMakeLists.txt
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/CMakeLists.txt
@@ -1,7 +1,44 @@
 
 # where should the scripts/..xml file be installed?  Perhaps in bin?
 
+set( TOOL_LIBRARIES
+	larpandora::LArPandora
+	larpandora::GeometryComponents
+	larpandoracontent::LArPandoraContent
+	lardata::AssociationUtil
+	lardata::Utilities
+	lardataobj::AnalysisBase
+	lardataobj::RecoBase
+	lardataobj::Simulation
+	larcoreobj::SimpleTypesAndConstants
+	nusimdata::SimulationBase
+	art::Persistency_Common
+	canvas::canvas
+	PandoraPFA::PandoraSDK
+	larpandora::GetDetectorType
+	larreco::ClusterFinder
+	larreco::ClusterParamsImportWrapper
+	larreco::RecoAlg_ClusterRecoUtil
+	larevt::ChannelStatusProvider
+	larevt::ChannelStatusService
+	larsim::MCCheater_ParticleInventoryService_service
+	lardata::DetectorClocksService
+	lardata::DetectorPropertiesService
+	larcore::Geometry_Geometry_service
+	larcorealg::Geometry
+	art_root_io::TFileService_service
+	art::Framework_Principal
+	art::Framework_Services_Registry
+	messagefacility::MF_MessageLogger
+	cetlib::cetlib
+	cetlib_except::cetlib_except
+	PandoraPFA::PandoraSDK
+)
+
+cet_build_plugin(LArPandoraHitCollectionToolICARUS art::tool LIBRARIES ${TOOL_LIBRARIES})
+
 install_fhicl()
+install_source()
 
 add_subdirectory(scripts)
 

--- a/icaruscode/TPC/Tracking/ICARUSPandora/LArPandoraHitCollectionToolICARUS_tool.cc
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/LArPandoraHitCollectionToolICARUS_tool.cc
@@ -43,8 +43,7 @@ namespace lar_pandora {
 
     for (unsigned int i = 0; i < theHits->size(); ++i) {
       const art::Ptr<recob::Hit> hit(theHits, i);
-      if ( channelTimeHits.find(std::make_pair(hit->Channel(), int(hit->PeakTime()))) == channelTimeHits.end() ) channelTimeHits[std::make_pair(hit->Channel(), int(hit->PeakTime()))] = 1;
-      else continue;
+      if ( std::exchange( channelTimeHits[std::make_pair(hit->Channel(),int(hit->PeakTime()))], 1 ) ) continue;
       hitVector.push_back(hit);
     }
 

--- a/icaruscode/TPC/Tracking/ICARUSPandora/LArPandoraHitCollectionToolICARUS_tool.cc
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/LArPandoraHitCollectionToolICARUS_tool.cc
@@ -1,0 +1,56 @@
+/**
+ *  @file  larpandora/LArPandoraInterface/Tools/LArPandoraHitCollectionToolICARUS_tool.cc
+ * 
+ *  @brief Define class for hit collection tools and implements ICARUS tool, with a duplication filter
+ * 
+ */
+
+#include "art/Utilities/ToolMacros.h"
+
+#include "larpandora/LArPandoraInterface/LArPandoraHitCollectionTool.h"
+
+#include "art/Framework/Principal/Event.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include <map>
+
+namespace HitCollectionTools {
+
+  class LArPandoraHitCollectionToolICARUS : public HitCollectionTool
+  {
+  public:
+    explicit LArPandoraHitCollectionToolICARUS(const fhicl::ParameterSet& pset);
+    void CollectHits(const art::Event& evt, const std::string& label, lar_pandora::HitVector& hitVector) override;
+  };
+
+  LArPandoraHitCollectionToolICARUS::LArPandoraHitCollectionToolICARUS(const fhicl::ParameterSet& pset){}
+
+  void LArPandoraHitCollectionToolICARUS::CollectHits(const art::Event& evt, const std::string& label, lar_pandora::HitVector& hitVector)
+  {
+    std::map< std::pair<raw::ChannelID_t, int>, unsigned int > channelTimeHits; // converting the float PeakTime to int for the second item in pair
+
+    art::Handle<std::vector<recob::Hit>> theHits;
+    evt.getByLabel(label, theHits);
+
+    if (!theHits.isValid()) {
+      mf::LogDebug("LArPandoraHitCollectionToolICARUS") << "  Failed to find hits... " << std::endl;
+      return;
+    }
+    else {
+      mf::LogDebug("LArPandoraHitCollectionToolICARUS") << "  Found: " << theHits->size() << " Hits " << std::endl;
+    }
+
+    for (unsigned int i = 0; i < theHits->size(); ++i) {
+      const art::Ptr<recob::Hit> hit(theHits, i);
+      if ( channelTimeHits.find(std::make_pair(hit->Channel(), int(hit->PeakTime()))) == channelTimeHits.end() ) channelTimeHits[std::make_pair(hit->Channel(), int(hit->PeakTime()))] = 1;
+      else continue;
+      hitVector.push_back(hit);
+    }
+
+    mf::LogDebug("LArPandoraHitCollectionToolICARUS") << "  Passing along " << hitVector.size() << " Hits " << std::endl;
+  }
+
+} // namespace HitCollectionTools
+
+DEFINE_ART_CLASS_TOOL(HitCollectionTools::LArPandoraHitCollectionToolICARUS)

--- a/icaruscode/TPC/Tracking/ICARUSPandora/LArPandoraHitCollectionToolICARUS_tool.cc
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/LArPandoraHitCollectionToolICARUS_tool.cc
@@ -15,18 +15,18 @@
 
 #include <map>
 
-namespace HitCollectionTools {
+namespace lar_pandora {
 
-  class LArPandoraHitCollectionToolICARUS : public HitCollectionTool
+  class LArPandoraHitCollectionToolICARUS : public IHitCollectionTool
   {
   public:
     explicit LArPandoraHitCollectionToolICARUS(const fhicl::ParameterSet& pset);
-    void CollectHits(const art::Event& evt, const std::string& label, lar_pandora::HitVector& hitVector) override;
+    void CollectHits(const art::Event& evt, const std::string& label, HitVector& hitVector) override;
   };
 
   LArPandoraHitCollectionToolICARUS::LArPandoraHitCollectionToolICARUS(const fhicl::ParameterSet& pset){}
 
-  void LArPandoraHitCollectionToolICARUS::CollectHits(const art::Event& evt, const std::string& label, lar_pandora::HitVector& hitVector)
+  void LArPandoraHitCollectionToolICARUS::CollectHits(const art::Event& evt, const std::string& label, HitVector& hitVector)
   {
     std::map< std::pair<raw::ChannelID_t, int>, unsigned int > channelTimeHits; // converting the float PeakTime to int for the second item in pair
 
@@ -51,6 +51,6 @@ namespace HitCollectionTools {
     mf::LogDebug("LArPandoraHitCollectionToolICARUS") << "  Passing along " << hitVector.size() << " Hits " << std::endl;
   }
 
-} // namespace HitCollectionTools
+} // namespace lar_pandora
 
-DEFINE_ART_CLASS_TOOL(HitCollectionTools::LArPandoraHitCollectionToolICARUS)
+DEFINE_ART_CLASS_TOOL(lar_pandora::LArPandoraHitCollectionToolICARUS)

--- a/icaruscode/TPC/Tracking/ICARUSPandora/pandoramodules_icarus.fcl
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/pandoramodules_icarus.fcl
@@ -19,6 +19,7 @@ icarus_basicpandora:
     ShouldRunCosmicRecoOption:                   false
     ShouldPerformSliceId:                        false
     PrintOverallRecoStatus:                      false
+    HitCollectionTool:                           { tool_type: LArPandoraHitCollectionToolICARUS }
 }
 
 icarus_pandora:                                  @local::icarus_basicpandora


### PR DESCRIPTION
Depends on https://github.com/PandoraPFA/larpandora/pull/28

This adds to icaruscode an alternative HitCollection algorithm, as an art tool, that we can use with pandora to try to avoid it getting passed two copies of some of the hits from Cluster3D.

In addition to just generally liking that people have eyes on the code to make sure they don't spot issues, I have a few questions:

1. I'm not super familiar with, let's say, the "right" way to put together the cet stuff in CMakeLists to get the code to build. This code at least builds but may well be bringing in libraries it doesn't need or doing something else impractical or even unwanted. Is there guidance on this or is what's here seemingly ok?

2. I realized that the tool uses a few things which aren't expressly `#include`d like `fhicl::ParameterSet` or `lar_pandora::HitVector`, for examples. The latter should be included via `LArPandoraHitCollectionTool.h` bringing in `LArPandoraHelper.h`. Not sure off-hand where `ParameterSet` is brought in from the way it is now. Is it preferred that I explicitly add includes for `LArPandoraHelper.h` and `ParameterSet.h`?