### PR TITLE
Renamed GSL header (gsl_util → util)

### DIFF
--- a/icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.h
+++ b/icaruscode/PMT/Algorithms/DiscretePhotoelectronPulse.h
@@ -21,7 +21,7 @@
 #include "lardataalg/Utilities/quantities/electronics.h" // tick, counts_f
 
 // guidelines library
-#include "gsl/gsl_util" // gsl::index
+#include "gsl/util" // gsl::index
 
 // C++ standard library
 #include <string>


### PR DESCRIPTION
This is due maintenance to remove a new warning at compilation stage.