### PR TITLE
CopyBeamTimePMTwaveforms module to support MC

### DIFF
--- a/fcl/reco/Definitions/decoderdefs_icarus.fcl
+++ b/fcl/reco/Definitions/decoderdefs_icarus.fcl
@@ -81,6 +81,8 @@ decodeTriggerAutodetect: {
 copyPMTonBeam: {
                     module_type:        CopyBeamTimePMTwaveforms
                     Waveforms:          @nil # must override
+                    SelectInterval:    { Start: "-7 us"  Duration: "26 us" }
+                    TimeReference:     "BeamGate"
                     WaveformBaselineAssns: ""
 }
 

--- a/fcl/reco/Definitions/decoderdefs_icarus.fcl
+++ b/fcl/reco/Definitions/decoderdefs_icarus.fcl
@@ -81,7 +81,7 @@ decodeTriggerAutodetect: {
 copyPMTonBeam: {
                     module_type:        CopyBeamTimePMTwaveforms
                     Waveforms:          @nil # must override
-                    TimeReference:      "BeamGate"
+                    WaveformBaselineAssns: ""
 }
 
 END_PROLOG

--- a/fcl/reco/Definitions/stage0_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs.fcl
@@ -487,6 +487,7 @@ icarus_stage0_producers.purityana1.FillAnaTuple:                                
 icarus_stage0_producers.purityana1.PersistPurityInfo:                                          false
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
 
-icarus_stage0_producers.daqPMTonbeam.Waveforms: daqPMT
+icarus_stage0_producers.daqPMTonbeam.Waveforms:             daqPMT
+icarus_stage0_producers.daqPMTonbeam.WaveformBaselineAssns: pmtbaselines
 
 END_PROLOG

--- a/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
@@ -1,4 +1,5 @@
-#include "decoderTools_icarus.fcl"
+// #include "decoderTools_icarus.fcl"
+#include "decoderdefs_icarus.fcl"
 #include "trigger_emulation_icarus.fcl"
 #include "icarus_ophitfinder.fcl"
 #include "icarus_flashfinder.fcl"
@@ -31,7 +32,13 @@ icarus_stage0_mc_producers:
 
     @table::icarus_standard_triggersim.producers  # from trigger_emulation_icarus.fcl
     
+    opdaqmeta:         {
+                           module_type: OpDetWaveformMetaMaker
+                           Waveforms:   opdaq
+                       }
+    
     pmtbaselines:      @local::icarus_opreco_pedestal_fromchannel_MC  # from icarus_ophitfinder.fcl
+    opdetonbeam:       @local::copyPMTonBeam  # from decoderdefs_icarus.fcl
     ophit:             @local::icarus_ophit_data
     mcophit:           @local::ICARUSMCOpHit
 
@@ -61,5 +68,10 @@ icarus_stage0_mc_crt:  [ crthit,
                          crttrack, 
                        	 crtpmt
 		       ]
+
+# adapt input labels
+icarus_stage0_mc_producers.opdetonbeam.Waveforms:              opdaq
+icarus_stage0_mc_producers.opdetonbeam.OpDetWaveformMetaAssns: opdaqmeta
+icarus_stage0_mc_producers.opdetonbeam.WaveformBaselineAssns:  pmtbaselines
 
 END_PROLOG

--- a/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_mc_defs.fcl
@@ -32,11 +32,6 @@ icarus_stage0_mc_producers:
 
     @table::icarus_standard_triggersim.producers  # from trigger_emulation_icarus.fcl
     
-    opdaqmeta:         {
-                           module_type: OpDetWaveformMetaMaker
-                           Waveforms:   opdaq
-                       }
-    
     pmtbaselines:      @local::icarus_opreco_pedestal_fromchannel_MC  # from icarus_ophitfinder.fcl
     opdetonbeam:       @local::copyPMTonBeam  # from decoderdefs_icarus.fcl
     ophit:             @local::icarus_ophit_data
@@ -71,7 +66,6 @@ icarus_stage0_mc_crt:  [ crthit,
 
 # adapt input labels
 icarus_stage0_mc_producers.opdetonbeam.Waveforms:              opdaq
-icarus_stage0_mc_producers.opdetonbeam.OpDetWaveformMetaAssns: opdaqmeta
 icarus_stage0_mc_producers.opdetonbeam.WaveformBaselineAssns:  pmtbaselines
 
 END_PROLOG

--- a/icaruscode/PMT/CMakeLists.txt
+++ b/icaruscode/PMT/CMakeLists.txt
@@ -148,6 +148,9 @@ cet_build_plugin(PMTnoNoiseGeneratorTool art::tool
 
 cet_build_plugin(CopyBeamTimePMTwaveforms art::module
   LIBRARIES
+    icaruscode::PMT_Data
+    icarusalg::Utilities
+    sbnobj::ICARUS_PMT_Data
     lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
     lardataalg::DetectorInfo
     lardataobj::RawData

--- a/icaruscode/PMT/CopyBeamTimePMTwaveforms_module.cc
+++ b/icaruscode/PMT/CopyBeamTimePMTwaveforms_module.cc
@@ -80,7 +80,7 @@ namespace icarus { class CopyBeamTimePMTwaveforms; }
  * * `std::vector<raw::OpDetWaveform>`: a copy of the selected waveforms from
  *   the original collection (`Waveforms` configuration parameter).
  * * `art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>` (optional):
- *   association of the copied waveforms to their existing metadata
+ *   association _of the copied waveforms_ to their existing metadata
  *   (`OpDetWaveformMetaAssns` configuration parameter)
  * 
  * 
@@ -430,8 +430,8 @@ void icarus::CopyBeamTimePMTwaveforms::produce
   //
   // fetch input
   //
-  auto const& waveformHandle
-    = event.getValidHandle<std::vector<raw::OpDetWaveform>>(fWaveformTag);
+  auto const& waveforms
+    = event.getProduct<std::vector<raw::OpDetWaveform>>(fWaveformTag);
 
   art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta> const* waveMetaAssns
     = doAssns(Metadata)
@@ -456,21 +456,21 @@ void icarus::CopyBeamTimePMTwaveforms::produce
   // the assumption: the associations are in the same order as the
   // original waveforms, and none is missing; this allows us to skip
   // art::FindOneP calls. If not true... art::FindOneP is a way.
-  if (waveMetaAssns && (waveMetaAssns->size() != waveformHandle->size())) {
+  if (waveMetaAssns && (waveMetaAssns->size() != waveforms.size())) {
     throw art::Exception{ art::errors::LogicError }
       << "CopyBeamTimePMTwaveforms association logic assumption is broken"
       " by metadata (I)."
       "\nPlease contact the author for a fix.\n";
   }
   if (
-    waveBaselineAssns && (waveBaselineAssns->size() != waveformHandle->size())
+    waveBaselineAssns && (waveBaselineAssns->size() != waveforms.size())
   ) {
     throw art::Exception{ art::errors::LogicError }
       << "CopyBeamTimePMTwaveforms association logic assumption is broken"
       " by baselines (I)."
       "\nPlease contact the author for a fix.\n";
   }
-  if (waveRMSassns && (waveRMSassns->size() != waveformHandle->size())) {
+  if (waveRMSassns && (waveRMSassns->size() != waveforms.size())) {
     throw art::Exception{ art::errors::LogicError }
       << "CopyBeamTimePMTwaveforms association logic assumption is broken"
       " by RMS (I)."
@@ -487,7 +487,7 @@ void icarus::CopyBeamTimePMTwaveforms::produce
     mf::LogDebug(fLogCategory)
       << "Event " << event.id() << " has beam gate starting at " << beamGateTime
       << " and trigger at " << triggerTime << "."
-      << "\nNow extracting information from " << waveformHandle->size()
+      << "\nNow extracting information from " << waveforms.size()
         << " waveforms."
       ;
   }
@@ -520,10 +520,9 @@ void icarus::CopyBeamTimePMTwaveforms::produce
     : nullptr
     ;
   
-  art::PtrMaker<raw::OpDetWaveform> const makeWaveformPtr
-    { event, waveformHandle.id() };
+  art::PtrMaker<raw::OpDetWaveform> const makeWaveformPtr{ event };
   
-  for (auto const& [ iWaveform, waveform ]: util::enumerate(*waveformHandle)) {
+  for (auto const& [ iWaveform, waveform ]: util::enumerate(waveforms)) {
     
     if (!overlaps(targetInterval, waveform)) continue;
     

--- a/icaruscode/PMT/SimPMTIcarus_module.cc
+++ b/icaruscode/PMT/SimPMTIcarus_module.cc
@@ -10,18 +10,22 @@
 #include "icaruscode/PMT/PMTpedestalGeneratorTool.h"
 #include "icaruscode/PMT/PMTnoiseGeneratorTool.h"
 #include "icaruscode/PMT/SinglePhotonPulseFunctionTool.h"
+#include "icaruscode/PMT/Algorithms/OpDetWaveformMetaUtils.h" // OpDetWaveformMetaMaker
 #include "icaruscode/PMT/Algorithms/PMTsimulationAlg.h"
 #include "icaruscode/PMT/Algorithms/PedestalGeneratorAlg.h"
 #include "icaruscode/PMT/Algorithms/NoiseGeneratorAlg.h"
 #include "icaruscode/PMT/Algorithms/PhotoelectronPulseFunction.h"
+#include "icaruscode/IcarusObj/OpDetWaveformMeta.h"
 
 // LArSoft libraries
 #include "larcore/CoreUtils/ServiceUtil.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/Utilities/quantities/spacetime.h" // nanosecond
 #include "lardataobj/RawData/OpDetWaveform.h"
 #include "lardataobj/Simulation/SimPhotons.h"
+#include "larcorealg/CoreUtils/enumerate.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 
 // framework libraries
@@ -31,7 +35,10 @@
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+#include "art/Persistency/Common/PtrMaker.h"
 #include "art/Utilities/make_tool.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/Ptr.h"
 #include "canvas/Utilities/InputTag.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "fhiclcpp/types/DelegatedParameter.h"
@@ -44,6 +51,7 @@
 
 // C/C++ standard library
 #include <vector>
+#include <tuple> // std::tie()
 #include <atomic> // std::atomic_flag
 #include <iterator> // std::back_inserter()
 #include <memory> // std::make_unique()
@@ -81,6 +89,8 @@ namespace icarus::opdet {
    *   `art::RandomNumberGenerator` (which match the random engine classes
    *   derived from `clhep::HepRandomEngine` in CLHEP 2.3 except
    *   `NonRandomEngine` and `RandEngine`);
+   * * **MakeMetadata** (boolean, default: `true`): produces waveform metadata
+   *   objects.
    * * **WritePhotons** (boolean, default: `false`): saves in an additional
    *   `sim::SimPhotons` collection the photons effectively contributing to
    *   the waveforms; currently, no selection ever happens and all photons are
@@ -107,6 +117,17 @@ namespace icarus::opdet {
    * A collection of optical detector waveforms
    * (`std::vector<raw::OpDetWaveform>`) is produced.
    * See `icarus::opdet::PMTsimulationAlg` algorithm documentation for details.
+   * 
+   * If `MakeMetadata` configuration parameter is set `true`, a collection of
+   * `std::vector<sbn::OpDetWaveformMeta>` is produced, one per waveform, in the
+   * same order as the waveform data product (satisfying the
+   * @ref LArSoftProxyDefinitionParallelData "parallel data product"
+   * requirement). A regular
+   * `art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>` association is
+   * also produced. The on-trigger/on-beam flags are assigned according to the
+   * times reported by `DetectorClocks` service provider; the trigger in
+   * particular is unlikely to be meaningful, given that to emulate it the
+   * waveforms are typically needed.
    * 
    * If `WritePhotons` configuration parameter is set `true`, a collection of
    * the scintillation photons (`std::vector<sim::SimPhotons>`) which
@@ -178,6 +199,12 @@ namespace icarus::opdet {
 
       fhicl::TableFragment<icarus::opdet::PMTsimulationAlgMaker::Config> algoConfig;
       
+      fhicl::Atom<bool> MakeMetadata {
+        Name("MakeMetadata"),
+        Comment("writes a metadata object for each waveform"),
+        true
+      };
+      
       fhicl::Atom<bool> writePhotons {
           Name("WritePhotons"),
           Comment
@@ -241,6 +268,7 @@ namespace icarus::opdet {
     /// Input tag for simulated scintillation photons (or photoelectrons).
     art::InputTag fInputModuleName;
     
+    bool fMakeMetadata; ///< Whether to produce waveform metadata.
     bool fWritePhotons { false }; ///< Whether to save contributing photons.
     
     CLHEP::HepRandomEngine&  fEfficiencyEngine;
@@ -260,6 +288,17 @@ namespace icarus::opdet {
     /// True if `firstTime()` has already been called.
     std::atomic_flag fNotFirstTime;
     
+    /// Returns the metadata of `waveforms` and their associations.
+    std::pair<
+      std::vector<sbn::OpDetWaveformMeta>,
+      art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>
+      >
+      makeMetadata(
+        art::Event const& event,
+        std::vector<raw::OpDetWaveform> const& waveforms,
+        detinfo::DetectorTimings const& detTimings
+      ) const;
+    
     /// Returns whether no other event has been processed yet.
     bool firstTime() { return !fNotFirstTime.test_and_set(); }
     
@@ -273,6 +312,7 @@ SimPMTIcarus::SimPMTIcarus(Parameters const& config)
     : EDProducer{config}
     // configuration
     , fInputModuleName(config().inputModuleLabel())
+    , fMakeMetadata(config().MakeMetadata())
     , fWritePhotons(config().writePhotons())
     // random engines
     , fEfficiencyEngine(art::ServiceHandle<rndm::NuRandomService>()->registerAndSeedEngine(
@@ -308,6 +348,10 @@ SimPMTIcarus::SimPMTIcarus(Parameters const& config)
   {
     // Call appropriate produces<>() functions here.
     produces<std::vector<raw::OpDetWaveform>>();
+    if (fMakeMetadata) {
+      produces<std::vector<sbn::OpDetWaveformMeta>>();
+      produces<art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>>();
+    }
     if (fWritePhotons) produces<std::vector<sim::SimPhotons> >();
     
     fNotFirstTime.clear(); // superfluous in C++20
@@ -404,15 +448,65 @@ SimPMTIcarus::SimPMTIcarus(Parameters const& config)
     mf::LogInfo("SimPMTIcarus") << "Generated " << pulseVecPtr->size()
       << " waveforms out of " << nopch << " optical channels.";
     
+    // waveform metadata
+    std::unique_ptr<std::vector<sbn::OpDetWaveformMeta>> metadataVec;
+    std::unique_ptr<art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>>
+      metadataAssns;
+    if (fMakeMetadata) {
+      metadataVec = std::make_unique<std::vector<sbn::OpDetWaveformMeta>>();
+      metadataAssns =
+        std::make_unique<art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>>
+        ();
+      
+      auto const detTimings = detinfo::makeDetectorTimings
+        (art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e))
+        ;
+      std::tie(*metadataVec, *metadataAssns)
+        = makeMetadata(e, *pulseVecPtr, detTimings);
+    }
+    
     //
     // save the result
     //
     e.put(std::move(pulseVecPtr));
+    if (fMakeMetadata) {
+      e.put(std::move(metadataVec));
+      e.put(std::move(metadataAssns));
+    }
     if (simphVecPtr) e.put(std::move(simphVecPtr));
   } // SimPMTIcarus::produce()
   
   
-// ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  std::pair<
+    std::vector<sbn::OpDetWaveformMeta>,
+    art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>
+    >
+  SimPMTIcarus::makeMetadata(
+    art::Event const& event,
+    std::vector<raw::OpDetWaveform> const& waveforms,
+    detinfo::DetectorTimings const& detTimings
+  ) const {
+    
+    std::vector<sbn::OpDetWaveformMeta> meta;
+    art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta> assns;
+    
+    art::PtrMaker<raw::OpDetWaveform> const makeWaveformPtr{ event };
+    art::PtrMaker<sbn::OpDetWaveformMeta> const makeMetaPtr{ event };
+    
+    sbn::OpDetWaveformMetaMaker const makeOpDetWaveformMeta{ detTimings };
+    
+    for (auto const& [iWaveform, waveform ]: util::enumerate(waveforms)) {
+      meta.push_back(makeOpDetWaveformMeta(waveform));
+      assns.addSingle(makeWaveformPtr(iWaveform), makeMetaPtr(iWaveform));
+    } // for waveforms
+    
+    return { std::move(meta), std::move(assns) };
+    
+  } // SimPMTIcarus::makeMetadata()
+  
+  
+  // ---------------------------------------------------------------------------
   DEFINE_ART_MODULE(SimPMTIcarus)
   
   


### PR DESCRIPTION
The `CopyBeamTimePMTwaveforms` is used for size reduction of data samples.
It makes a copy of selected PMT waveforms, only if they contain a time point.

In production, that point is chosen to be the time of opening of the beam gate. This effectively forces the preservation of a waveform that extends from -7 to +19 µs from the beam gate front.

For a potential future use in MC samples, we would like the coverage to be similar.
This module could not guarantee that, since the duration of the waveform around the beam gate is shorter.
This pull request changes the module to accept a time interval instead of a single time point, and it will copy all the waveforms that overlap with that time interval. In this way it is guaranteed that no information is lost (there may still be gaps in that interval, but they are not covered by any existing information — in fact, in the current configuration these gaps could only contain noise).

This pull request includes:
* extension of `CopyBeamTimePMTwaveforms` to support a time interval instead of time point.
* update of _data_ Stage0 configurations of this module to cover the interval [ -7 ; +19 ] µs from the beam gate opening.
* addition to _MC_ Stage0 configuration of this module (but this module is still *not* executed in any MC Stage0 or Stage1 job).
* "bonus": `CopyBeamTimePMTwaveforms` can now also copy the associations to baseline and RMS data products (without this, after waveforms are dropped the discovery of baseline of each waveform requires major hoops).
* "bonus": extended PMT digitisation module to produce `sbn::OpDetWaveformMeta` objects that preserve a bit of information for all the waveforms even when the waveforms are dropped; this is to match the behaviour of ICARUS PMT decoder.

This branch takes advantage of an utility introduced by SBNSoftware/icarusalg#71.

The branch was tested with `run2_stage0_icarus.fcl`, a variant of `run2_stage0_icarus_mc.fcl` and one of `run2_stage1_icarus_MC.fcl` (with different capitalisation... Tracy!!!).

Reviewers: not very sure here. I throw two names here, but if they push back I am not sure who else.