### PR TITLE
Processing for trigger efficiency and related changes to trigger efficiency analysis

### DIFF
--- a/fcl/reco/Definitions/stage1_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage1_icarus_defs.fcl
@@ -61,6 +61,8 @@ icarus_stage1_producers:
  ## crt producer
   crttrack:          @local::standard_crttrackproducer
   CRTT0Matching:     @local::standard_crtt0producer
+  CRTT0MatchingW:    @local::standard_crtt0producerW
+  CRTT0MatchingE:    @local::standard_crtt0producerE
 }
 
 icarus_stage1_filters:
@@ -165,6 +167,8 @@ icarus_reco_fm:                    [ fmatchCryoE,
 icarus_crttrack:                   [crttrack]
 
 icarus_crtt0match:                 [CRTT0Matching]
+
+icarus_crtt0match_eff:		   [CRTT0MatchingE, CRTT0MatchingW]
 
 ### Below we include overrides for the modules above
 

--- a/fcl/reco/Definitions/stage1_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage1_icarus_defs.fcl
@@ -168,7 +168,7 @@ icarus_crttrack:                   [crttrack]
 
 icarus_crtt0match:                 [CRTT0Matching]
 
-icarus_crtt0match_eff:		   [CRTT0MatchingE, CRTT0MatchingW]
+icarus_crtt0match_eff:             [CRTT0MatchingE, CRTT0MatchingW]
 
 ### Below we include overrides for the modules above
 

--- a/fcl/reco/Stage1/Run2/trigger_eff_stage1_icarus.fcl
+++ b/fcl/reco/Stage1/Run2/trigger_eff_stage1_icarus.fcl
@@ -1,0 +1,63 @@
+#include "stage1_icarus_driver_common.fcl"
+
+process_name: stage1
+
+physics.reco: [ flashfilter,
+                @sequence::icarus_filter_cluster3D,
+                @sequence::icarus_pandora_Gauss,
+                @sequence::icarus_reco_fm,
+                @sequence::icarus_crttrack,
+                @sequence::icarus_crtt0match_eff,
+                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
+
+physics.outana:            [ @sequence::icarus_analysis_modules ]
+physics.trigger_paths:     [ reco ]
+physics.end_paths:         [ outana, stream1 ]
+outputs.out1.fileName:     "%ifb_%tc-%p.root"
+outputs.out1.dataTier:     "reconstructed"
+outputs.out1.SelectEvents: [ reco ]
+outputs.out1.outputCommands: [
+  "keep *_*_*_*",
+  "drop *_caloskimCalorimetryCryoE_*_*",
+  "drop *_caloskimCalorimetryCryoW_*_*"
+]
+
+# Disabled Space-Charge service for calorimetry
+services.SpaceChargeService: {
+    EnableCalEfieldSCE: false
+    EnableCalSpatialSCE: false
+    EnableCorrSCE: false
+    EnableSimEfieldSCE: false
+    EnableSimSpatialSCE: false
+    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
+    RepresentationType: "Voxelized_TH3"
+    service_provider: "SpaceChargeServiceICARUS"
+}
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "DEBUG"     #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       Cluster3DICARUS:
+       {
+         limit: 5
+         reportEvery: 1
+       }
+       SnippetHit3D:
+       {
+         limit: 5
+         reportEvery: 1
+       }
+       default:
+       {
+         limit: 0  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 0
+       }
+     }
+  }
+}
+

--- a/fcl/reco/Stage1/Run2/trigger_eff_stage1_icarus.fcl
+++ b/fcl/reco/Stage1/Run2/trigger_eff_stage1_icarus.fcl
@@ -1,63 +1,7 @@
-#include "stage1_icarus_driver_common.fcl"
+#include "stage1_run2_icarus.fcl"
 
-process_name: stage1
+# neuter the CRT/TPC matching module already scheduled
+physics.producers.CRTT0Matching.module_type: DummyProducer
 
-physics.reco: [ flashfilter,
-                @sequence::icarus_filter_cluster3D,
-                @sequence::icarus_pandora_Gauss,
-                @sequence::icarus_reco_fm,
-                @sequence::icarus_crttrack,
-                @sequence::icarus_crtt0match_eff,
-                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
-
-physics.outana:            [ @sequence::icarus_analysis_modules ]
-physics.trigger_paths:     [ reco ]
-physics.end_paths:         [ outana, stream1 ]
-outputs.out1.fileName:     "%ifb_%tc-%p.root"
-outputs.out1.dataTier:     "reconstructed"
-outputs.out1.SelectEvents: [ reco ]
-outputs.out1.outputCommands: [
-  "keep *_*_*_*",
-  "drop *_caloskimCalorimetryCryoE_*_*",
-  "drop *_caloskimCalorimetryCryoW_*_*"
-]
-
-# Disabled Space-Charge service for calorimetry
-services.SpaceChargeService: {
-    EnableCalEfieldSCE: false
-    EnableCalSpatialSCE: false
-    EnableCorrSCE: false
-    EnableSimEfieldSCE: false
-    EnableSimSpatialSCE: false
-    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
-    RepresentationType: "Voxelized_TH3"
-    service_provider: "SpaceChargeServiceICARUS"
-}
-
-services.message.destinations :
-{
-  STDCOUT:
-  {
-     type:      "cout"      #tells the message service to output this destination to cout
-     threshold: "DEBUG"     #tells the message service that this destination applies to WARNING and higher level messages
-     categories:
-     {
-       Cluster3DICARUS:
-       {
-         limit: 5
-         reportEvery: 1
-       }
-       SnippetHit3D:
-       {
-         limit: 5
-         reportEvery: 1
-       }
-       default:
-       {
-         limit: 0  #don't print anything at the infomsg level except the explicitly named categories
-         reportEvery: 0
-       }
-     }
-  }
-}
-
+# add a cryostat-split configuration
+physics.reco: [ @sequence::physics.reco, @sequence::icarus_crtt0match_eff ]

--- a/icaruscode/Analysis/trigger/ArtObjects/CMakeLists.txt
+++ b/icaruscode/Analysis/trigger/ArtObjects/CMakeLists.txt
@@ -1,0 +1,9 @@
+build_dictionary(
+  DICTIONARY_LIBRARIES
+    lardataobj::RecoBase
+    lardataobj::Simulation
+    canvas::canvas
+)
+
+install_headers()
+install_source()

--- a/icaruscode/Analysis/trigger/ArtObjects/TrackTreeStoreObj.h
+++ b/icaruscode/Analysis/trigger/ArtObjects/TrackTreeStoreObj.h
@@ -1,0 +1,117 @@
+#ifndef SBN_TRACKTREESTOREOBJ_H
+#define SBN_TRACKTREESTOREOBJ_H
+
+#include "cstdint" // std::uint64_t
+#include <limits>
+
+namespace sbn {
+
+  /**
+   * 
+   * Middle point is cutting the track in two chunks with the same length.
+   * 
+   * The part "before" the cathode is always the one at lower _x_ coordinates
+   * than the cathode itself.
+   * 
+   */
+  struct selTrackInfo {
+    static constexpr float NoPosition = -999999.0;
+    
+    int trackID = -1;
+    float t0 = NoPosition;
+    float start_x = NoPosition;
+    float start_y = NoPosition;
+    float start_z = NoPosition;
+    float end_x = NoPosition;
+    float end_y = NoPosition;
+    float end_z = NoPosition;
+    float middle_x = NoPosition; ///< Half-way distance along the trajectory.
+    float middle_y = NoPosition; ///< Half-way distance along the trajectory.
+    float middle_z = NoPosition; ///< Half-way distance along the trajectory.
+    float atcathode_x = NoPosition; ///< Cathode crossing point of trajectory.
+    float atcathode_y = NoPosition; ///< Cathode crossing point of trajectory.
+    float atcathode_z = NoPosition; ///< Cathode crossing point of trajectory.
+    float midbeforecathode_x = NoPosition; ///< Midpoint of subpath before cathode.
+    float midbeforecathode_y = NoPosition; ///< Midpoint of subpath before cathode.
+    float midbeforecathode_z = NoPosition; ///< Midpoint of subpath before cathode.
+    float midaftercathode_x = NoPosition; ///< Midpoint of subpath after cathode.
+    float midaftercathode_y = NoPosition; ///< Midpoint of subpath after cathode.
+    float midaftercathode_z = NoPosition; ///< Midpoint of subpath after cathode.
+    float beforecathode = -1; ///< Track path length before cathode (lower _x_).
+    float aftercathode = -1; ///< Track path length before cathode (higher _x_).
+    float length = -1.0;
+    float energy = NoPosition;
+    float charge_int = NoPosition;
+    float charge_dqdx = NoPosition;
+    float dir_x = NoPosition;
+    float dir_y = NoPosition;
+    float dir_z = NoPosition;
+  };  // selTrackInfo
+
+  struct selBeamInfo {
+    static constexpr float NoTime = -999999.0;
+    
+    float beamGateSimStart = NoTime;
+    float beamGateDuration = -1.0;
+    unsigned int beamGateType = 999;
+  };
+  
+  struct selTriggerInfo {
+    unsigned int beamType = 0;
+    std::uint64_t triggerTime = 0;
+    std::uint64_t beamGateTime = 0;
+    unsigned int triggerID = 0;
+    unsigned int gateID = 0;
+  };
+  
+  struct selSimTriggerInfo {
+    
+    static constexpr double NoTime = -999999.0;
+    
+    double time = NoTime; ///< Time of the trigger in electronics time scale.
+    
+  };
+
+  struct selLightInfo {
+    static constexpr float NoPosition = -999999.0;
+    int flash_id = -1;
+    float sum_pe = NoPosition;
+    float flash_time = NoPosition;
+    float flash_x = NoPosition;
+    float flash_y = NoPosition;
+    float flash_z = NoPosition;
+    float diff_flash_t0 = NoPosition;
+  };
+
+  struct selHitInfo {
+    static constexpr float NoValue = -999999.0;
+    static constexpr uint16_t NoVal = 65535;
+    float integral = NoValue;
+    float sumadc = NoValue;
+    float width = NoValue; ///< RMS
+    float pk_time = NoVal;
+    float px = NoValue;
+    float py = NoValue;
+    float pz = NoValue;
+    float dirx = NoValue;
+    float diry = NoValue;
+    float dirz = NoValue;
+    uint16_t mult = NoVal;
+    uint16_t wire = NoVal;
+    uint16_t plane = NoVal;
+    int channel = NoVal;
+    uint16_t tpc = NoVal;
+    int16_t end = -32767;
+    int16_t start = -32767;
+    int id = NoValue;
+    bool oncalo = false;
+    float pitch = NoValue;
+    float dqdx = NoValue;
+    float dEdx = NoValue;
+    float rr = NoValue;
+    
+  };
+  
+} // namespace sbn
+
+#endif // SBN_TRACKTREESTOREOBJ_H

--- a/icaruscode/Analysis/trigger/ArtObjects/classes.h
+++ b/icaruscode/Analysis/trigger/ArtObjects/classes.h
@@ -1,0 +1,7 @@
+#include "canvas/Persistency/Common/Wrapper.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/Assns.h"
+
+#include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/Simulation/BeamGateInfo.h"
+

--- a/icaruscode/Analysis/trigger/ArtObjects/classes_def.xml
+++ b/icaruscode/Analysis/trigger/ArtObjects/classes_def.xml
@@ -1,0 +1,10 @@
+<lcgdict>
+
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+  <class name="art::Assns<recob::Track,sim::BeamGateInfo,void>" />
+  <class name="art::Assns<sim::BeamGateInfo,recob::Track,void>" />
+  <class name="art::Wrapper<art::Assns<recob::Track,sim::BeamGateInfo,void> >" />
+  <class name="art::Wrapper<art::Assns<sim::BeamGateInfo,recob::Track,void> >" />
+
+</lcgdict>

--- a/icaruscode/Analysis/trigger/BeamGateInfoFromTracksCRT_module.cc
+++ b/icaruscode/Analysis/trigger/BeamGateInfoFromTracksCRT_module.cc
@@ -1,0 +1,426 @@
+/**
+ * @file   BeamGateInfoFromTracks_module.cc
+ * @brief  Writes a collection of sim::BeamGateInfo from track times.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   November 22, 2021
+ */
+
+// LArSoft libraries
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
+#include "lardataalg/DetectorInfo/DetectorTimingTypes.h" // simulation_time
+#include "lardataalg/Utilities/intervals_fhicl.h" // nanoseconds from FHiCL
+#include "lardataalg/Utilities/quantities/spacetime.h" // nanoseconds, ...
+#include "lardataalg/Utilities/MultipleChoiceSelection.h"
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/RecoBase/PFParticle.h"
+#include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/Simulation/BeamGateInfo.h"
+
+// framework libraries
+#include "art/Framework/Core/SharedProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Persistency/Common/PtrMaker.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Utilities/InputTag.h"
+#include "canvas/Utilities/Exception.h"
+#include "cetlib_except/exception.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <vector>
+#include <string>
+#include <memory> // std::make_unique()
+#include <utility> // std::move()
+
+
+//------------------------------------------------------------------------------
+namespace icarus::trigger { class BeamGateInfoFromTracks; }
+
+/**
+ * @brief Writes a set collection of beam gates into each event.
+ * 
+ * This module writes a list of `sim::BeamGateInfo` based on the time associated
+ * to a selection of reconstructed tracks.
+ * 
+ * It may be used as input to modules which require to operate on beam gates,
+ * to select time(s) around the reconstructed (and selected) tracks.
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * This module acts on a _selection_ of tracks, which implies that the input is
+ * a set of _pointers_ to tracks rather than to an actual track collection.
+ * For each track, an associated time is required.
+ * 
+ * * `std::vector<art::Ptr<recob::PFParticle>>` (tag from `T0selProducer`):
+ *   list of the selected particles to be considered
+ * * `art::Assns<anab::T0, recob::PFParticle>` (tag from `T0Producer`):
+ *   association between particles and their time, which must include all
+ *   pointers to the tracks listed in `T0selProducer`: each of those particles
+ *   must be associated with exactly one `anab::T0`. The time convention is
+ *   described in @ref icarus_BeamGateInfoFromTracks_times "its own section".
+ * 
+ * 
+ * Output data products
+ * =====================
+ *
+ * * `std::vector<sim::BeamGateInfo>`: a collection of as many
+ *   `sim::BeamGateInfo` as the `BeamGates` configuration parameter entries,
+ *   with the content from them.
+ * * `art::Assns<sim::BeamGateInfo, recob::PFParticle>`: courtesy association
+ *   between the selected particle and its gate, in the same order as the
+ *   gates in their data product.
+ * * `art::Assns<sim::BeamGateInfo, anab::T0>`: courtesy association between
+ *   the particle time and its gate, in the same order as the gates in their
+ *   data product.
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * A terse online description of the parameters is printed by running
+ * `lar --print-description BeamGateInfoFromTracks`.
+ * 
+ * * `T0selProducer` (input tag, mandatory): the list of pointers to the
+ *   particles to be considered.
+ * * `T0Producer` (input tag, mandatory): the association of particles with
+ *   their times.
+ * * `GateStartOffset` (time string, mandatory): the time of the opening of
+ *   the gate with respect to the time of the particle; a positive offset means
+ *   that the gate starts _after_ the time of the particle.
+ * * `GateEndOffset` (time string, mandatory): the time of the closing of
+ *   the gate with respect to the time of the particle.
+ * * `GateType` (string, default: "unknown"): type of the gates being written;
+ *   see online description for the configuration keys representing the values
+ *   of `sim::GateType`.
+ * * `LogCategory` (string, default: `BeamGateInfoFromTracks`): name of the
+ *     output stream category for console messages (managed by MessageFacility
+ *     library).
+ *
+ *
+ * @note Time strings are strings with a value and its mandatory unit. For
+ *       example, 5.5 microseconds are expressed as `"5.5 us"` or `"5500 ns"`.
+ *
+ * Time scales
+ * ============
+ *
+ * @anchor icarus_BeamGateInfoFromTracks_times
+ * 
+ * This module was introduced as a mean to determine the proper time intervals
+ * when to apply a trigger simulation.
+ * It is evident that for this use case a precise result requires the timing
+ * of the gates carefully aligned with the timing of the PMT.
+ * (the convention is that the PMT waveforms have a timestamp in the
+ * @ref DetectorClocksOpticalElectronicsTime "electronics time reference").
+ * 
+ * The time of the gates created by this module is offered as
+ * `sim::BeamGateInfo`; LArSoft prescribes it to be be specified in nanoseconds
+ * and in @ref DetectorClocksSimulationTime "simulation time reference").
+ * Designed for simulation, this time scale refers to the opening of the beam
+ * gate (or its surrogate definition in samples with no beam to be gated).
+ * Or so is my understanding of it.
+ * 
+ * The input `anab::T0`, on the other end, as produced by the Pandora pattern
+ * recognition algorithm, and ultimately relative to the trigger time. In a
+ * perfectly aligned setup, this is equivalent to the trigger time in real data.
+ * 
+ * The output of this module attempts to adhere to that convention, and it
+ * defines the gate boundaries with respect to the beam gate time.
+ * 
+ */
+class icarus::trigger::BeamGateInfoFromTracks: public art::SharedProducer {
+  
+    public:
+  
+  using nanoseconds = util::quantities::intervals::nanoseconds;
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    enum class GateType_t { // we need to translate enum into a strong type
+        kUnknown = sim::kUnknown
+      , kBNB     = sim::kBNB
+      , kNuMI    = sim::kNuMI
+    };
+    
+    /// Selector for `Type` parameter.
+    static util::MultipleChoiceSelection<GateType_t> const GateTypeSelector;
+    
+    
+    fhicl::Atom<art::InputTag> T0selProducer {
+      Name("T0selProducer"),
+      Comment
+        ("tag of the selected particles (as a collection of art::Ptr)")
+      // mandatory
+      };
+    
+    fhicl::Atom<art::InputTag> T0Producer {
+      Name("T0Producer"),
+      Comment("tag of the input track time (t0) information")
+      // mandatory
+      };
+    
+    
+    fhicl::Atom<nanoseconds> GateStartOffset {
+      Name("GateStartOffset"),
+      Comment("offset from time track to gate start")
+      };
+
+    fhicl::Atom<nanoseconds> GateEndOffset {
+      Name("GateEndOffset"),
+      Comment("offset from time track to gate end")
+      };
+    
+    fhicl::Atom<std::string> GateType {
+      Name("GateType"),
+      Comment("beam gate type: " + GateTypeSelector.optionListString()),
+      GateTypeSelector.get(GateType_t::kUnknown).name()
+      };
+    
+    
+    fhicl::Atom<std::string> LogCategory {
+      Name("LogCategory"),
+      Comment("name of the category used for the output"),
+      "BeamGateInfoFromTracks" // default
+      };
+    
+    
+    sim::BeamType_t getGateType() const
+      {
+        try {
+          return static_cast<sim::BeamType_t>
+            (GateTypeSelector.parse(GateType()).value());
+        }
+        catch (util::MultipleChoiceSelectionBase::UnknownOptionError const& e)
+        {
+          throw art::Exception(art::errors::Configuration)
+            << "Invalid value for '" << GateType.name()
+            << "' parameter: '" << e.label() << "'; valid options: "
+            << GateTypeSelector.optionListString() << ".\n";
+        }
+      } // getGateType()
+  
+  
+  }; // struct Config
+  
+  using Parameters = art::SharedProducer::Table<Config>;
+  
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  // --- BEGIN Constructors ----------------------------------------------------
+  
+  explicit BeamGateInfoFromTracks
+    (Parameters const& config, art::ProcessingFrame const&);
+  
+  // --- END Constructors ------------------------------------------------------
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Fills the plots. Also extracts the information to fill them with.
+  virtual void produce(art::Event& event, art::ProcessingFrame const&) override;
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  art::InputTag const fT0selProducer; ///< Input particles.
+  art::InputTag const fT0Producer; ///< Input particle/time associations.
+  
+  /// Offset of gate start from particle time.
+  nanoseconds const fGateStartOffset;
+  nanoseconds const fGateDuration; ///< Width of the gate being created.
+  
+  sim::BeamType_t const fBeamGateType; ///< Type of gate saved.
+  
+  /// Message facility stream category for output.
+  std::string const fLogCategory;
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+}; // class icarus::trigger::BeamGateInfoFromTracks
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+namespace {
+  
+  template <typename T>
+  std::unique_ptr<T> moveToUniquePtr(T& data)
+    { return std::make_unique<T>(std::move(data)); }
+
+} // local namespace
+
+
+//------------------------------------------------------------------------------
+namespace icarus::trigger {
+  
+  util::MultipleChoiceSelection<BeamGateInfoFromTracks::Config::GateType_t> const
+  BeamGateInfoFromTracks::Config::GateTypeSelector
+    {
+        { GateType_t::kUnknown, "unknown" }
+      , { GateType_t::kBNB,     "BNB" }
+      , { GateType_t::kNuMI,    "NuMI" }
+    };
+  
+} // namespace icarus::trigger
+
+
+//------------------------------------------------------------------------------
+icarus::trigger::BeamGateInfoFromTracks::BeamGateInfoFromTracks
+  (Parameters const& config, art::ProcessingFrame const&)
+  : art::SharedProducer(config)
+  // configuration
+  , fT0selProducer(config().T0selProducer())
+  , fT0Producer(config().T0Producer())
+  , fGateStartOffset(config().GateStartOffset())
+  , fGateDuration(config().GateEndOffset() - fGateStartOffset)
+  , fBeamGateType(config().getGateType())
+  , fLogCategory(config().LogCategory())
+{
+  
+  async<art::InEvent>();
+  
+  //
+  // output data declaration
+  //
+  produces<std::vector<sim::BeamGateInfo>>();
+  //produces<art::Assns<sim::BeamGateInfo, recob::PFParticle>>();
+  produces<art::Assns<sim::BeamGateInfo, recob::Track>>();
+  produces<art::Assns<sim::BeamGateInfo, anab::T0>>();
+  
+  //
+  // configuration report (short)
+  //
+  auto const& beamType
+    = Config::GateTypeSelector.get(Config::GateType_t{ fBeamGateType });
+  
+  mf::LogInfo{ fLogCategory }
+    << "Configuration:"
+    << "\n - particle selection: '" << fT0selProducer.encode() << '\''
+    << "\n - associated times: '" << fT0Producer.encode() << '\''
+    << "\n - gate around particle time: " << fGateStartOffset
+    << " -- " << (fGateStartOffset+fGateDuration)
+    << " (" << fGateDuration << "; gate type: \"" << beamType.name()
+    << "\" [#" << fBeamGateType << "])"
+    ;
+  
+} // icarus::trigger::BeamGateInfoFromTracks::BeamGateInfoFromTracks()
+
+
+//------------------------------------------------------------------------------
+void icarus::trigger::BeamGateInfoFromTracks::produce
+  (art::Event& event, art::ProcessingFrame const&)
+{
+  
+  //
+  // fetch input
+  //
+  //auto const& particles
+  //= event.getProduct<std::vector<art::Ptr<recob::PFParticle>>>(fT0selProducer);
+
+  auto const& tracks                                                                                             
+    = event.getProduct<std::vector<art::Ptr<recob::Track>>>(fT0selProducer);  
+
+  mf::LogDebug(fLogCategory)
+    << "Writing gates for " << tracks.size() << " tracks.";
+
+  art::FindOneP<anab::T0> const trackT0(tracks, event, fT0Producer);
+  
+  detinfo::DetectorTimings const detTimings {
+    art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event)
+    };
+  
+  // add this offset to a time vs. trigger to make it vs. beam gate
+  nanoseconds const triggerToBeamGate
+    = detTimings.TriggerTime() - detTimings.BeamGateTime();
+  
+  //
+  // create the content
+  //
+  std::vector<sim::BeamGateInfo> gates;
+  art::Assns<sim::BeamGateInfo, recob::Track> gateToParticle;
+  art::Assns<sim::BeamGateInfo, anab::T0> gateToTime;
+  
+  art::PtrMaker<sim::BeamGateInfo> const makeGatePtr { event };
+  
+  for (auto const& [ iTracks, trackPtr ]: util::enumerate(tracks)) {
+    
+    art::Ptr<anab::T0> const t0Ptr = trackT0.at(iTracks);
+    if (t0Ptr.isNull()) {
+      art::Exception e { art::errors::NotFound };
+      e << "Selected track #" << iTracks << " (";
+      if (trackPtr) e << "ID=" << trackPtr->ID() << ", ";
+      e << "#" << trackPtr.key()
+        << " in its collection) has no associated time."
+        ;
+      throw e << '\n';
+    } // if no T0
+    
+    // t0 is stored in trigger time
+    detinfo::timescales::trigger_time const t0
+      { util::quantities::points::nanosecond(t0Ptr->Time()) };
+    
+    // 1DetectorTimings1 does not handle the beam gate time when converting to
+    // simulation time, so I need to explicitly add the difference
+    detinfo::timescales::simulation_time const gateStart
+      = detTimings.toSimulationTime(t0 + triggerToBeamGate + fGateStartOffset);
+    
+    // time conversion is currently redundant here, left as documentation
+    sim::BeamGateInfo gate {
+        gateStart.value()                                 // start
+      , fGateDuration.convertInto<nanoseconds>().value()  // width
+      , fBeamGateType                                     // type
+      };
+    
+    {
+      mf::LogTrace log{ fLogCategory };
+      log << "Gate for selected track #" << iTracks << " (";
+      if (trackPtr) log << "ID=" << trackPtr->ID() << ", ";
+      log << "#" << trackPtr.key()
+        << " in its collection): time = " << t0 << " => "
+        << gate.Start() << " -- " << (gate.Start() + gate.Width())
+        << " ns (" << gate.Width() << " ns)"
+        ;
+    }
+    
+    gates.push_back(std::move(gate));
+    
+    art::Ptr<sim::BeamGateInfo> gatePtr { makeGatePtr(gates.size() - 1) };
+    gateToParticle.addSingle(gatePtr, trackPtr);
+    gateToTime.addSingle(gatePtr, t0Ptr);
+    
+  } // for
+  
+  //
+  // store output
+  //
+  event.put(moveToUniquePtr(gates));
+  event.put(moveToUniquePtr(gateToParticle));
+  event.put(moveToUniquePtr(gateToTime));
+  
+} // icarus::trigger::BeamGateInfoFromTracks::produce()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(icarus::trigger::BeamGateInfoFromTracks)
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/Analysis/trigger/BeamGateInfoFromTracksCRT_module.cc
+++ b/icaruscode/Analysis/trigger/BeamGateInfoFromTracksCRT_module.cc
@@ -310,7 +310,7 @@ icarus::trigger::BeamGateInfoFromTracks::BeamGateInfoFromTracks
   // configuration report (short)
   //
   auto const& beamType
