### PR TITLE
Run-period-dependent channel mapping

### DIFF
--- a/fcl/reco/Definitions/CAEN_V1730_setup_icarus.fcl
+++ b/fcl/reco/Definitions/CAEN_V1730_setup_icarus.fcl
@@ -195,6 +195,9 @@ icarus_V1730_16thChannel_misc_setup_Run1: {
 #     * `s`: side: `0` for bottom ("bot"), `1` for top ("top")
 #     For example, the digit 5 (0b101) is the crate `wetop`.
 # * `B`: board inside the crate: 1, 2 or 3.
+# 
+# Note that this convention is currently (v09_77_00) required and assumed by
+# `PMTWaveformTimeCorrectionExtractor::findWaveformTimeCorrections()`.
 #
 icarus_V1730_West_setup_Run1: [
 

--- a/fcl/utilities/dump_hits_icarus.fcl
+++ b/fcl/utilities/dump_hits_icarus.fcl
@@ -1,0 +1,79 @@
+#
+# File:     dump_hits_icarus.fcl
+# Purpose:  Dump on screen hit content of ICARUS data.
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     August 11, 2023
+# Version:  1.0
+#
+# Dumps `gaushitTPC[EW][EW]` hit collections.
+#
+# Service dependencies:
+# - message facility
+#
+
+BEGIN_PROLOG
+
+dumphits: {
+  module_type:              DumpHits
+  
+  # output category (used in `messages` configuration)
+  OutputCategory:          "DumpHits"
+  
+  # specify the label of the recob::Hit producer (need to override)
+  HitModuleLabel:          @nil
+  
+  # hits have no associated raw digits nor wires
+  CheckRawDigitAssociation: false
+  CheckWireAssociation:     false
+  
+} # dumphits
+
+END_PROLOG
+
+
+# ------------------------------------------------------------------------------
+process_name: DumpHits
+
+services: {
+  message: {
+    destinations: {
+      
+      # grab all the "DumpHits" messages and put them in DumpHits.log
+      DumpHits: {
+        append: false
+        categories: {
+          DumpHits: { limit: -1 }
+          default: { limit: 0 }
+        }
+        filename: "DumpHits.log"
+        threshold: "INFO"
+        type: "file"
+      } # DumpHits
+      
+      LogStandardOut: {
+        categories: {
+          DumpHits: { limit: 0 }
+          default: {}
+        }
+        threshold: "WARNING"
+        type: "cout"
+      } # LogStandardOut
+      
+    } # destinations
+  } # message
+} # services
+
+
+physics: {
+  analyzers: {
+  
+    dumphitsEE: { @table::dumphits  HitModuleLabel: "gaushitTPCEE" }
+    dumphitsEW: { @table::dumphits  HitModuleLabel: "gaushitTPCEW" }
+    dumphitsWE: { @table::dumphits  HitModuleLabel: "gaushitTPCWE" }
+    dumphitsWW: { @table::dumphits  HitModuleLabel: "gaushitTPCWW" }
+    
+  } # analyzers
+  
+  dumpers: [ dumphitsEE, dumphitsEW, dumphitsWE, dumphitsWW ]
+  
+} # physics

--- a/fcl/utilities/dump_ophits_icarus.fcl
+++ b/fcl/utilities/dump_ophits_icarus.fcl
@@ -1,0 +1,52 @@
+#
+# File:     dump_ophits_icarus.fcl
+# Purpose:  Dump on screen optical hit content of ICARUS data.
+# Author:   Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:     August 11, 2023
+# Version:  1.0
+#
+# Dumps `ophit` hit collection.
+#
+# Service dependencies:
+# - message facility
+#
+
+process_name: DumpOpHits
+
+services.message: {
+  destinations: {
+    
+    # grab all the "DumpOpHits" messages and put them in DumpOpHits.log
+    DumpOpHits: {
+      append: false
+      categories: {
+        DumpOpHits: { limit: -1 }
+        default: { limit: 0 }
+      }
+      filename: "DumpOpHits.log"
+      threshold: "INFO"
+      type: "file"
+    } # DumpOpHits
+    
+    LogStandardOut: {
+      categories: {
+        DumpOpHits: { limit: 0 }
+        default: {}
+      }
+      threshold: "WARNING"
+      type: "cout"
+    } # LogStandardOut
+    
+  } # destinations
+} # message
+
+
+physics.analyzers.dumpophits: {
+  module_type:       DumpOpHits
+  
+  # output category (used in `messages` configuration above)
+  OutputCategory:   "DumpOpHits"
+  OpHitModuleLabel:  ophit
+}
+
+physics.dumpers: [ dumpophits ]

--- a/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
@@ -229,17 +229,19 @@ int callback(void *data, int argc, char **argv, char **azColName)
     
     if( rc != SQLITE_OK ) 
       {
-	std::cout << "ChannelMapSQLite::GetDataset: SQL error: " << zErrMsg << std::endl;
-	sqlite3_free(zErrMsg);
+        mf::LogError("ChannelMapSQLite")
+          << "ChannelMapSQLite::GetDataset: SQL error: " << zErrMsg;
+        sqlite3_free(zErrMsg);
       } 
     else 
       {
-        std::cout << "ChannelMapSQLite::GetDataset: Successfully read database" << std::endl;
+        mf::LogDebug("ChannelMapSQLite")
+          << "ChannelMapSQLite::GetDataset: Successfully read database";
       }
     
     sqlite3_close(database);
     
-    return 0;
+    return rc;
   }
   
 // -----------------------------------------------------

--- a/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
@@ -5,6 +5,9 @@
  *
  */
 
+// ICARUS libraries
+#include "icaruscode/Decode/ChannelMapping/RunPeriods.h"
+
 // Framework Includes
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -27,6 +30,7 @@
 #include <sqlite3.h> 
 #include <time.h>
 
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 // implementation follows
 
@@ -45,9 +49,20 @@ public:
   explicit ChannelMapSQLite(fhicl::ParameterSet const &pset);
   
   /**
-   *  @brief  Destructor
+   * @brief   Prepares the object for queries pertaining the specified period.
+   * @param   period the period to be prepared for
+   * @return  whether values cached from the previous period are invalidated
+   * 
+   * Periods are defined in `icarusDB::RunPeriods` class.
+   * 
+   * If the return value is `true`, caller should follow by rebuilding all the
+   * maps they need to use.
+   * If the return value is `false`, all maps built after the previous call to
+   * `SelectPeriod()` are still current for `period`: building new ones is not
+   * necessary, but it's not harmful either (at most, wasteful).
    */
-  ~ChannelMapSQLite();
+  virtual bool SelectPeriod(RunPeriod period) override;
+  
   
   /**
    *  @brief Define the returned data structures for a mapping between TPC Fragment IDs
@@ -82,6 +97,17 @@ public:
   virtual int BuildSideCRTCalibrationMap(SideCRTChannelToCalibrationMap&) const override;  
   
 private:
+
+  /// Record of all relevant table names.
+  struct TableNames_t {
+    std::string TPCfragmentMap;
+    std::string TPCreadoutBoardMap;
+    std::string PMTfragmentMap;
+    std::string CRTsideMap;
+    std::string CRTtopMap;
+    // NOTE: CRT side calibration is is a different type of database which uses a timestamp
+  };
+
   // Recover data from postgres database
   int GetDataset(const std::string&, int func(void*,int,char**,char**), void*) const;
   
@@ -89,6 +115,13 @@ private:
   std::string fDBFileName;          //< File name of our sqlite database
   std::string fCalibDBFileName;     //< File name of our side crt calibration sqlite database
   std::string fTag;                 //< Tag for conditioned database
+
+  /// The set of tables being served. Chosen by `SelectRun()`.
+  TableNames_t const* fCurrentTable = nullptr;
+
+  /// The list of names of tables.
+  static std::array<TableNames_t, RunPeriods::NPeriods> const TableNameSets;
+
 };
 
 ChannelMapSQLite::ChannelMapSQLite(fhicl::ParameterSet const &pset)
@@ -101,10 +134,50 @@ ChannelMapSQLite::ChannelMapSQLite(fhicl::ParameterSet const &pset)
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
+std::array<ChannelMapSQLite::TableNames_t, RunPeriods::NPeriods> const
+ChannelMapSQLite::TableNameSets{
+  TableNames_t{
+      "readout_boards"  // TPCfragmentMap
+    , "daq_channels"    // TPCreadoutBoardMap
+    , "pmt_placements"  // PMTfragmentMap
+    , "feb_channels"    // CRTsideMap
+    , "crtfeb"          // CRTtopMap
+  },
+  TableNames_t{
+      "readout_boards"          // TPCfragmentMap
+    , "daq_channels"            // TPCreadoutBoardMap
+    , "pmt_placements_Aug2023"  // PMTfragmentMap
+    , "feb_channels"            // CRTsideMap
+    , "crtfeb"                  // CRTtopMap
+  }
+};
 
-ChannelMapSQLite::~ChannelMapSQLite()
-{
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+bool ChannelMapSQLite::SelectPeriod(RunPeriod period) {
+  
+  auto const iPeriod = static_cast<unsigned int>(period);
+  TableNames_t const* newSet = &(TableNameSets.at(iPeriod));
+  
+  if (fCurrentTable == newSet) {
+    mf::LogDebug("ChannelMapSQLite")
+      << "Period #" << iPeriod << " already selected";
+  }
+  else if (fCurrentTable) {
+    mf::LogDebug("ChannelMapSQLite") << "Switched from period #"
+      << (fCurrentTable - &(TableNameSets[0])) << " to #" << iPeriod;
+  }
+  else {
+    mf::LogDebug("ChannelMapSQLite") << "Switching to period #" << iPeriod;
+  }
+  
+  if (fCurrentTable == newSet) return false;
+  
+  fCurrentTable = newSet;
+  return true;
+  
 }
+
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -135,6 +208,9 @@ int callback(void *data, int argc, char **argv, char **azColName)
     
     if (!searchPath.find_file(fDBFileName, fullFileName))
       throw cet::exception("ChannelMapSQLite::GetDataset") << "Can't find input file: '" << fDBFileName << "'\n";
+    
+    mf::LogDebug("ChannelMapSQLite")
+      << "Database file: '" << fullFileName << "'.";
     
     // Set up to open the database
     sqlite3* database;
@@ -177,7 +253,7 @@ int buildTPCFragmentIDToReadoutIDMap_callback(void* dataIn, int argc, char**argv
 
     IChannelMapping::TPCFragmentIDToReadoutIDMap& fragmentBoardMap = *(IChannelMapping::TPCFragmentIDToReadoutIDMap*)dataIn;
 
-    // Include a by hand mapping of fragement ID to crate
+    // Include a by hand mapping of fragment ID to crate
     // Note that we now know we can get this from the "flanges" table... so an upgrade coming soon...
     using FlangeIDToCrateMap = std::map<size_t,std::string>;
     FlangeIDToCrateMap flangeIDToCrateMap;
@@ -303,7 +379,8 @@ int buildTPCFragmentIDToReadoutIDMap_callback(void* dataIn, int argc, char**argv
   //-----------------------------------------------------
   int ChannelMapSQLite::BuildTPCFragmentIDToReadoutIDMap(TPCFragmentIDToReadoutIDMap& fragmentBoardMap) const
   {
-    const std::string dataType("readout_boards");
+    assert(fCurrentTable);
+    const std::string dataType(fCurrentTable->TPCfragmentMap);
     
     // Recover the data from the database
     int error = GetDataset(dataType,buildTPCFragmentIDToReadoutIDMap_callback,&fragmentBoardMap);
@@ -360,7 +437,8 @@ int buildTPCFragmentIDToReadoutIDMap_callback(void* dataIn, int argc, char**argv
   
   int ChannelMapSQLite::BuildTPCReadoutBoardToChannelMap(TPCReadoutBoardToChannelMap& rbChanMap) const
   {
-    const std::string  dataType("daq_channels");
+    assert(fCurrentTable);
+    const std::string  dataType(fCurrentTable->TPCreadoutBoardMap);
     
     // Recover the data from the database
     int error = GetDataset(dataType,buildTPCReadoutBoardToChannelMap_callback,&rbChanMap);
@@ -399,7 +477,8 @@ int buildTPCFragmentIDToReadoutIDMap_callback(void* dataIn, int argc, char**argv
     // clearing is cleansing
     fragmentToDigitizerChannelMap.clear();
     // Recover the information from the database on the mapping 
-    const std::string  dataType("pmt_placements");
+    assert(fCurrentTable);
+    const std::string  dataType(fCurrentTable->PMTfragmentMap);
     
     // Recover the data from the database
     int error = GetDataset(dataType,buildFragmentToDigitizerChannelMap_callback,&fragmentToDigitizerChannelMap);
@@ -440,7 +519,8 @@ int buildTPCFragmentIDToReadoutIDMap_callback(void* dataIn, int argc, char**argv
     // clearing is cleansing
     crtChannelIDToHWtoSimMacAddressPairMap.clear();
     // Recover the information from the database on the mapping
-    const std::string  dataType("feb_channels");
+    assert(fCurrentTable);
+    const std::string  dataType(fCurrentTable->CRTsideMap);
     
     // Recover the data from the database
     int error = GetDataset(dataType,buildCRTChannelIDToHWtoSimMacAddressPairMap_callback,&crtChannelIDToHWtoSimMacAddressPairMap);
@@ -473,7 +553,8 @@ int buildTPCFragmentIDToReadoutIDMap_callback(void* dataIn, int argc, char**argv
     // clearing is cleansing
     topcrtHWtoSimMacAddressPairMap.clear();
     // Recover the information from the database on the mapping
-    const std::string  dataType("crtfeb");
+    assert(fCurrentTable);
+    const std::string  dataType(fCurrentTable->CRTtopMap);
     
     // Recover the data from the database
     int error = GetDataset(dataType,buildTopCRTHWtoSimMacAddressPairMap_callback,&topcrtHWtoSimMacAddressPairMap);

--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.h
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProvider.h
@@ -22,6 +22,12 @@
 
 // -----------------------------------------------------------------------------
 namespace icarusDB { class ICARUSChannelMapProvider; }
+/**
+ * @brief Interface to the channel mapping databases of TPC, CRT and PMT subdetectors.
+ * 
+ * Before retrieving the information, a run period (`forPeriod()`) or a run
+ * (`forRun()`) must be selected.
+ */
 class icarusDB::ICARUSChannelMapProvider: public IICARUSChannelMap
 {
 public:
@@ -66,6 +72,13 @@ public:
     /// Returns the PMT fragment ID for the specified channel mapping database key.
     static constexpr unsigned int DBkeyToPMTfragmentID(unsigned int DBkey);
 
+  
+    /// Loads the mapping for `run`, returns whether a new mapping was loaded.
+    bool                                    forRun(int run)                         override;
+    
+    /// Loads the mapping for `period`, returns whether a new mapping was loaded.
+    bool                                    forPeriod(icarusDB::RunPeriod period)   override;
+
 private:
     
     bool fDiagnosticOutput;
@@ -84,10 +97,17 @@ private:
 
     std::unique_ptr<IChannelMapping>               fChannelMappingTool;
 
+
+    /// Has the channel mapping tool fill the mapping caches.
+    void readFromDatabase();
+
+    
     /// Returns the list of board channel-to-PMT channel ID mapping within the specified fragment.
     /// @returns a pointer to the mapping list, or `nullptr` if invalid fragment
     DigitizerChannelChannelIDPairVec const* findPMTfragmentEntry
       (unsigned int fragmentID) const;
+    
+    
 
 }; // icarusDB::ICARUSChannelMapProvider
 

--- a/icaruscode/Decode/ChannelMapping/IChannelMapping.h
+++ b/icaruscode/Decode/ChannelMapping/IChannelMapping.h
@@ -10,6 +10,9 @@
 #ifndef IChannelMapping_h
 #define IChannelMapping_h
 
+// ICARUS libraries
+#include "icaruscode/Decode/ChannelMapping/RunPeriods.h"
+
 // Framework Includes
 #include "fhiclcpp/ParameterSet.h"
 
@@ -27,6 +30,18 @@ namespace icarusDB
      *  @brief  Virtual Destructor
      */
     virtual ~IChannelMapping() noexcept = default;
+    
+    /**
+     *  @brief Prepares the tool to serve information about the specified run period.
+     *  @param period the run period to be served
+     *  @return whether the served values are going to be different than before
+     * 
+     * If this method returns `false`, the values from the previous call to it
+     * are still current.
+     * 
+     * Run periods are defined in `icarusDB::RunPeriods`.
+     */
+    virtual bool SelectPeriod(icarusDB::RunPeriod period) = 0;
     
     /**
      *  @brief Define the returned data structures for a mapping between TPC Fragment IDs

--- a/icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h
+++ b/icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h
@@ -12,6 +12,8 @@
 #ifndef IICARUSChannelMap_H
 #define IICARUSChannelMap_H
 
+#include "icaruscode/Decode/ChannelMapping/RunPeriods.h"
+
 #include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 
 #include <vector>
@@ -35,7 +37,14 @@ class IICARUSChannelMap //: private lar::EnsureOnlyOneSchedule
 {
 public:
     virtual ~IICARUSChannelMap() noexcept = default;
-
+    
+    
+    /// Loads the mapping for `run`, returns whether a new mapping was loaded.
+    virtual bool                                    forRun(int run)                               = 0;
+    
+    /// Loads the mapping for `period`, returns whether a new mapping was loaded.
+    virtual bool                                    forPeriod(icarusDB::RunPeriod period)         = 0;
+    
     // Section to access fragment to board mapping
     virtual bool                                    hasFragmentID(const unsigned int)       const = 0;
     /// Returns the number of TPC fragment IDs known to the service.
@@ -57,8 +66,8 @@ public:
     virtual unsigned int                            nPMTfragmentIDs() const = 0;
     virtual const DigitizerChannelChannelIDPairVec& getChannelIDPairVec(const unsigned int) const = 0;
 
-    virtual unsigned int                            getSimMacAddress(const unsigned int)    const = 0;    
-    virtual unsigned int                         gettopSimMacAddress(const unsigned int)    const = 0;    
+    virtual unsigned int                            getSimMacAddress(const unsigned int)    const = 0;
+    virtual unsigned int                         gettopSimMacAddress(const unsigned int)    const = 0;
 
     virtual std::pair<double, double>          getSideCRTCalibrationMap(int mac5, int chan) const = 0;
 };

--- a/icaruscode/Decode/ChannelMapping/RunPeriods.h
+++ b/icaruscode/Decode/ChannelMapping/RunPeriods.h
@@ -1,0 +1,84 @@
+/**
+ * @file   icaruscode/Decode/ChannelMapping/RunPeriods.h
+ * @brief  Utilities to define run periods.
+ * @date   August 8, 2023
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ */
+
+#ifndef ICARUSCODE_DECODE_CHANNELMAPPING_RUNPERIODS_H
+#define ICARUSCODE_DECODE_CHANNELMAPPING_RUNPERIODS_H
+
+
+// C/C++ standard libraries
+#include <array>
+
+// -----------------------------------------------------------------------------
+namespace icarusDB {
+  
+  /// List of run periods.
+  enum class RunPeriod: unsigned int {
+    Runs0to2,   ///< Runs from the very beginning to Summer 2023.
+    Runs3andOn, ///< Runs from Summer 2023 on.
+    
+    // leave the following one as last, of course:
+    NPeriods ///< Number of run periods.
+  };
+  
+  /// Returns an array with all run periods. Also in `RunPeriods::All`.
+  constexpr std::array<RunPeriod, static_cast<unsigned int>(RunPeriod::NPeriods)>
+    allPeriods() noexcept;
+  
+  /// Returns the number of supported periods.
+  constexpr std::size_t NPeriods() noexcept
+    { return static_cast<std::size_t>(RunPeriod::NPeriods); }
+  
+  struct RunPeriods;
+  
+} // namespace icarusDB
+
+
+// -----------------------------------------------------------------------------
+inline constexpr std::array<icarusDB::RunPeriod, icarusDB::NPeriods()>
+icarusDB::allPeriods() noexcept {
+  std::array<RunPeriod, NPeriods()> periods{};
+  for (unsigned int p = 0; p < NPeriods(); ++p)
+    periods[p] = static_cast<RunPeriod>(p);
+  return periods;
+}
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Definition of supported run periods.
+ * 
+ * This static class currently provides only the transformation from a run
+ * number to a run period (`withRun()`).
+ */
+struct icarusDB::RunPeriods {
+  
+  static constexpr std::size_t NPeriods = icarusDB::NPeriods();
+  
+  /// The list of all supported periods.
+  static constexpr std::array<RunPeriod, NPeriods> All = allPeriods();
+  
+  
+  /**
+   * @brief Returns the period of the specified `run`.
+   * @return the period `run` belongs to, or `NPeriods` if not supported
+   */
+  static constexpr RunPeriod withRun(int run)
+    {
+      
+      if (run < 0xBADCAFE) return RunPeriod::Runs0to2; // FIXME set the correct run number
+      if (run < 0xBADCAFE) return RunPeriod::Runs3andOn; // FIXME set the correct run number
+      
+      return RunPeriod::NPeriods;
+      
+    }
+  
+}; // icarusDB::RunPeriods
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_DECODE_CHANNELMAPPING_RUNPERIODS_H

--- a/icaruscode/Timing/PMTWaveformTimeCorrectionExtractor.cxx
+++ b/icaruscode/Timing/PMTWaveformTimeCorrectionExtractor.cxx
@@ -47,11 +47,11 @@ icarus::timing::PMTWaveformTimeCorrectionExtractor::Error::Error
 
 icarus::timing::PMTWaveformTimeCorrectionExtractor::MultipleCorrectionsForChannel
 ::MultipleCorrectionsForChannel
-  (unsigned int existing, unsigned int additional)
+  (unsigned int channel, unsigned int existing, unsigned int additional)
     : Error{
-      "Attempt to overwrite correction from channel "
-      + std::to_string(existing) + " with one from channel "
-      + std::to_string(additional) + "\n"
+      "Attempt to overwrite the correction for channel "
+      + std::to_string(channel) + " (from channel " + std::to_string(existing)
+      + ") with another (from channel " + std::to_string(additional) + ")\n"
       }
 {}
 
@@ -224,7 +224,7 @@ void icarus::timing::PMTWaveformTimeCorrectionExtractor::findWaveformTimeCorrect
             PMTWaveformTimeCorrection& correction = correctionFor(channelID);
             if (correction.isValid()) {
               throw MultipleCorrectionsForChannel
-                { correction.channelID, waveChannelID };
+                { channelID, correction.channelID, waveChannelID };
             }
             
             correction.channelID = waveChannelID;

--- a/icaruscode/Timing/PMTWaveformTimeCorrectionExtractor.h
+++ b/icaruscode/Timing/PMTWaveformTimeCorrectionExtractor.h
@@ -70,7 +70,10 @@ class icarus::timing::PMTWaveformTimeCorrectionExtractor {
 
         /// Exception thrown when trying to overwrite a correction.
         struct MultipleCorrectionsForChannel: Error {
-            MultipleCorrectionsForChannel(unsigned int existing, unsigned int additional);
+            MultipleCorrectionsForChannel(
+                unsigned int channel,
+                unsigned int existing, unsigned int additional
+            );
         };
 
         /// Exception thrown when correction requested from a non-special channel.


### PR DESCRIPTION
Due to the change in cabling of the PMT, a slightly different mapping will required from the time of the swap on.
Using the old mapping would result in some of the channels being applied the wrong corrections.

This pull request introduces in `ICARUSChannelMapService`, its provider and the implementing tools a run-period awareness, and a simple class to (hard-codedly) map run numbers to periods, `icarusDB::RunPeriods`, is also provided.

This is technically a breaking change: the service _provider_ (`ICARUSChannelMapProvider`) used to load the data at construction; now this is not true any more, and a `withRun()` or `withPeriod()` call must be executed before the object is available for use. This is automatically done by the _art_ service wrapper, ``ICARUSChannelMapService`, but users not using the service but rather the provider directly, e.g. in a _gallery_ environment, will have to make that call now.
To ensure the most backward compatibility, the service _art_ does load the run period `Runs0to2` immediately at construction, so that code that used to cache the mapping at construction or begin of job will still work with old data.
I am not aware of such code for PMT in `icaruscode`, and `Stage0` did not show any. For the other subdetectors, mapping is always the same; should that change in the future, a code survey will be needed.

I have tested the code with a new SQLite database provided by @mvicenzi, mocking up the run period boundary.
I have noticed no difference in the TPC hits, and the expected differences in the optical hits (that is, no difference with respect to the output obtained from a production release when using run period `Runs0to2`, and differences on the changed channels for the new period).

**THIS IS A DRAFT PR**, but please start reviewing it now so that when the hardware change is happening we are ready to update it and merge it. Merging must happen after:
 * the new PMT mapping DB is added to `icarus_data`
 * the cable swap has happened on hardware
 * the code has been updated to reflect the actual run number boundary between the old and the new period

Asking for review from TPC, PMT and CRT people.
