### PR TITLE
This updates the Run1 definitions for develop.

### DIFF
--- a/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
@@ -14,6 +14,7 @@
 #include "trigger_emulation_icarus.fcl"
 #include "crt_decoderdefs_icarus.fcl"
 #include "crthitproducer.fcl"
+#include "crtpmtmatchingproducer.fcl"
 #include "wcls-decode-to-sig-base.fcl"
 #include "icarus_FilterDataIntegrity.fcl"
 #include "icarus_FilterCRTPMTMatching.fcl"
@@ -51,6 +52,9 @@ icarus_stage0_analyzers:
 # set the name of our `extractPMTconfig` and `extractTriggerConfig` for our decoders
 decodeTriggerV2.DecoderTool.TrigConfigLabel: triggerconfig
 decodeTriggerV3.DecoderTool.TrigConfigLabel: triggerconfig
+decodeTriggerAutodetect.DecoderTool.Decoders[0].ToolConfig.TrigConfigLabel: triggerconfig
+decodeTriggerAutodetect.DecoderTool.Decoders[1].ToolConfig.TrigConfigLabel: triggerconfig
+decodeTriggerAutodetect.DecoderTool.Decoders[2].ToolConfig.TrigConfigLabel: triggerconfig
 decodePMT.PMTconfigTag: pmtconfig
 decodePMT.TriggerTag:   daqTrigger
 
@@ -71,7 +75,7 @@ icarus_stage0_producers:
 
   daqCRT:                         @local::crtdaq_icarus
 
-  daqTrigger:                     @local::decodeTriggerV2
+  daqTrigger:                     @local::decodeTriggerAutodetect
 
   ### calwire producers
   decon1droi:                     @local::icarus_decon1droi
@@ -100,6 +104,9 @@ icarus_stage0_producers:
 
   ### CRT hit finder producer
   crthit:                         @local::standard_crthitproducer	
+
+  ### CRTPMTMatching producer
+  crtpmt:			  @local::standard_crtpmtmatchingproducer
 
   ### trigger emulation foundation
   pmtconfigbaselines:             @local::icarus_pmtconfigbaselines
@@ -265,7 +272,8 @@ icarus_stage0_2d_multiTPC:         [ @sequence::icarus_stage0_multiTPC_2d_TPC,
 
 icarus_stage0_CRT:                 [
                                      daqCRT,
-                                     crthit
+                                     crthit,
+				     crtpmt
                                    ]
 
 icarus_stage0_data:                [

--- a/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
@@ -113,12 +113,15 @@ icarus_stage0_producers:
   pmtthr:                         @local::icarus_pmtdiscriminatethr
   
   ### Optical hit finder
+  pmtbaselines:                   @local::icarus_opreco_pedestal_fromchannel_data  # from icarus_ophitfinder.fcl
   ophituncorrected:               @local::icarus_ophit_data
   ophit:                          @local::icarus_ophit_timing_correction
   ophitfulluncorrected:           @local::icarus_ophitdebugger_data
   ophitfull:                      @local::icarus_ophit_timing_correction
   opflashCryoE:                   @local::ICARUSSimpleFlashDataCryoE
   opflashCryoW:                   @local::ICARUSSimpleFlashDataCryoW
+
+  daqPMTonbeam:                   @local::copyPMTonBeam
 
   ### Purity monitoring
   purityana0:                     { module_type: "ICARUSPurityDQM" }
@@ -242,6 +245,7 @@ icarus_stage0_PMT:                 [ triggerconfig,
                                      daqPMT,
                                      pmtconfigbaselines,
                                      pmtthr,
+                                     pmtbaselines,
                                      ophituncorrected,
                                      ophit,
                                      opflashCryoE,
@@ -488,5 +492,7 @@ icarus_stage0_producers.purityana1.PersistPurityInfo:                           
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
 icarus_stage0_producers.purityana1.PersistPurityInfo:                                          false
 icarus_stage0_producers.purityana1.FillAnaTuple:                                               false
+
+icarus_stage0_producers.daqPMTonbeam.Waveforms: daqPMT
 
 END_PROLOG

--- a/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
+++ b/fcl/reco/Definitions/stage0_icarus_defs_run1.fcl
@@ -249,7 +249,8 @@ icarus_stage0_PMT:                 [ triggerconfig,
                                      ophituncorrected,
                                      ophit,
                                      opflashCryoE,
-                                     opflashCryoW
+                                     opflashCryoW,
+                                     daqPMTonbeam
                                    ]
 
 icarus_stage0_PMT_BNB:             [ @sequence::icarus_stage0_PMT,

--- a/fcl/reco/Stage0/Run1/stage0_run1_icarus.fcl
+++ b/fcl/reco/Stage0/Run1/stage0_run1_icarus.fcl
@@ -15,8 +15,17 @@ physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamROOT ]
 
 # Drop the artdaq format files on output
-outputs.rootOutput.outputCommands: ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_ophituncorrected_*_*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
-#outputs.rootOutput.SelectEvents:   [path]
+outputs.rootOutput.outputCommands: [
+    "keep *_*_*_*",
+    "drop *_*_*_DAQ*",
+    "drop *_ophituncorrected_*_*",
+    "drop raw::OpDetWaveforms_daqPMT__*",
+    "drop *_daqTPCROI_*_*",
+    "drop *_decon1droi_*_*",
+    "drop *_decon1DroiTPC*_*_*",
+    "keep *_daq_ICARUSTrigger*_*"
+    ]
+outputs.rootOutput.SelectEvents:   [path]
 
 ## Modify the event selection for the purity analyzers
 physics.analyzers.purityinfoana0.SelectEvents:    [ path ]


### PR DESCRIPTION
A bug was found where the Stage0 definitions for Run1 did not include CRTPMTMatching Producer module.
This PR fixes the issues. I ask @PetrilloAtWork for his reviews, to understands if there are other items missing from the Stage0 definitions for Run1 which are on the other hand present in Stage0 definitions for Run2.

This is a PR for develop release
