### PR TITLE
Various fhicl file fixes to production release

### DIFF
--- a/fcl/g4/intime_g4_icarus.fcl
+++ b/fcl/g4/intime_g4_icarus.fcl
@@ -117,3 +117,31 @@ physics.producers.mcreco.UseSimEnergyDeposit: false
 physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
 physics.producers.mcreco.UseSimEnergyDepositLite: true
 physics.producers.mcreco.IncludeDroppedParticles: true
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+      ## Turning off the spewing of warnings coming from these two modules
+       SimDriftElectrons:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       McReco:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       default:
+       {
+         limit: 5  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/fcl/g4/standard_g4_icarus.fcl
+++ b/fcl/g4/standard_g4_icarus.fcl
@@ -87,3 +87,31 @@ outputs.rootoutput: @local::icarus_rootoutput
 
 
 # ------------------------------------------------------------------------------
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+      ## Turning off the spewing of warnings coming from these two modules
+       SimDriftElectrons:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       McReco:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       default:
+       {
+         limit: 5  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
@@ -133,3 +133,6 @@ physics.producers.generator.SubBoxLength: "subboxLength 60 "
 services.LArG4Parameters.ParticleKineticEnergyCut: 0.0005
 physics.producers.larg4intime.KeepParticlesInVolumes: [ "volDetEnclosure" ]
 physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
+
+# Store MCParticleLite in G4 to store dropped particles from KeepEMShowerDaughters: false
+physics.producers.larg4intime.StoreDroppedMCParticles: true

--- a/fcl/reco/CMakeLists.txt
+++ b/fcl/reco/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(FlashMatchSimple)
 add_subdirectory(ForCITests)
 #add_subdirectory(archive)
 add_subdirectory(Definitions)
+add_subdirectory(larcv)
 add_subdirectory(Stage0)
 add_subdirectory(Stage1)
 

--- a/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
@@ -15,6 +15,7 @@
 #include "crt_decoderdefs_icarus.fcl"
 #include "crthitproducer.fcl"
 #include "wcls-decode-to-sig-base.fcl"
+#include "icarus_FilterCRTPMTMatching.fcl"
 
 BEGIN_PROLOG
 
@@ -163,6 +164,7 @@ icarus_stage0_filters:
                              TriggerDataLabel:   "daqTrigger"
                              TriggerType:        "Unknown"
                           }
+   crtpmtmatchingfilter: @local::icarus_FilterCRTPMTMatching
 }
 
 
@@ -272,6 +274,14 @@ icarus_stage0_data:                [
                                      daqTPCROI, 
                                      @sequence::icarus_stage0_multiTPC
                                    ]
+ 
+icarus_stage0_data_crtpmtfilter:   [
+                                     @sequence::icarus_stage0_PMT, 
+                                     @sequence::icarus_stage0_CRT,
+                                     crtpmtmatchingfilter,
+                                     daqTPCROI, 
+                                     @sequence::icarus_stage0_multiTPC
+                                  ]
 
 icarus_stage0_2d_data:             [
                                      @sequence::icarus_stage0_PMT, 
@@ -279,6 +289,14 @@ icarus_stage0_2d_data:             [
                                      daqTPCROI, 
                                      @sequence::icarus_stage0_2d_multiTPC
                                    ]
+
+icarus_stage0_2d_data_crtpmtfilter: [
+                                      @sequence::icarus_stage0_PMT, 
+                                      @sequence::icarus_stage0_CRT,
+                                      crtpmtmatchingfilter,
+                                      daqTPCROI, 
+                                      @sequence::icarus_stage0_2d_multiTPC
+                                    ]
 
 ### Below we include overrides for the modules above
 

--- a/fcl/reco/Definitions/stage1_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage1_icarus_defs.fcl
@@ -18,6 +18,7 @@
 #include "crtbacktracker_icarus.fcl"
 #include "crtt0matchingalg_icarus.fcl"
 #include "crtt0producer_icarus.fcl"
+## The below can be found from the softlink to Supera in sbncode
 #include "supera_modules.fcl"
 
 BEGIN_PROLOG
@@ -105,6 +106,8 @@ icarus_stage1_analyzers.caloskimW.SelectEvents: [reco]
 icarus_stage1_analyzers.caloskimW.CALOproducer: caloskimCalorimetryCryoW 
 icarus_stage1_analyzers.caloskimW.SilenceMissingDataProducts: true
 
+icarus_stage1_analyzers.supera.unique_filename: true
+
 ### Below are a list of convenient sequences that can be used for production/typical users. ###
 
 # Set up the standard analysis chain
@@ -114,8 +117,11 @@ icarus_analysis_modules:           [  caloskimE
                                      ,CRTDataAnalysis
                                    ]
 
+icarus_analysis_supera:            [ supera
+                                   ]
+
 icarus_analysis_larcv_modules:     [  @sequence::icarus_analysis_modules
-                                     ,supera 
+                                     ,@sequence::icarus_analysis_supera 
                                    ]
 
 # Set up filtering of cluster3D hits by cryostat
@@ -177,7 +183,7 @@ icarus_stage1_filters.TPCHitFilterCryoW.HitDataLabelVec: ["cluster3DCryoW"]
 icarus_stage1_filters.TPCHitFilterCryoW.MaximumHits:     60000 
 
 icarus_stage1_filters.TPCHitFilterCryoE.HitDataLabelVec: ["cluster3DCryoE"]
-icarus_stage1_filters.TPCHitFilterCryoE.MaximumHits:     60000    
+icarus_stage1_filters.TPCHitFilterCryoE.MaximumHits:     60000 
 
 ## Definitions for running the 3D clustering by Cryostat
 icarus_stage1_producers.cluster3DCryoW.MakeSpacePointsOnly:                                      true

--- a/fcl/reco/Stage0/Run1/stage0_run1_crtpmtfilter_icarus.fcl
+++ b/fcl/reco/Stage0/Run1/stage0_run1_crtpmtfilter_icarus.fcl
@@ -1,0 +1,22 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common_run1.fcl"
+
+process_name: stage0
+
+## Define the path we'll execute
+physics.path:     [ @sequence::icarus_stage0_data_crtpmtfilter ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamROOT ]
+
+# Drop the artdaq format files on output
+outputs.outCommon.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_ophituncorrected_*_*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ path ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ path ]

