### PR TITLE
Adding trigger emulation to CAF [SBN2023A]

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -308,7 +308,8 @@ cafmaker.TrackRangeLabel: "pandoraTrackRange"
 cafmaker.CRTHitLabel: "crthit"
 cafmaker.CRTTrackLabel: "crttrack"
 cafmaker.OpFlashLabel: "opflash"
-cafmaker.TriggerLabel: "daqTrigger"
+# cafmaker.TriggerLabel: "daqTrigger" # see also https://github.com/SBNSoftware/icaruscode/issues/556
+cafmaker.TriggerLabel: "emuTrigger"
 cafmaker.FlashTrigLabel: "" # unavailable
 cafmaker.SimChannelLabel: "largeant"
 cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -31,4 +31,6 @@ physics.producers.cafmaker.GenLabel: ""
 physics.producers.cafmaker.SimChannelLabel: ""
 physics.producers.cafmaker.SystWeightLabels: []
 
+physics.producers.cafmaker.TriggerLabel: "daqTrigger" # the general configuration, for MC, has a different one (see also https://github.com/SBNSoftware/icaruscode/issues/556)
+
 #include "icarus_data_recombination.fcl"

--- a/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
@@ -360,6 +360,8 @@ icarus_standard_triggersim: {
       Pattern:               @local::icarus_triggergate_basic.SelectedPattern
       BeamGates:             triggersimgates
       TriggerTimeResolution: "8 ns" # this should probably be 12 or 24 ns
+      EmitEmpty:             true
+      ExtraInfo:             true
     }
     
   } # producers


### PR DESCRIPTION
This pull request aims to have a simulated trigger response in the CAF data for production.

The trigger simulation is already ran in the standard simulation workflow, with the input tag `emuTrigger`.
The changes operate at two levels:
1. Enable the production of `sbn::ExtraTriggerInfo` by the trigger simulation module; this is a feature that was recently introduced but had not been enabled for this workflow.
2. Direct CAF making module to the trigger response data product.

## Enable the production of `sbn::ExtraTriggerInfo`

The module responsible of the final step of the simulation, including the emission of `raw::Trigger` and `sbn::ExtraTriggerInfo` data products, is [`TriggerSimulationOnGates`](https://icarus-exp.fnal.gov/at_work/software/doc/icaruscode/latest/classicarus_1_1trigger_1_1TriggerSimulationOnGates.html).
As documented in that module, the latter data product is fairly incomplete, as many of the aspects of the trigger system are at a level lower than the one we simulate.
Also, this module always produces a `raw::Trigger` data product and a `sbn::ExtraTriggerInfo` one; the documentation also describes the values assigned when no trigger is fired.

## Direct CAF making module to the trigger response data product

The base configuration for CAF making is written for simulation. However, it is using as trigger data product tag the standard _data_ trigger `daqTrigger`. In simulation this ended up having no effect, since such data product deliberately does not exist — trigger simulation module instance is called `emuTrigger`.
Several modules refer to `daqTrigger` as trigger data product for whatever they need it for. The approach of this pull request is to just add the response of the trigger simulation, without affecting the reconstruction.
Therefore, the CAF making module in the simulation workflow now uses `emuTrigger` instead of `daqTrigger`, but all the other modules still look at `daqTrigger`, most noticeably `DetectorClocksService`.
At the same time, the trigger tag in the data configuration is now explicitly set (back) to `daqTrigger`.
The topic whether it's feasible and desirable to use `daqTrigger` for all the modules is tracked in issue #556.

## Other considerations

The configuration used for the simulation is the one that was already set for `emuTrigger`, which is a trigger representative of ICARUS hardware global trigger. Its parameters are ultimately defined in [`trigger_emulation_icarus.fcl`](https://github.com/SBNSoftware/icaruscode/blob/develop/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl) (configuration table `icarus_standard_triggersim`) and [`icarus_trigger.fcl`](https://github.com/SBNSoftware/icaruscode/blob/develop/icaruscode/PMT/Trigger/trigger_icarus.fcl) (`icarus_triggergate_basic` configuration table).

The simulation itself has not been extensively validated with the Monte Carlo sample and it should not be considered at physics analysis quality yet, but feedback to the ICARUS trigger working group and to @PetrilloAtWork  is greatly appreciated.

## Merge and reviewers

This request is intended for the *production branch* (`develop` will be updated at a later time).

* @JackSmedley (if I only could add him...), @brucehoward-physics as informed CAF users
* @gputnam also as maintainer of the CAF making configurations (?)
