### PR TITLE
PMT timing corrections from local db + Run 1 cosmics corrections [SBN2023A]

### DIFF
--- a/icaruscode/Timing/CMakeLists.txt
+++ b/icaruscode/Timing/CMakeLists.txt
@@ -13,6 +13,8 @@ set(	LIB_LIBRARIES
         wda::wda
         icaruscode_IcarusObj
         sbnobj::Common_PMT_Data
+	larevt::CalibrationDBI_IOVData
+	larevt::CalibrationDBI_Providers
 )
 set(	SERVICE_LIBRARIES
 	icaruscode_Timing

--- a/icaruscode/Timing/CMakeLists.txt
+++ b/icaruscode/Timing/CMakeLists.txt
@@ -10,7 +10,6 @@ set(	LIB_LIBRARIES
         messagefacility::MF_MessageLogger
         lardataobj::RecoBase
         lardata::Utilities
-        wda::wda
         icaruscode_IcarusObj
         sbnobj::Common_PMT_Data
 	larevt::CalibrationDBI_IOVData

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -207,10 +207,10 @@ void icarusDB::PMTTimingCorrectionsProvider::readTimeCorrectionDatabase(const ar
     if( fVerbose ) {
 
         mf::LogInfo(fLogCategory) << "Dump information from database " << std::endl;
-        mf::LogInfo(fLogCategory) << "channel, trigger cable delay, reset cable delay, laser corrections, muons corrections" << std::endl;
-
+        mf::LogVerbatim(fLogCategory) << "channel, trigger cable delay, reset cable delay, laser corrections, muons corrections" << std::endl;
         for( auto const & [key, value] : fDatabaseTimingCorrections ){
-            mf::LogInfo(fLogCategory) << key << " " 
+            mf::LogVerbatim(fLogCategory) 
+                  << key << " " 
                   << value.triggerCableDelay << "," 
                   << value.resetCableDelay << ", " 
                   << value.laserCableDelay << ", "

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -40,7 +40,7 @@ icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
 
 // -------------------------------------------------------------------------------
 
-uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_t run ) {
+uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_t run ) const{
 
    // Run number to timestamp used in the db
    // DBFolder.h only takes 19 digit (= timestamp in nano second),

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -16,6 +16,7 @@
 
 // Database interface helpers
 #include "larevt/CalibrationDBI/Providers/DBFolder.h"
+#include "larevt/CalibrationDBI/IOVData/TimeStampDecoder.h"
 
 // C/C++ standard libraries
 #include <string>
@@ -68,6 +69,10 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
+    mf::LogTrace(fLogCategory)
+           << "Fetched IoV [ " << db.CachedStart().DBStamp() << " ; " << db.CachedEnd().DBStamp()
+           << " ] to cover t=" << RunToDatabaseTimestamp(run)
+           << " [=" << lariov::TimeStampDecoder::DecodeTimeStamp(RunToDatabaseTimestamp(run)).DBStamp() << "]";
 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
@@ -126,6 +131,10 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
+    mf::LogTrace(fLogCategory)
+           << "Fetched IoV [ " << db.CachedStart().DBStamp() << " ; " << db.CachedEnd().DBStamp()
+           << " ] to cover t=" << RunToDatabaseTimestamp(run)
+           << " [=" << lariov::TimeStampDecoder::DecodeTimeStamp(RunToDatabaseTimestamp(run)).DBStamp() << "]";
 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
@@ -162,6 +171,10 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t ru
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
+    mf::LogTrace(fLogCategory)
+           << "Fetched IoV [ " << db.CachedStart().DBStamp() << " ; " << db.CachedEnd().DBStamp()
+           << " ] to cover t=" << RunToDatabaseTimestamp(run)
+           << " [=" << lariov::TimeStampDecoder::DecodeTimeStamp(RunToDatabaseTimestamp(run)).DBStamp() << "]";
 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -27,15 +27,15 @@ icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
     (const fhicl::ParameterSet& pset) 
     : fVerbose{ pset.get<bool>("Verbose", false) }
     , fLogCategory{ pset.get<std::string>("LogCategory", "PMTTimingCorrection") }
-    , fTags{ pset.get<fhicl::ParameterSet>("CorrectionsTags") }
     { 
-	fCablesTag  = fTags.get<std::string>("CablesTag", "v1r0");
-	fLaserTag   = fTags.get<std::string>("LaserTag", "v1r0");
-	fCosmicsTag = fTags.get<std::string>("CosmicsTag", "v1r0");
+        fhicl::ParameterSet const tags{ pset.get<fhicl::ParameterSet>("CorrectionsTags") };
+	fCablesTag  = tags.get<std::string>("CablesTag", "v1r0");
+	fLaserTag   = tags.get<std::string>("LaserTag", "v1r0");
+	fCosmicsTag = tags.get<std::string>("CosmicsTag", "v1r0");
 	if( fVerbose ) mf::LogInfo(fLogCategory) << "Database tags for timing corrections:\n"
 						 << "Cables corrections  " << fCablesTag << "\n"  
 						 << "Laser corrections   " << fLaserTag  << "\n"
-						 << "Cosmics corrections " << fCosmicsTag << std::endl;
+						 << "Cosmics corrections " << fCosmicsTag;
     }
 
 // -------------------------------------------------------------------------------
@@ -51,7 +51,7 @@ uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_
    uint64_t timestamp = runNum+1000000000;
    timestamp *= 1000000000;
 
-   if( fVerbose ) mf::LogInfo(fLogCategory) << "Run " << runNum << " corrections from DB timestamp " << timestamp << std::endl;
+   if( fVerbose ) mf::LogInfo(fLogCategory) << "Run " << runNum << " corrections from DB timestamp " << timestamp;
    
    return timestamp;
 }
@@ -72,11 +72,11 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
       throw cet::exception
-        ( "PMTTimingCorrectionsProvider: GetChannelList() returned " + std::to_string(res) + " on run " + std::to_string(run) + " query in " + dbname);
+        ( "PMTTimingCorrectionsProvider" ) << "GetChannelList() returned " << res << " on run " << run << " query in " << dbname << "\n";
     }
     
     if (channelList.empty()) {
-      throw cet::exception("PMTTimingCorrectionsProvider: got an empty channel list for run " + std::to_string(run) + " in " + dbname);
+      throw cet::exception("PMTTimingCorrectionsProvider") << "Got an empty channel list for run " << run << " in " << dbname << "\n";
     }
 
     for( auto channel : channelList ) {
@@ -84,17 +84,17 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
         // PPS reset correction
         double reset_distribution_delay = 0;
         int error  = db.GetNamedChannelData( channel, "reset_distribution_delay", reset_distribution_delay );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'reset_distribution_delay' on table " + dbname );
+        if( error ) throw cet::exception("PMTTimingCorrectionsProvider") << "Encountered error (code " << error << ") while trying to access 'reset_distribution_delay' on table " << dbname << "\n";
 
         // Trigger cable delay
         double trigger_reference_delay = 0;
         error  = db.GetNamedChannelData( channel, "trigger_reference_delay", trigger_reference_delay );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'trigger_reference_delay' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << Encountered error (code " << error << ") while trying to access 'trigger_reference_delay' on table " << dbname << "\n";
 
         // Phase correction
         double phase_correction = 0;
 	error = db.GetNamedChannelData( channel, "phase_correction", phase_correction );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'phase_correction' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error <<  ") while trying to access 'phase_correction' on table " << dbname << "\n";
    
         /// This is the delay due to the cables connecting the 'global' trigger crate FPGA to the spare channel of the first digitizer in each VME crates. 
         /// The phase correction is an additional fudge factor 
@@ -130,11 +130,11 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
       throw cet::exception
-        ( "PMTTimingCorrectionsProvider: GetChannelList() returned " + std::to_string(res) + " on run " + std::to_string(run) + " query in " + dbname);
+        ( "PMTTimingCorrectionsProvider" ) << "GetChannelList() returned " << res << " on run " << run << " query in " << dbname << "\n";
     }
     
     if (channelList.empty()) {
-      throw cet::exception("PMTTimingCorrectionsProvider: got an empty channel list for run " + std::to_string(run) + " in " + dbname);
+      throw cet::exception("PMTTimingCorrectionsProvider") << "got an empty channel list for run " << run << " in " << dbname << "\n";
     }
 
     for( auto channel : channelList ) {
@@ -142,7 +142,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
         // Laser correction
         double t_signal = 0;
         int error  = db.GetNamedChannelData( channel, "t_signal", t_signal );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 't_signal' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error << ") while trying to access 't_signal' on table " << dbname << "\n";
 
         /// pmt_laser_delay: delay from the Electron Transit time inside the PMT 
         /// and the PMT signal cable 
@@ -166,11 +166,11 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t ru
     std::vector<unsigned int> channelList;
     if (int res = db.GetChannelList(channelList); res != 0) {
       throw cet::exception
-        ( "PMTTimingCorrectionsProvider: GetChannelList() returned " + std::to_string(res) + " on run " + std::to_string(run) + " query in " + dbname);
+        ( "PMTTimingCorrectionsProvider" ) << "GetChannelList() returned " << res << " on run " << run << " query in " << dbname << "\n";
     }
 
     if (channelList.empty()) {
-      throw cet::exception("PMTTimingCorrectionsProvider: got an empty channel list for run " + std::to_string(run) + " in " + dbname);
+      throw cet::exception("PMTTimingCorrectionsProvider") << "Got an empty channel list for run " << run << " in " << dbname << "\n";
     }
 
     for( auto channel : channelList ) {
@@ -178,7 +178,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t ru
         // Cosmics correction
  	double mean_residual_ns = 0;
 	int error = db.GetNamedChannelData( channel, "mean_residual_ns", mean_residual_ns );
-        if( error ) throw cet::exception( "Encountered error (code " + std::to_string(error) + ") while trying to access 'mean_residual_ns' on table " + dbname );
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error << ") while trying to access 'mean_residual_ns' on table " << dbname << "\n";
 
         /// pmt_cosmics_residual: time residuals from downward going cosmics tracks 
         /// correcting for point-like laser emission and pmts that do not see laser light

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -1,7 +1,7 @@
 /**
  * @file   icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
  * @brief  Service for the PMT timing corrections.
- * @author Andrea Scarpelli (ascarpell@bnl.gov)
+ * @author Andrea Scarpelli (ascarpell@bnl.gov), Matteo Vicenzi (mvicenzi@bnl.gov)
  */
 
 // Framework includes
@@ -10,114 +10,87 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "cetlib_except/exception.h"
 
-#include "lardata/DetectorInfoServices/DetectorClocksService.h"
-
+// Local
 #include "icaruscode/Timing/PMTTimingCorrections.h"
 #include "icaruscode/Timing/PMTTimingCorrectionsProvider.h"
 
 // Database interface helpers
-#include "wda.h"
+#include "larevt/CalibrationDBI/Providers/DBFolder.h"
 
 // C/C++ standard libraries
-#include <memory> // std::unique_ptr<>
-#include <optional>
 #include <string>
-#include <utility> // std::move()
-#include <cassert>
 #include <tuple>
 
 //--------------------------------------------------------------------------------
 
 icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
     (const fhicl::ParameterSet& pset) 
-    : fUrl{ pset.get<std::string>("DatabaseURL", "https://dbdata0vm.fnal.gov:9443/icarus_con_prod/app/data?") }
-    , fTimeout{ pset.get<unsigned int>("Timeout", 1000) }
-    , fVerbose{ pset.get<bool>("Verbose", false) }
+    : fVerbose{ pset.get<bool>("Verbose", false) }
     , fLogCategory{ pset.get<std::string>("LogCategory", "PMTTimingCorrection") }
-    , fClocksData{ art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob() }
+    , fTag{ pset.get<std::string>("Tag", "v1r0") }
     { }
-
 
 // -------------------------------------------------------------------------------
 
-/// Access the PostgreSQL calibration database for icarus
-/// Query depends on the run 
-int icarusDB::PMTTimingCorrectionsProvider::ConnectToDataset(
-    const std::string& name, uint32_t run, Dataset& dataset ) const {
+uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_t run ) {
 
-    int error = 0;
-    std::string url = fUrl + "f="+name +"&t="+std::to_string(run);
-    dataset = getDataWithTimeout( url.c_str(), "", fTimeout, &error );
-    if ( error ){
-        throw cet::exception(fLogCategory) 
-          << "Calibration database access failed. URL (" << url 
-          << ") Error code: " << error;
-    }
-    if ( getHTTPstatus(dataset) !=200 ){
-        throw cet::exception(fLogCategory)
-            << "Calibration database access failed. URL (" << url
-            << "). HTTP error status: " << getHTTPstatus(dataset) 
-            << ". HTTP error message: " << getHTTPmessage(dataset); 
-    }
+   // Run number to timestamp used in the db
+   // DBFolder.h only takes 19 digit (= timestamp in nano second),
+   // but ICARUS tables are currently using run numbers
+   // Step 1) Add 1000000000 to the run number; e.g., run XXXXX -> 10000XXXXX
+   // Step 2) Multiply 1000000000
+   uint64_t runNum = uint64_t(run);
+   uint64_t timestamp = runNum+1000000000;
+   timestamp *= 1000000000;
 
-    return error;
-
+   return timestamp;
 }
 
-
-// -----------------------------------------------------------------------------
+// -------------------------------------------------------------------------------
 
 /// Function to look up the calibration database at the table holding the pmt hardware cables corrections
 void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t run ) { 
 
     // pmt_cables_delay: delays of the cables relative to trigger 
     // and reset distribution
-    const std::string name("pmt_cables_delays_data");
-    Dataset dataset;
-    int error = ConnectToDataset( name, run, dataset );
+    const std::string dbname("pmt_cables_delays_data");
+    lariov::DBFolder db(dbname, "", "", fTag, true, false);
 
-    if (error) throw(std::exception());
+    bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
+    if( !ret ) throw(std::exception());
 
-    for( int row=4; row < getNtuples(dataset); row++ ) {
+    for( unsigned int channel=0; channel < 360; channel++ ) {
+        
+        // PPS reset correction
+        double reset_distribution_delay = 0;
+        int error  = db.GetNamedChannelData( channel, "reset_distribution_delay", reset_distribution_delay );
+        if( error ) throw std::runtime_error( "Encountered error while trying to access 'reset_distribution_delay' on table " + dbname );
 
-        Tuple tuple = getTuple(dataset, row);
+        // Trigger cable delay
+        double trigger_reference_delay = 0;
+        error  = db.GetNamedChannelData( channel, "trigger_reference_delay", trigger_reference_delay );
+        if( error ) throw std::runtime_error( "Encountered error while trying to access 'trigger_reference_delay' on table " + dbname );
 
-        if( tuple != NULL ) {
-
-            unsigned int channel_id = getLongValue( tuple, 0, &error );
-            if( error ) throw std::runtime_error( "Encountered error while trying to access 'channel_id' on table " + name );
-            
-            // PPS reset correction
-            double reset_distribution_delay = getDoubleValue( tuple, 11, &error );
-            if( error ) throw std::runtime_error( "Encountered error '" + std::to_string(error) + "' while trying to access 'reset_distribution_delay' on table " + name );
-
-            // Trigger cable delay
-            double trigger_reference_delay = getDoubleValue( tuple, 10, &error );
-            if( error ) throw std::runtime_error( "Encountered error while trying to access 'trigger_reference_delay' on table " + name );
-
-            // Phase correction
-            double phase_correction = getDoubleValue( tuple, 13, &error );
-            if( error ) throw std::runtime_error( "Encountered error while trying to access 'phase_correction' on table " + name );
+        // Phase correction
+        double phase_correction = 0;
+	error = db.GetNamedChannelData( channel, "phase_correction", phase_correction );
+        if( error ) throw std::runtime_error( "Encountered error while trying to access 'phase_correction' on table " + dbname );
    
-            /// This is the delay due to the cables connecting the 'global' FPGA of the trigger crate to the spare channel of the first digitizer in each VME crates. 
-            ////The phase correction is an additional fudge factor 
-            /// holding local variation due to constant clock offsets (it can be up to 8 ns)
-            /// It can be absorbed within other corrections if necessary
-            /// Corrections are saved in ns, but icaruscode wants us
-            /// Correction are saved with the sing correspoding to their time direction 
-            fDatabaseTimingCorrections[channel_id].triggerCableDelay = -(trigger_reference_delay-phase_correction)/1000.;
+        /// This is the delay due to the cables connecting the 'global' trigger crate FPGA to the spare channel of the first digitizer in each VME crates. 
+        /// The phase correction is an additional fudge factor 
+        /// holding local variation due to constant clock offsets (it can be up to 8 ns)
+        /// It can be absorbed within other corrections if necessary
+        /// Corrections are saved in ns, but icaruscode wants us
+        /// Correction are saved with the sing correspoding to their time direction 
+        fDatabaseTimingCorrections[channel].triggerCableDelay = -(trigger_reference_delay-phase_correction)/1000.;
 
-            /// This is the delay along the distribution line of the TTT reset
-            /// The phase correction is an additional fudge factor 
-            /// holding local variation due to constant clock offsets (it can be up to 8 ns)
-            /// It can be absorbed within other corrections if necessary
-            /// Corrections are saved in ns, but icaruscode wants us
-            /// Corrections are additive! 
-            fDatabaseTimingCorrections[channel_id].resetCableDelay = (reset_distribution_delay-phase_correction)/1000.; 
-
-            releaseTuple(tuple);
-        }
-
+        /// This is the delay along the distribution line of the TTT reset
+        /// The phase correction is an additional fudge factor 
+        /// holding local variation due to constant clock offsets (it can be up to 8 ns)
+        /// It can be absorbed within other corrections if necessary
+        /// Corrections are saved in ns, but icaruscode wants us
+        /// Corrections are additive! 
+        fDatabaseTimingCorrections[channel].resetCableDelay = (reset_distribution_delay-phase_correction)/1000.; 
     }
 
 }
@@ -128,72 +101,53 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
 /// Function to look up the calibration database at the table holding the pmt timing corrections measured using the laser
 void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run ) { 
 
-    const std::string name("pmt_laser_timing_data");
-    Dataset dataset;
-    int error = ConnectToDataset( name, run, dataset );
+    const std::string dbname("pmt_laser_timing_data");
+    lariov::DBFolder db(dbname, "", "", fTag, true, false);
 
-    if (error) throw(std::exception());
+    bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
+    if( !ret ) throw(std::exception());
 
-    for( int row=4; row < getNtuples(dataset); row++ ) {
+    for( unsigned int channel=0; channel < 360; channel++ ) {
+        
+        // Laser correction
+        double t_signal = 0;
+        int error  = db.GetNamedChannelData( channel, "t_signal", t_signal );
+        if( error ) throw std::runtime_error( "Encountered error while trying to access 't_signal' on table " + dbname );
 
-        Tuple tuple = getTuple(dataset, row);
-        if( tuple != NULL ) {
-
-            unsigned int channel_id = getLongValue( tuple, 0, &error );
-            if( error ) throw std::runtime_error( "Encountered error while trying to access channel_id on table " + name );
-
-            double t_signal = getDoubleValue( tuple, 5, &error );
-            if( error ) throw std::runtime_error( "Encountered error while trying to access 't_signal' on table " + name );
-
-            /// pmt_laser_delay: delay from the Electron Transit time inside the PMT 
-            /// and the PMT signal cable 
-            /// corrections are saved in ns, but icaruscode wants us
-            /// Corrections are additive! 
-            fDatabaseTimingCorrections[channel_id].laserCableDelay = -t_signal/1000.; 
-
-            releaseTuple(tuple);
-        }
-
+        /// pmt_laser_delay: delay from the Electron Transit time inside the PMT 
+        /// and the PMT signal cable 
+        /// corrections are saved in ns, but icaruscode wants us
+        /// Corrections are additive! 
+        fDatabaseTimingCorrections[channel].laserCableDelay = -t_signal/1000.; 
     }
-
 }
 
 // -----------------------------------------------------------------------------
 
-/*
 /// Function to look up the calibration database at the table holding the pmt timing corrections measured using cosmic muons
-void icarus::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t run ) { 
+void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t run ) { 
 
-    const std::string name("pmt_muons_timing_data");
-    Dataset dataset;
-    int error = ConnectToDataset( name, run, dataset );
+    const std::string dbname("pmt_cosmics_timing_data");
+    lariov::DBFolder db(dbname, "", "", fTag, true, false);
 
-    if (error) throw(std::exception());
+    bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
+    if( !ret ) throw(std::exception());
 
-    for( int row=4; row < getNtuples(dataset); row++ ) {
+    for( unsigned int channel=0; channel < 360; channel++ ) {
+        
+        // Cosmics correction
+ 	double mean_residual_ns = 0;
+        int error = db.GetNamedChannelData( channel, "mean_residual_ns", mean_residual_ns );
+        if( error ) throw std::runtime_error( "Encountered error while trying to access 'mean_residual_ns' on table " + dbname );
 
-        Tuple tuple = getTuple(dataset, row);
-        if( tuple != NULL ) {
-
-            unsigned int channel_id = getLongValue( tuple, 0, &error );
-            if( error ) throw std::runtime_error( "Encountered error while trying to access channel_id on table " + name );
-
-            double t_signal = getDoubleValue( tuple, 5, &error );
-            if( error ) throw std::runtime_error( "Encountered error while trying to access 't_signal' on table " + name );
-
-            /// pmt_laser_delay: delay from the Electron Transit time inside the PMT 
-            /// and the PMT signal cable 
-            /// corrections are saved in ns, but icaruscode wants us
-            /// Corrections are additive! 
-            fDatabaseTimingCorrections[channel_id].cosmicsCorrections = t_signal/1000.; 
-
-            releaseTuple(tuple);
-        }
-
+        /// pmt_cosmics_residual: time residuals from downward going cosmics tracks 
+        /// correcting for point-like laser emission and pmts that do not see laser light
+        /// corrections are saved in ns, but icaruscode wants us
+        /// Corrections are additive! 
+        fDatabaseTimingCorrections[channel].cosmicsCorrections = -mean_residual_ns/1000.; 
     }
 
 }
-*/
 
 
 // -----------------------------------------------------------------------------
@@ -207,15 +161,13 @@ void icarusDB::PMTTimingCorrectionsProvider::readTimeCorrectionDatabase(const ar
     fDatabaseTimingCorrections.clear();
 
     ReadPMTCablesCorrections(run.id().run());
-
     ReadLaserCorrections(run.id().run());
-
-    //ReadCosmicsCorrections(run.id().run());
+    ReadCosmicsCorrections(run.id().run());
 
     if( fVerbose ) {
 
         mf::LogInfo(fLogCategory) << "Dump information from database " << std::endl;
-        mf::LogInfo(fLogCategory) << "channel, trigger cable delay, reset cable delay, laser corrections, muons correctsions" << std::endl;
+        mf::LogInfo(fLogCategory) << "channel, trigger cable delay, reset cable delay, laser corrections, muons corrections" << std::endl;
 
         for( auto const & [key, value] : fDatabaseTimingCorrections ){
             mf::LogInfo(fLogCategory) << key << " " 

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -27,8 +27,16 @@ icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
     (const fhicl::ParameterSet& pset) 
     : fVerbose{ pset.get<bool>("Verbose", false) }
     , fLogCategory{ pset.get<std::string>("LogCategory", "PMTTimingCorrection") }
-    , fTag{ pset.get<std::string>("Tag", "v1r0") }
-    { }
+    , fTags{ pset.get<fhicl::ParameterSet>("CorrectionsTags") }
+    { 
+	fCablesTag  = fTags.get<std::string>("CablesTag", "v1r0");
+	fLaserTag   = fTags.get<std::string>("LaserTag", "v1r0");
+	fCosmicsTag = fTags.get<std::string>("CosmicsTag", "v1r0");
+	if( fVerbose ) mf::LogInfo(fLogCategory) << "Database tags for timing corrections:\n"
+						 << "Cables corrections  " << fCablesTag << "\n"  
+						 << "Laser corrections   " << fLaserTag  << "\n"
+						 << "Cosmics corrections " << fCosmicsTag << std::endl;
+    }
 
 // -------------------------------------------------------------------------------
 
@@ -56,7 +64,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
     // pmt_cables_delay: delays of the cables relative to trigger 
     // and reset distribution
     const std::string dbname("pmt_cables_delays_data");
-    lariov::DBFolder db(dbname, "", "", fTag, true, false);
+    lariov::DBFolder db(dbname, "", "", fCablesTag, true, false);
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
@@ -114,7 +122,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
 void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run ) { 
 
     const std::string dbname("pmt_laser_timing_data");
-    lariov::DBFolder db(dbname, "", "", fTag, true, false);
+    lariov::DBFolder db(dbname, "", "", fLaserTag, true, false);
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;
@@ -150,7 +158,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
 void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t run ) { 
 
     const std::string dbname("pmt_cosmics_timing_data");
-    lariov::DBFolder db(dbname, "", "", fTag, true, false);
+    lariov::DBFolder db(dbname, "", "", fCosmicsTag, true, false);
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
     mf::LogDebug(fLogCategory) << dbname + " corrections" << (ret? "": " not") << " updated for run " << run;

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -28,11 +28,11 @@ icarusDB::PMTTimingCorrectionsProvider::PMTTimingCorrectionsProvider
     : fVerbose{ pset.get<bool>("Verbose", false) }
     , fLogCategory{ pset.get<std::string>("LogCategory", "PMTTimingCorrection") }
     { 
-        fhicl::ParameterSet const tags{ pset.get<fhicl::ParameterSet>("CorrectionsTags") };
-	fCablesTag  = tags.get<std::string>("CablesTag", "v1r0");
-	fLaserTag   = tags.get<std::string>("LaserTag", "v1r0");
-	fCosmicsTag = tags.get<std::string>("CosmicsTag", "v1r0");
-	if( fVerbose ) mf::LogInfo(fLogCategory) << "Database tags for timing corrections:\n"
+        fhicl::ParameterSet const tags{ pset.get<fhicl::ParameterSet>("CorrectionTags") };
+        fCablesTag  = tags.get<std::string>("CablesTag");
+        fLaserTag   = tags.get<std::string>("LaserTag");
+        fCosmicsTag = tags.get<std::string>("CosmicsTag");
+        if( fVerbose ) mf::LogInfo(fLogCategory) << "Database tags for timing corrections:\n"
 						 << "Cables corrections  " << fCablesTag << "\n"  
 						 << "Laser corrections   " << fLaserTag  << "\n"
 						 << "Cosmics corrections " << fCosmicsTag;
@@ -89,7 +89,7 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
         // Trigger cable delay
         double trigger_reference_delay = 0;
         error  = db.GetNamedChannelData( channel, "trigger_reference_delay", trigger_reference_delay );
-        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << Encountered error (code " << error << ") while trying to access 'trigger_reference_delay' on table " << dbname << "\n";
+        if( error ) throw cet::exception( "PMTTimingCorrectionsProvider" ) << "Encountered error (code " << error << ") while trying to access 'trigger_reference_delay' on table " << dbname << "\n";
 
         // Phase correction
         double phase_correction = 0;

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.cxx
@@ -43,6 +43,8 @@ uint64_t icarusDB::PMTTimingCorrectionsProvider::RunToDatabaseTimestamp( uint32_
    uint64_t timestamp = runNum+1000000000;
    timestamp *= 1000000000;
 
+   if( fVerbose ) mf::LogInfo(fLogCategory) << "Run " << runNum << " corrections from DB timestamp " << timestamp << std::endl;
+   
    return timestamp;
 }
 
@@ -57,9 +59,12 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadPMTCablesCorrections( uint32_t 
     lariov::DBFolder db(dbname, "", "", fTag, true, false);
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
-    if( !ret ) throw(std::exception());
+    if( !ret ) throw std::runtime_error( "Unable to find or open " + dbname + ".db");
 
-    for( unsigned int channel=0; channel < 360; channel++ ) {
+    std::vector<unsigned int> channelList;
+    ret = db.GetChannelList(channelList);
+
+    for( auto channel : channelList ) {
         
         // PPS reset correction
         double reset_distribution_delay = 0;
@@ -105,9 +110,12 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadLaserCorrections( uint32_t run 
     lariov::DBFolder db(dbname, "", "", fTag, true, false);
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
-    if( !ret ) throw(std::exception());
+    if( !ret ) throw std::runtime_error( "Unable to find or open `" + dbname + ".db`");
 
-    for( unsigned int channel=0; channel < 360; channel++ ) {
+    std::vector<unsigned int> channelList;
+    ret = db.GetChannelList(channelList);
+
+    for( auto channel : channelList ) {
         
         // Laser correction
         double t_signal = 0;
@@ -131,13 +139,16 @@ void icarusDB::PMTTimingCorrectionsProvider::ReadCosmicsCorrections( uint32_t ru
     lariov::DBFolder db(dbname, "", "", fTag, true, false);
 
     bool ret = db.UpdateData( RunToDatabaseTimestamp(run) ); // select table based on run number   
-    if( !ret ) throw(std::exception());
+    if( !ret ) throw std::runtime_error("Unable to find or open `" + dbname + ".db`");
 
-    for( unsigned int channel=0; channel < 360; channel++ ) {
+    std::vector<unsigned int> channelList;
+    ret = db.GetChannelList(channelList);
+
+    for( auto channel : channelList ) {
         
         // Cosmics correction
  	double mean_residual_ns = 0;
-        int error = db.GetNamedChannelData( channel, "mean_residual_ns", mean_residual_ns );
+	int error = db.GetNamedChannelData( channel, "mean_residual_ns", mean_residual_ns );
         if( error ) throw std::runtime_error( "Encountered error while trying to access 'mean_residual_ns' on table " + dbname );
 
         /// pmt_cosmics_residual: time residuals from downward going cosmics tracks 

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.h
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.h
@@ -33,10 +33,10 @@ namespace icarusDB::details {
   /// Structure for single channel corrections
   struct PMTTimeCorrectionsDB { 
 
-    double triggerCableDelay=0;  ///< ns
-    double resetCableDelay=0;    ///< ns
-    double laserCableDelay=0;    ///< ns
-    double cosmicsCorrections=0; ///< ns
+    double triggerCableDelay=0;  ///< [&micro;s]
+    double resetCableDelay=0;    ///< [&micro;s]
+    double laserCableDelay=0;    ///< [&micro;s]
+    double cosmicsCorrections=0; ///< [&micro;s]
     
   };
   
@@ -48,6 +48,8 @@ namespace icarusDB{ class PMTTimingCorrectionsProvider; }
  * 
  * This module reads the PMT timing corrections from the database.
  * Corrections are picked according to the run number being processed.  
+ *
+ * All time corrections are offsets (in microseconds) that need to be _added_ to the uncorrected time.
  * 
  * Configuration parameters
  * -------------------------

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.h
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.h
@@ -23,7 +23,6 @@
 #include "icaruscode/Timing/PMTTimingCorrections.h"
 
 // Database interface helpers
-#include "larevt/CalibrationDBI/Providers/DBFolder.h"
 
 // C/C++ standard libraries
 #include <string>
@@ -53,7 +52,10 @@ namespace icarusDB{ class PMTTimingCorrectionsProvider; }
  * 
  * Configuration parameters
  * -------------------------
- * * `Tag` (default: `false`): Tag for database versioning
+ * * `CorrectionsTags`: tags to select the correction versions:
+ *     * `CablesTag` (default: `v1r0`): correction for cable delay.
+ *     * `LaserTag` (default: `v1r0`): first order PMT time correction, from laser data.
+ *     * `CosmicsTag` (default: `v1r0`): second order PMT time correction, from cosmic rays.
  * * `Verbose` (default: `false`): Print-out the corrections read from the database.
  * * `LogCategory` (default: `PMTTimingCorrection")
  *
@@ -94,7 +96,6 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
 
         bool fVerbose = false; ///< Whether to print the configuration we read.
         std::string fLogCategory; ///< Category tag for messages.
-	fhicl::ParameterSet fTags; ///< List of database tags
 	std::string fCablesTag;  ///< Tag for cable corrections database.	
 	std::string fLaserTag;   ///< Tag for laser corrections database.
 	std::string fCosmicsTag; ///< Tag for cosmics corrections database.	

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.h
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.h
@@ -1,7 +1,7 @@
 /**
  * @file   icaruscode/Timing/PMTTimingCorrectionsProvider.h
  * @brief  Service for the PMT timing corrections.
- * @author Andrea Scarpelli (ascarpell@bnl.gov)
+ * @author Andrea Scarpelli (ascarpell@bnl.gov), Matteo Vicenzi (mvicenzi@bnl.gov)
  */
 
 #ifndef ICARUSCODE_TIMING_PMTIMINGCORRECTIONSPROVIDER_H
@@ -19,32 +19,24 @@
 #include "fhiclcpp/types/Sequence.h"
 #include "cetlib_except/exception.h"
 
-#include "lardata/DetectorInfoServices/DetectorClocksService.h"
-
+// Local
 #include "icaruscode/Timing/PMTTimingCorrections.h"
 
 // Database interface helpers
-#include "wda.h"
+#include "larevt/CalibrationDBI/Providers/DBFolder.h"
 
 // C/C++ standard libraries
-#include <memory> // std::unique_ptr<>
-#include <optional>
 #include <string>
-#include <utility> // std::move()
-#include <cassert>
-#include <tuple>
 
 namespace icarusDB::details {
     
-  struct PMTTimeCorrectionsDB {
+  /// Structure for single channel corrections
+  struct PMTTimeCorrectionsDB { 
 
-    double triggerCableDelay=0; ///< Expect nanoseconds.
-
-    double resetCableDelay=0; ///< Expect nanoseconds.
-
-    double laserCableDelay=0; ///< Expect nanoseconds.
-
-    double cosmicsCorrections=0; ///< Expect nanoseconds.
+    double triggerCableDelay=0;  ///< ns
+    double resetCableDelay=0;    ///< ns
+    double laserCableDelay=0;    ///< ns
+    double cosmicsCorrections=0; ///< ns
     
   };
   
@@ -54,26 +46,15 @@ namespace icarusDB{ class PMTTimingCorrectionsProvider; }
 /**
  * @brief 
  * 
- * This module reads 
- * 
- * Input
- * ------
- * 
- * 
- * Output
- * -------
- * 
- * 
+ * This module reads the PMT timing corrections from the database.
+ * Corrections are picked according to the run number being processed.  
  * 
  * Configuration parameters
  * -------------------------
- * 
- * 
- * 
- * Multithreading
- * ---------------
- * 
- * 
+ * * `Tag` (default: `false`): Tag for database versioning
+ * * `Verbose` (default: `false`): Print-out the corrections read from the database.
+ * * `LogCategory` (default: `PMTTimingCorrection")
+ *
  */
 class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
 
@@ -81,20 +62,25 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
 
         PMTTimingCorrectionsProvider(const fhicl::ParameterSet& pset);
 
+	/// Read timing corrections from the database
         void readTimeCorrectionDatabase(const art::Run& run);
 
+	/// Get time delay on the trigger line
         double getTriggerCableDelay( unsigned int channelID ) const override {
             return getChannelCorrOrDefault(channelID).triggerCableDelay;
         };
 
+	/// Get time delay on the PPS reset line 
         double getResetCableDelay( unsigned int channelID ) const override {
             return getChannelCorrOrDefault(channelID).resetCableDelay;
         };
 
+	/// Get timing corrections from laser data
         double getLaserCorrections( unsigned int channelID ) const override {
             return getChannelCorrOrDefault(channelID).laserCableDelay;
         };
 
+	/// Get timing corrections from cosmics data
         double getCosmicsCorrections( unsigned int channelID ) const override {
             return getChannelCorrOrDefault(channelID).cosmicsCorrections;
         };
@@ -102,25 +88,14 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
     private:
         
         using PMTTimeCorrectionsDB = details::PMTTimeCorrectionsDB;
-
-        std::string fUrl;
-
-        unsigned int fTimeout;
-
-        bool fCorrectCablesDelay;
+        static constexpr PMTTimeCorrectionsDB CorrectionDefaults {}; ///< Default values
 
         bool fVerbose = false; ///< Whether to print the configuration we read.
-  
         std::string fLogCategory; ///< Category tag for messages.
+	std::string fTag; ///< Tag for database version.	
 
-        /// Interface to LArSoft configuration for detector timing.
-        detinfo::DetectorClocksData const fClocksData;
-
-        static constexpr PMTTimeCorrectionsDB CorrectionDefaults {};
-        
-
+	/// Map of corrections by channel
         std::map<unsigned int, PMTTimeCorrectionsDB> fDatabaseTimingCorrections;
-        
         
         /// Internal access to the channel correction record; returns defaults if not present.
         PMTTimeCorrectionsDB const& getChannelCorrOrDefault
@@ -130,8 +105,8 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
                 return (it == fDatabaseTimingCorrections.end())? CorrectionDefaults: it->second;
             }
 
-        int ConnectToDataset(const std::string& name, 
-            uint32_t run, Dataset& dataset ) const;
+	/// Convert run number to internal database
+	uint64_t RunToDatabaseTimestamp(uint32_t run);
 
         void ReadPMTCablesCorrections(uint32_t run);
 

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.h
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.h
@@ -94,7 +94,10 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
 
         bool fVerbose = false; ///< Whether to print the configuration we read.
         std::string fLogCategory; ///< Category tag for messages.
-	std::string fTag; ///< Tag for database version.	
+	fhicl::ParameterSet fTags; ///< List of database tags
+	std::string fCablesTag;  ///< Tag for cable corrections database.	
+	std::string fLaserTag;   ///< Tag for laser corrections database.
+	std::string fCosmicsTag; ///< Tag for cosmics corrections database.	
 
 	/// Map of corrections by channel
         std::map<unsigned int, PMTTimeCorrectionsDB> fDatabaseTimingCorrections;

--- a/icaruscode/Timing/PMTTimingCorrectionsProvider.h
+++ b/icaruscode/Timing/PMTTimingCorrectionsProvider.h
@@ -15,17 +15,15 @@
 #include "art/Framework/Principal/Run.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "cetlib_except/exception.h"
-#include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/Sequence.h"
-#include "cetlib_except/exception.h"
+#include "fhiclcpp/ParameterSet.h"
 
 // Local
 #include "icaruscode/Timing/PMTTimingCorrections.h"
 
-// Database interface helpers
-
 // C/C++ standard libraries
 #include <string>
+#include <map>
+#include <stdint.h>
 
 namespace icarusDB::details {
     
@@ -52,7 +50,7 @@ namespace icarusDB{ class PMTTimingCorrectionsProvider; }
  * 
  * Configuration parameters
  * -------------------------
- * * `CorrectionsTags`: tags to select the correction versions:
+ * * `CorrectionTags`: tags to select the correction versions:
  *     * `CablesTag` (default: `v1r0`): correction for cable delay.
  *     * `LaserTag` (default: `v1r0`): first order PMT time correction, from laser data.
  *     * `CosmicsTag` (default: `v1r0`): second order PMT time correction, from cosmic rays.
@@ -112,7 +110,7 @@ class icarusDB::PMTTimingCorrectionsProvider : public PMTTimingCorrections {
             }
 
 	/// Convert run number to internal database
-	uint64_t RunToDatabaseTimestamp(uint32_t run);
+	uint64_t RunToDatabaseTimestamp(uint32_t run) const;
 
         void ReadPMTCablesCorrections(uint32_t run);
 

--- a/icaruscode/Timing/timing_corrections_tags.fcl
+++ b/icaruscode/Timing/timing_corrections_tags.fcl
@@ -1,0 +1,27 @@
+# File:    timing_corrections_tags.fcl
+# Author:  M. Vicenzi (mvicenzi@bnl.gov)
+# Date:    August 21, 2023
+# Purpose: Tags definitions for the PMT timing calibration databases
+
+BEGIN_PROLOG
+
+# These are the standard tags for analyses on Run 1 data
+# These tagged versions of the databases only contain tables relevant for Run 1
+PMTtimingCorrectionsTags_Run1: {
+  CablesTag:    "v1r0"  # tables for run>=0 (null) and run>=8046
+  LaserTag:     "v1r0"  # tables for run>=0 (null) and run>=8046
+  CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
+}
+
+# These are the standard tags for analyses on Run 1 and Run 2 data (as of August 2023)
+# These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
+# Notes: 
+#  - No cosmics corrections are available for Run 2
+#  - Laser and cable corrections do not cover the entire Run 2 period
+PMTtimingCorrectionsTags_Run2_August2023: {
+  CablesTag:    "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9773
+  LaserTag:     "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9773
+  CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
+}
+
+END_PROLOG

--- a/icaruscode/Timing/timing_corrections_tags.fcl
+++ b/icaruscode/Timing/timing_corrections_tags.fcl
@@ -7,7 +7,7 @@ BEGIN_PROLOG
 
 # These are the standard tags for analyses on Run 1 data
 # These tagged versions of the databases only contain tables relevant for Run 1
-PMTtimingCorrectionsTags_Run1: {
+PMTtimingCorrectionTags_Run1: {
   CablesTag:    "v1r0"  # tables for run>=0 (null) and run>=8046
   LaserTag:     "v1r0"  # tables for run>=0 (null) and run>=8046
   CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
@@ -18,7 +18,7 @@ PMTtimingCorrectionsTags_Run1: {
 # Notes: 
 #  - No cosmics corrections are available for Run 2
 #  - Laser and cable corrections do not cover the entire Run 2 period
-PMTtimingCorrectionsTags_Run2_August2023: {
+PMTtimingCorrectionTags_Run2_August2023: {
   CablesTag:    "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9773
   LaserTag:     "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9773
   CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 

--- a/icaruscode/Timing/timing_icarus.fcl
+++ b/icaruscode/Timing/timing_icarus.fcl
@@ -6,7 +6,7 @@ icarus_pmttimingservice:
 {
     # service name:   IPMTTimingCorrectionService
     service_provider: PMTTimingCorrectionService
-    CorrectionsTags:  @local::PMTtimingCorrectionsTags_Run2_August2023
+    CorrectionTags:   @local::PMTtimingCorrectionTags_Run2_August2023
     Verbose:          false
 }
 

--- a/icaruscode/Timing/timing_icarus.fcl
+++ b/icaruscode/Timing/timing_icarus.fcl
@@ -1,10 +1,12 @@
+#include "timing_corrections_tags.fcl"
+
 BEGIN_PROLOG
 
 icarus_pmttimingservice:
 {
     # service name:   IPMTTimingCorrectionService
     service_provider: PMTTimingCorrectionService
-    Tag:              "v1r0"
+    CorrectionsTags:  @local::PMTtimingCorrectionsTags_Run2_August2023
     Verbose:          false
 }
 

--- a/icaruscode/Timing/timing_icarus.fcl
+++ b/icaruscode/Timing/timing_icarus.fcl
@@ -2,10 +2,10 @@ BEGIN_PROLOG
 
 icarus_pmttimingservice:
 {
-    # service name: IPMTTimingCorrectionService
+    # service name:   IPMTTimingCorrectionService
     service_provider: PMTTimingCorrectionService
-    DatabaseURL:   "https://dbdata0vm.fnal.gov:9443/icarus_con_prod/app/data?"
-    Timeout:   1000
+    Tag:              "v1r0"
+    Verbose:          false
 }
 
 icarus_ophit_timing_correction:


### PR DESCRIPTION
This is twin PR of #614 meant for production.

It contains two things:
- Switch to using local database for PMT time corrections 
- Introduction of cosmics corrections. These can be disabled by setting the fcl parameter `CorrectCosmics` (from `icaruscode/Timing/timing_icarus.fcl`) to `false`.

Cosmics corrections require `icarus_data` 09_77_00 or newer, which should already be satisfied in the latest production patches.