### PR TITLE
Update laser calibration tags for run2

### DIFF
--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -40,7 +40,7 @@ icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
 
 // -------------------------------------------------------------------------------
 
-uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_t run ) {
+uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_t run ) const{
 
    // Run number to timestamp used in the db
    // DBFolder.h only takes 19 digit (= timestamp in nano second),

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -16,6 +16,7 @@
 
 // Database interface helpers
 #include "larevt/CalibrationDBI/Providers/DBFolder.h"
+#include "larevt/CalibrationDBI/IOVData/TimeStampDecoder.h"
 
 // C/C++ standard libraries
 #include <string>
@@ -68,6 +69,10 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
+    mf::LogTrace(fLogCategory)
+           << "Fetched IoV [ " << db.CachedStart().DBStamp() << " ; " << db.CachedEnd().DBStamp()
+           << " ] to cover t=" << RunToDatabaseTimestamp(run)
+           << " [=" << lariov::TimeStampDecoder::DecodeTimeStamp(RunToDatabaseTimestamp(run)).DBStamp() << "]";
 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
@@ -126,6 +131,10 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
+    mf::LogTrace(fLogCategory)
+           << "Fetched IoV [ " << db.CachedStart().DBStamp() << " ; " << db.CachedEnd().DBStamp()
+           << " ] to cover t=" << RunToDatabaseTimestamp(run)
+           << " [=" << lariov::TimeStampDecoder::DecodeTimeStamp(RunToDatabaseTimestamp(run)).DBStamp() << "]";
 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
@@ -162,6 +171,10 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t ru
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
+    mf::LogTrace(fLogCategory)
+           << "Fetched IoV [ " << db.CachedStart().DBStamp() << " ; " << db.CachedEnd().DBStamp()
+           << " ] to cover t=" << RunToDatabaseTimestamp(run)
+           << " [=" << lariov::TimeStampDecoder::DecodeTimeStamp(RunToDatabaseTimestamp(run)).DBStamp() << "]";
 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -27,15 +27,15 @@ icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
     (const fhicl::ParameterSet& pset) 
     : fVerbose{ pset.get<bool>("Verbose", false) }
     , fLogCategory{ pset.get<std::string>("LogCategory", "PMTTimingCorrection") }
-    , fTags{ pset.get<fhicl::ParameterSet>("CorrectionsTags") }
     { 
-	fCablesTag  = fTags.get<std::string>("CablesTag", "v1r0");
-	fLaserTag   = fTags.get<std::string>("LaserTag", "v1r0");
-	fCosmicsTag = fTags.get<std::string>("CosmicsTag", "v1r0");
+        fhicl::ParameterSet const tags{ pset.get<fhicl::ParameterSet>("CorrectionsTags") };
+	fCablesTag  = tags.get<std::string>("CablesTag", "v1r0");
+	fLaserTag   = tags.get<std::string>("LaserTag", "v1r0");
+	fCosmicsTag = tags.get<std::string>("CosmicsTag", "v1r0");
 	if( fVerbose ) mf::LogInfo(fLogCategory) << "Database tags for timing corrections:\n"
 						 << "Cables corrections  " << fCablesTag << "\n"  
 						 << "Laser corrections   " << fLaserTag  << "\n"
-						 << "Cosmics corrections " << fCosmicsTag << std::endl;
+						 << "Cosmics corrections " << fCosmicsTag;
     }
 
 // -------------------------------------------------------------------------------
@@ -51,7 +51,7 @@ uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_
    uint64_t timestamp = runNum+1000000000;
    timestamp *= 1000000000;
 
-   if( fVerbose ) mf::LogInfo(fLogCategory) << "Run " << runNum << " corrections from DB timestamp " << timestamp << std::endl;
+   if( fVerbose ) mf::LogInfo(fLogCategory) << "Run " << runNum << " corrections from DB timestamp " << timestamp;
    
    return timestamp;
 }
@@ -72,11 +72,11 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
       throw cet::exception
