### PR TITLE
Removed trigger decoder V3 assertion

### DIFF
--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
@@ -731,11 +731,6 @@ namespace daq
       }
     };
 
-    // we expect the LVDS status bits to follow this pattern:
-    for (auto const& cryoInfo [[maybe_unused]]: fTriggerExtra->cryostats)
-      for (auto LVDS [[maybe_unused]]: cryoInfo.LVDSstatus)
-        assert((LVDS & 0xFF000000FF000000) == 0);
-    
     //
     // absolute time trigger (raw::ExternalTrigger)
     //


### PR DESCRIPTION
The assertion ensured that bits that were assumed unused were indeed not used. The addition of adder information on some of those bits invalidated the check.

Reviewers: @jzettle is enjoying his rest and this is urgent, so it goes to run coordination and trigger expert.