### PR TITLE
Correction of a bug where a vector was not cleared.

### DIFF
--- a/icaruscode/CRT/CRTPMTMatchingAna_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingAna_module.cc
@@ -644,8 +644,8 @@ void icarus::crt::CRTPMTMatchingAna::ClearVecs() {
   fMatchedCRTamplitude.clear();
   fDirection.clear();
   fDistance.clear();
-  fDistance.clear();
   fTofOpHit.clear();
+  fTofOpFlash.clear();
   fVelocity.clear();
   fCRTGateDiff.clear();
 }


### PR DESCRIPTION
There was a bug where a vector of time differences between flashes and CRT hits was not cleared.
