### PR TITLE
Update laser calibration tags for run2 [SBN2023A]

### DIFF
--- a/icaruscode/Timing/timing_corrections_tags.fcl
+++ b/icaruscode/Timing/timing_corrections_tags.fcl
@@ -24,4 +24,14 @@ PMTtimingCorrectionTags_Run2_August2023: {
   CosmicsTag:   "v1r0"  # tables for run>=0 (null) and run>=8046 
 }
 
+# These are the standard tags for analyses on Run 1 and Run 2 data (as of September 2023)
+# These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
+# Notes: 
+#  - No cosmics corrections are available for Run 2
+PMTtimingCorrectionTags_Run2_Sept2023: {
+  CablesTag:    "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
+  LaserTag:     "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
+  CosmicsTag:   "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9301 (null) 
+}
+
 END_PROLOG

--- a/icaruscode/Timing/timing_icarus.fcl
+++ b/icaruscode/Timing/timing_icarus.fcl
@@ -6,7 +6,7 @@ icarus_pmttimingservice:
 {
     # service name:   IPMTTimingCorrectionService
     service_provider: PMTTimingCorrectionService
-    CorrectionTags:   @local::PMTtimingCorrectionTags_Run2_August2023
+    CorrectionTags:   @local::PMTtimingCorrectionTags_Run2_Sept2023
     Verbose:          false
 }
 


### PR DESCRIPTION
Twin PR of #626 

- Laser corrections now cover the entire Run 2 period.
- A null table is added so that cosmics corrections for Run 1 are NOT applied to Run 2 data.

(The `icarus_data` v09_79_01 requirement is already satisfied by production since the last patch release)