### PR TITLE
`prodtext_standard_icarus.fcl`: add mandatory parameter

### DIFF
--- a/fcl/gen/text/prodtext_standard_icarus.fcl
+++ b/fcl/gen/text/prodtext_standard_icarus.fcl
@@ -95,6 +95,7 @@ physics: {
     generator: {
       module_type:    TextFileGen
       InputFileName: "HEPevents.txt"
+      Offset:         0
     }
     
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Commit LArSoft/larsim#85 added a mandatory parameter `Offset` to `TextFileGen` module, a breaking change which ICARUS codebase did not absorb.
This is the belated fix.

Thanks to Hector Carranza (whose GitHub user I can't find) for reporting this issue.

Suggested reviewers:
* @SFBayLaser, workflow overlord
* The Real Ndrej, because of retaliation