### PR TITLE
Set ReferencePMTFromTriggerToBeam to false for MC CAFs

### DIFF
--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -53,3 +53,5 @@ physics:
 physics.producers.cafmaker.CRTSimT0Offset: @local::standard_icarus_crtsimalg.GlobalT0Offset
 # Blinding not needed for MC
 physics.producers.cafmaker.CreateBlindedCAF: false
+# MC times are already measured w.r.t. the beam gate
+physics.producers.cafmaker.ReferencePMTFromTriggerToBeam: false


### PR DESCRIPTION
This PR disables the parameter used to convert OpFlash times saved in CAFs from trigger reference time to beam gate reference time for MC cafmakerjobs. This shift was only ever meant to be applied to data, as MC uses beam gate reference time anyway. Before trigger emulation was introduced, it did not matter that the shift was also applied to MC because it was just adding `0`. Now that there is a meaningful trigger time in our simulation, it is necessary to turn this off. 

_For CAFs already produced with trigger emulation and without this PR_, one can still recover the real time of each flash by subtracting off the value `triggerinfo.trigger_within_gate`.