-    = Config::GateTypeSelector.get(Config::GateType_t{ fBeamGateType });
+    = Config::GateTypeSelector.get(static_cast<Config::GateType_t>(fBeamGateType));
   
   mf::LogInfo{ fLogCategory }
     << "Configuration:"

--- a/icaruscode/Analysis/trigger/CMakeLists.txt
+++ b/icaruscode/Analysis/trigger/CMakeLists.txt
@@ -73,9 +73,10 @@ cet_build_plugin(TimeTrackTreeStorage art::module
 
 cet_build_plugin(TimeTrackTreeStorageCRT art::module
   LIBRARIES
-  icaruscode_Analysis_trigger
-  icaruscode_PMT_Algorithms
-  icaruscode_Decode_DataProducts
+  icaruscode::Analysis_trigger
+  icaruscode_CRTUtils
+  icaruscode::PMT_Algorithms
+  icaruscode::Decode_DataProducts
   larcore::Geometry_Geometry_service
   larcorealg::Geometry
   lardataobj::AnalysisBase

--- a/icaruscode/Analysis/trigger/CMakeLists.txt
+++ b/icaruscode/Analysis/trigger/CMakeLists.txt
@@ -23,7 +23,24 @@ cet_build_plugin(TimedTrackSelector art::module
   ROOT::Core
   )
 
+cet_build_plugin(TimedTrackSelectorCRT art::module
+  LIBRARIES
+  icarusalg::Utilities
+  lardataobj::AnalysisBase
+  lardataobj::RecoBase
+  messagefacility::MF_MessageLogger
+  ROOT::Core
+  )
+
 cet_build_plugin(BeamGateInfoFromTracks  art::module
+  LIBRARIES
+  lardataobj::Simulation
+  lardataobj::AnalysisBase
+  lardataobj::RecoBase
+  lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+  )
+
+cet_build_plugin(BeamGateInfoFromTracksCRT  art::module
   LIBRARIES
   lardataobj::Simulation
   lardataobj::AnalysisBase
@@ -52,6 +69,29 @@ cet_build_plugin(TimeTrackTreeStorage art::module
   fhiclcpp::fhiclcpp
   messagefacility::MF_MessageLogger
 )
+
+cet_build_plugin(TimeTrackTreeStorageCRT art::module
+  LIBRARIES
+  icaruscode_Analysis_trigger
+  icaruscode_PMT_Algorithms
+  icaruscode_Decode_DataProducts
+  larcore::Geometry_Geometry_service
+  larcorealg::Geometry
+  lardataobj::AnalysisBase
+  lardataobj::RecoBase
+  lardataobj::RawData
+  lardataobj::Simulation
+  ROOT::Tree
+  ROOT::Core
+  art_root_io::TFileService_service
+  art::Framework_Services_Registry
+  art::Framework_Core
+  art::Framework_Principal
+  canvas::canvas
+  fhiclcpp::fhiclcpp
+  messagefacility::MF_MessageLogger
+)
+
 
 install_headers()
 install_source()

--- a/icaruscode/Analysis/trigger/CMakeLists.txt
+++ b/icaruscode/Analysis/trigger/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(Objects)
+add_subdirectory(ArtObjects)
 add_subdirectory(scripts)
 
 file(GLOB lib_srcs *.cxx details/*.cxx)

--- a/icaruscode/Analysis/trigger/Objects/TrackTreeStoreObj.h
+++ b/icaruscode/Analysis/trigger/Objects/TrackTreeStoreObj.h
@@ -82,11 +82,16 @@ namespace sbn {
     static constexpr float NoPosition = -999999.0;
     int flash_id = -1;
     float sum_pe = NoPosition;
-    float flash_time = NoPosition;
+    float flash_time = NoPosition; ///< Nominal flash time [us]
     float flash_x = NoPosition;
     float flash_y = NoPosition;
     float flash_z = NoPosition;
-    float diff_flash_t0 = NoPosition;
+    float diff_flash_pos = NoPosition; ///< Distance from track middle point [cm]
+    float diff_flash_t0 = NoPosition; ///< Time from track time `t0` [us]
+    float diff_flash_TPCt0 = NoPosition; ///< Time from TPC time `t0_TPC` [us]
+    float diff_flash_CRTt0 = NoPosition; ///< Time from CRT time `t0_CRT` [us]
+    bool flash_closest_to_track = false; ///< Is this the smallest `diff_flash_t0`?
+    bool flash_nearest_to_track = false; ///< Is this the smallest `diff_flash_pos`?
   };
 
   struct selHitInfo {

--- a/icaruscode/Analysis/trigger/Objects/TrackTreeStoreObj.h
+++ b/icaruscode/Analysis/trigger/Objects/TrackTreeStoreObj.h
@@ -19,16 +19,16 @@ namespace sbn {
     static constexpr float NoEnergy = -999999.0;
     static constexpr double NoTime = -99999.0;
     
-    int trackID = -1;
-    double t0 = NoTime;
-    double t0_TPC = NoTime;
-    double t0_CRT = NoPosition;
-    float start_x = NoPosition;
-    float start_y = NoPosition;
-    float start_z = NoPosition;
-    float end_x = NoPosition;
-    float end_y = NoPosition;
-    float end_z = NoPosition;
+    int trackID = -1; ///< `recob::Track::ID()` from the reconstructed track.
+    double t0 = NoTime; ///< Best time of the track (used for selection) [us]
+    double t0_TPC = NoTime; ///< Time of (cathode crossing) track from TPC reconstruction [us]
+    double t0_CRT = NoPosition; ///< Time of track from association with CRT hit [us]
+    float start_x = NoPosition; ///< Start of the track (assumed downgoing) [cm]
+    float start_y = NoPosition; ///< Start of the track (assumed downgoing) [cm]
+    float start_z = NoPosition; ///< Start of the track (assumed downgoing) [cm]
+    float end_x = NoPosition; ///< End of the track (assumed downgoing) [cm]
+    float end_y = NoPosition; ///< End of the track (assumed downgoing) [cm]
+    float end_z = NoPosition; ///< End of the track (assumed downgoing) [cm]
     float middle_x = NoPosition; ///< Half-way distance along the trajectory.
     float middle_y = NoPosition; ///< Half-way distance along the trajectory.
     float middle_z = NoPosition; ///< Half-way distance along the trajectory.
@@ -43,15 +43,15 @@ namespace sbn {
     float midaftercathode_z = NoPosition; ///< Midpoint of subpath after cathode.
     float beforecathode = -1; ///< Track path length before cathode (lower _x_).
     float aftercathode = -1; ///< Track path length before cathode (higher _x_).
-    float length = -1.0;
-    float energy = NoEnergy;
-    float energy_int = NoEnergy;
-    float charge_int = NoEnergy;
-    float energy_range = NoEnergy;
-    // float charge_dqdx = NoPosition;
-    float dir_x = NoPosition;
-    float dir_y = NoPosition;
-    float dir_z = NoPosition;
+    float length = -1.0; ///< Full track length [cm]
+    float energy = NoEnergy; ///< Total energy as reported by calorimetry [MeV]
+    float energy_int = NoEnergy; ///< Integral of all (dE/dx) x dx [MeV]
+    float charge_int = NoEnergy; ///< Integral of all (dQ/dx) x dx [electrons?]
+    float energy_range = NoEnergy; ///< Energy from range (assuming stopping) [MeV]
+    float dir_x = NoPosition; ///< Direction vector at the start if the track.
+    float dir_y = NoPosition; ///< Direction vector at the start if the track.
+    float dir_z = NoPosition; ///< Direction vector at the start if the track.
+    float driftCorrX = 0.0; ///< Shift applied to track position for time [cm]
   };  // selTrackInfo
 
   struct selBeamInfo {

--- a/icaruscode/Analysis/trigger/Objects/TrackTreeStoreObj.h
+++ b/icaruscode/Analysis/trigger/Objects/TrackTreeStoreObj.h
@@ -16,9 +16,13 @@ namespace sbn {
    */
   struct selTrackInfo {
     static constexpr float NoPosition = -999999.0;
+    static constexpr float NoEnergy = -999999.0;
+    static constexpr double NoTime = -99999.0;
     
     int trackID = -1;
-    float t0 = NoPosition;
+    double t0 = NoTime;
+    double t0_TPC = NoTime;
+    double t0_CRT = NoPosition;
     float start_x = NoPosition;
     float start_y = NoPosition;
     float start_z = NoPosition;
@@ -40,16 +44,18 @@ namespace sbn {
     float beforecathode = -1; ///< Track path length before cathode (lower _x_).
     float aftercathode = -1; ///< Track path length before cathode (higher _x_).
     float length = -1.0;
-    float energy = NoPosition;
-    float charge_int = NoPosition;
-    float charge_dqdx = NoPosition;
+    float energy = NoEnergy;
+    float energy_int = NoEnergy;
+    float charge_int = NoEnergy;
+    float energy_range = NoEnergy;
+    // float charge_dqdx = NoPosition;
     float dir_x = NoPosition;
     float dir_y = NoPosition;
     float dir_z = NoPosition;
   };  // selTrackInfo
 
   struct selBeamInfo {
-    static constexpr float NoTime = -999999.0;
+    static constexpr float NoTime = -99999.0;
     
     float beamGateSimStart = NoTime;
     float beamGateDuration = -1.0;
@@ -66,7 +72,7 @@ namespace sbn {
   
   struct selSimTriggerInfo {
     
-    static constexpr double NoTime = -999999.0;
+    static constexpr double NoTime = -99999.0;
     
     double time = NoTime; ///< Time of the trigger in electronics time scale.
     
@@ -110,6 +116,26 @@ namespace sbn {
     float dEdx = NoValue;
     float rr = NoValue;
     
+  };
+  
+  struct selCRTpoint {
+    static constexpr double Nowhere = -999999.0;
+    static constexpr double NoTime = -99999.0;
+    static constexpr int NoRegion = -1;
+    double time = NoTime; ///< Hit time from trigger [us]
+    double x = Nowhere;
+    double y = Nowhere;
+    double z = Nowhere;
+    float resolution = -1.0;
+    float DCA = Nowhere;
+    int region = NoRegion;
+  };
+  
+  struct selCRTInfo {
+    static constexpr double NoTime = -99999.0;
+    selCRTpoint entry;
+    selCRTpoint exit;
+    double time = NoTime; ///< Matching time from trigger [us]
   };
   
 } // namespace sbn

--- a/icaruscode/Analysis/trigger/Objects/classes_def.xml
+++ b/icaruscode/Analysis/trigger/Objects/classes_def.xml
@@ -2,7 +2,8 @@
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
-  <class name="sbn::selTrackInfo" ClassVersion="16">
+  <class name="sbn::selTrackInfo" ClassVersion="17">
+   <version ClassVersion="17" checksum="591740725"/>
    <version ClassVersion="16" checksum="3241616212"/>
    <version ClassVersion="15" checksum="352409387"/>
    <version ClassVersion="14" checksum="4105307536"/>

--- a/icaruscode/Analysis/trigger/Objects/classes_def.xml
+++ b/icaruscode/Analysis/trigger/Objects/classes_def.xml
@@ -23,7 +23,8 @@
    <version ClassVersion="11" checksum="2335077475"/>
    <version ClassVersion="10" checksum="2486880499"/>
   </class>
-  <class name="sbn::selLightInfo" ClassVersion="13">
+  <class name="sbn::selLightInfo" ClassVersion="14">
+   <version ClassVersion="14" checksum="2709766870"/>
    <version ClassVersion="13" checksum="3810861666"/>
    <version ClassVersion="12" checksum="2145002064"/>
    <version ClassVersion="11" checksum="4227899354"/>

--- a/icaruscode/Analysis/trigger/Objects/classes_def.xml
+++ b/icaruscode/Analysis/trigger/Objects/classes_def.xml
@@ -2,7 +2,8 @@
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
-  <class name="sbn::selTrackInfo" ClassVersion="15">
+  <class name="sbn::selTrackInfo" ClassVersion="16">
+   <version ClassVersion="16" checksum="3241616212"/>
    <version ClassVersion="15" checksum="352409387"/>
    <version ClassVersion="14" checksum="4105307536"/>
    <version ClassVersion="13" checksum="471742515"/>
@@ -34,10 +35,19 @@
    <version ClassVersion="10" checksum="2893769828"/>
   </class>
 
-  <class name="std::vector<sbn::selTrackInfo>" />    
+  <class name="sbn::selCRTpoint" ClassVersion="10" >
+   <version ClassVersion="10" checksum="852776335"/>
+  </class>
+  
+  <class name="sbn::selCRTInfo" ClassVersion="10" >
+   <version ClassVersion="10" checksum="2923224810"/>
+  </class>
+
+  <class name="std::vector<sbn::selTrackInfo>" />
   <class name="std::vector<sbn::selBeamInfo>" />
   <class name="std::vector<sbn::selTriggerInfo>" />
   <class name="std::vector<sbn::selLightInfo>" />
   <class name="std::vector<sbn::selHitInfo>" />
+  <class name="std::vector<sbn::selCRTInfo>" />
   
 </lcgdict>

--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
@@ -1,0 +1,827 @@
+/**
+ * @file    TimeTrackTreeStorage_module.cc
+ * @authors Jacob Zettlemoyer (FNAL, jzettle@fnal.gov),
+ *          Animesh Chatterjee (U. Pittsburgh, anc238@pitt.edu),
+ *          Gianluca Petrillo (SLAC, petrillo@slac.stanford.edu)
+ * @date    Tue Sep 21 10:33:10 2021
+ * 
+ * Borrowed heavily from Gray Putnam's existing TrackCaloSkimmer
+ */
+
+// ICARUS libraries
+#include "icaruscode/Analysis/trigger/details/TriggerResponseManager.h"
+#include "icaruscode/Analysis/trigger/details/CathodeCrossingUtils.h"
+#include "icaruscode/Analysis/trigger/Objects/TrackTreeStoreObj.h"
+#include "icaruscode/PMT/Algorithms/PMTverticalSlicingAlg.h"
+#include "icaruscode/Utilities/TrajectoryUtils.h"
+#include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
+
+// LArSoft libraries
+// #include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/OpDetGeo.h"
+#include "larcorealg/CoreUtils/counter.h"
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/AnalysisBase/Calorimetry.h"
+#include "lardataobj/RecoBase/PFParticle.h"
+#include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/RecoBase/OpFlash.h"
+#include "lardataobj/RecoBase/OpHit.h"
+#include "lardataobj/RecoBase/Hit.h"
+// #include "lardataobj/RecoBase/SpacePoint.h"
+#include "lardataobj/RecoBase/TrackHitMeta.h"
+// #include "lardataobj/RecoBase/PFParticleMetadata.h"
+#include "lardataobj/RawData/OpDetWaveform.h" // raw::Channel_t
+#include "lardataobj/Simulation/BeamGateInfo.h"
+#include "lardataobj/RawData/TriggerData.h" // raw::Trigger
+
+// framework libraries
+#include "art_root_io/TFileService.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/types/TableAs.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// ROOT libraries
+#include "TTree.h"
+
+// C/C++ libraries
+#include <vector>
+#include <string>
+#include <utility> // std::move(), std::pair
+#include <cmath>
+
+
+namespace {
+  
+  // ---------------------------------------------------------------------------
+  /// Returns the sequence of `track` valid points (as geometry points).
+  std::vector<geo::Point_t> extractTrajectory
+    (recob::Track const& track, bool reverse = false)
+  {
+    std::vector<geo::Point_t> trackPath;
+    std::size_t index = track.FirstValidPoint();
+    while (index != recob::TrackTrajectory::InvalidIndex) {
+      trackPath.push_back(track.LocationAtPoint(index));
+      if (++index >= track.NPoints()) break;
+      index = track.NextValidPoint(index);
+    }
+    if (reverse) std::reverse(trackPath.begin(), trackPath.end());
+    return trackPath;
+  } // extractTrajectory()
+  
+} // local namespace
+
+
+// -----------------------------------------------------------------------------
+namespace sbn { class TimeTrackTreeStorage; }
+/**
+ * @brief Fills a ROOT tree with track-based triggering information.
+ * 
+ * 
+ * Track selection criteria
+ * =========================
+ * 
+ * This module does not perform almost any selection: it processes all the
+ * reconstructed particle flow objects (PFO) (typically from Pandora) selected
+ * by the module in `T0selProducer`, which may perform the desired selection.
+ * For every PFO which is associated to a track (`recob::Track`), that
+ * associated track and the associated time (`anab::T0`) are saved in a tree
+ * entry.
+ * 
+ * 
+ * Optical detector information
+ * -----------------------------
+ * 
+ * Currently, _all_ reconstructed flashes in the cryostat are saved together
+ * with _each_ tree entry, i.e. to each selected track. There is no attempt to
+ * match a single flash to a track.
+ * 
+ * 
+ * 
+ * Trigger information
+ * ====================
+ * 
+ * There are two distinct groups of information about triggers in the tree.
+ * The first one is the hardware trigger, that is the trigger that was actually
+ * used to decide to record the event. That is the same information for all
+ * tracks within the same event (and the same in both cryostats, too).
+ * The other group of information is from trigger logic simulation on the
+ * collected data (optical detector waveforms): there may be multiple branches
+ * in this group, one for each simulated trigger logic, and each tree entry,
+ * corresponding to a selected track, may have its own value for each trigger
+ * logic response.
+ * 
+ * 
+ * Simulated trigger information
+ * ------------------------------
+ * 
+ * A branch is added for each configured trigger logic.
+ * This module actually ignores the details of the logic yielding the results:
+ * a trigger result is a group of data products under the same tag.
+ * For example, a tag `M1` (presumably, a very loose trigger logic requiring
+ * just one PMT pair above threshold anywhere in the detector, with no hint of
+ * which that threshold is) will produce a branch with name `"M1"` including
+ * information from the `M1` data products (so far, only a collection of
+ * `raw::Trigger` is read).
+ * It is assumed that there is one trigger result for each selected track
+ * (as found in the data product from `T0selProducer` configuration parameter).
+ * Note that a trigger object is expected to be present _regardless whether
+ * the trigger fired or not_. It is assumed that the trigger fired if at least
+ * one of the `raw::Trigger::TriggerBits()` is set, not fired otherwise.
+ * 
+ * Each branch mirrors a data record, `TriggerInfo_t`, reporting the response
+ * for one simulated trigger logic.
+ * The structure and interpretation of the trigger response branch is described
+ * in ROOT TTree code by the string in
+ * `TriggerInfo_t::TriggerResponseBranchStructure`, and its meaning is:
+ * * `fired` (boolean): whether this trigger has triggered at all during the
+ *   considered trigger gate.
+ * * `time` (double): time of the trigger, taken directly from
+ *   `raw::Trigger::TriggerTime()`; it is expected to be measurent in
+ *   microseconds and relative to the nominal time reference of the event,
+ *   which for data is the hardware trigger time and for simulation is the
+ *   "hardware" beam gate time (however that is defined).
+ * * `gate` (double): start time of the gate where the trigger logic was
+ *   simulated. It is in the same time scale as the trigger time, and
+ *   directly taken from `raw::Trigger::BeamGateTime()`.
+ * 
+ * 
+ */
+class sbn::TimeTrackTreeStorage : public art::EDAnalyzer {
+  
+  using TriggerInputSpec_t
+    = sbn::details::TriggerResponseManager::TriggerInputSpec_t;
+  
+public:
+  
+  /// Data record the trigger response branch is based on.
+  using TriggerInfo_t = sbn::details::TriggerResponseManager::TriggerInfo_t;
+  
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    /// Information on a single trigger source for the tree.
+    struct TriggerSpecConfig {
+      
+      fhicl::Atom<std::string> Name {
+        fhicl::Name("Name"),
+        Comment("name of the trigger (e.g. `\"M5O3\"`)")
+        };
+      fhicl::Atom<art::InputTag> TriggerTag {
+        fhicl::Name("TriggerTag"),
+        Comment("tag of the input trigger info data product")
+        };
+      
+    }; // TriggerSpecConfig
+    using TriggerSpecConfigTable
+      = fhicl::TableAs<TriggerInputSpec_t, TriggerSpecConfig>;
+    
+    
+    fhicl::Atom<art::InputTag> PFPproducer {
+      Name("PFPproducer"),
+      Comment("tag of the input particle flow objects to process")
+      // mandatory
+      };
+    
+    fhicl::OptionalAtom<art::InputTag> T0Producer {
+      Name("T0Producer"),
+      Comment("tag of the input track time (t0) information [as PFPproducer]")
+      // default: as PFPproducer
+      };
+    
+    fhicl::OptionalAtom<art::InputTag> T0selProducer {
+      Name("T0selProducer"),
+      Comment
+        ("tag of the selected tracks (as a collection of art::Ptr) [as PFPproducer]")
+      // default: as PFPproducer
+      };
+    
+    fhicl::Atom<art::InputTag> TrackProducer {
+      Name("TrackProducer"),
+      Comment("tag of the association of particles to tracks")
+      // mandatory
+      };
+
+    fhicl::Atom<art::InputTag> TrackFitterProducer {
+      Name("TrackFitterProducer"),
+        Comment("tag of the association of the tracks with the hits")
+        // mandatory                                                                                    
+        };
+
+    fhicl::Atom<art::InputTag> CaloProducer {
+      Name("CaloProducer"),
+        Comment("tag of the association of the tracks with the calorimetry module")
+        //mandatory
+        };
+          
+    
+    fhicl::Atom<art::InputTag> BeamGateProducer {
+      Name("BeamGateProducer"),
+      Comment("tag of beam gate information")
+      // mandatory
+      };
+    
+    fhicl::Atom<art::InputTag> TriggerProducer {
+      Name("TriggerProducer"),
+      Comment("tag of hardware trigger information")
+      // mandatory
+      };
+    
+    fhicl::Atom<art::InputTag> FlashProducer {
+      Name("FlashProducer"),
+      Comment("tag of flash information")
+      //mandatory
+      };
+
+    fhicl::Sequence<TriggerSpecConfigTable> EmulatedTriggers {
+      Name("EmulatedTriggers"),
+      Comment("the emulated triggers to include in the tree")
+    };
+    
+    fhicl::Atom<std::string> LogCategory {
+      Name("LogCategory"),
+      Comment("label for output messages of this module instance"),
+      "TimeTrackTreeStorage" // default
+      };
+
+    fhicl::Atom<float> MODA {
+      Name("MODA"),
+      Comment("first recombination parameter for dE/dx calculations"),
+      0.930 //default
+      };
+    
+    fhicl::Atom<float> MODB {
+      Name("MODB"),
+      Comment("second recombination parameter for dE/dx calculations"),
+      0.212
+      };
+    
+    fhicl::Atom<float> Wion {
+      Name("Wion"),
+      Comment("work function for recombination"),
+      0.0000236016
+      };
+    
+    fhicl::Atom<float> Efield {
+      Name("Efield"),
+      Comment("Electric field in kV/cm"),
+      0.5
+      };
+    
+    fhicl::Atom<bool> ForceDowngoing {
+      Name("ForceDowngoing"),
+      Comment("force all tracks to be downgoing, flipping them when necessary"),
+      false
+      };
+    
+  }; // Config
+  
+  using Parameters = art::EDAnalyzer::Table<Config>;
+  
+  explicit TimeTrackTreeStorage(Parameters const& p);
+
+  sbn::selHitInfo makeHit(const recob::Hit &hit,
+                          unsigned hkey,
+                          const recob::Track &trk,
+                          const recob::TrackHitMeta &thm,
+                          const std::vector<art::Ptr<anab::Calorimetry>> &calo,
+                          const geo::GeometryCore *geo);
+
+  float dEdx_calc(float dQdx, 
+                  float A,
+                  float B,
+                  float Wion,
+                  float E);
+
+  void analyze(art::Event const& e) override;
+  
+  void endJob() override;
+
+private:
+  
+  
+  // --- BEGIN -- Configuration parameters -------------------------------------
+  
+  art::InputTag const fPFPproducer;
+  art::InputTag const fT0Producer;
+  art::InputTag const fT0selProducer;
+  art::InputTag const fTrackProducer;
+  art::InputTag const fTrackFitterProducer;
+  art::InputTag const fCaloProducer;
+  art::InputTag const fBeamGateProducer;
+  art::InputTag const fTriggerProducer;
+  art::InputTag const fFlashProducer;
+  std::string const fLogCategory;
+  float const fMODA;
+  float const fMODB;
+  float const fWion;
+  float const fEfield;
+  bool const fForceDowngoing; ///< Whether to force all tracks to be downgoing.
+  
+  // --- END ---- Configuration parameters -------------------------------------
+
+  // --- BEGIN -- Tree buffers -------------------------------------------------
+  
+  unsigned int fEvent;
+  unsigned int fRun;
+  unsigned int fSubRun;
+  
+  sbn::selTrackInfo fTrackInfo; //change to one entry per track instead of per event 
+  sbn::selBeamInfo fBeamInfo;
+  sbn::selTriggerInfo fTriggerInfo;
+  sbn::selLightInfo fFlashInfo;
+  std::vector<sbn::selLightInfo> fFlashStore;
+  sbn::selHitInfo fHitInfo;
+  std::vector<sbn::selHitInfo> fHitStore;
+  // --- END ---- Tree buffers -------------------------------------------------
+  
+  // --- BEGIN -- Cached information -------------------------------------------
+  
+  /// PMT geometry objects, grouped by wall (drift) coordinate.
+  std::vector<std::pair<double, std::vector<raw::Channel_t>>> fPMTwalls;
+  
+  // --- BEGIN -- Cached information -------------------------------------------
+  
+  
+  TTree *fStoreTree = nullptr;
+
+  unsigned int fTotalProcessed = 0;
+  
+  
+  // `convert()` needs to be a free function
+  friend TriggerInputSpec_t convert(Config::TriggerSpecConfig const& config);
+  
+  
+  // --- BEGIN -- Trigger response branches ------------------------------------
+  
+  /// Manages filling of trigger result branches.
+  sbn::details::TriggerResponseManager fTriggerResponses;
+  
+  // --- END ---- Trigger response branches ------------------------------------
+  
+  /// Accesses detector geometry to return all PMT split by wall.
+  std::vector<std::pair<double, std::vector<raw::Channel_t>>>
+    computePMTwalls() const;
+
+}; // sbn::TimeTrackTreeStorage
+
+
+// -----------------------------------------------------------------------------
+namespace sbn {
+  
+  TimeTrackTreeStorage::TriggerInputSpec_t convert
+    (TimeTrackTreeStorage::Config::TriggerSpecConfig const& config)
+  {
+    return {
+        config.Name()       // name
+      , config.TriggerTag() // inputTag
+      };
+  } // convert(sbn::TriggerSpecConfig)
+  
+} // namespace sbn
+
+
+// -----------------------------------------------------------------------------
+sbn::TimeTrackTreeStorage::TimeTrackTreeStorage(Parameters const& p)
+  : EDAnalyzer{p}
+  // configuration
+  , fPFPproducer      { p().PFPproducer() }
+  , fT0Producer       { p().T0Producer().value_or(fPFPproducer) }
+  , fT0selProducer    { p().T0selProducer().value_or(fPFPproducer) }
+  , fTrackProducer    { p().TrackProducer() }
+  , fTrackFitterProducer { p().TrackFitterProducer() }
+  , fCaloProducer     { p().CaloProducer() }
+  , fBeamGateProducer { p().BeamGateProducer() }
+  , fTriggerProducer  { p().TriggerProducer() }
+  , fFlashProducer    { p().FlashProducer() }
+  , fLogCategory      { p().LogCategory() }
+  , fMODA             { p().MODA() }
+  , fMODB             { p().MODB() }
+  , fWion             { p().Wion() }
+  , fEfield           { p().Efield() }
+  , fForceDowngoing    { p().ForceDowngoing() }
+  // algorithms
+  , fPMTwalls         { computePMTwalls() }
+  , fStoreTree {
+      art::ServiceHandle<art::TFileService>()->make<TTree>
+        ("TimedTrackStorage", "Timed Track Tree")
+      }
+  , fTriggerResponses
+      { p().EmulatedTriggers(), consumesCollector(), *fStoreTree }
+{
+  
+  //
+  // declaration of input
+  //
+  
+  // consumes<std::vector<recob::PFParticle>>(fPFPproducer); // not yet?
+  consumes<std::vector<art::Ptr<recob::Track>>>(fT0selProducer);
+  consumes<sbn::ExtraTriggerInfo>(fTriggerProducer);
+  consumes<std::vector<sim::BeamGateInfo>>(fBeamGateProducer);
+  consumes<art::Assns<recob::PFParticle, recob::Track>>(fTrackProducer);
+  consumes<art::Assns<recob::Track, anab::T0>>(fT0Producer);
+  consumes<art::Assns<recob::Hit, recob::Track, recob::TrackHitMeta>>(fTrackProducer);
+  consumes<recob::OpFlash>(fFlashProducer);
+
+  //
+  // tree population
+  //
+  fStoreTree->Branch("run", &fRun);
+  fStoreTree->Branch("subrun", &fSubRun);
+  fStoreTree->Branch("event", &fEvent);
+  fStoreTree->Branch("beamInfo", &fBeamInfo);
+  fStoreTree->Branch("triggerInfo", &fTriggerInfo);
+  fStoreTree->Branch("selTracks", &fTrackInfo);
+  fStoreTree->Branch("selFlashes", &fFlashStore); //store all flashes in an event for all tracks
+  fStoreTree->Branch("selHits", &fHitStore);
+  //fStoreTree->Branch("selFlashes", &fFlashInfo);
+  
+} // sbn::TimeTrackTreeStorage::TimeTrackTreeStorage()
+
+
+void sbn::TimeTrackTreeStorage::analyze(art::Event const& e)
+{
+  const geo::GeometryCore *geom = lar::providerFrom<geo::Geometry>();
+  // Implementation of required member function here.
+  fEvent = e.event();
+  fSubRun = e.subRun();
+  fRun = e.run();
+  fBeamInfo = {};
+  
+  std::vector<art::Ptr<recob::Track>> const& tracks = e.getProduct<std::vector<art::Ptr<recob::Track>>> (fT0selProducer);
+  if(tracks.empty()) {
+    mf::LogDebug(fLogCategory) << "No tracks in '" << fT0selProducer.encode() << "'.";
+    return;
+  }
+
+  std::vector<sim::BeamGateInfo> const& beamgate = e.getProduct<std::vector<sim::BeamGateInfo>> (fBeamGateProducer);
+  if(beamgate.empty())
+    mf::LogWarning(fLogCategory) << "No Beam Gate Information!";
+  else {
+    if(beamgate.size() > 1)
+      mf::LogWarning(fLogCategory) << "Event has multiple beam gate info labels! (maybe this changes later to be standard)";
+    sim::BeamGateInfo const& bg = beamgate[0];
+    fBeamInfo.beamGateSimStart = bg.Start();
+    fBeamInfo.beamGateDuration = bg.Width();
+    fBeamInfo.beamGateType = bg.BeamType();
+  }
+
+  sbn::ExtraTriggerInfo const &triggerinfo = e.getProduct<sbn::ExtraTriggerInfo> (fTriggerProducer);
+  fTriggerInfo.beamType = value(triggerinfo.sourceType);
+  fTriggerInfo.triggerTime = triggerinfo.triggerTimestamp;
+  fTriggerInfo.beamGateTime = triggerinfo.beamGateTimestamp;
+  fTriggerInfo.triggerID = triggerinfo.triggerID;
+  fTriggerInfo.gateID = triggerinfo.gateID;
+  
+  //mf::LogTrace(fLogCategory) << "HERE!";
+  //art::FindOneP<recob::Track> particleTracks(pfparticles,e,fTrackProducer);
+  art::FindOneP<anab::T0> t0Tracks(tracks,e,fT0Producer);  
+  std::vector<recob::OpFlash> const &particleFlashes = e.getProduct<std::vector<recob::OpFlash>>(fFlashProducer);
+  //art::FindOneP<recob::SpacePoint> particleSPs(pfparticles, e, fT0selProducer);
+  //mf::LogTrace(fLogCategory) << "PFParticles size: " << pfparticles.size() << " art::FindOneP Tracks Size: " << particleTracks.size();
+  art::ValidHandle<std::vector<recob::Track>> allTracks = e.getValidHandle<std::vector<recob::Track>>(fTrackProducer);
+  //auto particles = e.getValidHandle<std::vector<recob::PFParticle>>(fPFPproducer);
+  //art::FindManyP<anab::T0> pandora_t0Tracks(particles, e, fPFPproducer);
+  art::FindManyP<recob::Hit,recob::TrackHitMeta> trkht(allTracks,e,fTrackProducer); //for track hits
+  art::FindManyP<anab::Calorimetry> calorim(allTracks, e, fCaloProducer);  
+  
+  // get an extractor bound to this event
+  sbn::details::TriggerResponseManager::Extractors triggerResponseExtractors
+    = fTriggerResponses.extractorsFor(e);
+  unsigned int processed = 0;
+  
+  for(unsigned int iTrack = 0; iTrack < tracks.size(); ++iTrack)
+  {
+    art::Ptr<recob::Track> const& trackPtr = tracks.at(iTrack);
+    if(trackPtr.isNull()) continue;
+    
+    fFlashInfo = {};
+    fFlashStore.clear();
+    fHitStore.clear();
+    
+    art::Ptr<anab::T0> const& t0Ptr = t0Tracks.at(iTrack);
+    //auto pandora_t0Ptr = pandora_t0Tracks.at(trackPtr.key());
+    float const track_t0 = t0Ptr->Time();
+    //float pandora_t0 = -99999.0;
+    //if(!pandora_t0Ptr.empty())
+    //{
+    //float const pandora_t0 = pandora_t0Ptr->Time();
+    //}
+    //std::cout << "CRT-TPC matching algo T0: " << track_t0/1e3 << "Pandora t0 value: " << pandora_t0/1e3 << std::endl; 
+    if(!particleFlashes.empty())
+    {
+      //float min_flash_t0_diff = 999999.0; 
+      for(unsigned int iFlash = 0; iFlash < particleFlashes.size(); ++iFlash)
+      {
+        fFlashInfo = {};
+        recob::OpFlash const flashPtr = particleFlashes.at(iFlash);
+        float const flash_pe = flashPtr.TotalPE();
+        float const flash_time = flashPtr.Time();
+        float const flash_x = flashPtr.XCenter();
+        float const flash_y = flashPtr.YCenter();
+        float const flash_z = flashPtr.ZCenter();
+        float flash_t0_diff = flash_time - track_t0/1e3;
+        //if(std::abs(flash_t0_diff) < min_flash_t0_diff)
+          //{ 
+        fFlashInfo.flash_id = iFlash;
+        fFlashInfo.sum_pe = flash_pe;
+        fFlashInfo.flash_time = flash_time;
+        fFlashInfo.flash_x = flash_x;
+        fFlashInfo.flash_y = flash_y;
+        fFlashInfo.flash_z = flash_z;
+        fFlashInfo.diff_flash_t0 = flash_t0_diff;
+        //min_flash_t0_diff = std::abs(flash_t0_diff);
+        fFlashStore.push_back(fFlashInfo);
+        //}
+      }
+    }
+    sbn::selTrackInfo trackInfo;
+    trackInfo.trackID = trackPtr->ID();
+    trackInfo.t0 = track_t0/1e3; //is this in nanoseconds? Will convert to seconds so I can understand better
+    //if(track_t0/1e3 < 10 && track_t0/1e3 > -10)
+    //mf::LogTrace(fLogCategory) << track_t0/1e3 << " Run is: " << fRun << " SubRun is: " << fSubRun << " Event is: " << fEvent << " Track ID is: " << trackPtr->ID();
+    
+    recob::tracking::Point_t startPoint = trackPtr->Start();
+    recob::tracking::Point_t endPoint = trackPtr->End();
+    recob::tracking::Vector_t startDir = trackPtr->StartDirection();
+    bool const flipTrack = fForceDowngoing && (startDir.Y() > 0.0);
+    if (flipTrack) {
+      std::swap(startPoint, endPoint);
+      startDir = -trackPtr->EndDirection();
+    }
+    
+    trackInfo.start_x = startPoint.X();
+    trackInfo.start_y = startPoint.Y();
+    trackInfo.start_z = startPoint.Z();
+    trackInfo.end_x = endPoint.X();
+    trackInfo.end_y = endPoint.Y();
+    trackInfo.end_z = endPoint.Z();
+    trackInfo.dir_x = startDir.X();
+    trackInfo.dir_y = startDir.Y();
+    trackInfo.dir_z = startDir.Z();
+    trackInfo.length = trackPtr->Length();
+    
+    std::vector<geo::Point_t> const trackPath
+      = extractTrajectory(*trackPtr, flipTrack);
+    geo::Point_t const middlePoint
+      = util::pathMiddlePoint(trackPath.begin(), std::prev(trackPath.end()));
+    trackInfo.middle_x = middlePoint.X();
+    trackInfo.middle_y = middlePoint.Y();
+    trackInfo.middle_z = middlePoint.Z();
+    
+    //
+    // determination of cathode crossing
+    //
+    // this determination should be independent of track direction;
+    icarus::CathodeDesc_t const cathode
+      = icarus::findTPCcathode(middlePoint, *geom);
+    
+    icarus::CathodeCrossing_t crossInfo
+      = icarus::detectCrossing(trackPath.begin(), trackPath.end(), cathode);
+    
+    if (crossInfo) {
+      
+      auto itBeforeCathode = trackPath.begin() + crossInfo.indexBefore;
+      auto itAfterCathode = trackPath.begin() + crossInfo.indexAfter;
+      
+      geo::Point_t middleBeforeCathode
+        = util::pathMiddlePoint(trackPath.begin(), itBeforeCathode);
+      geo::Point_t middleAfterCathode
+        = util::pathMiddlePoint(itAfterCathode, std::prev(trackPath.end()));
+      
+        // "before" is defined as "smaller x", so:
+      if (distance(middleAfterCathode, cathode) < 0.0) {
+        assert(distance(middleBeforeCathode, cathode) >= 0.0);
+        std::swap(crossInfo.indexBefore, crossInfo.indexAfter);
+        std::swap(itBeforeCathode, itAfterCathode);
+        std::swap(crossInfo.before, crossInfo.after);
+        std::swap(middleBeforeCathode, middleAfterCathode);
+      }
+      
+      trackInfo.beforecathode = crossInfo.before;
+      trackInfo.aftercathode = crossInfo.after;
+      
+      geo::Point_t const& atCathodePoint = crossInfo.crossingPoint;
+      trackInfo.atcathode_x = atCathodePoint.X();
+      trackInfo.atcathode_y = atCathodePoint.Y();
+      trackInfo.atcathode_z = atCathodePoint.Z();
+      
+      trackInfo.midbeforecathode_x = middleBeforeCathode.X();
+      trackInfo.midbeforecathode_y = middleBeforeCathode.Y();
+      trackInfo.midbeforecathode_z = middleBeforeCathode.Z();
+      
+      trackInfo.midaftercathode_x = middleAfterCathode.X();
+      trackInfo.midaftercathode_y = middleAfterCathode.Y();
+      trackInfo.midaftercathode_z = middleAfterCathode.Z();
+      
+    } // if crossing
+    
+    //Animesh added hit information - 2/8/2022
+
+    unsigned int plane = 0; //hit plane number
+
+    std::vector<art::Ptr<recob::Hit>> const& allHits = trkht.at(trackPtr.key());
+    std::vector<const recob::TrackHitMeta*> const& trkmetas = trkht.data(trackPtr.key());
+    std::vector<art::Ptr<anab::Calorimetry>> const& calorimetrycol = calorim.at(trackPtr.key());
+    std::vector<std::vector<unsigned int>> hits(plane);
+
+    // art::FindManyP<recob::SpacePoint> fmspts(allHits, e, fT0selProducer);
+    // or art::FindManyP<recob::SpacePoint> fmspts(allHits, e, fSpacePointModuleLabel); // Not sure how to define it
+    for (size_t ih = 0; ih < allHits.size(); ++ih)
+    {
+      //hits[allHits[ih]->WireID().Plane].push_back(ih);
+      sbn::selHitInfo hinfo = makeHit(*allHits[ih], allHits[ih].key(), *trackPtr, *trkmetas[ih], calorimetrycol, geom);
+      if(hinfo.plane == 2)
+        fHitStore.push_back(hinfo);
+
+    }
+    float totE = 0;
+    float totq_int = 0;
+    float totq_dqdx = 0;
+    for (size_t i = 0; i < fHitStore.size(); ++i)
+    {
+      if(fHitStore[i].dEdx > -1)
+      {
+        float E_hit = fHitStore[i].dEdx*fHitStore[i].pitch; //energy of hit, in MeV?
+        totE += E_hit;
+      }
+
+      if(fHitStore[i].dqdx > -1)
+      {
+        float q_hit = fHitStore[i].integral;
+        totq_int += q_hit;
+        float q_hit_dqdx = fHitStore[i].dqdx*fHitStore[i].pitch;
+        totq_dqdx += q_hit_dqdx;
+      }
+      /*
+      if(fHitStore[i].pitch > 1 && fHitStore[i].dqdx < 100)
+      {
+        std::cout << "In strange peak! Event: " << fEvent << " Track ID: " << trackInfo.trackID << " Hit ID: " << i << " Total Number of hits: " << fHitStore.size() << std::endl;
+      }
+      */
+    }
+    trackInfo.energy = totE;
+    trackInfo.charge_int = totq_int;
+    trackInfo.charge_dqdx = totq_dqdx;
+    fTrackInfo = std::move(trackInfo);
+    /*
+    for(size_t trajp = 0; trajp < trackPtr->NumberTrajectoryPoints()-1; ++trajp)
+    {
+      TVector3 cur_point(trackPtr->TrajectoryPoint(traj_p).position.X(), trackPtr->TrajectoryPoint(traj_p).position.Y(), trackPtr->TrajectoryPoint(traj_p).position.Z());
+      TVector3 next_point(trackPtr->TrajectoryPoint(traj_p+1).position.X(), trackPtr->TrajectoryPoint(traj_p+1).position.Y(), trackPtr->TrajectoryPoint(traj_p+1).position.Z());
+      if(abs(cur_point.X()) < 170 && abs(next_point.X()) > 170)
+        //interpolate to get cathode crossing point
+        
+    }
+    */
+    
+    triggerResponseExtractors.fetch(iTrack); // TODO no check performed; need to find a way
+  
+    ++processed;
+    ++fTotalProcessed;
+    fStoreTree->Fill();
+  } // for particle
+  
+  mf::LogInfo(fLogCategory) << "Particles Processed: " << processed;
+
+} // sbn::TimeTrackTreeStorage::analyze()
+
+
+sbn::selHitInfo sbn::TimeTrackTreeStorage::makeHit(const recob::Hit &hit,
+                                                   unsigned hkey,
+                                                   const recob::Track &trk,
+                                                   const recob::TrackHitMeta &thm,
+                                                   const std::vector<art::Ptr<anab::Calorimetry>> &calo,
+                                                   const geo::GeometryCore *geo)
+{
+
+  // TrackHitInfo to save
+  sbn::selHitInfo hinfo;
+
+  // information from the hit object
+  hinfo.integral = hit.Integral();
+  hinfo.sumadc = hit.SummedADC();
+  hinfo.width = hit.RMS();
+  hinfo.pk_time = hit.PeakTime();
+  hinfo.mult = hit.Multiplicity();
+  hinfo.wire = hit.WireID().Wire;
+  hinfo.plane = hit.WireID().Plane;
+  hinfo.channel = geo->PlaneWireToChannel(hit.WireID());
+  hinfo.tpc = hit.WireID().TPC;
+  hinfo.end = hit.EndTick();
+  hinfo.start = hit.StartTick();
+  hinfo.id = (int)hkey;
+
+  bool const badhit = (thm.Index() == std::numeric_limits<unsigned int>::max()) ||
+    (!trk.HasValidPoint(thm.Index()));
+
+  //hinfo.ontraj = !badhit;
+  // Save trajectory information if we can
+  if(!badhit)
+  {
+    geo::Point_t const& loc = trk.LocationAtPoint(thm.Index());
+    hinfo.px = loc.X();
+    hinfo.py = loc.Y();
+    hinfo.pz = loc.Z();
+  
+    geo::Vector_t const& dir = trk.DirectionAtPoint(thm.Index());
+    hinfo.dirx = dir.X();
+    hinfo.diry = dir.Y();
+    hinfo.dirz = dir.Z();
+    
+    // And determine if the Hit is on a Calorimetry object
+    for (const art::Ptr<anab::Calorimetry> &c: calo) {
+      if (c->PlaneID().Plane != hinfo.plane) continue;
+      
+      // Found the plane! Now find the hit:
+      for (unsigned i_calo = 0; i_calo < c->dQdx().size(); i_calo++) {
+        // "TpIndices" match to the hit key
+        if (c->TpIndices()[i_calo] != hkey) continue;
+        // Fill the calo information associated with the hit 
+        hinfo.oncalo = true;
+        hinfo.pitch = c->TrkPitchVec()[i_calo];
+        hinfo.dqdx = c->dQdx()[i_calo];
+        hinfo.dEdx = dEdx_calc(hinfo.dqdx, fMODA, fMODB, fWion, fEfield);
+        hinfo.rr = c->ResidualRange()[i_calo];
+        break;
+      } // for i_calo
+      break;
+    } // for c
+  }
+  
+  return hinfo;
+}
+
+float sbn::TimeTrackTreeStorage::dEdx_calc(float dQdx,
+                                           float A,
+                                           float B,
+                                           float Wion,
+                                           float E) 
+{
+  float LAr_density_gmL = 1.389875; //LAr density in g/cm^3
+  float alpha = A;
+  float beta = B/(LAr_density_gmL*E);
+  float dEdx = ((std::exp(dQdx*Wion*beta) - alpha)/beta)*3.278;
+ 
+  return dEdx;
+  
+}
+
+
+// -----------------------------------------------------------------------------
+void sbn::TimeTrackTreeStorage::endJob() {
+  
+  mf::LogInfo(fLogCategory) << "Processed " << fTotalProcessed << " tracks.";
+  
+} // sbn::TimeTrackTreeStorage::endJob()
+
+
+// -----------------------------------------------------------------------------
+std::vector<std::pair<double, std::vector<raw::Channel_t>>>
+sbn::TimeTrackTreeStorage::computePMTwalls() const {
+  
+  geo::GeometryCore const& geom { *lar::providerFrom<geo::Geometry>() };
+  
+  // run the algorithm to identify the PMT walls (as groups of geo::OpDetGeo)
+  std::vector<std::pair<double, std::vector<geo::OpDetGeo const*>>> opDetWalls
+    = icarus::trigger::PMTverticalSlicingAlg{}.PMTwalls(geom);
+  
+  // and weirdly, the only portable way to go from a OpDetGeo to its channel
+  // is to build a map (maybe because it's not guaranteed to be 1-to-1?)
+  std::map<geo::OpDetGeo const*, raw::Channel_t> opDetToChannel;
+  for (auto const channel: util::counter<raw::Channel_t>(geom.MaxOpChannel()))
+    opDetToChannel[&geom.OpDetGeoFromOpChannel(channel)] = channel;
+  
+  // rewrite the data structure replacing each detector with its readout channel
+  std::vector<std::pair<double, std::vector<raw::Channel_t>>> channelWalls;
+  for (auto const& [ coord, PMTs ]: opDetWalls) {
+    std::vector<raw::Channel_t> channels;
+    channels.reserve(PMTs.size());
+    for (geo::OpDetGeo const* PMT: PMTs)
+      channels.push_back(opDetToChannel.at(PMT));
+    
+    channelWalls.emplace_back(coord, std::move(channels));
+  } // for walls
+  
+  return channelWalls;
+} // sbn::TimeTrackTreeStorage::computePMTwalls()
+
+
+// -----------------------------------------------------------------------------
+
+DEFINE_ART_MODULE(sbn::TimeTrackTreeStorage)

--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
@@ -667,7 +667,7 @@ void sbn::TimeTrackTreeStorage::analyze(art::Event const& e)
     }
     trackInfo.energy = totE;
     trackInfo.charge_int = totq_int;
-    trackInfo.charge_dqdx = totq_dqdx;
+    // trackInfo.charge_dqdx = totq_dqdx;
     fTrackInfo = std::move(trackInfo);
     /*
     for(size_t trajp = 0; trajp < trackPtr->NumberTrajectoryPoints()-1; ++trajp)

--- a/icaruscode/Analysis/trigger/TimedTrackSelectorCRT_module.cc
+++ b/icaruscode/Analysis/trigger/TimedTrackSelectorCRT_module.cc
@@ -1,0 +1,475 @@
+/**
+ * @file    icaruscode/Analysis/trigger/TimedTrackSelector_module.cc
+ * @date    September 17, 2021
+ * @authors Animesh Chatterjee (ANC238@pitt.edu),
+ *          Gianluca Petrillo (petrillo@slac.stanford.edu),
+ *          Jacob Zettlemoyer (jzettle@fnal.gov)
+ * 
+ */
+
+#define MF_DEBUG
+
+// SBN and ICARUS libraries
+#ifdef USE_ATOMICPASSCOUNTER
+#include "icarusalg/Utilities/AtomicPassCounter.h"
+#else // !USE_ATOMICPASSCOUNTER
+#include "icarusalg/Utilities/PassCounter.h"
+#endif // USE_ATOMICPASSCOUNTER
+
+// LArSoft libraries
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/RecoBase/Track.h"
+
+
+// framework libraries
+#include "art/Framework/Core/SharedFilter.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/Atom.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// C/C++ standard library
+#include <vector>
+#include <string>
+#include <atomic>
+#include <memory>
+#include <limits>
+
+// -----------------------------------------------------------------------------
+namespace sbn { class TimedTrackSelector; }
+/**
+ * @brief Selects tracks with time information.
+ * 
+ * This module produces a list of "tracks" that are associated to a time.
+ * Optionally, it can select only the tracks with that time in a specified
+ * range.
+ * 
+ * This module is a filter that will return `true` for an event if at least one
+ * of its tracks is selected. This threshold can be adjusted by configuration.
+ * 
+ * 
+ * Input
+ * ------
+ * 
+ * The input file is expected to contain the time information and association
+ * to "tracks", which are actually represented by `recob::PFParticle` rather
+ * than `recob::Track`.
+ * Note that the track data products are not explicitly required.
+ * 
+ * 
+ * Output
+ * -------
+ * 
+ * The filter _produces_ a list of pointers to the selected tracks; the list
+ * will mix tracks from different data products if multiple input collections
+ * are specified. A track is selected if all the following apply:
+ * 
+ * 1. the track is associated to a time;
+ * 2. only if a time range is specified, that track time must fall within.
+ * 
+ * The filter passes the event if:
+ *  * the number of selected tracks is within the configured range of requested
+ *    tracks per event.
+ * 
+ * 
+ * Configuration options
+ * ----------------------
+ * 
+ * * `TrackTimeTags` (list of data product tags, required): data product of the
+ *    times and their associations tracks.
+ * * `MinT0` (real, optional): if specified, tracks are selected only if their
+ *     associated time is not earlier than this value. Time is in the same time
+ *     scale as the associated track time, which is expected to be the
+ *     @ref DetectorClocksTriggerTime "trigger time scale" but in nanoseconds.
+ * * `MaxT0` (real, optional): if specified, tracks are selected only if their
+ *     associated time is earlier than this value. This time is in the same
+ *     time scale as `MinT0`.
+ * * `MinTracks` (integer, default: `1`): the filter "passes" the event only if
+ *     at least these many tracks are selected; disable this by setting it to
+ *     `0`.
+ * * `MaxTracks` (integer, default: a large number): if specified, filter
+ *     "passes" the event only if at most these many tracks are selected.
+ * * `OnlyPandoraTracks` (flag, default: `true`): saves only the particles which
+ *     have been recognised as track-like. The definition was taken from
+   *     Pandora (`larpandoracontent` `v03_26_01`) and includes charged pions and
+   *     kaons, protons and muons. Note that Pandora itself does not do a full
+ *     particle type identification and it uses only the codes for muons and
+ *     electrons, to distinguish track-like and shower-like topologies, plus
+ *     neutrino codes.
+ * * `SaveTracks` (flag, default: `true`): produces a list of _art_ pointers
+ *     to the selected particles. This is the default behaviour of the module.
+ *     On the other end, the module can be used solely for its filtering
+ *     capability, in which case saving the list is not necessary and this
+ *     option allows omitting it.
+ * 
+ */
+class sbn::TimedTrackSelector: public art::SharedFilter {
+  
+public:
+  
+  static constexpr double NoMinTime { std::numeric_limits<double>::lowest() };
+  static constexpr double NoMaxTime { std::numeric_limits<double>::max() };
+  static constexpr double NoAngleCut {std::numeric_limits<double>::lowest() };
+  static constexpr unsigned int NoMinTracks { 0U };
+  static constexpr unsigned int NoMaxTracks
+  { std::numeric_limits<unsigned int>::max() };
+  
+  
+  /// Module configuration parameters.
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    
+    fhicl::Sequence<art::InputTag> TrackTimeTags {
+      Name{ "TrackTimeTags" },
+	Comment{ "data products with trach time information (and associations)" }
+    };
+    
+    fhicl::Atom<double> MinT0 {
+      Name{ "MinT0" },
+	Comment{ "Select only tracks not earlier than this time [ns]" },
+      NoMinTime
+	};
+    
+    fhicl::Atom<double> MaxT0 {
+      Name{ "MaxT0" },
+	Comment{ "Select only tracks earlier than this time [ns]" },
+      NoMaxTime
+	};
+    
+    fhicl::Atom<unsigned int> MinTracks {
+      Name{ "MinTracks" },
+	Comment{ "Pass only events with at least these many selected tracks" },
+      1U
+	};
+    
+    fhicl::Atom<unsigned int> MaxTracks {
+      Name{ "MaxTracks" },
+	Comment{ "Pass only events with at most these many selected tracks" },
+      NoMaxTracks
+	};
+
+    fhicl::Atom<double> AngleCosCut {
+      Name{ "AngleCosCut" },
+        Comment{ "Select only tracks with an direction cosine wrt vertical less than this" },
+      NoAngleCut
+        };
+	  
+    
+    fhicl::Atom<bool> OnlyPandoraTracks {
+      Name{ "OnlyPandoraTracks" },
+	Comment{
+        "Select a \"track\" only if its particle flow object"
+        " has the particle ID of a track"
+	  },
+      true
+	};
+    
+    fhicl::Atom<bool> SaveTracks {
+      Name{ "SaveTracks" },
+	Comment{ "Whether to write the list of selected tracks" },
+      true
+	};
+    
+    fhicl::Atom<std::string> LogCategory {
+      Name{ "LogCategory" },
+	Comment{ "name of a message facility stream for this module" },
+      "TimedTrackSelector"
+	};
+    
+  }; // Config
+  
+  
+  using Parameters = art::SharedFilter::Table<Config>;
+  
+  explicit TimedTrackSelector
+  (Parameters const& params, art::ProcessingFrame const&);
+  
+  bool filter(art::Event& event, art::ProcessingFrame const&) override;
+  
+  /// Prints end-job summary.
+  void endJob(art::ProcessingFrame const&) override;
+  
+
+private:
+
+  // --- BEGIN -- Configuration parameters -------------------------------------
+  
+  /// List of track-time association input tags.
+  std::vector<art::InputTag> const fTrackTimeTags;
+  
+  double const fMinT0;  ///< Minimum track time for track selection.
+  double const fMaxT0;  ///< Maximum track time for track selection.
+
+  double const fAngleCosCut; ///< Minimum track angle wrt vertical for track selection  
+  /// Minimum selected tracks for event selection.
+  unsigned int const fMinTracks;
+  /// Maximum selected tracks for event selection.
+  unsigned int const fMaxTracks;
+  
+  bool const fOnlyPandoraTracks; ///< Save only tracks identified as such.
+  bool const fSaveTracks;  ///< Whether to save selected tracks into the event.
+  
+  std::string const fLogCategory; ///< Message facility stream name.
+  
+  // --- END ---- Configuration parameters -------------------------------------
+  
+  /// Counter of passed events (not thread-safe).
+#ifdef USE_ATOMICPASSCOUNTER
+  icarus::ns::util::AtomicPassCounter<> fPassRate;
+#else // !USE_ATOMICPASSCOUNTER
+  icarus::ns::util::PassCounter<> fPassRate;
+#endif // USE_ATOMICPASSCOUNTER
+  
+  
+  /**
+   * @brief Adds to `selectedTracks` qualifying tracks from `timeTracks`.
+   * @param timeTracks time/track associations
+   * @param[out] selectedTracks collection to expand with the qualifying tracks
+   * @return the number of qualifying tracks found in `timeTracks` and added
+   */
+  unsigned int selectTracks(
+			    art::Assns<recob::Track, anab::T0> const& timeTracks, std::vector<art::Ptr<recob::Track>>& selectedTracks
+			    ) const;
+  
+  
+  /// Returns whether the specified track (with specified time) qualifies.
+  bool isTrackSelected
+  (recob::Track const& track, anab::T0 const& time) const;
+
+  /// Returns whether the specified `particle` flow object is a track.
+  //static bool isTrack(recob::Track const& particle);
+  
+  /// Returns if the number of tracks `nTracks` satisfies filter requirements.
+  bool selectedTracksRequirement(unsigned int nTracks) const;
+  
+
+}; // sbn::TimedTrackSelector
+
+
+// -----------------------------------------------------------------------------
+// ---  Implementation
+// -----------------------------------------------------------------------------
+
+int fTotalTracks = 0;
+
+sbn::TimedTrackSelector::TimedTrackSelector
+(Parameters const& params, art::ProcessingFrame const&)
+  : art::SharedFilter{ params }
+  , fTrackTimeTags{ params().TrackTimeTags() }
+  , fMinT0{ params().MinT0() }
+  , fMaxT0{ params().MaxT0() }
+  , fAngleCosCut{ params().AngleCosCut() }
+  , fMinTracks{ params().MinTracks() }
+  , fMaxTracks{ params().MaxTracks() }
+  , fOnlyPandoraTracks{ params().OnlyPandoraTracks() }
+  , fSaveTracks{ params().SaveTracks() }
+  , fLogCategory{ params().LogCategory() }
+{
+  async<art::InEvent>();
+  
+  if (fSaveTracks)
+    produces<std::vector<art::Ptr<recob::Track>>>();
+  
+  //
+  // configuration dump
+  //
+  {
+    mf::LogInfo log{ fLogCategory };
+    log << "Configuration:"
+	<< "\n  * tracks required to be associated to a time (cathode-crossers)"
+      ;
+    log << "\n  * track time:";
+    if (fMinT0 == NoMinTime) {
+      if (fMaxT0 == NoMaxTime) log << " any";
+      else                     log << " before " << fMaxT0;
+    }
+    else {
+      log << " from " << fMinT0;
+      if (fMaxT0 == NoMaxTime) log << " on";
+      else                     log << " to " << fMaxT0;
+    }
+    
+    log << "\n  * selected tracks per event: ";
+    if (fMinTracks == NoMinTracks) {
+      if (fMaxTracks == NoMaxTracks) log << "any";
+      else log << fMaxTracks << " or less";
+    }
+    else {
+      if (fMaxTracks == NoMaxTracks) log << fMinTracks << " or more";
+      else log << "between " << fMinTracks << " and " << fMaxTracks;
+    }
+    log << "\n  * selected tracks will" << (fSaveTracks? "": " not")
+	<< " be saved";
+  } // end local scope
+  
+} // sbn::TimedTrackSelector::TimedTrackSelector()
+
+
+// -----------------------------------------------------------------------------
+bool sbn::TimedTrackSelector::filter
+(art::Event& event, art::ProcessingFrame const&)
+{
+  
+  mf::LogDebug(fLogCategory) << "Processing " << event.id();
+  
+  //
+  // select tracks from each of the input tags
+  //
+  std::vector<art::Ptr<recob::Track>> selectedTracks;
+  for (art::InputTag const& inputTag: fTrackTimeTags) {
+    auto const& T0toTrack
+      = event.getProduct<art::Assns<recob::Track, anab::T0>>(inputTag);
+    unsigned int const newTracks = selectTracks(T0toTrack, selectedTracks);
+    
+    mf::LogTrace(fLogCategory)
+      << "From '" << inputTag.encode() << "': "
+      << newTracks << " tracks selected"
+      ;
+    
+  } // for
+
+  unsigned int const nSelectedTracks = selectedTracks.size();
+  
+  
+  //
+  // save track list in the event
+  //
+  
+  // after this, selectedTracks may be empty. JCZ: Not quite, I think the access to selectedTracks[0] in the log statement throws a segfault it it's empty, now fixed
+  if (fSaveTracks) {
+    event.put(
+	      std::make_unique<std::vector<art::Ptr<recob::Track>>>(selectedTracks)
+	      );
+    if(selectedTracks.size() > 0)
+      {
+	mf::LogTrace(fLogCategory)
+	  << "InputTag for this product is: "
+	  << event.getProductDescription(selectedTracks[0].id())->inputTag();
+      }
+  }
+  
+  
+  //
+  // filter logic
+  //
+  
+  bool const passed = selectedTracksRequirement(nSelectedTracks);
+  fPassRate.add(passed);
+  mf::LogTrace(fLogCategory) << event.id()
+			     << ' ' << (passed? "passed": "rejected") << " (" << nSelectedTracks
+			     << " selected tracks)."; // funny fact: we don't know the total track count, JCZ: I think I fixed that fact although I could be completely wrong
+  
+  
+  mf::LogDebug(fLogCategory) << "Completed " << event.id();
+
+  mf::LogDebug(fLogCategory) << "There are now " << fTotalTracks << " total tracks selected.";
+
+  return passed;
+  
+} // sbn::TimedTrackSelector::filter()
+
+
+// -----------------------------------------------------------------------------
+void sbn::TimedTrackSelector::endJob(art::ProcessingFrame const&) {
+  
+  mf::LogInfo(fLogCategory) << "Selected " << fPassRate.passed()
+			    << '/' << fPassRate.total() << " events with qualifying tracks.";
+  
+} // sbn::TimedTrackSelector::endJob()
+
+
+// -----------------------------------------------------------------------------
+unsigned int sbn::TimedTrackSelector::selectTracks(
+						   art::Assns<recob::Track, anab::T0> const& timeTracks, std::vector<art::Ptr<recob::Track>>& selectedTracks
+						   ) const {
+  
+  unsigned int nSelectedTracks { 0U };
+  for (auto const& [ trackPtr, t0Ptr ]: timeTracks) {
+    
+    // if fOnlyPandoraTracks is false, we don't need the track, so we avoid
+    // dereferencing the pointer: a reference from a null pointer will be
+    // passed around and will cause a segmentation violation at the first access
+    recob::Track const* track = fOnlyPandoraTracks? &*trackPtr: nullptr;
+    
+    if (!isTrackSelected(*track, *t0Ptr)) continue;
+    
+    MF_LOG_TRACE(fLogCategory) << "Track #" << trackPtr.key() << " selected.";
+    
+    selectedTracks.push_back(trackPtr);
+    ++nSelectedTracks;
+    ++fTotalTracks;
+  } // for
+  
+  return nSelectedTracks;
+  
+} // sbn::TimedTrackSelector::selectTracks()
+
+
+// -----------------------------------------------------------------------------
+bool sbn::TimedTrackSelector::isTrackSelected
+(recob::Track const& track, anab::T0 const& time) const
+{
+  
+  double const T0 = time.Time();
+  MF_LOG_TRACE(fLogCategory) << "Track time: " << T0;
+  /*
+  if (fOnlyPandoraTracks && !isTrack(track)) {
+  MF_LOG_TRACE(fLogCategory) << "Not a track (ID=" << track.PdgCode()
+  << ") => discarded!";
+    return false;
+  }
+  */
+  if ((T0 < fMinT0) || (T0 >= fMaxT0)) {
+    MF_LOG_TRACE(fLogCategory) << "Time out of range [ " << fMinT0 << "; "
+			       << fMaxT0 << " ] => discarded!";
+    return false;
+  }
+
+  //double angle = track.StartDirection().Y();
+  
+  //if(angle > fAngleCosCut && fAngleCosCut != NoAngleCut)
+  //return false;
+  
+  
+  return true;
+} // sbn::TimedTrackSelector::isTrackSelected()
+
+
+// -----------------------------------------------------------------------------
+/*
+bool sbn::TimedTrackSelector::isTrack(recob::Track const& track) {
+  
+  switch (std::abs(track.PdgCode())) {
+    case 13:   // muon
+    case 211:  // charged pion
+    case 321:  // charged kaon
+    case 2212: // proton
+      return true;
+    default:
+      return false;
+  } // switch
+  return false;
+} // sbn::TimedTrackSelector::isTrack()
+*/
+
+// -----------------------------------------------------------------------------
+bool sbn::TimedTrackSelector::selectedTracksRequirement
+(unsigned int nTracks) const
+{
+  return (nTracks >= fMinTracks) && (nTracks <= fMaxTracks);
+} // sbn::TimedTrackSelector::selectedTracks()
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_MODULE(sbn::TimedTrackSelector)
+
+
+// -----------------------------------------------------------------------------

--- a/icaruscode/Analysis/trigger/createtree_timed_tracks_icarus_CRT.fcl
+++ b/icaruscode/Analysis/trigger/createtree_timed_tracks_icarus_CRT.fcl
@@ -28,6 +28,7 @@ END_PROLOG
 #include "triggeremu_data_config_icarus.fcl"
 #include "icarus_trackcalo_skimmer.fcl"
 #include "calorimetry_icarus.fcl"
+# 
 
 BEGIN_PROLOG
 
@@ -63,9 +64,9 @@ process_name: storeTree
 
 # ------------------------------------------------------------------------------
 services: {
-  message:     @local::icarus_message_services_interactive_debug
   @table::triggeremu_data_config_icarus.services # from triggeremu_data_config_icarus.fcl
   @table::icarus_common_services
+  message:     @local::icarus_message_services_interactive_debug
   TimeTracker: {}
   TFileService: {
     fileName: "timedtracks_store_triggeremu.root"
@@ -118,21 +119,28 @@ physics: {
 
     #calorimetry
 
-    calorimetryCryoE: @local::caloskim_calorimetry
-    calorimetryCryoW: @local::caloskim_calorimetry
+    calorimetryCryoE: {
+      @table::standard_gnocchicaloicarus  # from calorimetryICARUS.fcl
+      TrackModuleLabel: "pandoraTrackGausCryoE"
+    }
+    calorimetryCryoW: {
+      @table::standard_gnocchicaloicarus  # from calorimetryICARUS.fcl
+      TrackModuleLabel: "pandoraTrackGausCryoW"
+    }
     
   }
 
   analyzers: {
     t0TreeStoreW: {
       @table::timetracktreestorage_base
-      PFPproducer: "pandoraGausCryoW"
-      T0Producer: "CRTT0MatchingW"
       T0selProducer: "t0selectorW"
+      T0Producer: "pandoraGausCryoW"
+      PFPproducer: "pandoraTrackGausCryoW"
       TrackProducer: "pandoraTrackGausCryoW"
       TrackFitterProducer: "pandoraTrackGausCryoW"
       CaloProducer: "calorimetryCryoW"
       FlashProducer: "opflashCryoW"
+      CRTMatchingProducer: "CRTT0MatchingW"
       EmulatedTriggers: [
         { Name:       "M1"    TriggerTag: "simTiledORM1W" },
         { Name:       "S3"    TriggerTag: "simTiledORS3W" },
@@ -153,13 +161,14 @@ physics: {
 
     t0TreeStoreE: {
       @table::timetracktreestorage_base
-      PFPproducer: "pandoraGausCryoE"
-      T0Producer: "CRTT0MatchingE"
       T0selProducer: "t0selectorE"
+      T0Producer: "pandoraGausCryoE"
+      PFPproducer: "pandoraTrackGausCryoE"
       TrackProducer: "pandoraTrackGausCryoE"
       TrackFitterProducer: "pandoraTrackGausCryoE"
       CaloProducer: "calorimetryCryoE"
       FlashProducer: "opflashCryoE"
+      CRTMatchingProducer: "CRTT0MatchingE"
       EmulatedTriggers: [
         { Name:       "M1"    TriggerTag: "simTiledORM1E" },
         { Name:       "S3"    TriggerTag: "simTiledORS3E" },
@@ -186,7 +195,7 @@ physics: {
   trigger_paths: [ runprod, selectionW, selectionE]
   ana: [ t0TreeStoreW, t0TreeStoreE ]
   streams: [ "rootoutput" ]
-  end_paths: [ ana ]
+  end_paths: [ ana, streams ]
   
 } # physics
 
@@ -209,6 +218,7 @@ outputs: {
     outputCommands: [
       "drop *"
       , "keep sbn::PMTconfiguration_*_*_*", "keep *_daqTrigger_*_*"
+      , "keep *_CRTT0Matching*_*_*", "keep *_daqTrigger_*_*"
       , "keep *_pandoraGausCryo*_*_stage1", "drop *recob::SpacePoint*_pandoraGausCryo*_*_stage1", "keep *_pandoraTrackGausCryo*_*_stage1"
       , "keep *_cluster3DCryo*_*_*", "drop *recob::SpacePoint*_cluster3DCryo*_*_*"
       , "keep *_opflashCryo*_*_*"
@@ -218,5 +228,3 @@ outputs: {
 
   }
 }
-
-#include "icarus_data_recombination.fcl"

--- a/icaruscode/Analysis/trigger/createtree_timed_tracks_icarus_CRT.fcl
+++ b/icaruscode/Analysis/trigger/createtree_timed_tracks_icarus_CRT.fcl
@@ -1,0 +1,222 @@
+#
+# File:    createtree_timed_tracks_icarus.fcl
+# Purpose: Store selected timed tracks with energy estimation and trigger emulation into flat ROOT trees.
+# Authors: Animesh Chatterjee (ANC238@pitt.edu),
+#          Gianluca Petrillo (petrillo@slac.stanford.edu),
+#          Jacob Zettlemoyer (jzettle@fnal.gov)
+# Date:    September 22, 2021
+#
+#
+
+BEGIN_PROLOG
+###
+### fix settings (so that will not be overridden later);
+### these are defined in `triggeremu_data_config_icarus.fcl`
+###
+
+# do not emulate any fixed level threshold (only `pmtthr`)
+triggeremu_data_config_icarus.settings.PMTADCthresholds @protect_ignore: []
+
+
+END_PROLOG
+
+
+#include "messages_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+#include "services_common_icarus.fcl"
+#include "trigger_icarus.fcl"
+#include "triggeremu_data_config_icarus.fcl"
+#include "icarus_trackcalo_skimmer.fcl"
+#include "calorimetry_icarus.fcl"
+
+BEGIN_PROLOG
+
+timetracktreestorage_base: {
+  module_type: "TimeTrackTreeStorageCRT"
+  BeamGateProducer: "daqTrigger"
+  TriggerProducer:  "daqTrigger"
+  MODA: 0.930
+  MODB: 0.212
+  Wion: 0.0000236016
+  Efield: 0.5
+  ForceDowngoing: true
+}
+
+gatesFromTracks_icarus: {
+
+  module_type: BeamGateInfoFromTracksCRT
+  
+  GateStartOffset: "-15 us"
+  GateEndOffset:   "+5 us"
+  
+  T0Producer:    @nil  # must override
+  T0selProducer: @nil  # must override
+  
+} # gatesFromTracks_icarus
+
+
+END_PROLOG
+
+# ------------------------------------------------------------------------------
+process_name: storeTree
+
+
+# ------------------------------------------------------------------------------
+services: {
+  message:     @local::icarus_message_services_interactive_debug
+  @table::triggeremu_data_config_icarus.services # from triggeremu_data_config_icarus.fcl
+  @table::icarus_common_services
+  TimeTracker: {}
+  TFileService: {
+    fileName: "timedtracks_store_triggeremu.root"
+  }
+}
+
+# customization of message destinations from trigger emulation
+services.message.destinations: {
+  @table::services.message.destinations
+  @table::triggeremu_data_config_icarus.messagedestinations
+}
+
+services.SpaceChargeService: @local::icarus_spacecharge
+
+physics: {
+  filters: {
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    t0selectorW: {
+      module_type: TimedTrackSelectorCRT
+      #AngleCosCut: -0.9396926
+      #TrackTimeTags: [ pandoraGausCryoW, pandoraGausCryoE ]
+      TrackTimeTags: [ "CRTT0MatchingW" ]
+
+    } # t0selectorW
+
+    t0selectorE: {
+      module_type: TimedTrackSelectorCRT
+      #AngleCosCut: -0.9396926
+      TrackTimeTags: [ "CRTT0MatchingE" ]
+    }
+  }
+
+  producers: {
+
+    gatesFromTracksE: {
+      @table::gatesFromTracks_icarus
+    
+      T0Producer:    "CRTT0MatchingE"
+      T0selProducer: t0selectorE
+    }
+    
+    gatesFromTracksW: {
+      @table::gatesFromTracks_icarus
+      
+      T0Producer:    "CRTT0MatchingW"
+      T0selProducer: t0selectorW
+    }
+  
+    @table::triggeremu_data_config_icarus.producers # from triggeremu_data_config_icarus.fcl
+
+    #calorimetry
+
+    calorimetryCryoE: @local::caloskim_calorimetry
+    calorimetryCryoW: @local::caloskim_calorimetry
+    
+  }
+
+  analyzers: {
+    t0TreeStoreW: {
+      @table::timetracktreestorage_base
+      PFPproducer: "pandoraGausCryoW"
+      T0Producer: "CRTT0MatchingW"
+      T0selProducer: "t0selectorW"
+      TrackProducer: "pandoraTrackGausCryoW"
+      TrackFitterProducer: "pandoraTrackGausCryoW"
+      CaloProducer: "calorimetryCryoW"
+      FlashProducer: "opflashCryoW"
+      EmulatedTriggers: [
+        { Name:       "M1"    TriggerTag: "simTiledORM1W" },
+        { Name:       "S3"    TriggerTag: "simTiledORS3W" },
+        { Name:       "S5"    TriggerTag: "simTiledORS5W" },
+        { Name:       "S8"    TriggerTag: "simTiledORS8W" },
+        { Name:      "S10"    TriggerTag: "simTiledORS10W" },
+        { Name:      "S15"    TriggerTag: "simTiledORS15W" },
+        { Name:       "M1s"   TriggerTag: "simSlidingORM1W" },
+        { Name:       "S3s"   TriggerTag: "simSlidingORS3W" },
+        { Name:       "S5s"   TriggerTag: "simSlidingORS5W" },
+        { Name:       "S8s"   TriggerTag: "simSlidingORS8W" },
+        { Name:      "S10s"   TriggerTag: "simSlidingORS10W" },
+        { Name:      "S15s"   TriggerTag: "simSlidingORS15W" }
+      ]
+      LogCategory: "TimeTrackTreeStorageCryoW"
+      SelectEvents: [ "selectionW" ]
+      }
+
+    t0TreeStoreE: {
+      @table::timetracktreestorage_base
+      PFPproducer: "pandoraGausCryoE"
+      T0Producer: "CRTT0MatchingE"
+      T0selProducer: "t0selectorE"
+      TrackProducer: "pandoraTrackGausCryoE"
+      TrackFitterProducer: "pandoraTrackGausCryoE"
+      CaloProducer: "calorimetryCryoE"
+      FlashProducer: "opflashCryoE"
+      EmulatedTriggers: [
+        { Name:       "M1"    TriggerTag: "simTiledORM1E" },
+        { Name:       "S3"    TriggerTag: "simTiledORS3E" },
+        { Name:       "S5"    TriggerTag: "simTiledORS5E" },
+        { Name:       "S8"    TriggerTag: "simTiledORS8E" },
+        { Name:      "S10"    TriggerTag: "simTiledORS10E" },
+        { Name:      "S15"    TriggerTag: "simTiledORS15E" },
+        { Name:       "M1s"   TriggerTag: "simSlidingORM1E" },
+        { Name:       "S3s"   TriggerTag: "simSlidingORS3E" },
+        { Name:       "S5s"   TriggerTag: "simSlidingORS5E" },
+        { Name:       "S8s"   TriggerTag: "simSlidingORS8E" },
+        { Name:      "S10s"   TriggerTag: "simSlidingORS10E" },
+        { Name:      "S15s"   TriggerTag: "simSlidingORS15E" }
+      ]
+      LogCategory: "TimeTrackTreeStorageCryoE"
+      SelectEvents: [ "selectionE" ]
+      }
+
+  } #analyzers
+  
+  selectionW: [ "t0selectorW", "gatesFromTracksW", @sequence::triggeremu_data_config_icarus.producerpathW ]
+  selectionE: [ "t0selectorE", "gatesFromTracksE", @sequence::triggeremu_data_config_icarus.producerpathE ]
+  runprod: [calorimetryCryoE, calorimetryCryoW]
+  trigger_paths: [ runprod, selectionW, selectionE]
+  ana: [ t0TreeStoreW, t0TreeStoreE ]
+  streams: [ "rootoutput" ]
+  end_paths: [ ana ]
+  
+} # physics
+
+physics.producers.calorimetryCryoE.TrackModuleLabel: "pandoraTrackGausCryoE"
+physics.producers.calorimetryCryoW.TrackModuleLabel: "pandoraTrackGausCryoW"
+
+# disable the functionality of the module without removing it from path (for convenience)
+physics.producers.pmtfixedthr.module_type: DummyProducer
+
+
+# ------------------------------------------------------------------------------
+outputs: {
+  rootoutput: {
+    @table::icarus_rootoutput
+    
+    fileProperties: { maxInputFiles: 1 }
+    checkFileName: false
+    
+    # these data products are enough to rerun this job (until hits are needed):
+    outputCommands: [
+      "drop *"
+      , "keep sbn::PMTconfiguration_*_*_*", "keep *_daqTrigger_*_*"
+      , "keep *_pandoraGausCryo*_*_stage1", "drop *recob::SpacePoint*_pandoraGausCryo*_*_stage1", "keep *_pandoraTrackGausCryo*_*_stage1"
+      , "keep *_cluster3DCryo*_*_*", "drop *recob::SpacePoint*_cluster3DCryo*_*_*"
+      , "keep *_opflashCryo*_*_*"
+      , "keep *_*_*_TrgEmu", "keep *_*_*_T0sel"
+      , "keep *_*_*_storeTree"
+      ]
+
+  }
+}
+
+#include "icarus_data_recombination.fcl"

--- a/icaruscode/Analysis/trigger/details/CathodeCrossingUtils.cxx
+++ b/icaruscode/Analysis/trigger/details/CathodeCrossingUtils.cxx
@@ -18,22 +18,22 @@
 
 // -----------------------------------------------------------------------------
 icarus::CathodeDesc_t icarus::findTPCcathode
-  (geo::Point_t const& point, geo::GeometryCore const& geom)
+(geo::Point_t const& point, geo::GeometryCore const& geom)
 {
   geo::CryostatGeo const* pCryo = geom.PositionToCryostatPtr(point);
   if (!pCryo) return {}; // all invalid, goodbye
   
   return {
-      findCathodeCenter(*pCryo)                   // center
-    , -(pCryo->TPC(0).DriftDir())  // normal
-    };
+    findCathodeCenter(*pCryo)                   // center
+      , -(pCryo->TPC(0).DriftDir())  // normal
+      };
   
 } // icarus::findTPCcathode()
 
 
 // -----------------------------------------------------------------------------
 double icarus::distance(geo::Point_t const& point, CathodeDesc_t const& cathode)
-  { return (point - cathode.center).Dot(cathode.normal); }
+{ return (point - cathode.center).Dot(cathode.normal); }
 
 
 // -----------------------------------------------------------------------------
@@ -43,11 +43,8 @@ geo::Point_t icarus::findCathodeCenter(geo::CryostatGeo const& cryo) {
   geo::vect::MiddlePointAccumulator cathodePos;
   
   for (geo::TPCGeo const& TPC: cryo.IterateTPCs())
-      cathodePos.add(TPC.GetCathodeCenter());
+    cathodePos.add(TPC.GetCathodeCenter());
   
   return cathodePos.middlePoint();
   
 } // icarus::findCathodeCenter()
-
-
-// -----------------------------------------------------------------------------

--- a/icaruscode/Analysis/trigger/select_timed_tracks_CRT_icarus.fcl
+++ b/icaruscode/Analysis/trigger/select_timed_tracks_CRT_icarus.fcl
@@ -1,0 +1,118 @@
+#
+# File:    select_timed_tracks_icarus.fcl
+# Purpose: Add selection of tracks with time information to the events.
+# Authors: Animesh Chatterjee (ANC238@pitt.edu),
+#          Gianluca Petrillo (petrillo@slac.stanford.edu),
+#          Jacob Zettlemoyer (jzettle@fnal.gov)
+# Date:    September 17, 2021
+#
+#
+
+#include "messages_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+#include "services_common_icarus.fcl"
+
+BEGIN_PROLOG
+
+gatesFromTracks_icarus: {
+
+  module_type: BeamGateInfoFromTracksCRT
+  
+  GateStartOffset: "-15 us"
+  GateEndOffset:   "+15 us"
+  
+  T0Producer:    @nil  # must override
+  T0selProducer: @nil  # must override
+  
+} # gatesFromTracks_icarus
+
+
+END_PROLOG
+
+
+# ------------------------------------------------------------------------------
+process_name: T0sel
+
+
+# ------------------------------------------------------------------------------
+services: {
+  message:     @local::icarus_message_services_interactive_debug
+  @table::icarus_common_services
+  TimeTracker: {}
+}
+
+
+# ------------------------------------------------------------------------------
+physics: {
+
+  producers: {
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    gatesFromTracksE: {
+      @table::gatesFromTracks_icarus
+    
+      T0Producer:    "CRTT0Matching::CRTT0Matching"
+      T0selProducer: t0selectorE
+    }
+    
+    gatesFromTracksW: {
+      @table::gatesFromTracks_icarus
+      
+      T0Producer:    "CRTT0Matching::CRTT0Matching"
+      T0selProducer: t0selectorW
+    }
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+  } # producers
+  
+  
+  filters: {
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    t0selectorW: {
+      module_type: TimedTrackSelectorCRT
+      
+      #TrackTimeTags: [ pandoraGausCryoW, pandoraGausCryoE ]
+      TrackTimeTags: [ "CRTT0Matching::CRTT0Matching" ] #pandoraGausCryoW
+      
+    } # t0selectorW
+
+    t0selectorE: {
+      module_type: TimedTrackSelectorCRT
+      TrackTimeTags: [ "CRTT0Matching::CRTT0Matching" ] #pandoraGausCryoE
+    }
+    
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+  } # filters
+  
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  selectionW: [ "t0selectorW" , "gatesFromTracksW" ]
+  selectionE: [ "t0selectorE" , "gatesFromTracksE" ]
+  
+  streams: [ "rootoutput" ]
+  
+} # physics
+
+
+# ------------------------------------------------------------------------------
+outputs: {
+  rootoutput: {
+    @table::icarus_rootoutput
+    outputCommands: [
+      "drop *", "keep *_pmtconfig_*_stage0",
+      "keep *_daqTrigger_*_stage0",
+      "keep *_daqPMT_*_stage0",
+      "keep *_opflashCryo*_*_*",
+      "keep *_*_*_stage1",
+      "keep *_*_*_T0sel"
+      ]
+  }
+}
+
+#source.inputCommands: ["keep *_*_*_*", "drop *_CRTT0Matching_*_stage1"]
+
+
+# ------------------------------------------------------------------------------

--- a/icaruscode/CRT/CRTUtils/crtt0matchingalg_icarus.fcl
+++ b/icaruscode/CRT/CRTUtils/crtt0matchingalg_icarus.fcl
@@ -24,6 +24,54 @@ standard_crtt0matchingalg:
     TSMode: 2				    
 }
 
+standard_crtt0matchingalgW:
+{
+    DistanceLimit:       200.                # Maximum DCA between projected crossing point and CRT hit, default = 100 cm
+    MinTrackLength:      20.                # Minimum track length to perform T0 matching on, default = 20 cm.
+                                            #    No attempt is made to tag tracks shorter than this
+    TrackDirectionFrac:  0.5                # the fraction of track used to determine direction, don't mess with this
+
+    TPCTrackLabel:       ["pandoraTrackGausCryoW"]
+    DirMethod: 1                            # method to determine track direction for extraploation
+                                            #   1=endpoints (default), 2=average;  must use endpoints if applying SCE position corrections
+    SCEposCorr: true                        # apply SCE position corrections to track before extrapolating
+                                            #    use false if the input tracks already have SCE corrections applied
+    DCAuseBox: false                        # false = distance to point (default), true = distance to box edge
+    DCAoverLength: false                    # false = use DCA to select closest CRT hit (default), true = use DCA/extrapolation_length
+    DoverLLimit: 1.0                        # 1.0 default, this is the sin of the opening angle between the track extrapolation and the line connecting
+                                            #     the track endpoint and the CRT hit
+                                            # note that both limits (distance and DoverL) are used independent of which one is used to select
+                                            #    the closest hit.  Matches with values less than either limit are not considered.
+    PEcut: 10                               # Only consider CRT hits with PE values larger than this, default = 0.0
+    MaxUncert:  20                          # Only consider CRT hits with position uncertainties below this value (cm) default =1000.0 cm
+                                            #    a cut value of 20 is recommended if one wants to remove all single strip hits
+    TSMode: 2
+}
+
+standard_crtt0matchingalgE:
+{
+    DistanceLimit:       200.                # Maximum DCA between projected crossing point and CRT hit, default = 100 cm
+    MinTrackLength:      20.                # Minimum track length to perform T0 matching on, default = 20 cm.
+                                            #    No attempt is made to tag tracks shorter than this
+    TrackDirectionFrac:  0.5                # the fraction of track used to determine direction, don't mess with this
+
+    TPCTrackLabel:       ["pandoraTrackGausCryoE"]
+    DirMethod: 1                            # method to determine track direction for extraploation
+                                            #   1=endpoints (default), 2=average;  must use endpoints if applying SCE position corrections
+    SCEposCorr: true                        # apply SCE position corrections to track before extrapolating
+                                            #    use false if the input tracks already have SCE corrections applied
+    DCAuseBox: false                        # false = distance to point (default), true = distance to box edge
+    DCAoverLength: false                    # false = use DCA to select closest CRT hit (default), true = use DCA/extrapolation_length
+    DoverLLimit: 1.0                        # 1.0 default, this is the sin of the opening angle between the track extrapolation and the line connecting
+                                            #     the track endpoint and the CRT hit
+                                            # note that both limits (distance and DoverL) are used independent of which one is used to select
+                                            #    the closest hit.  Matches with values less than either limit are not considered.
+    PEcut: 10                               # Only consider CRT hits with PE values larger than this, default = 0.0
+    MaxUncert:  20                          # Only consider CRT hits with position uncertainties below this value (cm) default =1000.0 cm
+                                            #    a cut value of 20 is recommended if one wants to remove all single strip hits
+    TSMode: 2
+}
+
 icarus_crtt0matchingalg_crID:
 {
     DistanceLimit:       35.                # Maximum distance between projected crossing point and CRT hit
@@ -41,5 +89,6 @@ icarus_crthitt0producer:
     TriggerLabel:  "daqTrigger"
     T0Alg:                @local::standard_crtt0matchingalg
 }
+
 
 END_PROLOG

--- a/icaruscode/CRT/CRTUtils/crtt0matchingalg_icarus.fcl
+++ b/icaruscode/CRT/CRTUtils/crtt0matchingalg_icarus.fcl
@@ -26,50 +26,14 @@ standard_crtt0matchingalg:
 
 standard_crtt0matchingalgW:
 {
-    DistanceLimit:       200.                # Maximum DCA between projected crossing point and CRT hit, default = 100 cm
-    MinTrackLength:      20.                # Minimum track length to perform T0 matching on, default = 20 cm.
-                                            #    No attempt is made to tag tracks shorter than this
-    TrackDirectionFrac:  0.5                # the fraction of track used to determine direction, don't mess with this
-
+    @table::standard_crtt0matchingalg
     TPCTrackLabel:       ["pandoraTrackGausCryoW"]
-    DirMethod: 1                            # method to determine track direction for extraploation
-                                            #   1=endpoints (default), 2=average;  must use endpoints if applying SCE position corrections
-    SCEposCorr: true                        # apply SCE position corrections to track before extrapolating
-                                            #    use false if the input tracks already have SCE corrections applied
-    DCAuseBox: false                        # false = distance to point (default), true = distance to box edge
-    DCAoverLength: false                    # false = use DCA to select closest CRT hit (default), true = use DCA/extrapolation_length
-    DoverLLimit: 1.0                        # 1.0 default, this is the sin of the opening angle between the track extrapolation and the line connecting
-                                            #     the track endpoint and the CRT hit
-                                            # note that both limits (distance and DoverL) are used independent of which one is used to select
-                                            #    the closest hit.  Matches with values less than either limit are not considered.
-    PEcut: 10                               # Only consider CRT hits with PE values larger than this, default = 0.0
-    MaxUncert:  20                          # Only consider CRT hits with position uncertainties below this value (cm) default =1000.0 cm
-                                            #    a cut value of 20 is recommended if one wants to remove all single strip hits
-    TSMode: 2
 }
 
 standard_crtt0matchingalgE:
 {
-    DistanceLimit:       200.                # Maximum DCA between projected crossing point and CRT hit, default = 100 cm
-    MinTrackLength:      20.                # Minimum track length to perform T0 matching on, default = 20 cm.
-                                            #    No attempt is made to tag tracks shorter than this
-    TrackDirectionFrac:  0.5                # the fraction of track used to determine direction, don't mess with this
-
+    @table::standard_crtt0matchingalg
     TPCTrackLabel:       ["pandoraTrackGausCryoE"]
-    DirMethod: 1                            # method to determine track direction for extraploation
-                                            #   1=endpoints (default), 2=average;  must use endpoints if applying SCE position corrections
-    SCEposCorr: true                        # apply SCE position corrections to track before extrapolating
-                                            #    use false if the input tracks already have SCE corrections applied
-    DCAuseBox: false                        # false = distance to point (default), true = distance to box edge
-    DCAoverLength: false                    # false = use DCA to select closest CRT hit (default), true = use DCA/extrapolation_length
-    DoverLLimit: 1.0                        # 1.0 default, this is the sin of the opening angle between the track extrapolation and the line connecting
-                                            #     the track endpoint and the CRT hit
-                                            # note that both limits (distance and DoverL) are used independent of which one is used to select
-                                            #    the closest hit.  Matches with values less than either limit are not considered.
-    PEcut: 10                               # Only consider CRT hits with PE values larger than this, default = 0.0
-    MaxUncert:  20                          # Only consider CRT hits with position uncertainties below this value (cm) default =1000.0 cm
-                                            #    a cut value of 20 is recommended if one wants to remove all single strip hits
-    TSMode: 2
 }
 
 icarus_crtt0matchingalg_crID:

--- a/icaruscode/CRT/crtt0producer_icarus.fcl
+++ b/icaruscode/CRT/crtt0producer_icarus.fcl
@@ -17,4 +17,26 @@ standard_crtt0producer:
    CRTBackTrack:        @local::standard_crtbacktracker
 }
 
+standard_crtt0producerW:
+{
+   module_type:         "icaruscode/CRT/CRTT0Matching"
+   CrtHitModuleLabel:   "crthit"           # name of crt hit producer
+   TpcTrackModuleLabel: ["pandoraTrackGausCryoW"]     # name of tpc track producer
+   PFParticleLabel:     ["pandoraGausCryoW"] # PFParticle producer module label
+   TriggerLabel:        "daqTrigger"
+   T0Alg:               @local::standard_crtt0matchingalgW
+   CRTBackTrack:        @local::standard_crtbacktracker
+}
+
+standard_crtt0producerE:
+{
+   module_type:         "icaruscode/CRT/CRTT0Matching"
+   CrtHitModuleLabel:   "crthit"           # name of crt hit producer
+   TpcTrackModuleLabel: ["pandoraTrackGausCryoE"]     # name of tpc track producer
+   PFParticleLabel:     ["pandoraGausCryoE"] # PFParticle producer module label
+   TriggerLabel:        "daqTrigger"
+   T0Alg:               @local::standard_crtt0matchingalgE
+   CRTBackTrack:        @local::standard_crtbacktracker
+}
+
 END_PROLOG

--- a/icaruscode/CRT/crtt0producer_icarus.fcl
+++ b/icaruscode/CRT/crtt0producer_icarus.fcl
@@ -1,8 +1,5 @@
-#include "services_icarus_simulation.fcl"
-#include "services_common_icarus.fcl"
 #include "crtbacktracker_icarus.fcl"
 #include "crtt0matchingalg_icarus.fcl"
-#include "simulationservices_icarus.fcl"
 
 BEGIN_PROLOG
 
@@ -19,24 +16,18 @@ standard_crtt0producer:
 
 standard_crtt0producerW:
 {
-   module_type:         "icaruscode/CRT/CRTT0Matching"
-   CrtHitModuleLabel:   "crthit"           # name of crt hit producer
+   @table::standard_crtt0producer
    TpcTrackModuleLabel: ["pandoraTrackGausCryoW"]     # name of tpc track producer
    PFParticleLabel:     ["pandoraGausCryoW"] # PFParticle producer module label
-   TriggerLabel:        "daqTrigger"
    T0Alg:               @local::standard_crtt0matchingalgW
-   CRTBackTrack:        @local::standard_crtbacktracker
 }
 
 standard_crtt0producerE:
 {
-   module_type:         "icaruscode/CRT/CRTT0Matching"
-   CrtHitModuleLabel:   "crthit"           # name of crt hit producer
+   @table::standard_crtt0producer
    TpcTrackModuleLabel: ["pandoraTrackGausCryoE"]     # name of tpc track producer
    PFParticleLabel:     ["pandoraGausCryoE"] # PFParticle producer module label
-   TriggerLabel:        "daqTrigger"
    T0Alg:               @local::standard_crtt0matchingalgE
-   CRTBackTrack:        @local::standard_crtbacktracker
 }
 
 END_PROLOG

--- a/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
+++ b/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
@@ -82,7 +82,7 @@ private:
   std::map<uint64_t, ScaleInfo> fScaleInfos;
 
   // Helpers
-  const ScaleInfo GetScaleInfo(uint64_t timestamp);
+  const ScaleInfo& GetScaleInfo(uint64_t timestamp);
 };
 
 DEFINE_ART_CLASS_TOOL(NormalizeYZSQL)
@@ -153,7 +153,7 @@ icarus::calo::NormalizeYZSQL::NormalizeYZSQL(fhicl::ParameterSet const &pset):
 
 void icarus::calo::NormalizeYZSQL::configure(const fhicl::ParameterSet& pset) {}
 
-const icarus::calo::NormalizeYZSQL::ScaleInfo icarus::calo::NormalizeYZSQL::GetScaleInfo(uint64_t timestamp) {
+const icarus::calo::NormalizeYZSQL::ScaleInfo& icarus::calo::NormalizeYZSQL::GetScaleInfo(uint64_t timestamp) {
   // check the cache
   if (fScaleInfos.count(timestamp)) {
     return fScaleInfos.at(timestamp);
@@ -207,16 +207,14 @@ const icarus::calo::NormalizeYZSQL::ScaleInfo icarus::calo::NormalizeYZSQL::GetS
   std::sort(thisscale.bins.begin(), thisscale.bins.end());
 
   // Set the cache
-  fScaleInfos[timestamp] = thisscale;
+  return fScaleInfos[timestamp] = std::move(thisscale);
 
-  return thisscale;
 }
 
 double icarus::calo::NormalizeYZSQL::Normalize(double dQdx, const art::Event &e, 
     const recob::Hit &hit, const geo::Point_t &location, const geo::Vector_t &direction, double t0) {
   // Get the info
-  ScaleInfo i = GetScaleInfo(e.time().timeHigh());
-
+  ScaleInfo const& i = GetScaleInfo(e.time().timeHigh());
 
   // compute itpc
   int cryo = hit.WireID().Cryostat;

--- a/icaruscode/Utilities/ArtAssociationCaches.h
+++ b/icaruscode/Utilities/ArtAssociationCaches.h
@@ -1,0 +1,275 @@
+/**
+ * @file    icaruscode/Utilities/ArtAssociationCaches.h
+ * @brief   Caching utilities for _art_ associations.
+ * @author  Gianluca Petrillo (SLAC, petrillo@slac.stanford.edu)
+ * @date    March 5, 2023
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_ARTASSOCIATIONCACHES_H
+#define ICARUSCODE_UTILITIES_ARTASSOCIATIONCACHES_H
+
+
+// LArSoft and ICARUS libraries
+#include "icaruscode/Utilities/ComparisonHelpers.h"
+#include "larcorealg/CoreUtils/get_elements.h" // util::get_const_elements()
+
+// framework libraries
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Provenance/ProductID.h"
+
+// C/C++ libraries
+#include <algorithm> // std::inplace_merge(), std::binary_search(), ...
+#include <vector>
+#include <utility> // std::move(), ...
+
+
+// -----------------------------------------------------------------------------
+namespace util {
+  template <typename Left, typename Right> class OneToOneAssociationCache;
+} // namespace util
+/**
+ * @brief Cache with fast lookup for associations to _art_ pointers.
+ * @tparam Left the type for the query
+ * @tparam Right the associated type to discover
+ * 
+ * This object is functionally similar to `art::FindOneP` in that it presents
+ * the information from an _art_ association.
+ * The main difference is that `art::FindOneP` requires to know at construction
+ * all the pointers we are interested in, and then it accesses them by the index
+ * in the interesting pointers list. `OneToOneAssociationCache` instead reads in
+ * all the available associations and keeps them available for lookup based on
+ * the full _art_ pointer.
+ * `art::FindOneP` should be preferred whenever it is suitable, since it is
+ * faster. On the other end, `OneToOneAssociationCache` is more flexible in that
+ * queries don't need to rely on the knowledge of the index of the pointer at
+ * construction time, but it's slower (lookup takes logarithmic rather than
+ * constant time).
+ * 
+ * Example of usage:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * util::OneToOneAssociationCache const cache
+ *   { event.getProduct<art::Assns<recob::Track, anab::T0>>(T0tag) };
+ * 
+ * std::cout << selectedTracks.size() << " tracks selected:";
+ * for (art::Ptr<recob::Track> const& trackPtr: selectedTracks) {
+ *   art::Ptr<anab::T0> const& t0ptr = cache(trackPtr);
+ *   std::cout << "\n  track ID=" << trackPtr->ID();
+ *   if (t0ptr) std::cout << " pinned to time " << t0ptr->Time() << " ns";
+ *   else std::cout << " time is not known";
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Note that, assuming `selectedTracks` is an object of type
+ * `std::vector<art::Ptr<recob::Track>>`, this specific example could have been
+ * better written with `art::FindOneP cache{ selectedTracks, event, T0tag };`
+ * (or just `art::FindOne`), but the lookup should then track the index of the
+ * track in `selectedTracks` itself.
+ * 
+ */
+template <typename Left, typename Right>
+class util::OneToOneAssociationCache {
+  
+    public:
+  using Assns_t = art::Assns<Left, Right>;
+  using Cache_t = OneToOneAssociationCache<Left, Right>;
+  
+  /**
+   * @brief Default constructor: an empty cache.
+   * 
+   * The only supported ways to fill a default-constructed cache are assignment
+   * and a call to `mergeCache()` from an existing cache object.
+   */
+  OneToOneAssociationCache() = default;
+  
+  /// Constructor: reads the associations from `assns`.
+  OneToOneAssociationCache(Assns_t const& assns);
+  
+  /**
+   * @brief Constructor from a sequence.
+   * @tparam BIter type of begin iterator
+   * @tparam EIter type of end iterator
+   * @tparam begin begin forward iterator of the input sequence
+   * @tparam end end forward iterator of the input sequence
+   * 
+   * This constructor copies the associations from the `begin`/`end` sequence.
+   * The elements of the sequence shoudl be pairs of _art_ pointers, the first
+   * with the left object and the second with the right object associated to it.
+   * 
+   * Requirements
+   * -------------
+   * 
+   * The value pointed by the iterators should be such that applying to it
+   * `get<0>()` and `get<1>()` returns an _art_ pointer to the left and right
+   * type respectively (or something that can be converted into it).
+   * 
+   * Sequences of _art_ pointer pairs and `art::Assns` have iterators compatible
+   * with these requirements.
+   */
+  template <typename BIter, typename EIter>
+  OneToOneAssociationCache(BIter begin, EIter end);
+  
+  
+  /// Copies the entries of the `other` cache into this one.
+  void mergeCache(Cache_t const& other);
+  
+  
+  // --- BEGIN -- Query interface ----------------------------------------------
+  /// Returns whether the cache has no element in.
+  bool empty() const;
+  
+  /// Returns whether a pointer with the given product `id` is in cache.
+  bool hasProduct(art::ProductID const& id) const;
+
+  /// Returns whether a pointer from the same data product as `ptr` is in cache.
+  bool hasProduct(art::Ptr<Left> const& ptr) const;
+
+  /// Returns the "right" object associated to the "left" `ptr`.
+  art::Ptr<Right> lookup(art::Ptr<Left> const& ptr) const;
+  
+  /// Returns the "right" object associated to the "left" `ptr`.
+  art::Ptr<Right> operator() (art::Ptr<Left> const& ptr) const;
+  
+  // --- END ---- Query interface ----------------------------------------------
+  
+    private:
+  
+  /// The current content of the cache.
+  std::vector<typename Assns_t::assn_t> fCache;
+  std::vector<art::ProductID> fProducts; ///< Product IDs featured in the cache.
+  
+  void prepareCache();
+  
+  /// Updates the internal record of product IDs.
+  void updateProducts();
+  
+}; // class util::OneToOneAssociationCache
+
+
+namespace util {
+  // deduction guide: pick the types from the ones of the association
+  template <typename Left, typename Right>
+  OneToOneAssociationCache(art::Assns<Left, Right> const& assns)
+    -> OneToOneAssociationCache<Left, Right>;
+}
+
+
+// -----------------------------------------------------------------------------
+// --- Template implementation
+// -----------------------------------------------------------------------------
+// --- util::OneToOneAssociationCache
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+util::OneToOneAssociationCache<Left, Right>::OneToOneAssociationCache
+  (Assns_t const& assns)
+  : OneToOneAssociationCache{ assns.begin(), assns.end() }
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+template <typename BIter, typename EIter>
+util::OneToOneAssociationCache<Left, Right>::OneToOneAssociationCache
+  (BIter begin, EIter end)
+{
+  using std::get;
+  for (auto it = begin; it != end; ++it)
+    fCache.emplace_back(get<0>(*it), get<1>(*it));
+  prepareCache();
+} // util::OneToOneAssociationCache<>::OneToOneAssociationCache(Iter)
+
+
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+void util::OneToOneAssociationCache<Left, Right>::mergeCache
+  (Cache_t const& other)
+{
+  // associations
+  fCache.reserve(fCache.size() + other.fCache.size());
+  auto const itNew = fCache.end();
+  fCache.insert(itNew, other.fCache.begin(), other.fCache.end());
+  std::inplace_merge(fCache.begin(), itNew, fCache.end());
+  // product IDs
+  std::vector<art::ProductID> newProducts;
+  std::set_union(
+    fProducts.cbegin(), fProducts.cend(),
+    other.fProducts.begin(), other.fProducts.end(),
+    back_inserter(newProducts)
+    );
+  fProducts = std::move(newProducts);
+} // util::OneToOneAssociationCache<>::mergeCache()
+
+
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+bool util::OneToOneAssociationCache<Left, Right>::empty() const
+  { return fCache.empty(); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+bool util::OneToOneAssociationCache<Left, Right>::hasProduct
+  (art::ProductID const& id) const
+{
+  return std::binary_search(fProducts.begin(), fProducts.end(), id);
+}
+
+
+template <typename Left, typename Right>
+bool util::OneToOneAssociationCache<Left, Right>::hasProduct
+  (art::Ptr<Left> const& ptr) const
+  { return hasProduct(ptr.id()); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+auto util::OneToOneAssociationCache<Left, Right>::lookup
+  (art::Ptr<Left> const& ptr) const -> art::Ptr<Right>
+{
+  auto const cend = fCache.end();
+  auto const it = std::lower_bound(
+    fCache.begin(), cend, ptr,
+    util::ElementComp<art::Ptr<Left>, 0>() // compare with Ptr from element 0
+    );
+  if ((it == cend) || (it->first != ptr)) return {};
+  return it->second;
+} // util::OneToOneAssociationCache<>::lookup()
+
+
+template <typename Left, typename Right>
+auto util::OneToOneAssociationCache<Left, Right>::operator()
+  (art::Ptr<Left> const& ptr) const -> art::Ptr<Right>
+  { return lookup(ptr); }
+
+
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+void util::OneToOneAssociationCache<Left, Right>::prepareCache() {
+  std::sort(fCache.begin(), fCache.end());
+  updateProducts();
+}
+
+
+// -----------------------------------------------------------------------------
+template <typename Left, typename Right>
+void util::OneToOneAssociationCache<Left, Right>::updateProducts() {
+  fProducts.clear();
+  if (fCache.empty()) return;
+  if (fCache.front().first == fCache.back().first) // worth a special case
+    fProducts.push_back(fCache.front().first.id());
+  else {
+    auto it = fCache.cbegin();
+    auto const cend = fCache.cend();
+    fProducts.push_back(it->first.id());
+    while (++it != cend) {
+      if (it->first.id() != fProducts.back())
+        fProducts.push_back(it->first.id());
+    }
+  }
+} // util::OneToOneAssociationCache<>::updateProducts()
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_UTILITIES_ARTASSOCIATIONCACHES_H

--- a/icaruscode/Utilities/ComparisonHelpers.h
+++ b/icaruscode/Utilities/ComparisonHelpers.h
@@ -1,0 +1,116 @@
+/**
+ * @file    icaruscode/Utilities/ComparisonHelpers.h
+ * @brief   Small utilities to facilitate sorting and lookup.
+ * @author  Gianluca Petrillo (SLAC, petrillo@slac.stanford.edu)
+ * @date    March 5, 2023
+ * 
+ * This is a header-only library.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_COMPARISONHELPERS_H
+#define ICARUSCODE_UTILITIES_COMPARISONHELPERS_H
+
+
+// C/C++ libraries
+#include <utility> // std::move(), std::get()
+
+
+// -----------------------------------------------------------------------------
+namespace util {
+  template <typename Key, std::size_t N, typename Comp = std::less<>>
+  class ElementComp;
+}
+
+/**
+ * @brief Functor applying a specified function on a certain tuple element.
+ * @tparam Key type of the key comparison
+ * @tparam N the number of the element to apply the functor on
+ * @tparam Comp the type of the functor
+ * 
+ * The `Key` type is the type of the element `N` of the tuples being compared.
+ * 
+ * Example of usage:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * std::vector<std::pair<int, std::string>> names;
+ * 
+ * std::sort(names.begin(), names.end()); // sorts by int, then std::string
+ * 
+ * int code = 7;
+ * if (!std::binary_search(names.begin(), names.end(), code, ElementComp<int, 0>{}))
+ *   std::cerr << "code=" << code << " not available" << std::endl;
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * @note This comparison object may fail to compile when used with tuple
+ *       objects that are convertible to the `Key` type.
+ * 
+ */
+template <typename Key, std::size_t N, typename Comp /* = std::less<> */>
+class util::ElementComp {
+  
+  Comp comp; ///< Local copy of the comparer object.
+  
+    public:
+  
+  using Key_t = Key; ///< Type of the value being compared.
+  
+  using Compare_t = Comp; ///< Type of comparison functor.
+  
+  /// Index of the tuple being compared.
+  static constexpr std::size_t Index = N;
+  
+  /// Constructor: can specify the comparison between keys.
+  ElementComp(Compare_t comp = {}): comp(std::move(comp)) {}
+  
+  // --- BEGIN -- Comparison operators -----------------------------------------
+  /// @name Comparison operators.
+  /// @{
+  template <typename Tuple>
+  constexpr bool operator()(Key_t const& a, Tuple const& b) const noexcept
+    { return cmp(a, b, comp); }
+  
+  template <typename Tuple>
+  constexpr bool operator()(Tuple const& a, Key_t const& b) const noexcept
+    { return cmp(a, b, comp); }
+  
+  template <typename Tuple>
+  constexpr bool operator()(Key_t const& a, Key_t const& b) const noexcept
+    { return cmp(a, b, comp); }
+  
+  /// @}
+  // --- END ---- Comparison operators -----------------------------------------
+  
+  
+  // --- BEGIN -- Static comparisons -------------------------------------------
+  /// @name Static comparisons and utilities.
+  /// @{
+  
+  /// Returns the key of a tuple.
+  template <typename Tuple>
+  static auto getKey(Tuple const& tuple) -> decltype(auto)
+    { using std::get; return get<Index>(tuple); }
+  
+  template <typename Tuple, typename Cmp = Comp>
+  static constexpr bool cmp
+    (Key_t const& a, Tuple const& b, Cmp comp = {}) noexcept
+    { return comp(a, getKey(b)); }
+  
+  template <typename Tuple, typename Cmp = Comp>
+  static constexpr bool cmp
+    (Tuple const& a, Key_t const& b, Cmp comp = {}) noexcept
+    { return comp(getKey(a), b); }
+  
+  template <typename Tuple, typename Cmp = Comp>
+  static constexpr bool cmp
+    (Key_t const& a, Key_t const& b, Cmp comp = {}) noexcept
+    { return comp(a, b); }
+  
+  /// @}
+  // --- END ---- Static comparisons -------------------------------------------
+  
+}; // util::ElementComp<>
+
+
+// -----------------------------------------------------------------------------
+
+
+#endif // ICARUSCODE_UTILITIES_COMPARISONHELPERS_H


### PR DESCRIPTION
This PR encompasses the updates discussed in the trigger meeting on the trigger efficiency. Most of the changes are restricted to a separate directory used for the trigger efficiency analysis directly but the main change relevant for the collaboration as a whole is a stage1 fcl file that runs the CRTT0Matching module separately for both the west and east cryostats and creates a separate data product based on those. At the moment this is a standalone fcl file that can be run separately. 

One thing I recall is that some of these changes are tied to a larreco change, https://github.com/LArSoft/larreco/pull/54 (@PetrilloAtWork am I correct?) and https://github.com/SBNSoftware/icaruscode/pull/543 so we need to know whether that is compatible I have it working in my own area thanks to Gianluca but I assume this does depend on that as well. It could be adventurous for this to converge in a week+ but it would help assuming if not we are locked out of doing this via the production group for the foreseeable future. 

Please add any other reviewers that are useful, I at least want to start the discussion. I have not done extensive stage1 processing tests using this branch myself but I do have it compiling also including the above dependent PRs.  