### PR TITLE
Fix a bug in `SlidingWindowTriggerSimulation`

### DIFF
--- a/fcl/detsim/commissioning/triggersim_icarus_data.fcl
+++ b/fcl/detsim/commissioning/triggersim_icarus_data.fcl
@@ -229,6 +229,14 @@ physics.analyzers.effSlidingORW.DetectorParticleTag: @erase
 physics.analyzers.effSlidingORW.EnergyDeposits:      []
 
 
+# keep decoded hardware information too
+outputs.rootoutput.outputCommands: [
+  @sequence::outputs.rootoutput.outputCommands
+  , "keep *_daqTrigger_*_*"
+#  , "keep *_daqPMT_*_*"   # this would also keep waveforms etc.
+  ]
+
+
 
 # ------------------------------------------------------------------------------
 # --- Configuration override guide

--- a/icaruscode/PMT/Trigger/SlidingWindowTriggerSimulation_module.cc
+++ b/icaruscode/PMT/Trigger/SlidingWindowTriggerSimulation_module.cc
@@ -844,21 +844,6 @@ void icarus::trigger::SlidingWindowTriggerSimulation::initializePlots() {
   // 
   // per-threshold plots; should this initialization be set into its own method?
   // 
-  for (auto const& [ thr, info ]
-    : util::zip(util::get_elements<0U>(fADCthresholds), fThresholdPlots))
-  {
-    PlotSandbox_t& plots
-      = fPlots.addSubSandbox("Thr" + thr, "Threshold: " + thr);
-    
-    plots.make<TGraph>(
-      "TriggerTimeVsHWTrigVsBeam",
-      "Time of the trigger: emulated vs. hardware"
-        ";hardware trigger time (relative to beam gate opening)  [ #mus ]"
-        ";emulated trigger time (relative to beam gate opening)  [ #mus ]"
-      );
-    
-  } // for thresholds
-  
   fThresholdPlots.resize(
     size(fADCthresholds),
     {
@@ -868,6 +853,20 @@ void icarus::trigger::SlidingWindowTriggerSimulation::initializePlots() {
       BinnedContent_t{ beamGateBinning.binWidth() } // triggerTimesVsBeam
     }
     );
+  
+  for (std::string const& thr: util::get_elements<0U>(fADCthresholds)) {
+    PlotSandbox_t& plots
+      = fPlots.addSubSandbox("Thr" + thr, "Threshold: " + thr);
+    
+    plots.make<TGraph>(
+      "TriggerTimeVsHWTrigVsBeam",
+      "Time of the trigger: emulated vs. hardware"
+        ";hardware trigger time (relative to beam gate opening)  [ #mus ]"
+        ";emulated trigger time (relative to beam gate opening)  [ #mus ]",
+      PlotSandbox_t::NoNameTitle
+      );
+    
+  } // for thresholds
   
 } // icarus::trigger::SlidingWindowTriggerSimulation::initializePlots()
 


### PR DESCRIPTION
The affected module is used to run trigger emulation and create `raw::Trigger` data products out of them, and to create plots at the same time. It's not the module used for the global trigger simulation.
It used to crash, with this fix it does not any more. The bug does not affect the simulation, just the plots.
That's pretty much it.
Not sure if it needs a review...