### PR TITLE
Last bits for the release?

### DIFF
--- a/fcl/configurations/database_icarus.fcl
+++ b/fcl/configurations/database_icarus.fcl
@@ -21,7 +21,7 @@ icarus_siov_channelstatus_service: @local::standard_siov_channelstatus_service
 
 icarus_siov_channelstatus_service.service_provider:                                        SIOVChannelStatusICARUSService
 icarus_siov_channelstatus_service.ChannelStatusProvider.DatabaseRetrievalAlg.DBFolderName: "tpc_channelstatus_data"
-icarus_siov_channelstatus_service.ChannelStatusProvider.DatabaseRetrievalAlg.DBTag:        "v1r0"
+icarus_siov_channelstatus_service.ChannelStatusProvider.DatabaseRetrievalAlg.DBTag:        "v1r1"
 icarus_siov_channelstatus_service.ChannelStatusProvider.DatabaseRetrievalAlg.DBUrl:        "https://dbdata0vm.fnal.gov:9443/icarus_con_prod/app/"
 icarus_siov_channelstatus_service.ChannelStatusProvider.DatabaseRetrievalAlg.UseSQLite:    true
 icarus_siov_channelstatus_service.ChannelStatusProvider.UseDB:                             true

--- a/fcl/g4/intime_g4_icarus.fcl
+++ b/fcl/g4/intime_g4_icarus.fcl
@@ -27,8 +27,8 @@
 #include "services_icarus_simulation.fcl"
 #include "largeantmodules_icarus.fcl"
 #include "photpropservices_icarus.fcl"
-##include "g4inforeducer.fcl"
-##include "mcreco.fcl"
+#include "g4inforeducer.fcl"
+#include "mcreco.fcl"
 
 process_name: G4
 

--- a/fcl/g4/intime_g4_icarus.fcl
+++ b/fcl/g4/intime_g4_icarus.fcl
@@ -65,17 +65,17 @@ physics:
                   EDepTag:     "largeant:TPCActive"
                   MakeAnaTree: false
                 }
-#    sedlite:    @local::sbn_largeant_info_reducer # needs to run right after largeant
-#         
-#    # Saving MC information needed for the ML effort
-#    mcreco:     @local::standard_mcreco
+    sedlite:    @local::sbn_largeant_info_reducer # needs to run right after largeant
+         
+    # Saving MC information needed for the ML effort
+    mcreco:     @local::standard_mcreco
 
    rns:      { module_type: "RandomNumberSaver" }
  }
 
  #define the producer and filter modules for this path, order matters, 
  #filters reject all following items.  see lines starting physics.producers below
- merge: [rns, larg4outtime, largeant, ionization ] #, sedlite, mcreco]
+ merge: [rns, larg4outtime, largeant, ionization, sedlite, mcreco]
  
  #define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]
@@ -104,17 +104,16 @@ services.LArG4Parameters.ParticleKineticEnergyCut: 0.0005
 physics.producers.larg4outtime.KeepParticlesInVolumes: [ "volDetEnclosure" ]
 physics.producers.larg4outtime.InputLabels: [ "GenInTimeSorter:outtime" ]
 
-## Store MCParticleLite in G4 to store dropped particles from KeepEMShowerDaughters: false
-#physics.producers.larg4outtime.StoreDroppedMCParticles: true
-#
-## ------------------------------------------------------------------------------
-#
-## Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
-#physics.producers.mcreco.SimChannelLabel: "sedlite"
-#physics.producers.mcreco.MCParticleLabel: "largeant"
-#physics.producers.mcreco.MCParticleLiteLabel: "largeant"
-#physics.producers.mcreco.UseSimEnergyDeposit: false
-#physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
-#physics.producers.mcreco.UseSimEnergyDepositLite: true
-#physics.producers.mcreco.IncludeDroppedParticles: true
-#
+# Store MCParticleLite in G4 to store dropped particles from KeepEMShowerDaughters: false
+physics.producers.larg4outtime.StoreDroppedMCParticles: true
+
+# ------------------------------------------------------------------------------
+
+# Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
+physics.producers.mcreco.SimChannelLabel: "sedlite"
+physics.producers.mcreco.MCParticleLabel: "largeant"
+physics.producers.mcreco.MCParticleLiteLabel: "largeant"
+physics.producers.mcreco.UseSimEnergyDeposit: false
+physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
+physics.producers.mcreco.UseSimEnergyDepositLite: true
+physics.producers.mcreco.IncludeDroppedParticles: true

