### PR TITLE
Don't apply PMT correction on old data where it's not available

### DIFF
--- a/fcl/reco/Stage0/RunA/stage0_runA_icarus_triggerV1.fcl
+++ b/fcl/reco/Stage0/RunA/stage0_runA_icarus_triggerV1.fcl
@@ -1,8 +1,44 @@
-#include "stage0_run2_icarus.fcl"
+#
+# File:    stage0_runA_icarus_triggerV1.fcl
+# Purpose: Runs Stage0 for runs 7932 and earlier.
+#
+# Runs older than circa 7932, before March 2022, were taken with physics
+# triggers. Compared to Run1:
+# * PMT readout:
+#     - uses 6+9 us buffers (not 3+7).
+#     - artificial trigger primitives are sent at beam gate opening
+#       time (not 4 us before -- the "veto" was not introduced
+#       either) and 6 us after the beam gate, covering -6/+15 us
+#       from the beam gate (more if a NuMI trigger happens late).
+#     - on the 16th channel of the first readout board the trigger
+#       primitive signals are sent, not the global trigger one.
+#       These signals appear like three peaks (the two artificial
+#       primitives plus the one at global trigger time) and they are
+#       not suitable for the trigger timing correction developed for
+#       Run2, which assumes a single sharp signal at global trigger
+#       time. These signals are not very reliable either: one board
+#       does not see them, another sees them seriously distorted,
+#       and sometimes other boards see them distorted too.
+#       For this reason, this configuration disables the correction.
+#     - it is assumed that the counter reset signal (PPS) is sent to
+#       all the readout boards at the same time and therefore the
+#       trigger primitive propagation delay is automatically
+#       accounted for by the counter values.
+# * trigger:
+#     - trigger information is in the unversioned format
+#       (postumous v1).
+#     - no trigger configuration information is saved in FHiCL.
+#
+# As usual, Stage0 runs the full optical simulation chain.
+#
 
+#include "stage0_run2_icarus.fcl"
 
 # trigger configuration is not saved in DAQ FHiCL, hence it's not available:
 physics.producers.triggerconfig.module_type: DummyProducer
 
 # trigger is version 1 (and autodetection does not work for the reason above)
 physics.producers.daqTrigger: @local::decodeTrigger
+
+# no global trigger waveform available for correction: omit it
+physics.producers.daqPMT.CorrectionInstance: @erase


### PR DESCRIPTION
The standard Run1 (and Run2) Stage0 configuration utilizes the signal on some of the spare channels of PMT readout boards to align the PMT waveforms with the global trigger.
That assumes that those channels have the digitised global trigger signal, which has been the case since Run1 included and a bit earlier.
Some runs though do not have it for sure, including runs `7924` and `7926`, popular since they were eye-scanned for neutrino interactions. Those runs have a different signal in the channel, a trigger primitive signal which if used for the correction creates issues like a multi-peaked waveform time (and downstream flash time) distribution.

This pull request removes such correction from the decoding stage.
Unfortunately there are no staged data files that I know of between `7926` and `8460` (Run1) so I can't bisect to find the first run where this correction is possible.

## Mitigation for existing samples

Samples that have already that correction in can in principle be "uncorrected" at `recob::OpHit` level by subtracting to the hit time the correction that is stored in the `daqPMT` data product [`icarus::timing::PMTWaveformTimeCorrection::startTime`](https://icarus-exp.fnal.gov/at_work/software/doc/icaruscode/latest/structicarus_1_1timing_1_1PMTWaveformTimeCorrection.html). The data product is stored with one correction per channel ID (the index of the collection data product is the channel ID itself, but if `isValid()` is `false` then that channel has not, and was not applied, any correction).
Flash reconstruction, on the other end, should be rerun entirely on the uncorrected hits, as it's not possible to "undo" a correction on them.

## Review

Thanks to the many people that first reported the issue with run `7926` and then were _very_ patiently waiting for a resolution (including @justinjmueller, François Drielsma, @JackSmedley, @jedori0228...)
Reviewers:
* @mvicenzi as person informed on the corrections
* @gputnam (I am changing his configuration)

**Note**: this is a pull request against `develop`. If the same change is needed in a release branch, please let me know.
