### PR TITLE
Add flash ID to CRT/PMT matching and sorting them by flash time

### DIFF
--- a/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
@@ -503,22 +503,22 @@ namespace icarus::crt {
         
         double const tflash = flashPtr->Time();
         double const totPe  = flashPtr->TotalPE();
-	double const flashYWidth = flashPtr->YWidth();
-	double const flashZWidth = flashPtr->ZWidth();
+        double const flashYWidth = flashPtr->YWidth();
+        double const flashZWidth = flashPtr->ZWidth();
 
-	vector<recob::OpHit const*> const& hits = findManyHits.at(flashPtr.key());
+        vector<recob::OpHit const*> const& hits = findManyHits.at(flashPtr.key());
         int nPMTsTriggering = 0;
-	double firstOpHitPeakTime = 999999;
-	double firstOpHitStartTime = 999999;
+        double firstOpHitPeakTime = 999999;
+        double firstOpHitStartTime = 999999;
 
         geo::vect::MiddlePointAccumulator flashCentroid;
         for (auto const& hit : hits) {
           if (hit->Amplitude() > fPMTADCThresh) nPMTsTriggering++;
-	  if (firstOpHitPeakTime > hit->PeakTime()) firstOpHitPeakTime = hit->PeakTime();
-	  if(hit->HasStartTime()){
-	    if (firstOpHitStartTime > hit->StartTime()) firstOpHitStartTime = hit->StartTime(); 
-	    //mf::LogTrace("CRTPMTMatchingProducer") << "OpHit has a starttime " << hit->StartTime() << ", saving " <<  firstOpHitStartTime << " to firstOpHitStartTime.\n";
-	  }	  
+          if (firstOpHitPeakTime > hit->PeakTime()) firstOpHitPeakTime = hit->PeakTime();
+          if(hit->HasStartTime()){
+            if (firstOpHitStartTime > hit->StartTime()) firstOpHitStartTime = hit->StartTime(); 
+            //mf::LogTrace("CRTPMTMatchingProducer") << "OpHit has a starttime " << hit->StartTime() << ", saving " <<  firstOpHitStartTime << " to firstOpHitStartTime.\n";
+          }
 
           geo::Point_t const pos =
             fGeometryService->OpDetGeoFromOpChannel(hit->OpChannel())
@@ -541,7 +541,7 @@ namespace icarus::crt {
             << " hits above threshold)";
           continue;
         }
-	
+        
         double const thisRelGateTime = triggerGateDiff + tflash * 1e3; // ns
         bool const thisInTime_gate
           = thisRelGateTime > BeamGateMin && thisRelGateTime < BeamGateMax;
@@ -559,7 +559,7 @@ namespace icarus::crt {
             << "Entering matches (" << crtMatches.entering.size() << "):";
           for (auto const& entering : crtMatches.entering) {
             n_entering_matches++;
-	    CRTPtrs.push_back(entering.CRTHit);
+            CRTPtrs.push_back(entering.CRTHit);
             thisFlashCRTmatches.push_back(makeMatchedCRT(*entering.CRTHit, tflash, isRealData));
           }
         }
@@ -567,27 +567,27 @@ namespace icarus::crt {
           mf::LogTrace("CRTPMTMatchingProducer")
             << "Exiting matches (" << crtMatches.exiting.size() << "):";
           for (auto const& exiting : crtMatches.exiting) {
-	    n_exiting_matches++;
+            n_exiting_matches++;
             CRTPtrs.push_back(exiting.CRTHit);
             thisFlashCRTmatches.push_back(makeMatchedCRT(*exiting.CRTHit, tflash, isRealData));
           }
         }
         if (!thisFlashCRTmatches.empty() ) {
           mf::LogTrace("CRTPMTMatchingProducer") << "pushing back flash with "
-						 << thisFlashCRTmatches.size() << " CRT Matches. --> Match classification = " << std::to_string(static_cast<int>(eventType))<< "\n" ;
-	  mf::LogTrace("CRTPMTMatchingProducer") << "\tfirstOpHitPeakTime " << firstOpHitPeakTime << ", firstOpHitStartTime = " << firstOpHitStartTime << " (us)\n\ttotPe = " << totPe << "\n\tflashYWidth = " << flashYWidth << ", flashZWidth = " << flashZWidth << " (cm)\n";
+                                                 << thisFlashCRTmatches.size() << " CRT Matches. --> Match classification = " << std::to_string(static_cast<int>(eventType))<< "\n" ;
+          mf::LogTrace("CRTPMTMatchingProducer") << "\tfirstOpHitPeakTime " << firstOpHitPeakTime << ", firstOpHitStartTime = " << firstOpHitStartTime << " (us)\n\ttotPe = " << totPe << "\n\tflashYWidth = " << flashYWidth << ", flashZWidth = " << flashZWidth << " (cm)\n";
 
-	}
+        }
         FlashType thisFlashType = { /* .flashPos = */ flash_pos, // C++20: restore initializers
                                     /* .flashTime = */ tflash,
                                     /* .flashGateTime = */ thisRelGateTime / 1000.0, // -> us
                                     /* .firstOpHitPeakTime = */ firstOpHitPeakTime,
-				    /* .firstOpHitStartTime = */ firstOpHitStartTime,
-				    /* .inBeam = */ thisInTime_beam,
+                                    /* .firstOpHitStartTime = */ firstOpHitStartTime,
+                                    /* .inBeam = */ thisInTime_beam,
                                     /* .inGate = */ thisInTime_gate,
-				    /* .flashPE = */ totPe, 
-				    /* /.flashYWidth = */ flashYWidth,
-				    /* /.flashZWidth = */ flashZWidth,
+                                    /* .flashPE = */ totPe, 
+                                    /* /.flashYWidth = */ flashYWidth,
+                                    /* /.flashZWidth = */ flashZWidth,
                                     /* .classification = */ eventType,
                                     /* .CRTmatches = */ std::move(thisFlashCRTmatches)};
         

--- a/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
@@ -163,14 +163,16 @@ namespace icarus::crt {
    * -------
    * 
    * * `std::vector<icarus::crt::CRTPMTMatching>`: an entry for each matched
-   *   flash; the entry contains information of all the matched CRT hits and
-   *   the type of the matching:
+   *   flash. Entries are sorted by flast time, from the earliest to the latest,
+   *   irregardless of which of the input flash collections they come from.
+   *   Each entry contains information of all the matched CRT hits and the type
+   *   of the matching:
    *    * `flashID`: not saved yet (set to `0`).
    *    * `flashTime`: from `recob::OpFlash::Time()`.
    *    * `flashGateTime`: time of the flash from the beam gate opening.
    *    * `firstOpHitPeakTime`: first `recob::OpHit::PeakTime()` in the flash.
-   *    * `firstOpHitStartTime`: from `recob::OpHit::StartTime()`, only seemed 
-   *    *    filled for MC, left to default value otherwise.
+   *    * `firstOpHitStartTime`: from `recob::OpHit::StartTime()` in the flash;
+   *         only filled if present in the hit (`HasStartTime()`).
    *    * `flashInGate`: whether the flash is in the beam gate interval as
    *       configured via `BNBinBeamMin`/`BNBinBeamMax` or the corresponding
    *       settings for NuMI beam.

--- a/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
@@ -564,13 +564,16 @@ namespace icarus::crt {
         flashCentroid.add(pos, amp);
       }
       geo::Point_t const flash_pos = flashCentroid.middlePoint();
-      mf::LogTrace("CRTPMTMatchingProducer")
-        << "Now matching flash #" << flashPtr.key()
-        << " at " << flashPtr->Time() << " us and ("
-        << flashPtr->XCenter() << ", " << flashPtr->YCenter()
-          << ", " << flashPtr->ZCenter()
-        << ") cm [" << hits.size() << " op.hits] -> first time: "
-        << firstOpHitPeakTime << " us, centroid: " << flash_pos << " cm";
+      {
+        mf::LogTrace log("CRTPMTMatchingProducer");
+        log << "Now matching flash #" << flashPtr.key()
+          << " at " << flashPtr->Time() << " us and (";
+        if (flashPtr->hasXCenter()) log << flashPtr->XCenter();
+        else log << "n/a";
+        log << ", " << flashPtr->YCenter() << ", " << flashPtr->ZCenter()
+          << ") cm [" << hits.size() << " op.hits] -> first time: "
+          << firstOpHitPeakTime << " us, centroid: " << flash_pos << " cm";
+      }
       
       if (nPMTsTriggering < fnOpHitToTrigger) {
         mf::LogTrace("CRTPMTMatchingProducer")

--- a/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
@@ -167,7 +167,8 @@ namespace icarus::crt {
    *   irregardless of which of the input flash collections they come from.
    *   Each entry contains information of all the matched CRT hits and the type
    *   of the matching:
-   *    * `flashID`: not saved yet (set to `0`).
+   *    * `flashID`: an ID made up out of the flash content
+   *         (`icarus::crt::makeFlashID()`).
    *    * `flashTime`: from `recob::OpFlash::Time()`.
    *    * `flashGateTime`: time of the flash from the beam gate opening.
    *    * `firstOpHitPeakTime`: first `recob::OpHit::PeakTime()` in the flash.
@@ -379,7 +380,6 @@ namespace icarus::crt {
     icarus::crt::MatchedCRT makeMatchedCRT
       (sbn::crt::CRTHit const& hit, double tflash, bool isRealData) const;
     
-
   }; // class CRTPMTMatchingProducer
 
   CRTPMTMatchingProducer::CRTPMTMatchingProducer
@@ -618,7 +618,10 @@ namespace icarus::crt {
         mf::LogTrace("CRTPMTMatchingProducer") << "\tfirstOpHitPeakTime " << firstOpHitPeakTime << ", firstOpHitStartTime = " << firstOpHitStartTime << " (us)\n\ttotPe = " << totPe << "\n\tflashYWidth = " << flashYWidth << ", flashZWidth = " << flashZWidth << " (cm)\n";
 
       }
-      FlashType thisFlashType = { /* .flashPos = */ flash_pos, // C++20: restore initializers
+      
+      int const flashID = icarus::crt::makeFlashID(flashPtr.get());
+      FlashType thisFlashType = { /* .flashID = */ flashID, // C++20: restore initializers
+                                  /* .flashPos = */ flash_pos,
                                   /* .flashTime = */ tflash,
                                   /* .flashGateTime = */ thisRelGateTime / 1000.0, // -> us
                                   /* .firstOpHitPeakTime = */ firstOpHitPeakTime,
@@ -699,6 +702,7 @@ namespace icarus::crt {
              /* .sys = */ CRTSys,
              /* .region = */ CRTRegion};
   }
+
 
   DEFINE_ART_MODULE(CRTPMTMatchingProducer)
 

--- a/icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.cxx
+++ b/icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.cxx
@@ -9,11 +9,15 @@
 // Library header
 #include "icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.h"
 
+// LArSoft libraries
+#include "lardataobj/RecoBase/OpFlash.h"
+
 // framework libraries
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 // C++ standard libraries
 #include <utility>
+#include <cmath>
 
 
 // -----------------------------------------------------------------------------
@@ -123,7 +127,7 @@ icarus::crt::CRTPMTMatching icarus::crt::FillCRTPMT(FlashType const& flash)
   // UPDATE CRTPMTMatchingProducer class documentation when some missing items
   //        are added
   CRTPMTMatching crtpmt;
-  crtpmt.flashID = 0; //
+  crtpmt.flashID = flash.flashID;
   crtpmt.flashTime = flash.flashTime;
   crtpmt.flashGateTime = flash.flashGateTime;
   crtpmt.firstOpHitPeakTime = flash.firstOpHitPeakTime; 
@@ -144,5 +148,17 @@ icarus::crt::CRTPMTMatching icarus::crt::FillCRTPMT(FlashType const& flash)
   return crtpmt;
 }
 
+
+// -----------------------------------------------------------------------------
+int icarus::crt::makeFlashID
+  (recob::OpFlash const& flash, int /* version = std::numeric_limits<int>::max() */)
+{
+  // all versions now
+  return static_cast<int>(std::lround(flash.Time() * 1e6)); // us -> ps
+}
+
+int icarus::crt::makeFlashID
+  (recob::OpFlash const* flash, int version /* = std::numeric_limits<int>::max() */)
+  { return flash? makeFlashID(*flash, version): icarus::crt::CRTPMTMatching::NoID; }
 
 // -----------------------------------------------------------------------------

--- a/icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.h
+++ b/icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 
+namespace recob { class OpFlash; } // no need to know the details
 
 namespace icarus::crt {
 
@@ -35,6 +36,9 @@ namespace icarus::crt {
   };
 
   struct FlashType {
+    static constexpr auto NoID = icarus::crt::CRTPMTMatching::NoID;
+    
+    int flashID = NoID;
     geo::Point_t flashPos;
     double flashTime;
     double flashGateTime;
@@ -104,6 +108,27 @@ namespace icarus::crt {
 
   /// Fills a `CRTPMTMatching` record out of the specified `flash` information.
   CRTPMTMatching FillCRTPMT (FlashType const& flash);
+
+  //@{
+  /**
+   * @brief Returns an unique ID for the flash in `ptr`.
+   * @param flash a flash or its pointer
+   * @param version (default: latest) the ID creation algorithm version to use
+   * @return an unique ID for the flash in `ptr`
+   * 
+   * An ID is made up out of the flash.
+   * 
+   * Supported versions:
+   *  * `10`: ID is the flash time in picoseconds, rounded;
+   *          `icarus::crt::CRTPMTMatching::NoID` if flash is invalid
+   *          (e.g. null pointer)
+   */
+  int makeFlashID
+    (recob::OpFlash const& flash, int version = std::numeric_limits<int>::max());
+
+  int makeFlashID
+    (recob::OpFlash const* flash, int version = std::numeric_limits<int>::max());
+  //@}
 
 }
 

--- a/icaruscode/CRT/crtpmtmatchingproducer_icarus.fcl
+++ b/icaruscode/CRT/crtpmtmatchingproducer_icarus.fcl
@@ -7,20 +7,6 @@
 
 process_name: CRTPMTMatchingProducer
 
-services.message.destinations: {
-
-  # grab all the "DumpCRTPMTMatching" messages and put them in DumpCRTPMTMatching.log
-  LogCRTPMT: {
-    append: false
-    categories: {
-      DumpCRTPMTMatching: { limit: -1 }
-      default: { limit: 0 }
-    }
-    filename: "CRTPMTMatchingProd.log"
-    threshold: "INFO"
-    type: "file"
-  } # LogCRTPMT
-}
 services:
 {
   scheduler:                 { defaultExceptions: false }    # Make all uncaught exceptions fatal.

--- a/icaruscode/IcarusObj/CRTPMTMatching.h
+++ b/icaruscode/IcarusObj/CRTPMTMatching.h
@@ -10,6 +10,7 @@
 
 // C++ includes
 #include <vector>
+#include <limits>
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 
 namespace icarus::crt {
@@ -55,7 +56,7 @@ namespace icarus::crt {
   struct CRTPMTMatching{
     
     /// Special value to indicate the lack of information on an ID.
-    static constexpr int NoID = -1;
+    static constexpr int NoID = std::numeric_limits<int>::min();
 
     /// Special value to indicate the lack of information on a counter.
     static constexpr unsigned int NoCount

--- a/icaruscode/Utilities/DumpCRTPMTMatching_module.cc
+++ b/icaruscode/Utilities/DumpCRTPMTMatching_module.cc
@@ -288,7 +288,7 @@ void icarus::crt::DumpCRTPMTMatching::DumpMatching(
   // flash ID
   log << "\n" << indent << "  flash";
   if (matchInfo.flashID == CRTPMTMatching::NoID) log << " <unknown ID>";
-  else                                           log << " #" << matchInfo.flashID;
+  else                                           log << " ID=" << matchInfo.flashID;
   
   // flash times
   if (matchInfo.flashTime != CRTPMTMatching::NoTime)

--- a/icaruscode/Utilities/DumpCRTPMTMatching_module.cc
+++ b/icaruscode/Utilities/DumpCRTPMTMatching_module.cc
@@ -29,12 +29,6 @@
 #include "canvas/Utilities/InputTag.h"
 
 // C//C++ standard libraries
-// #include <algorithm>  // std::max(), std::sort(), std::transform()
-// #include <functional> // std::mem_fn()
-// #include <iomanip>    // std::setw()
-// #include <iterator>   // std::back_inserter()
-// #include <memory>     // std::unique_ptr()
-// #include <sstream>
 #include <optional>
 #include <map>
 #include <vector>

--- a/icaruscode/Utilities/DumpCRTPMTMatching_module.cc
+++ b/icaruscode/Utilities/DumpCRTPMTMatching_module.cc
@@ -351,9 +351,10 @@ void icarus::crt::DumpCRTPMTMatching::DumpMatching(
   if (flash) {
     log << "\n" << indent << "  associated flash: "
       << tagIndex(flash).encode() << "#"
-      << flash.key() << " at " << flash->Time() << " us and ("
-      << flash->XCenter() << ", " << flash->YCenter() << ", " << flash->ZCenter()
-      << ") cm";
+      << flash.key() << " at " << flash->Time() << " us and (";
+    if (flash->hasXCenter()) log << flash->XCenter();
+    else log << "n/a";
+    log << ", " << flash->YCenter() << ", " << flash->ZCenter() << ") cm";
   }
   if (!CRThits.empty()) {
     log << "\n" << indent << "  associated CRT hits:";


### PR DESCRIPTION
This pull request is meant to address the suggestions by @francescopoppi on the candidate version of the CRT/PMT matching producer:
 * flash ID should be added
 * matches should be sorted by flash time

Both require some choices, which I am explaining here.

## Flash ID

The `icarus::crt::CRTPMTMatching` object is ready to host as data member the ID of the flash that is being matched.
Unfortunately, `recob::OpFlash` is one of the data products which do not have an ID field.
On top of that, creating one is not trivial since the flashes live in ICARUS in two independent data products, one per cryostat. Given the absence of a native ID, the only reliable way to assign a flash an ID is to extract its value from the fields of the flash itself; otherwise, given a flash ID, there is no way to figure out to which of the original flashes it belongs to.
My choice here was to attempt an unique ID, which unfortunately makes it not easy to read (no such a thing like ID `1`, ID `2` etc.). The implementation is to use as an ID the time of the flash (`recob::OpFlash::Time()`) in _picoseconds_, rounded.
Technically this is _not guaranteed_ to be unique, but the chances of collision are quite negligible.

## Sorting the matches

The choice here was to sort the matches by the time (`recob::OpFlash::Time()`) of the flash being matched.
The tie breaker, for the unlikely case where two _different_ flashes have the same time, is on the largest number of photoelectrons, and finally on a technical detail (the order of their _art_ pointers).
The implementation mixes the matches between the flashes of the two cryostats. If this is not desired, the module should be run twice, each time on a single cryostat. Also, the order of the matches will not coincide with the order of the flashes any more (that rule had some exceptions already).
