### PR TITLE
Feature/cerati fix decoder mc

### DIFF
--- a/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
@@ -543,7 +543,11 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
 	    chanArr.first.push_back(daq::INoiseFilter::ChannelPlanePair(channel,planeIdx));
 	    chanArr.second.push_back(boardDataVec);
 	  }
-          processSingleImage(clockData, chanArr, coherentNoiseGrouping, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
+	  if (chanArr.second.size() < 64) {
+	      processSingleImage(clockData, chanArr, chanArr.second.size(), concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
+	  } else {
+	    processSingleImage(clockData, chanArr, coherentNoiseGrouping, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
+	  }
 	});
 
     }

--- a/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc
@@ -544,7 +544,7 @@ void MCDecoderICARUSTPCwROI::processSingleLabel(art::Event&                     
 	    chanArr.second.push_back(boardDataVec);
 	  }
 	  if (chanArr.second.size() < 64) {
-	      processSingleImage(clockData, chanArr, chanArr.second.size(), concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
+	    processSingleImage(clockData, chanArr, chanArr.second.size(), concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
 	  } else {
 	    processSingleImage(clockData, chanArr, coherentNoiseGrouping, concurrentRawDigits, concurrentRawRawDigits, coherentRawDigits, concurrentROIs);
 	  }


### PR DESCRIPTION
This PR restores the behavior of MCDecoderICARUSTPCwROI before my [PR536](https://github.com/SBNSoftware/icaruscode/pull/536). The problem was that the behavior of [these lines](https://github.com/SBNSoftware/icaruscode/blob/v09_68_00_01/icaruscode/Decode/MCDecoderICARUSTPCwROI_module.cc#L600-L603) was not captured in the previous version. This fix restores the behavior.