### PR TITLE
ArtHandleTrackerManager can now handle invalid handles

### DIFF
--- a/icaruscode/Utilities/ArtHandleTrackerManager.h
+++ b/icaruscode/Utilities/ArtHandleTrackerManager.h
@@ -830,6 +830,14 @@ art::ValidHandle<T> util::ArtHandleTrackerManager<Event>::getValidHandle
   (Args&&... args)
 {
   canOperate("getValidHandle()");
+  auto handle = fEvent->template getValidHandle<T>(std::forward<Args>(args)...);
+  if (!handle) {
+    // we can't write which input tag this is because we elected to have the
+    // most generic interface possible, so we don't know if in `Args` there is
+    // even any input tag. We could find out with additional effort.
+    mf::LogDebug{ fConfig.logCategory }
+      << "ArtHandleTrackerManager: invalid handle won't be registered.";
+  }
   return registerHandle
     (fEvent->template getValidHandle<T>(std::forward<Args>(args)...));
 }
@@ -844,6 +852,12 @@ auto util::ArtHandleTrackerManager<Event>::registerHandle
   using util::details::ProvenanceGetter;
   
   using Handle_t = std::decay_t<Handle>;
+  
+  if (!handle.isValid()) {
+    mf::LogDebug{ fConfig.logCategory }
+      << "Attempt to register an invalid handle.";
+    return std::forward<Handle>(handle);
+  }
   
   canOperate("registerHandle()");
   
@@ -937,11 +951,10 @@ template <typename Handle>
 Handle const* util::ArtHandleTrackerManager<Event>::findHandle
   (Handle const& like) const
 {
+  if (!like.isValid()) return nullptr;
   
   // look for it, one by one
   for (TrackerPtr const& tracker: fTrackers) {
-    
-    
     
     std::any anyHandlePtr = tracker->handlePtr();
     Handle const** handlePtr = std::any_cast<Handle const*>(&anyHandlePtr);


### PR DESCRIPTION
It was reported a segmentation fault from a module using `ArtHandleTrackerManager`. It turns out that the input of that module was defective and the handle being created was invalid, which `ArtHandleTrackerManager::getHandle()` could handle not.
Now it handles that scenario by not attempting to track an invalid handle and returning the invalid handle to the caller, similarly to the `art::Event::getHandle()` call that it is wrapping.

So that job will still fail, but with a meaningful error.
This is a bug fix of not very critical importance.

PR #616 is the twin change for production branch.