### PR TITLE
CAFmaker w/o event weights for detsim2d

### DIFF
--- a/fcl/caf/cafmaker_add_detsim2d_icarus.fcl
+++ b/fcl/caf/cafmaker_add_detsim2d_icarus.fcl
@@ -1,5 +1,3 @@
-#include "cafmakerjob_icarus.fcl"
-
 # over-write labels to use Wire-Cell SimChannels
 physics.producers.cafmaker.SimChannelLabel: "daq:simpleSC" # 2D drift
 

--- a/fcl/caf/cafmakerjob_icarus_detsim2d.fcl
+++ b/fcl/caf/cafmakerjob_icarus_detsim2d.fcl
@@ -1,16 +1,2 @@
-#include "cafmakerjob_icarus_systtools_and_fluxwgt.fcl"
-
-# over-write labels to use Wire-Cell SimChannels
-physics.producers.cafmaker.SimChannelLabel: "daq:simpleSC" # 2D drift
-
-# SimChannel's get re-made by 2D drift simulation -- use these to backtrack
-services.BackTrackerService.BackTracker.SimChannelModuleLabel: "daq:simpleSC"
-
-# MCReco also needs correct SimChannels
-# need to use new config names to make MCParticle/SimChannel labels different
-physics.producers.mcreco.G4ModName: @erase 
-physics.producers.mcreco.MCParticleLabel: "largeant"
-physics.producers.mcreco.SimChannelLabel: "daq:simpleSC"
-
-this_cal_constants: [1.343e-2, 1.338e-2, 0.01227]
-#include "set_caf_calconst.fcl"
+#include "cafmakerjob_icarus.fcl"
+#include "cafmaker_add_detsim2d_icarus.fcl"

--- a/fcl/caf/cafmakerjob_icarus_detsim2d_noevtwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_detsim2d_noevtwgt.fcl
@@ -1,0 +1,16 @@
+#include "cafmakerjob_icarus.fcl"
+
+# over-write labels to use Wire-Cell SimChannels
+physics.producers.cafmaker.SimChannelLabel: "daq:simpleSC" # 2D drift
+
+# SimChannel's get re-made by 2D drift simulation -- use these to backtrack
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "daq:simpleSC"
+
+# MCReco also needs correct SimChannels
+# need to use new config names to make MCParticle/SimChannel labels different
+physics.producers.mcreco.G4ModName: @erase 
+physics.producers.mcreco.MCParticleLabel: "largeant"
+physics.producers.mcreco.SimChannelLabel: "daq:simpleSC"
+
+this_cal_constants: [1.343e-2, 1.338e-2, 0.01227]
+#include "set_caf_calconst.fcl"

--- a/fcl/caf/cafmakerjob_icarus_detsim2d_systtools_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_icarus_detsim2d_systtools_and_fluxwgt.fcl
@@ -1,0 +1,2 @@
+#include "cafmakerjob_icarus_systtools_and_fluxwgt.fcl"
+#include "cafmaker_add_detsim2d_icarus.fcl"


### PR DESCRIPTION
New cafmaker fcl based on existing detsim2d cafmaker fcl, but without running systtools or fluxweight. The event weights fail to run on intime cosmic MC so this is needed to make those CAFs.