--- a/fcl/g4/intime_g4_icarus.fcl
+++ b/fcl/g4/intime_g4_icarus.fcl
@@ -56,7 +56,7 @@ physics:
  {
     larg4outtime:  @local::icarus_largeant
     largeant: {
-      module_type: "MergeSimSources"
+      module_type: "MergeSimSourcesSBN"
       InputSourcesLabels: [ "larg4intime","larg4outtime"]
       TrackIDOffsets: [ 10000000,20000000 ]
     }

--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
@@ -133,4 +133,3 @@ physics.producers.generator.SubBoxLength: "subboxLength 60 "
 services.LArG4Parameters.ParticleKineticEnergyCut: 0.0005
 physics.producers.larg4intime.KeepParticlesInVolumes: [ "volDetEnclosure" ]
 physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
-physics.producers.larg4intime.StoreDroppedMCParticles: true

--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
@@ -133,3 +133,4 @@ physics.producers.generator.SubBoxLength: "subboxLength 60 "
 services.LArG4Parameters.ParticleKineticEnergyCut: 0.0005
 physics.producers.larg4intime.KeepParticlesInVolumes: [ "volDetEnclosure" ]
 physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
+physics.producers.larg4intime.StoreDroppedMCParticles: true

--- a/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/ROIFinder_module.cc
@@ -164,6 +164,7 @@ private:
     bool                                                       fDiagnosticOutput;           ///< secret diagnostics flag
     bool                                                       fOutputHistograms;           ///< Output tuples/histograms?
     size_t                                                     fEventCount;                 ///< count of event processed
+    size_t                                                     fLeadTrail;                  ///< Number of bins to include each side of ROI
     
     std::map<size_t,std::unique_ptr<icarus_tool::IROILocator>> fROIToolMap;
 
@@ -201,6 +202,7 @@ void ROIFinder::reconfigure(fhicl::ParameterSet const& pset)
     fCorrectROIBaseline    = pset.get<bool                      >("CorrectROIBaseline",                                         false);
     fMinSizeForCorrection  = pset.get<size_t                    >("MinSizeForCorrection",                                          12);
     fMaxSizeForCorrection  = pset.get<size_t                    >("MaxSizeForCorrection",                                         512);
+    fLeadTrail             = pset.get<size_t                    >("LeadTrail",                                                      0);
     fOutputMorphed         = pset.get< bool                     >("OutputMorphed",                                               true);
     fDiagnosticOutput      = pset.get< bool                     >("DaignosticOutput",                                           false);
     fOutputHistograms      = pset.get< bool                     >("OutputHistograms",                                           false);
@@ -438,8 +440,6 @@ void  ROIFinder::processPlane(size_t                          idx,
     using CandidateROI    = std::pair<size_t, size_t>;
     using CandidateROIVec = std::vector<CandidateROI>;
 
-    size_t leadTrail(0);
-
     for(size_t waveIdx = 0; waveIdx < selectedVals.size(); waveIdx++)
     {
         // Skip if a bad channel
@@ -461,11 +461,11 @@ void  ROIFinder::processPlane(size_t                          idx,
         {
             if (selVals[idx])
             {
-                Size_t startTick = idx >= leadTrail ? idx - leadTrail : 0;
+                Size_t startTick = idx >= fLeadTrail ? idx - fLeadTrail : 0;
 
                 while(idx < selVals.size() && selVals[idx]) idx++;
 
-                size_t stopTick  = idx < selVals.size() - leadTrail ? idx + leadTrail : selVals.size();
+                size_t stopTick  = idx < selVals.size() - fLeadTrail ? idx + fLeadTrail : selVals.size();
 
                 candidateROIVec.emplace_back(startTick, stopTick);
             }

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -93,6 +93,7 @@ icarus_roifinder:
     CorrectROIBaseline:    false
     MinSizeForCorrection:  12
     MaxSizeForCorrection:  512
+    LeadTrail:             10
     OutputMorphed:         false
     DaignosticOutput:      false
     OutputHistograms:      false

--- a/test/ci/icarus_ci_intimecosmic_reco1_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_intimecosmic_reco1_quick_test_icaruscode.fcl
@@ -1,1 +1,1 @@
-#include "stage1_multiTPC_icarus_gauss_MC.fcl"
+#include "stage1_run2_icarus_MC.fcl"

--- a/test/ci/icarus_ci_nucosmics_reco1_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_nucosmics_reco1_quick_test_icaruscode.fcl
@@ -1,1 +1,1 @@
-#include "stage1_multiTPC_icarus_gauss_MC.fcl"
+#include "stage1_run2_icarus_MC.fcl"

--- a/test/ci/icarus_ci_single_reco1_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_single_reco1_quick_test_icaruscode.fcl
@@ -1,1 +1,1 @@
-#include "stage1_multiTPC_icarus_gauss_MC.fcl"
+#include "stage1_run2_icarus_MC.fcl"

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -251,7 +251,7 @@ wpdir	product_dir	wire-cell-cfg
 ####################################
 product				version		qual	flags		<table_format=2>
 fftw				v3_3_9		-
-icarus_data			v09_69_01	-
+icarus_data			v09_70_00	-
 icarus_signal_processing	v09_63_00_02	-
 icarusalg			v09_68_00	-
 icarusutil			v09_66_02	-


### PR DESCRIPTION
This includes some last minute updates:

1. Add some protection in space point building to try to avoid program termination when accessing the channel status DB
2. Switch to channel status DB version v1r1 which has matching channel lists for the two tables it currently contains
3. Update the CI test reco1 fhicl files to use the run 2 stage 1 fhicl files
4. Update the intime g4 fhicl file to include modules needed for ML work

Note that this needs icarus_data v09_70_00 to pick up the updated channel status DB and will need the new release of sbncode to get a fix to make sure the MCParticleLite works correctly. 