### PR TITLE
Updated PMT channel mapping (20230829) [develop]

### DIFF
--- a/icaruscode/Decode/ChannelMapping/ChannelMapPostGres_tool.cc
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapPostGres_tool.cc
@@ -141,6 +141,14 @@ ChannelMapPostGres::TableNameSets{
     , "Feb_channels"              // CRTsideMap
     , "topcrt_febs"               // CRTtopMap
     , "SideCRT_calibration_data"  // CRTsideCalibrationMap
+  },
+  TableNames_t{
+      "icarus_hw_readoutboard"    // TPCfragmentMap
+    , "icarus_hardware_prd"       // TPCreadoutBoardMap
+    , "Pmt_placement"             // PMTfragmentMap      TODO need the new table!
+    , "Feb_channels"              // CRTsideMap
+    , "topcrt_febs"               // CRTtopMap
+    , "SideCRT_calibration_data"  // CRTsideCalibrationMap
   }
 };
 

--- a/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
@@ -144,11 +144,18 @@ ChannelMapSQLite::TableNameSets{
     , "crtfeb"          // CRTtopMap
   },
   TableNames_t{
-      "readout_boards"          // TPCfragmentMap
-    , "daq_channels"            // TPCreadoutBoardMap
-    , "pmt_placements_Aug2023"  // PMTfragmentMap
-    , "feb_channels"            // CRTsideMap
-    , "crtfeb"                  // CRTtopMap
+      "readout_boards"            // TPCfragmentMap
+    , "daq_channels"              // TPCreadoutBoardMap
+    , "pmt_placements_23Aug2023"  // PMTfragmentMap
+    , "feb_channels"              // CRTsideMap
+    , "crtfeb"                    // CRTtopMap
+  },
+  TableNames_t{
+      "readout_boards"            // TPCfragmentMap
+    , "daq_channels"              // TPCreadoutBoardMap
+    , "pmt_placements_29Aug2023"  // PMTfragmentMap
+    , "feb_channels"              // CRTsideMap
+    , "crtfeb"                    // CRTtopMap
   }
 };
 
@@ -488,7 +495,8 @@ int buildTPCFragmentIDToReadoutIDMap_callback(void* dataIn, int argc, char**argv
     
     // If there was an error the function above would have printed a message so bail out
     if (error)
-      throw cet::exception("ChannelMapSQLite::BuildFragmentToDigitizerChannelMap") << "Encountered error in reading the database: '" << error << "'\n";
+      throw cet::exception("ChannelMapSQLite::BuildFragmentToDigitizerChannelMap")
+        << "Encountered error (code: " << error << ") in reading the database\n";
     
     return error;
   }

--- a/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapSQLite_tool.cc
@@ -236,7 +236,8 @@ int callback(void *data, int argc, char **argv, char **azColName)
     else 
       {
         mf::LogDebug("ChannelMapSQLite")
-          << "ChannelMapSQLite::GetDataset: Successfully read database";
+          << "ChannelMapSQLite::GetDataset: Successfully read database table '"
+          << table << "'";
       }
     
     sqlite3_close(database);

--- a/icaruscode/Decode/ChannelMapping/RunPeriods.h
+++ b/icaruscode/Decode/ChannelMapping/RunPeriods.h
@@ -17,8 +17,9 @@ namespace icarusDB {
   
   /// List of run periods.
   enum class RunPeriod: unsigned int {
-    Runs0to2,   ///< Runs from the very beginning to Summer 2023.
-    Runs3andOn, ///< Runs from Summer 2023 on.
+    Runs0to2,       ///< Runs from the very beginning to the first part of Summer 2023.
+    Run2shutdownB1, ///< A few runs in Summer 2023, break point 1 (August 23-29).
+    Runs3andOn,     ///< Runs from last part of Summer 2023 on.
     
     // leave the following one as last, of course:
     NPeriods ///< Number of run periods.
@@ -71,6 +72,8 @@ struct icarusDB::RunPeriods {
       
       if (run < 10369) return RunPeriod::Runs0to2;
       // new PMT mapping (swapped some digitizer channels)
+      if (run < 10441) return RunPeriod::Run2shutdownB1;
+      // new PMT mapping (swapped more digitizer channels)
       if (run < 0xBADCAFE) return RunPeriod::Runs3andOn; // large value; reminds me of Fermilab
       
       return RunPeriod::NPeriods;

--- a/icaruscode/Decode/ChannelMapping/RunPeriods.h
+++ b/icaruscode/Decode/ChannelMapping/RunPeriods.h
@@ -69,7 +69,7 @@ struct icarusDB::RunPeriods {
   static constexpr RunPeriod withRun(int run)
     {
       
-      if (run < 0x10369) return RunPeriod::Runs0to2;
+      if (run < 10369) return RunPeriod::Runs0to2;
       // new PMT mapping (swapped some digitizer channels)
       if (run < 0xBADCAFE) return RunPeriod::Runs3andOn; // large value; reminds me of Fermilab
       

--- a/icaruscode/Decode/ChannelMapping/channelmapping_icarus.fcl
+++ b/icaruscode/Decode/ChannelMapping/channelmapping_icarus.fcl
@@ -8,7 +8,7 @@ ChannelMappingPostGres: {
 
 ChannelMappingSQLite: {
     tool_type:          ChannelMapSQLite
-    DBFileName:         "ChannelMapICARUS.db"
+    DBFileName:         "ChannelMapICARUS_20230829.db"
     CalibDBFileName:    "crt_gain_reco_data"
     Tag:                "v1r0"
 	

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
@@ -731,11 +731,6 @@ namespace daq
       }
     };
 
-    // we expect the LVDS status bits to follow this pattern:
-    for (auto const& cryoInfo [[maybe_unused]]: fTriggerExtra->cryostats)
-      for (auto LVDS [[maybe_unused]]: cryoInfo.LVDSstatus)
-        assert((LVDS & 0xFF000000FF000000) == 0);
-    
     //
     // absolute time trigger (raw::ExternalTrigger)
     //

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -251,7 +251,7 @@ wpdir	product_dir	wire-cell-cfg
 ####################################
 product				version		qual	flags		<table_format=2>
 fftw				v3_3_10		-
-icarus_data			v09_77_00	-
+icarus_data			v09_78_00	-
 icarus_signal_processing	v09_75_00	-
 icarusalg			v09_78_02	-
 icarusutil			v09_75_00	-


### PR DESCRIPTION
This is an almost-twin PR of #623: that was for production branch, this is for develop.
The code is the same (:cherries:) with just an adjacent-change conflict resolved.
*But* in order to make any sense, `develop` code must also need to be able to _decode_ the new runs with the new mapping, which is the reason I have also put in this PR the workaround on the trigger decoder at PR #605, which had not been proposed for `develop` yet.

Reviewers: mostly @mvicenzi, because he's going to use this branch anyway to verify that mapping.
It is reasonable, but not absolutely necessary, for this PR to wait until his checks are completed (anyway these changes are already in the _production_ branch...).