### PR TITLE
Feature/cerati fix pnfs paths to cvmfs

### DIFF
--- a/fcl/gen/corsika/corsika_icarus.fcl
+++ b/fcl/gen/corsika/corsika_icarus.fcl
@@ -27,7 +27,7 @@ icarus_corsika_p: {
   @table::standard_CORSIKAGen_protons
   @table::icarus_corsika_settings
   
-  ShowerInputFiles:    [ "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/p_*.db" ]
+  ShowerInputFiles:    [ "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/cosmics/Fermilab/CORSIKA/standard/p_*.db" ]
 
 } # icarus_corsika_p
 
@@ -36,7 +36,7 @@ icarus_corsika_cmc: {
   @table::standard_CORSIKAGen_CMC
   @table::icarus_corsika_settings
   
-  ShowerInputFiles: [ "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/p_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/He_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/N_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/Mg_showers_*.db", "/pnfs/larsoft/persistent/physics/cosmics/Fermilab/CORSIKA/standard/Fe_showers_*.db" ]
+  ShowerInputFiles: [ "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/cosmics/Fermilab/CORSIKA/standard/p_showers_*.db", "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/cosmics/Fermilab/CORSIKA/standard/He_showers_*.db", "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/cosmics/Fermilab/CORSIKA/standard/N_showers_*.db", "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/cosmics/Fermilab/CORSIKA/standard/Mg_showers_*.db", "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/cosmics/Fermilab/CORSIKA/standard/Fe_showers_*.db" ]
 
 } # icarus_corsika_cmc
 

--- a/fcl/gen/genie/genie_icarus_bnb.fcl
+++ b/fcl/gen/genie/genie_icarus_bnb.fcl
@@ -56,7 +56,7 @@ icarus_genie_BNB_base: {
   BeamName:             "booster"
   EventGeneratorList:   "Default"
 # FluxCopyMethod:       "IFDH"
-  FluxSearchPaths:      "/pnfs/icarus/persistent/bnb_gsimple/fluxes_Oct2017/"
+  FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/BNB/standard/v01_00/"
   FluxFiles:            ["converted_beammc_icarus_*.root"]
   GHepPrintLevel:       13
   POTPerSpill:          5.0e12

--- a/fcl/gen/numi/genie_icarus_numioffaxis.fcl
+++ b/fcl/gen/numi/genie_icarus_numioffaxis.fcl
@@ -57,7 +57,7 @@ icarus_genie_NuMI_base: {
   FluxType:             "dk2nu"
   BeamName:             "numi"
   DetectorLocation:     "icarus-numi"
-  FluxSearchPaths:      "/pnfs/icarus/persistent/numiflux_sample/neutrino_flux/"
+  FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v02_00/"
   FluxFiles:            ["g4numiv6_minervame*.root"]
   
   POTPerSpill:          6.0e13 # same as BnB per batch, but 6 batches in spill


### PR DESCRIPTION
This PR updates the paths in production files that point to /pnfs (not visible from grid nodes) and updates them to the area under /cvmfs (visible)