--- a/fcl/reco/Stage0/Run2/stage0_run2_crtpmtfilter_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_crtpmtfilter_icarus.fcl
@@ -1,0 +1,36 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the path we'll execute
+physics.path:     [ @sequence::icarus_stage0_data_crtpmtfilter ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamROOT ]
+
+# Drop the artdaq format files on output, 
+# Drop all output from the TPC decoder stage
+# Drop all output from the 1D deconvolution stage
+# Drop the recob::Wire output from the roifinder (but keep the ChannelROIs)
+# Drop the reconstructed optical hits before the timing correction
+# Drop the PMT waveforms (will keep the ones from daqPMTonbeam)
+# Keep the Trigger fragment
+outputs.rootOutput.outputCommands: [
+    "keep *_*_*_*", 
+    "drop *_*_*_DAQ*",
+    "drop *_ophituncorrected_*_*",
+    "drop raw::OpDetWaveforms_daqPMT__*",
+    "drop *_daqTPCROI_*_*", 
+    "drop *_decon1droi_*_*", 
+    "drop recob::Wire*_roifinder_*_*",
+    "keep *_daq_ICARUSTriggerV*_*"]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ path ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ path ]

--- a/fcl/reco/Stage1/Run2/stage1_run2_icarus.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_icarus.fcl
@@ -39,7 +39,7 @@ services.message.destinations :
   STDCOUT:
   {
      type:      "cout"      #tells the message service to output this destination to cout
-     threshold: "DEBUG"     #tells the message service that this destination applies to WARNING and higher level messages
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
      categories:
      {
        Cluster3DICARUS:

--- a/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
@@ -78,15 +78,10 @@ services.message.destinations :
   STDCOUT:
   {
      type:      "cout"      #tells the message service to output this destination to cout
-     threshold: "DEBUG"     #tells the message service that this destination applies to WARNING and higher level messages
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
      categories:
      {
        Cluster3DICARUS:
-       {
-         limit: -1
-         reportEvery: 1
-       }
-       PMAlgTracker:
        {
          limit: -1
          reportEvery: 1

--- a/fcl/reco/larcv/CMakeLists.txt
+++ b/fcl/reco/larcv/CMakeLists.txt
@@ -1,0 +1,3 @@
+cet_enable_asserts()
+
+add_subdirectory(Run2)

--- a/fcl/reco/larcv/Run2/CMakeLists.txt
+++ b/fcl/reco/larcv/Run2/CMakeLists.txt
@@ -1,0 +1,3 @@
+cet_enable_asserts()
+
+install_fhicl()

--- a/fcl/reco/larcv/Run2/larcv_icarus.fcl
+++ b/fcl/reco/larcv/Run2/larcv_icarus.fcl
@@ -1,0 +1,11 @@
+#include "stage1_icarus_driver_common.fcl"
+
+process_name: larcv
+
+physics.reco: [ ]
+
+physics.outana:            [ @sequence::icarus_analysis_supera ]
+physics.trigger_paths:     [ reco ]
+physics.end_paths:         [ outana ]
+
+

--- a/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/recowire_icarus.fcl
@@ -93,7 +93,7 @@ icarus_roifinder:
     CorrectROIBaseline:    false
     MinSizeForCorrection:  12
     MaxSizeForCorrection:  512
-    LeadTrail:             10
+    LeadTrail:             0
     OutputMorphed:         false
     DaignosticOutput:      false
     OutputHistograms:      false


### PR DESCRIPTION
A few fhicl file fixes:
1) Remove the leading/trailing bins from the ROI finding to address apparent issues with pandora track/shower id
2) Add explicit fhicl files running the CRT PMT filter at stage 0 for both run 1 and run 2
3) Raise the message level in the stage 1 fhicl files from "DEBUG" to "INFO"
4) Kill the warning level messages at the g4 stage from SimDriftElectrons and McReco when it can't find a wire corresponding to a position, not sure if this is a real problem that we need to track down but so far it seems more an annoyance than a bug
5) Fix the intime generation file to insure the MCParticleLite collection is stored