-        ( "PMTTimingCorrectionsProvider: GetChannelList() returned " + std::to_string(res) + " on run " + std::to_string(run) + " query in " + dbname);
+        ( "PMTTimingCorrectionsProvider" ) << "GetChannelList() returned " << res << " on run " << run << " query in " << dbname << "\n";
     }
     
     if (channelList.empty()) {
-      throw cet::exception("PMTTimingCorrectionsProvider: got an empty channel list for run " + std::to_string(run) + " in " + dbname);
+      throw cet::exception("PMTTimingCorrectionsProvider") << "Got an empty channel list for run " << run << " in " << dbname << "\n";
     }
 
     for( auto channel : channelList ) {
@@ -84,17 +84,17 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
         // PPS reset correction
         double reset_distribution_delay = 0;
         int error  = db.GetNamedChannelData( channel, "reset_distribution_delay", reset_distribution_delay );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'reset_distribution_delay' on table " + dbname );
+        if( error ) throw cet::exception("PMTTimingCorrectionsProvider") << "Encountered error (code " << error << ") while trying to access 'reset_distribution_delay' on table " << dbname << "\n";
 
         // Trigger cable delay
         double trigger_reference_delay = 0;
         error  = db.GetNamedChannelData( channel, "trigger_reference_delay", trigger_reference_delay );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'trigger_reference_delay' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << Encountered error (code " << error << ") while trying to access 'trigger_reference_delay' on table " << dbname << "\n";
 
         // Phase correction
         double phase_correction = 0;
 	error = db.GetNamedChannelData( channel, "phase_correction", phase_correction );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'phase_correction' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error <<  ") while trying to access 'phase_correction' on table " << dbname << "\n";
    
         /// This is the delay due to the cables connecting the 'global' trigger crate FPGA to the spare channel of the first digitizer in each VME crates. 
         /// The phase correction is an additional fudge factor 
@@ -130,11 +130,11 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
       throw cet::exception
-        ( "PMTTimingCorrectionsProvider: GetChannelList() returned " + std::to_string(res) + " on run " + std::to_string(run) + " query in " + dbname);
+        ( "PMTTimingCorrectionsProvider" ) << "GetChannelList() returned " << res << " on run " << run << " query in " << dbname << "\n";
     }
     
     if (channelList.empty()) {
-      throw cet::exception("PMTTimingCorrectionsProvider: got an empty channel list for run " + std::to_string(run) + " in " + dbname);
+      throw cet::exception("PMTTimingCorrectionsProvider") << "got an empty channel list for run " << run << " in " << dbname << "\n";
     }
 
     for( auto channel : channelList ) {
@@ -142,7 +142,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
         // Laser correction
         double t_signal = 0;
         int error  = db.GetNamedChannelData( channel, "t_signal", t_signal );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 't_signal' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error << ") while trying to access 't_signal' on table " << dbname << "\n";
 
         /// pmt_laser_delay: delay from the Electron Transit time inside the PMT 
         /// and the PMT signal cable 
@@ -166,11 +166,11 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t ru
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
       throw cet::exception
-        ( "PMTTimingCorrectionsProvider: GetChannelList() returned " + std::to_string(res) + " on run " + std::to_string(run) + " query in " + dbname);
+        ( "PMTTimingCorrectionsProvider" ) << "GetChannelList() returned " << res << " on run " << run << " query in " << dbname << "\n";
     }
 
     if (channelList.empty()) {
-      throw cet::exception("PMTTimingCorrectionsProvider: got an empty channel list for run " + std::to_string(run) + " in " + dbname);
+      throw cet::exception("PMTTimingCorrectionsProvider") << "Got an empty channel list for run " << run << " in " << dbname << "\n";
     }
 
     for( auto channel : channelList ) {
@@ -178,7 +178,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t ru
         // Cosmics correction
  	double mean_residual_ns = 0;
 	int error = db.GetNamedChannelData( channel, "mean_residual_ns", mean_residual_ns );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'mean_residual_ns' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error << ") while trying to access 'mean_residual_ns' on table " << dbname << "\n";
 
         /// pmt_cosmics_residual: time residuals from downward going cosmics tracks 
         /// correcting for point-like laser emission and pmts that do not see laser light

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -20,6 +20,7 @@
 // C/C++ standard libraries
 #include <string>
 #include <vector>
+#include <sstream>
 
 //--------------------------------------------------------------------------------
 
@@ -207,16 +208,17 @@ void icarusDB::PMTTimingCorrectionsProvider::readTimeCorrectionDatabase(const ar
     if( fVerbose ) {
 
         mf::LogInfo(fLogCategory) << "Dump information from database " << std::endl;
-        mf::LogInfo(fLogCategory) << "channel, trigger cable delay, reset cable delay, laser corrections, muons corrections" << std::endl;
-
+	std::ostringstream ss;
+        ss << "channel, trigger cable delay, reset cable delay, laser corrections, muons corrections" << std::endl;
         for( auto const & [key, value] : fDatabaseTimingCorrections ){
-            mf::LogInfo(fLogCategory) << key << " " 
-                  << value.triggerCableDelay << "," 
-                  << value.resetCableDelay << ", " 
-                  << value.laserCableDelay << ", "
-                  << value.cosmicsCorrections << ","
-                  << std::endl; 
+            ss << key << " " 
+               << value.triggerCableDelay << "," 
+               << value.resetCableDelay << ", " 
+               << value.laserCableDelay << ", "
+               << value.cosmicsCorrections << ","
+               << std::endl; 
         }
+	mf::LogInfo(fLogCategory) << ss.str();
     }
 
 }

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -20,7 +20,6 @@
 // C/C++ standard libraries
 #include <string>
 #include <vector>
-#include <sstream>
 
 //--------------------------------------------------------------------------------
 
@@ -208,17 +207,16 @@ void icarusDB::PMTTimingCorrectionsProvider::readTimeCorrectionDatabase(const ar
     if( fVerbose ) {
 
         mf::LogInfo(fLogCategory) << "Dump information from database " << std::endl;
-	std::ostringstream ss;
-        ss << "channel, trigger cable delay, reset cable delay, laser corrections, muons corrections" << std::endl;
+        mf::LogVerbatim(fLogCategory) << "channel, trigger cable delay, reset cable delay, laser corrections, muons corrections" << std::endl;
         for( auto const & [key, value] : fDatabaseTimingCorrections ){
-            ss << key << " " 
+            mf::LogVerbatim(fLogCategory) 
+               << key << " " 
                << value.triggerCableDelay << "," 
                << value.resetCableDelay << ", " 
                << value.laserCableDelay << ", "
                << value.cosmicsCorrections << ","
                << std::endl; 
         }
-	mf::LogInfo(fLogCategory) << ss.str();
     }
 
 }

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -28,11 +28,11 @@ icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
     : fVerbose{ pset.get<bool>("Verbose", false) }
     , fLogCategory{ pset.get<std::string>("LogCategory", "PMTTimingCorrection") }
     { 
-        fhicl::ParameterSet const tags{ pset.get<fhicl::ParameterSet>("CorrectionsTags") };
-	fCablesTag  = tags.get<std::string>("CablesTag", "v1r0");
-	fLaserTag   = tags.get<std::string>("LaserTag", "v1r0");
-	fCosmicsTag = tags.get<std::string>("CosmicsTag", "v1r0");
-	if( fVerbose ) mf::LogInfo(fLogCategory) << "Database tags for timing corrections:\n"
+        fhicl::ParameterSet const tags{ pset.get<fhicl::ParameterSet>("CorrectionTags") };
+        fCablesTag  = tags.get<std::string>("CablesTag");
+        fLaserTag   = tags.get<std::string>("LaserTag");
+        fCosmicsTag = tags.get<std::string>("CosmicsTag");
+        if( fVerbose ) mf::LogInfo(fLogCategory) << "Database tags for timing corrections:\n"
 						 << "Cables corrections  " << fCablesTag << "\n"  
 						 << "Laser corrections   " << fLaserTag  << "\n"
 						 << "Cosmics corrections " << fCosmicsTag;
@@ -89,7 +89,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
         // Trigger cable delay
         double trigger_reference_delay = 0;
         error  = db.GetNamedChannelData( channel, "trigger_reference_delay", trigger_reference_delay );
-        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << Encountered error (code " << error << ") while trying to access 'trigger_reference_delay' on table " << dbname << "\n";
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error << ") while trying to access 'trigger_reference_delay' on table " << dbname << "\n";
 
         // Phase correction
         double phase_correction = 0;

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.h
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.h
@@ -23,7 +23,6 @@
 #include "icaruscode/Timing/PMTTimingCorrections.h"
 
 // Database interface helpers
-#include "larevt/CalibrationDBI/Providers/DBFolder.h"
 
 // C/C++ standard libraries
 #include <string>
@@ -53,7 +52,10 @@ namespace icarusDB{ class PMTTimingCorrectionsProvider; }
  * 
  * Configuration parameters
  * -------------------------
- * * `Tag` (default: `false`): Tag for database versioning
+ * * `CorrectionsTags`: tags to select the correction versions:
+ *     * `CablesTag` (default: `v1r0`): correction for cable delay.
+ *     * `LaserTag` (default: `v1r0`): first order PMT time correction, from laser data.
+ *     * `CosmicsTag` (default: `v1r0`): second order PMT time correction, from cosmic rays.
  * * `Verbose` (default: `false`): Print-out the corrections read from the database.
  * * `LogCategory` (default: `PMTTimingCorrection")
  *
@@ -94,7 +96,6 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
 
         bool fVerbose = false; ///< Whether to print the configuration we read.
         std::string fLogCategory; ///< Category tag for messages.
-	fhicl::ParameterSet fTags; ///< List of database tags
 	std::string fCablesTag;  ///< Tag for cable corrections database.	
 	std::string fLaserTag;   ///< Tag for laser corrections database.
 	std::string fCosmicsTag; ///< Tag for cosmics corrections database.	

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.h
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.h
@@ -15,17 +15,15 @@
 #include "art/Framework/Principal/Run.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "cetlib_except/exception.h"
-#include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/Sequence.h"
-#include "cetlib_except/exception.h"
+#include "fhiclcpp/ParameterSet.h"
 
 // Local
 #include "icaruscode/Timing/PMTTimingCorrections.h"
 
-// Database interface helpers
-
 // C/C++ standard libraries
 #include <string>
+#include <map>
+#include <stdint.h>
 
 namespace icarusDB::details {
     
@@ -52,7 +50,7 @@ namespace icarusDB{ class PMTTimingCorrectionsProvider; }
  * 
  * Configuration parameters
  * -------------------------
- * * `CorrectionsTags`: tags to select the correction versions:
+ * * `CorrectionTags`: tags to select the correction versions:
  *     * `CablesTag` (default: `v1r0`): correction for cable delay.
  *     * `LaserTag` (default: `v1r0`): first order PMT time correction, from laser data.
  *     * `CosmicsTag` (default: `v1r0`): second order PMT time correction, from cosmic rays.
@@ -112,7 +110,7 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
             }
 
 	/// Convert run number to internal database
-	uint64_t RunToDatabaseTimestamp(uint32_t run);
+	uint64_t RunToDatabaseTimestamp(uint32_t run) const;
 
         void ReadPMTCablesCorrections(uint32_t run);
 

--- a/icaruscode/Timing/timing_corrections_tags.fcl
+++ b/icaruscode/Timing/timing_corrections_tags.fcl
@@ -7,7 +7,7 @@ BEGIN_PROLOG
 
 # These are the standard tags for analyses on Run 1 data
 # These tagged versions of the databases only contain tables relevant for Run 1
-PMTtimingCorrectionsTags_Run1: {
+PMTtimingCorrectionTags_Run1: {
   CablesTag:    "v1r0"  # tables for run>=0 (null) and run>=8046
   LaserTag:     "v1r0"  # tables for run>=0 (null) and run>=8046
   CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
@@ -18,7 +18,7 @@ PMTtimingCorrectionsTags_Run1: {
 # Notes: 
 #  - No cosmics corrections are available for Run 2
 #  - Laser and cable corrections do not cover the entire Run 2 period
-PMTtimingCorrectionsTags_Run2_August2023: {
+PMTtimingCorrectionTags_Run2_August2023: {
   CablesTag:    "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9773
   LaserTag:     "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9773
   CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
@@ -28,7 +28,7 @@ PMTtimingCorrectionsTags_Run2_August2023: {
 # These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
 # Notes: 
 #  - No cosmics corrections are available for Run 2
-PMTtimingCorrectionsTags_Run2_Sept2023: {
+PMTtimingCorrectionTags_Run2_Sept2023: {
   CablesTag:    "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
   LaserTag:     "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
   CosmicsTag:   "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9301 (null) 

--- a/icaruscode/Timing/timing_corrections_tags.fcl
+++ b/icaruscode/Timing/timing_corrections_tags.fcl
@@ -24,4 +24,14 @@ PMTtimingCorrectionsTags_Run2_August2023: {
   CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
 }
 
+# These are the standard tags for analyses on Run 1 and Run 2 data (as of September 2023)
+# These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
+# Notes: 
+#  - No cosmics corrections are available for Run 2
+PMTtimingCorrectionsTags_Run2_Sept2023: {
+  CablesTag:    "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
+  LaserTag:     "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
+  CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
+}
+
 END_PROLOG

--- a/icaruscode/Timing/timing_corrections_tags.fcl
+++ b/icaruscode/Timing/timing_corrections_tags.fcl
@@ -31,7 +31,7 @@ PMTtimingCorrectionsTags_Run2_August2023: {
 PMTtimingCorrectionsTags_Run2_Sept2023: {
   CablesTag:    "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
   LaserTag:     "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
-  CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
+  CosmicsTag:   "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9301 (null) 
 }
 
 END_PROLOG

--- a/icaruscode/Timing/timing_icarus.fcl
+++ b/icaruscode/Timing/timing_icarus.fcl
@@ -6,7 +6,7 @@ icarus_pmttimingservice:
 {
     # service name:   IPMTTimingCorrectionService
     service_provider: PMTTimingCorrectionService
-    CorrectionsTags:  @local::PMTtimingCorrectionsTags_Run2_August2023
+    CorrectionsTags:  @local::PMTtimingCorrectionsTags_Run2_Sept2023
     Verbose:          false
 }
 

--- a/icaruscode/Timing/timing_icarus.fcl
+++ b/icaruscode/Timing/timing_icarus.fcl
@@ -6,7 +6,7 @@ icarus_pmttimingservice:
 {
     # service name:   IPMTTimingCorrectionService
     service_provider: PMTTimingCorrectionService
-    CorrectionsTags:  @local::PMTtimingCorrectionsTags_Run2_Sept2023
+    CorrectionTags:   @local::PMTtimingCorrectionTags_Run2_Sept2023
     Verbose:          false
 }
 


### PR DESCRIPTION
This PR updates the tags of the timing calibration databases (`v2r0` -> `v2r1`) to pick up the latest PMT laser corrections for Run 2. This is also necessary for the extractions of the next-level corrections for Run 2, as cosmics corrections are computed on top of the laser ones.

**Note**: This update depends on new `pmt_cable_delays_data.db` and `pmt_laser_timing_data.db` files, which should be packaged in a concurrent `icarus_data` release. These files have been produced by @jedori0228 and tested by both of us.

Asking reviews from people that are (willingly or not) involved in this business.