### PR TITLE
Fix a bug in PMT digitization

### DIFF
--- a/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
+++ b/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
@@ -560,7 +560,7 @@ icarus::opdet::PMTsimulationAlg::CreateFixedSizeOpDetWaveforms
   std::vector<BufferRange_t> buffers;
   buffers.reserve(std::distance(iNextTrigger, tend)); // worst case
   
-  auto lastBufferEnd { firstTick };
+  auto lastBufferEnd{ firstTick - detinfo::timescales::optical_time_ticks{ 1 }};
   while (iNextTrigger != tend) {
     
     BufferRange_t const buffer = makeBuffer(*iNextTrigger);


### PR DESCRIPTION
The algorithm creating readout buffers (future `raw::OpDetWaveform`) from the continuous readout was written expecting (and asserting) that a trigger primitive can't be at the first tick of the enable gate. This was a reasonable assumption when the trigger algorithm looked for a transition from the previous tick from below to above threshold. Now an alternative algorithm is also available which considers just the value of the sample compared to the threshold, so that expectation is violated and the assertion failed. A small change in the algorithm makes it robust to that rare occurrence.

Thanks to @gputnam for the perfect report (code version, input file, input configuration, error message). As a punishment, he gets to review the change.
