### PR TITLE
Removed CRT/PMT matching from stage0_runA_icarus_triggerV1.fcl

### DIFF
--- a/fcl/reco/Stage0/RunA/stage0_runA_icarus_triggerV1.fcl
+++ b/fcl/reco/Stage0/RunA/stage0_runA_icarus_triggerV1.fcl
@@ -36,6 +36,7 @@
 
 # trigger configuration is not saved in DAQ FHiCL, hence it's not available:
 physics.producers.triggerconfig.module_type: DummyProducer
+physics.filters.crtpmtmatchingfilter.module_type: DummyFilter
 
 # trigger is version 1 (and autodetection does not work for the reason above)
 physics.producers.daqTrigger: @local::decodeTrigger


### PR DESCRIPTION
Recent changes have introduced in Stage0 the PMT/CRT matching algorithm as a (noop) filter.
The current implementation of the algorithm requires input about trigger configuration.

The "RunA" configurations are based on the live Run2 configurations, so they are fated to include all the changes applied to the latter. The CRT/PMT matching one is a change that RunA can't support for lack of input information (trigger configuration started being saved in data just a bit earlier than Run1 start).

This request removes the CRT/PMT matching specifically for RunA Stage0 processing. It is possible to change the algorithm not to need that information (the work being done right now on the _producer_ side of the matching already does it), but this is not the content of this PR which just removes the algorithm.

Note: this is a pull request against `develop`. I have not queued any equivalent on the production branch.

Suggested reviewers:
* @gputnam : maintainer of RunA configurations
* François Drielsma, who I can't tag
