### PR TITLE
Fix to PMT decoder bug

### DIFF
--- a/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSPMT_module.cc
@@ -1903,8 +1903,11 @@ void icarus::DaqDecoderICARUSPMT::produce(art::Event& event) {
     = createRegularWaveformMetadata(waveformProducts, event, triggerInfo);
   
   
-  // put the data products into the event
-  for (auto&& [ category, waveforms ]: waveformProducts) {
+  // put the waveform data products we are required to save into the event
+  for (std::string const& category: fSaveWaveformsFrom) {
+    auto itData = waveformProducts.find(category);
+    if (itData == waveformProducts.end()) continue;
+    auto& waveforms = itData->second;
     mf::LogTrace(fLogCategory)
       << waveforms.size() << " PMT waveforms saved for "
       << (category.empty()? "standard": category) << " instance.";


### PR DESCRIPTION
When the configuration requests not to save any waveform (or maybe just the standard PMT waveforms), the decoder module would not declare them to _art_, but then it would attempt to put them into the _art_ event anyway, which _art_ did not like at all.

Fixed now removing the attempt to put the waveforms in the event in that condition.
Not a big deal, no hurry.

Tested with `stage0_run2_icarus.fcl` (verified that the waveforms are still saved) and with a special version of `decodePMT_icarus.fcl` with no waveform saving (verified that the commit fixes the issue).

No idea whom could review this... @mvicenzi? @SFBayLaser :black_joker:?

A twin PR #598 takes care of the production branch.
