### PR TITLE
Provide now-required QAlpha parameter

### DIFF
--- a/fcl/services/simulationservices_icarus.fcl
+++ b/fcl/services/simulationservices_icarus.fcl
@@ -68,6 +68,10 @@ icarus_largeantparameters: {
     LarqlAlpha: 0.0372
     LarqlBeta: 0.0124
     
+    #* alpha particle quenching factor
+    #* Doke et al. Jpn. J. Appl. Phys. Vol. 41 (2002) pp. 1538
+    QAlpha: 0.72
+
     #* ion+excitation work function in eV
     #* https://doi.org/10.1016/0168-9002(90)90011-T
     Wph: 19.5
@@ -148,4 +152,3 @@ icarus_backtracking_services: {
 
 
 END_PROLOG
-


### PR DESCRIPTION
This PR simply copies the `QAlpha` parameter as listed here:

https://github.com/LArSoft/larsim/blob/3e844a9349adfc27dd7ce8ac5141ff3eae764c67/larsim/Simulation/simulationservices.fcl#L59C14-L59C14

It would be better for ICARUS to refer to the parameters from the LArSoft `simulationservices.fcl` file through the `@local::` command than to just explicitly copy each parameter.