### PR TITLE
Large trigger code update: adder emulation, updates to pair-based trigger emulation

### DIFF
--- a/fcl/reco/Stage0/Run2/partial/stage0_run2_icarus_opdetonly.fcl
+++ b/fcl/reco/Stage0/Run2/partial/stage0_run2_icarus_opdetonly.fcl
@@ -1,0 +1,19 @@
+#
+# File:    stage0_run2_icarus_opdetonly.fcl
+# Purpose: Runs the optical detector and trigger reconstruction parts of Stage0
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    August 29, 2023
+# 
+# Written for icaruscode v09_72_00_05p1.
+#
+
+#include "stage0_run2_icarus.fcl"
+
+source.maxEvents: @erase
+
+physics.path:      [ @sequence::icarus_stage0_PMT ]
+
+physics.end_paths: [ streamROOT ]
+
+# be unstoppable
+physics.producers.daqPMT.SurviveExceptions: true

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV2_tool.cc
@@ -24,9 +24,9 @@
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/Utilities/quantities/spacetime.h" // util::quantities::nanosecond
-#include "lardataobj/RawData/ExternalTrigger.h" //JCZ: TBD, placeholder for now to represent the idea
+#include "lardataobj/RawData/ExternalTrigger.h"
 #include "lardataobj/RawData/TriggerData.h" // raw::Trigger
-#include "lardataobj/Simulation/BeamGateInfo.h" //JCZ:, another placeholder I am unsure if this and above will be combined at some point into a dedicated object 
+#include "lardataobj/Simulation/BeamGateInfo.h"
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV2Fragment.hh"
 
@@ -715,20 +715,19 @@ namespace daq
       : 0.0
       };
     
-    // beam gate - trigger: hope it's negative...
+    // beam gate, defined in simulation time, which should match beam gate time
+    // ... trivial:
+    fBeamGateInfo->emplace_back(0, gateWidth.value(), simGateType(beamGateBit));
+    
+    //
+    // relative time trigger (raw::Trigger)
+    //
     nanoseconds const gateStartFromTrigger{
       static_cast<double>(timestampDiff
         (fTriggerExtra->beamGateTimestamp, fTriggerExtra->triggerTimestamp)
         )
       }; // narrowing!!
     auto const elecGateStart = fDetTimings.TriggerTime() + gateStartFromTrigger;
-    auto const simGateStart = fDetTimings.toSimulationTime(elecGateStart);
-    fBeamGateInfo->emplace_back
-      (simGateStart.value(), gateWidth.value(), simGateType(beamGateBit));
-    
-    //
-    // relative time trigger (raw::Trigger)
-    //
     fRelTrigger->emplace_back(
       static_cast<unsigned int>(datastream_info.wr_event_no), // counter
       fDetTimings.TriggerTime().value(),                      // trigger_time

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
@@ -851,6 +851,13 @@ namespace daq
   } // TriggerDecoderV3::encodeLVDSbits()
   
   
+  template <unsigned int startBit, unsigned int nBits, typename T>
+  constexpr T TriggerDecoderV3::bits(T value) {
+    constexpr T nBitsMask = (nBits == sizeof(T)*8)? ~T{0}: T((1 << nBits) - 1);
+    return (value >> T(startBit)) & nBitsMask;
+  }
+  
+  
   std::uint16_t TriggerDecoderV3::encodeSectorBits
     (short int cryostat, short int connector, std::uint64_t connectorWord)
   {
@@ -876,13 +883,6 @@ namespace daq
       | (bits<FirstSectorBit,                  SectorBitsPerConnector>(connectorWord)                          )
       );
   } // TriggerDecoderV3::encodeSectorBits()
-  
-  
-  template <unsigned int startBit, unsigned int nBits, typename T>
-  constexpr T TriggerDecoderV3::bits(T value) {
-    constexpr T nBitsMask = (nBits == sizeof(T)*8)? ~T{0}: T((1 << nBits) - 1);
-    return (value >> T(startBit)) & nBitsMask;
-  }
   
   
   sim::BeamType_t TriggerDecoderV3::simGateType(sbn::triggerSource source)

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
@@ -24,10 +24,9 @@
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/Utilities/quantities/spacetime.h" // util::quantities::nanosecond
-#include "lardataobj/RawData/ExternalTrigger.h" //JCZ: TBD, placeholder for now to represent the idea
+#include "lardataobj/RawData/ExternalTrigger.h"
 #include "lardataobj/RawData/TriggerData.h" // raw::Trigger
-#include "lardataobj/Simulation/BeamGateInfo.h" //JCZ:, another placeholder I am unsure if this and above will be combined at some point into a dedicated object 
-
+#include "lardataobj/Simulation/BeamGateInfo.h"
 #include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerV3Fragment.hh"
 
 #include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
@@ -239,7 +238,7 @@ namespace daq
     TriggerPtr fPrevTrigger;
     std::unique_ptr<RelativeTriggerCollection> fRelTrigger;
     ExtraInfoPtr fTriggerExtra;
-    BeamGateInfoPtr fBeamGateInfo; 
+    BeamGateInfoPtr fBeamGateInfo;
     art::InputTag fTriggerConfigTag; ///< Data product with hardware trigger configuration.
     bool fDiagnosticOutput; ///< Produces large number of diagnostic messages, use with caution!
     bool fDebug; ///< Use this for debugging this tool
@@ -761,20 +760,19 @@ namespace daq
       : 0.0
       };
     
-    // beam gate - trigger: hope it's negative...
+    // beam gate, defined in simulation time, which should match beam gate time
+    // ... trivial:
+    fBeamGateInfo->emplace_back(0, gateWidth.value(), simGateType(beamGateBit));
+    
+    //
+    // relative time trigger (raw::Trigger)
+    //
     nanoseconds const gateStartFromTrigger{
       static_cast<double>(timestampDiff
         (fTriggerExtra->beamGateTimestamp, fTriggerExtra->triggerTimestamp)
         )
       }; // narrowing!!
     auto const elecGateStart = fDetTimings.TriggerTime() + gateStartFromTrigger;
-    auto const simGateStart = fDetTimings.toSimulationTime(elecGateStart);
-    fBeamGateInfo->emplace_back
-      (simGateStart.value(), gateWidth.value(), simGateType(beamGateBit));
-    
-    //
-    // relative time trigger (raw::Trigger)
-    //
     fRelTrigger->emplace_back(
       fTriggerExtra->triggerID,                               // counter
       fDetTimings.TriggerTime().value(),                      // trigger_time

--- a/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoder_tool.cc
@@ -21,9 +21,9 @@
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/Utilities/quantities/spacetime.h" // util::quantities::nanosecond
-#include "lardataobj/RawData/ExternalTrigger.h" //JCZ: TBD, placeholder for now to represent the idea
+#include "lardataobj/RawData/ExternalTrigger.h"
 #include "lardataobj/RawData/TriggerData.h" // raw::Trigger
-#include "lardataobj/Simulation/BeamGateInfo.h" //JCZ:, another placeholder I am unsure if this and above will be combined at some point into a dedicated object 
+#include "lardataobj/Simulation/BeamGateInfo.h"
 
 #include "sbndaq-artdaq-core/Overlays/ICARUS/ICARUSTriggerUDPFragment.hh"
 
@@ -427,30 +427,24 @@ namespace daq
     //
     // beam gate
     //
-    // beam gate - trigger: hope it's negative...
+    // defined in simulation time, which should match beam gate time... trivial:
     nanoseconds const gateStartFromTrigger{
       static_cast<double>(timestampDiff
         (fTriggerExtra->beamGateTimestamp, fTriggerExtra->triggerTimestamp)
         )
       }; // narrowing!!
-    auto const elecGateStart = fDetTimings.TriggerTime() + gateStartFromTrigger;
-    auto const simGateStart = fDetTimings.toSimulationTime(elecGateStart);
     switch (gate_type) {
       case TriggerGateTypes::BNB:
-        fBeamGateInfo->emplace_back
-          (simGateStart.value(), BNBgateDuration.value(), sim::kBNB);
+        fBeamGateInfo->emplace_back(0.0, BNBgateDuration.value(), sim::kBNB);
         break;
       case TriggerGateTypes::NuMI:
-        fBeamGateInfo->emplace_back
-          (simGateStart.value(), NuMIgateDuration.value(), sim::kNuMI);
+        fBeamGateInfo->emplace_back(0.0, NuMIgateDuration.value(), sim::kNuMI);
         break;
       case TriggerGateTypes::OffbeamBNB:
-        fBeamGateInfo->emplace_back
-          (simGateStart.value(), BNBgateDuration.value(), sim::kBNB);
+        fBeamGateInfo->emplace_back(0.0, BNBgateDuration.value(), sim::kBNB);
         break;
       case TriggerGateTypes::OffbeamNuMI:
-        fBeamGateInfo->emplace_back
-          (simGateStart.value(), NuMIgateDuration.value(), sim::kNuMI);
+        fBeamGateInfo->emplace_back(0.0, NuMIgateDuration.value(), sim::kNuMI);
         break;
       default:
         mf::LogWarning("TriggerDecoder") << "Unsupported gate type #" << gate_type;
@@ -459,6 +453,7 @@ namespace daq
     //
     // relative time trigger (raw::Trigger)
     //
+    auto const elecGateStart = fDetTimings.TriggerTime() + gateStartFromTrigger;
     fRelTrigger->emplace_back(
       static_cast<unsigned int>(datastream_info.wr_event_no), // counter
       fDetTimings.TriggerTime().value(),                      // trigger_time

--- a/icaruscode/PMT/Algorithms/CMakeLists.txt
+++ b/icaruscode/PMT/Algorithms/CMakeLists.txt
@@ -5,11 +5,12 @@ file(GLOB lib_srcs *.cxx)
 art_make_library(
         SOURCE ${lib_srcs}
 	LIBRARIES
-		icaruscode_Decode_DecoderTools
+		icaruscode::Decode_DecoderTools
+		icarusalg::Utilities
 		larcorealg::Geometry
 		lardataobj::RawData
-		icarusalg::Utilities
-                Microsoft.GSL::GSL
+		larcoreobj::headers
+		Microsoft.GSL::GSL
 		canvas::canvas
 		messagefacility::MF_MessageLogger
 		messagefacility::headers

--- a/icaruscode/PMT/Algorithms/OpDetWaveformMetaUtils.h
+++ b/icaruscode/PMT/Algorithms/OpDetWaveformMetaUtils.h
@@ -131,15 +131,16 @@ namespace sbn {
  * @brief Converter from `raw::OpDetWaveform` into `sbn::OpDetWaveformMeta`.
  * 
  * An object of this class is initialized once with some timings (e.g. once per
- * event), used to `make()` multiple `sbn::OpDetWaveformMeta` and then discarded:
+ * event), and then used to `make()` multiple `sbn::OpDetWaveformMeta`:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
  * 
  * detinfo::DetectorTimings const detTimings = detinfo::makeDetectorTimings
  *   (art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event));
  * 
  * std::vector<sbn::OpDetWaveformMeta> PMTinfo;
+ * sbn::OpDetWaveformMetaMaker const makeMetadata{ detTimings };
  * for (raw::OpDetWaveform const& waveform: waveforms)
- *   PMTinfo.push_back(makeOpDetWaveformMeta(waveform));
+ *   PMTinfo.push_back(makeMetadata(waveform));
  * 
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * 
@@ -158,7 +159,6 @@ class sbn::OpDetWaveformMetaMaker {
   /// Constructor: allows creation of `sbn::OpDetWaveformMeta` with full
   /// information.
   OpDetWaveformMetaMaker(detinfo::DetectorTimings const& detTimings);
-  
   
   /// Constructor: allows creation of `sbn::OpDetWaveformMeta` with no
   /// detector clocks service.

--- a/icaruscode/PMT/Algorithms/PMTverticalSlicingAlg.h
+++ b/icaruscode/PMT/Algorithms/PMTverticalSlicingAlg.h
@@ -138,6 +138,9 @@ class icarus::trigger::PMTverticalSlicingAlg {
   /// Returns a list of all `geo::OpDetGeo` in the whole geometry.
   static PMTlist_t getPMTs(geo::GeometryCore const& geom);
 
+  /// Returns the geometric center of the PMT `wall`.
+  static geo::Point_t PMTwallCenter(PMTtowerOnPlane_t const& wall);
+
   // pretty sure this is already in some feature branch if not in LArSoft...
   /// Returns whether `a` and `b` are parallel.
   static bool areParallel(geo::Vector_t const& a, geo::Vector_t const& b);

--- a/icaruscode/PMT/CMakeLists.txt
+++ b/icaruscode/PMT/CMakeLists.txt
@@ -182,6 +182,8 @@ art_make_library(
     "PMTStartCalibTime_module.cc"
     "PMTcoordinates_module.cc"
     "PhotonPropogationICARUS_module.cc"
+    "ReassociatePMTbaselines_module.cc"
+    "RequireOnBeamWaveforms_module.cc"
     "TrigInfo_module.cc"
     "wvfAnaicarus_module.cc"
     "AsymGaussPulseFunctionTool_tool.cc"
@@ -237,6 +239,36 @@ cet_build_plugin(PMTcoordinates art::module LIBRARIES ${MODULE_LIBRARIES})
 cet_build_plugin(PhotonPropogationICARUS art::module LIBRARIES ${MODULE_LIBRARIES})
 cet_build_plugin(TrigInfo art::module LIBRARIES ${MODULE_LIBRARIES})
 cet_build_plugin(wvfAnaicarus art::module LIBRARIES ${MODULE_LIBRARIES})
+
+cet_build_plugin(RequireOnBeamWaveforms art::module
+  LIBRARIES
+    icaruscode::IcarusObj
+    icarusalg::Utilities
+    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    larcore::Geometry_Geometry_service
+    larcore::headers
+    lardataalg::DetectorInfo
+    lardataalg::headers
+    larcorealg::Geometry
+    larcorealg::CoreUtils
+    lardataobj::RawData
+    art::Framework_Services_Registry
+  )
+
+cet_build_plugin(ReassociatePMTbaselines art::module
+  LIBRARIES
+    icaruscode::IcarusObj
+    icaruscode::PMT_Algorithms
+    icaruscode::PMT_Data
+    icarusalg::Utilities
+    sbnobj::ICARUS_PMT_Data
+    lardata::headers
+    lardataalg::headers
+    larcorealg::Geometry
+    lardataobj::RawData
+    art::Framework_Services_Registry
+  )
+
 
 
 install_headers()

--- a/icaruscode/PMT/CopyBeamTimePMTwaveforms_module.cc
+++ b/icaruscode/PMT/CopyBeamTimePMTwaveforms_module.cc
@@ -453,10 +453,10 @@ void icarus::CopyBeamTimePMTwaveforms::produce
     : nullptr
     ;
   
-  // the assumption: the associations are in the same order as the
-  // original waveforms, and none is missing; this allows us to skip
-  // art::FindOneP calls. If not true... art::FindOneP is a way.
   if (waveMetaAssns && (waveMetaAssns->size() != waveforms.size())) {
+    // the assumption: the associations are in the same order as the
+    // original waveforms, and none is missing; this allows us to skip
+    // art::FindOneP calls. If not true... art::FindOneP is a way.
     throw art::Exception{ art::errors::LogicError }
       << "CopyBeamTimePMTwaveforms association logic assumption is broken"
       " by metadata (I)."

--- a/icaruscode/PMT/ReassociatePMTbaselines_module.cc
+++ b/icaruscode/PMT/ReassociatePMTbaselines_module.cc
@@ -1,0 +1,563 @@
+/**
+ * @file   ReassociatePMTbaselines_module.cc
+ * @brief  Associates baseline objects to pruned optical waveforms.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 6, 2023
+ */
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/Algorithms/OpDetWaveformMetaUtils.h" // OpDetWaveformMetaMaker
+#include "icaruscode/PMT/Data/WaveformRMS.h"
+#include "icaruscode/IcarusObj/OpDetWaveformMeta.h"
+#include "icarusalg/Utilities/AssnsCrosser.h"
+#include "sbnobj/ICARUS/PMT/Data/WaveformBaseline.h"
+
+// LArSoft libraries
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
+#include "larcorealg/CoreUtils/counter.h"
+#include "lardataobj/RawData/OpDetWaveform.h"
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/SharedProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Utilities/InputTag.h"
+#include "cetlib_except/exception.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Atom.h"
+
+// C/C++ standard libraries
+#include <utility> // std::move()
+#include <memory> // std::unique_ptr
+#include <algorithm> // std::sort(), std::lower_bound()
+#include <vector>
+#include <string>
+#include <optional>
+#include <functional> // std::less
+#include <cassert>
+
+
+//------------------------------------------------------------------------------
+namespace icarus::trigger { class ReassociatePMTbaselines; }
+
+/**
+ * @brief Associates baseline and RMS objects to pruned optical waveforms.
+ * 
+ * The issue at hand is that baselines and their RMS are computed and assigned
+ * based on the full information available on a PMT channel, and then associated
+ * to all the waveforms of that channel. Then, those waveforms are dropped but
+ * some of them are _copied_ to a new data product. The issue is that this copy
+ * does not replicate the associations of the waveforms being copied.
+ * So we are left with all the baseline objects, all their associations to the
+ * original waveforms, no original waveform, and some other waveforms which are
+ * copies of part of the original ones. We are left to figure out which baseline
+ * belongs to which copied waveform.
+ * 
+ * In addition, baseline and RMS information do not contain a channel number.
+ * 
+ * This module applies heuristic algorithm based on the assumptions:
+ *  * associations between baselines and the original waveforms are still
+ *    present (even if the pointers to those waveforms can't be resolved);
+ *  * metadata of the original waveforms is still available and associated to
+ *    the original waveforms.
+ *  * RMS objects are in the same order as the baseline objects; it is assumed
+ *    that baseline of index _i_ has RMS of index _i_.
+ * 
+ * So the plan is to:
+ * 1. Identify the original waveform metadata matching the available waveform
+ *    copies (based on channel and timestamp);
+ * 2. Associate the metadata of the original waveforms with the baseline
+ *    by hopping through their waveform association;
+ * 3. Not to repeat the association traversal for RMS but rather use the result
+ *    from the baseline one, assuming RMS to mirror baselines.
+ * 4. Finally, create a new set of baseline and RMS objects associated
+ *    to the available waveform copies, in the same order (similar protocol).
+ * 
+ * 
+ * Output data products
+ * =====================
+ * 
+ * * `art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>`,
+ * * `art::Assns<raw::OpDetWaveform, icarus::WaveformRMS>`: associations between
+ *   each available waveform and its baseline and RMS.
+ * * `art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>` (if
+ *   `RecreateMetaAssns` is set): associations between each available waveform
+ *   and its metadata. Normally produced by `CopyBeamTimePMTwaveforms` module,
+ *   which was buggy until <a href="https://github.com/SBNSoftware/icaruscode/pull/617"><tt>icaruscode</tt> PR #617</a>) was merged.
+ * 
+ * 
+ * Input data products
+ * =====================
+ * 
+ * * `std::vector<raw::OpDetWaveform>` (`WaveformTag`): the available waveforms
+ *   which need to be associated to baselines and RMS.
+ * * `std::vector<sbn::OpDetWaveformMeta>` (`OriginalWaveformTag`): the
+ *   metadata of the _original_ waveforms (which may have been dropped).
+ * * `art::Assns<sbn::OpDetWaveformMeta, raw::OpDetWaveform>
+ *   (`OriginalWaveformTag`): the associations of the metadata above with the
+ *   original waveforms.
+ * * `art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>` (`BaselineTag`):
+ *   associations of the baselines to the original waveforms
+ * * `std::vector<icarus::WaveformRMS>` (optional, `RMSTag`): the RMS of
+ *   each of the original waveforms (does not need to be available).
+ * 
+ * 
+ * Service requirements
+ * ---------------------
+ * 
+ * The following services are _required_:
+ * * _art_ message facility
+ * * an implementation of `DetectorClocksService` for the determination of the
+ *   times for waveform metadata.
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * A terse description of the parameters is printed by running
+ * `lar --print-description ReassociatePMTbaselines`.
+ * 
+ * * `WaveformTag` (input tag): the data product containing all surviving
+ *   optical detector waveforms
+ * * `BaselineTag` (input tag): the data product containing one
+ *   baseline per waveform in data product (from `OpticalWaveforms`)
+ * * `RMSTag` (input tag, optional): the data product containing one baseline
+ *   per waveform in data product (from `OpticalWaveforms`)
+ * * `OriginalWaveformTag` (input tag): the data product creating the metadata
+ *   of the original waveforms, and possibly the associations to them.
+ * * `RecreateMetaAssns` (flag, default: `false`): if set, associations between
+ *   the waveforms in `WaveformTag` and the metadata of the corresponding ones
+ *   in the original waveform data product are (re)created.
+ * * `LogCategory` (string, default: `"ReassociatePMTbaselines"`): label
+ *   for the category of messages in the console output; this is the label
+ *   that can be used for filtering messages via MessageFacility service
+ *   configuration.
+ * 
+ * 
+ */
+class icarus::trigger::ReassociatePMTbaselines: public art::SharedProducer {
+  
+    public:
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    
+    fhicl::Atom<art::InputTag> WaveformTag{
+      Name{ "WaveformTag" },
+      Comment{ "input tag of digitized optical waveform data product" }
+      };
+    
+    fhicl::Atom<art::InputTag> BaselineTag{
+      Name{ "BaselineTag" },
+      Comment{ "input tag for waveform baselines associations to waveforms" }
+      };
+    
+    fhicl::OptionalAtom<art::InputTag> RMSTag{
+      Name{ "RMSTag" },
+      Comment{ "input tag for waveform RMS associations to waveforms" }
+      };
+    
+    fhicl::Atom<art::InputTag> OriginalWaveformTag{
+      Name{ "OriginalWaveformTag" },
+      Comment{ "input tag for original waveform baselines and metadata" }
+      };
+    
+    fhicl::Atom<bool> RecreateMetaAssns{
+      Name{ "RecreateMetaAssns" },
+      Comment{ "recreate the associations between metadata and waveforms" },
+      false
+      };
+    
+    fhicl::Atom<std::string> LogCategory{
+      Name{ "LogCategory" },
+      Comment{ "tag of the module output to console via message facility" },
+      "ReassociatePMTbaselines"
+      };
+    
+  }; // struct Config
+  
+  using Parameters = art::SharedProducer::Table<Config>;
+  
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  explicit ReassociatePMTbaselines
+    (Parameters const& config, art::ProcessingFrame const& frame);
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Creates the data products.
+  virtual void produce(art::Event& event, art::ProcessingFrame const&) override;
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  /// Sorting for `sbn::OpDetWaveformMeta` objects.
+  /// Compares channel, then start time, then stop time.
+  struct OpDetWaveformMetaSorter {
+    bool operator()
+      (sbn::OpDetWaveformMeta const& a, sbn::OpDetWaveformMeta const& b)
+      const noexcept;
+  };
+  
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  art::InputTag const fWaveformTag; ///< Optical waveform input tag.
+  
+  art::InputTag const fBaselineTag; ///< Waveform baseline input tag.
+  art::InputTag const fRMSTag; ///< Waveform RMS input tag.
+  
+  art::InputTag const fOriginalWaveformTag; ///< Original waveform input tag.
+  
+  bool const fRecreateMetaAssns; ///< Whether to recreate metadata associations.
+  
+  std::string const fLogCategory; ///< Category name for the console output stream.
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+  // --- BEGIN Service variables -----------------------------------------------
+  
+  // --- END Service variables -------------------------------------------------
+  
+  
+  
+}; // icarus::trigger::ReassociatePMTbaselines
+
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+namespace {
+  
+  // ---------------------------------------------------------------------------
+  /**
+   * @brief Keeps a map of the _art_ pointers of some objects.
+   * @tparam T type of the tracked objects; required to be comparable
+   * @tparam Comp (default: `std::less<T>`) type of functor comparison
+   * 
+   * The object looks up a _art_ pointer for an object which compares equal
+   * to a requested one.
+   * 
+   * To create an `PtrFinder` object, use `makePtrFinder()` helper function.
+   * 
+   * Requirements
+   * -------------
+   * 
+   * Object of type `Comp` must support:
+   * * `bool operator() (const T& a, const T& b)` returning whether `a` is
+   *   strictly before `b` (for whatever definition). This is a strict order
+   *   comparison.
+   * 
+   */
+  template <typename T, typename Comp = std::less<T>>
+  class PtrFinder {
+    
+    using Data_t = T;
+    
+    using Ptr_t = art::Ptr<Data_t>;
+    
+    using Storage_t = std::vector<Ptr_t>;
+    
+    struct Comparer {
+      
+      Comp cmp;
+      
+      bool operator() (Ptr_t const& a, Ptr_t const& b) const
+        { return cmp(*a, *b); }
+      bool operator() (Ptr_t const& a, Data_t const& b) const
+        { return cmp(*a, b); }
+      bool operator() (Data_t const& a, Ptr_t const& b) const
+        { return cmp(a, *b); }
+      bool operator() (Data_t const& a, Data_t const& b) const
+        { return cmp(a, b); }
+      
+    }; // Comparer
+    
+    
+    Storage_t fMap; ///< Cached map of objects.
+    
+    Comparer fComp; ///< Comparison operator
+    
+    /// Hidden constructor: create an object with `makeIndexMap()`.
+    PtrFinder(Storage_t sortedPtrs, Comp comp)
+      : fMap{ std::move(sortedPtrs) }, fComp{ std::move(comp) } {}
+    
+      public:
+    
+    /// Null pointer returned on lookup failure.
+    static art::Ptr<T> const NullPtr;
+    
+    /// Returns the _art_ pointer of the object equal to `obj`.
+    art::Ptr<T> const& operator[] (T const& obj) const
+      { return findObject(obj); }
+    
+    /// Returns the _art_ pointer of the object equal to `obj`.
+    art::Ptr<T> const& findObject(T const& obj) const;
+    
+    
+    // friends
+    template <typename Handle, typename OtherComp>
+    friend PtrFinder<typename Handle::element_type::value_type, OtherComp>
+      makePtrFinder(Handle const&, OtherComp);
+    
+  }; // class PtrFinder
+  
+  
+  // ---------------------------------------------------------------------------
+  /// Creates a `IndexMap` object with the specified collection and comparison.
+  template
+    <typename Handle, typename Comp = std::less<typename Handle::value_type>>
+  PtrFinder<typename Handle::element_type::value_type, Comp> makePtrFinder
+    (Handle const& handle, Comp comp = Comp{})
+  {
+    using Data_t = typename Handle::element_type::value_type;
+    
+    using PtrFinder_t = PtrFinder<Data_t, Comp>;
+    
+    typename PtrFinder_t::Storage_t sortedPtrs;
+    art::fill_ptr_vector(sortedPtrs, handle);
+    
+    std::sort(
+      begin(sortedPtrs), end(sortedPtrs), typename PtrFinder_t::Comparer{ comp }
+      );
+    
+    return PtrFinder_t{ std::move(sortedPtrs), std::move(comp) };
+  } // makePtrFinder()
+  
+  
+  // ---------------------------------------------------------------------------
+  template <typename T>
+  std::unique_ptr<T> moveToUniquePtr(T& obj)
+    { return std::make_unique<T>(std::move(obj)); }
+  
+} // local namespace
+
+namespace sbn {
+  
+  std::ostream& operator<<
+    (std::ostream& out, sbn::OpDetWaveformMeta const& meta)
+  {
+    out << "Ch=" << meta.ChannelNumber() << " Time=[ " << meta.startTime
+      << " ; " << meta.endTime << " ] (" << meta.nSamples << " samples)";
+    // should also print flags... I don't care here
+    return out;
+  }
+  
+} // namespace sbn
+
+
+//------------------------------------------------------------------------------
+//--- PtrFinder
+//------------------------------------------------------------------------------
+namespace {
+  
+  template <typename T, typename Comp /* = std::less<T> */>
+  art::Ptr<T> const PtrFinder<T, Comp>::NullPtr;
+  
+  
+  template <typename T, typename Comp /* = std::less<T> */>
+  art::Ptr<T> const& PtrFinder<T, Comp>::findObject(T const& obj) const {
+    
+    auto const it = std::lower_bound(fMap.begin(), fMap.end(), obj, fComp);
+    // lower_bound() points to an object `*it` no smaller than `obj`,
+    // so `comp(*it, obj)` is `false`: `*it` is greater or equal to `obj`;
+    // if `comp(obj, *it)` is `false` too, `obj` is _equal_ to `*it` and we have
+    // a match; otherwise, we still don't have a match.
+    return ((it == fMap.end()) || fComp(obj, *it))? NullPtr: *it;
+    
+  } // PtrFinder<>::findObject()
+  
+  
+} // local namespace
+
+//------------------------------------------------------------------------------
+//--- icarus::trigger::ReassociatePMTbaselines
+//------------------------------------------------------------------------------
+icarus::trigger::ReassociatePMTbaselines::ReassociatePMTbaselines
+  (Parameters const& config, art::ProcessingFrame const& frame)
+  : art::SharedProducer{ config }
+  // configuration
+  , fWaveformTag        { config().WaveformTag()                   }
+  , fBaselineTag        { config().BaselineTag()                   }
+  , fRMSTag             { config().RMSTag().value_or(fBaselineTag) }
+  , fOriginalWaveformTag{ config().OriginalWaveformTag()           }
+  , fRecreateMetaAssns  { config().RecreateMetaAssns()             }
+  , fLogCategory        { config().LogCategory()                   }
+  // service cache
+{
+  async<art::InEvent>();
+  
+  //
+  // configuration post-processing
+  //
+  {
+    mf::LogInfo log(fLogCategory);
+    log << "Configuration:"
+      "\n * match waveforms '" << fWaveformTag.encode()
+        << "' to waveform metadata '" << fOriginalWaveformTag.encode()
+        << "' via baselines '" << fBaselineTag.encode()
+        << "' and RMS '" << fRMSTag.encode()
+      ;
+    if (fRecreateMetaAssns) {
+      log
+        << "\n * recreate associations between matched waveforms and metadata";
+    }
+  } // nameless block
+  
+  //
+  // declaration of input
+  //
+  consumes<std::vector<raw::OpDetWaveform>>(fWaveformTag);
+  consumes<std::vector<sbn::OpDetWaveformMeta>>(fOriginalWaveformTag);
+  consumes<art::Assns<sbn::OpDetWaveformMeta, raw::OpDetWaveform>>
+    (fOriginalWaveformTag);
+  consumes<art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>>
+    (fBaselineTag);
+  consumes<art::Assns<raw::OpDetWaveform, icarus::WaveformRMS>>(fRMSTag);
+  // consumes<std::vector<icarus::WaveformBaseline>>(fBaselineTag);
+
+  //
+  // declaration of output
+  //
+  
+  produces<art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>>();
+  produces<art::Assns<raw::OpDetWaveform, icarus::WaveformRMS>>();
+  if (fRecreateMetaAssns)
+    produces<art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>>();
+  
+} // icarus::trigger::ReassociatePMTbaselines::ReassociatePMTbaselines()
+
+
+//------------------------------------------------------------------------------
+void icarus::trigger::ReassociatePMTbaselines::produce
+  (art::Event& event, art::ProcessingFrame const&)
+{
+  
+ /* 
+  * So the plan is to:
+  * 1. associate the metadata of the original waveforms with the baseline and RMS
+  *    by hopping through their waveform association;
+  * 2. identify the original waveform metadata matching the available waveform
+  *    copies (based on channel and timestamp);
+  * 3. finally, create a new set of baseline and RMS objects associated
+  *    to the available waveform copies, in the same order (similar protocol).
+  */
+  
+  detinfo::DetectorTimings const detTimings{
+    art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event)
+    };
+  
+  //
+  // prepare input
+  //
+  auto const& waveformHandle
+    = event.getValidHandle<std::vector<raw::OpDetWaveform>>(fWaveformTag);
+  
+  auto const& waveformRMShandle
+    = event.getValidHandle<std::vector<icarus::WaveformRMS>>(fRMSTag);
+  
+  auto const& origMetaHandle
+    = event.getValidHandle<std::vector<sbn::OpDetWaveformMeta>>
+      (fOriginalWaveformTag)
+    ;
+  
+  // associate original metadata with (original) baselines:
+  auto const metaToBaseline = makeAssnsCrosser(event,
+      icarus::ns::util::startFrom<sbn::OpDetWaveformMeta>{}
+    , icarus::ns::util::hopTo    <raw::OpDetWaveform>{ fOriginalWaveformTag }
+    , icarus::ns::util::hopTo    <icarus::WaveformBaseline>{ fBaselineTag }
+    );
+  
+  // find which original metadata we need
+  art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline> waveToBaseline;
+  art::Assns<raw::OpDetWaveform, icarus::WaveformRMS> waveToRMS;
+  art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta> waveToMeta;
+  
+  PtrFinder const metadataPointers
+    = makePtrFinder(origMetaHandle, OpDetWaveformMetaSorter{});
+  
+  sbn::OpDetWaveformMetaMaker const makeMetadata{ detTimings };
+ 
+  for (auto const iWave: util::counter(waveformHandle->size())) {
+    
+    art::Ptr<raw::OpDetWaveform> wavePtr{ waveformHandle, iWave };
+    raw::OpDetWaveform const& waveform{ *wavePtr };
+    
+    // recreate the metadata for this waveform and match it to the known one
+    sbn::OpDetWaveformMeta const meta{ makeMetadata(waveform) };
+    art::Ptr<sbn::OpDetWaveformMeta> origMetaPtr
+      = metadataPointers.findObject(meta);
+    if (!origMetaPtr) {
+      // this warning suggests either a bug in the algorithm, a violation of
+      // the assumptions or some wrong configuration.
+      mf::LogProblem{ fLogCategory }
+        << "Waveform '" << fWaveformTag.encode() << "' #" << wavePtr.key()
+        << " (" << meta << ") couldn't be matched to any original waveform.";
+      continue;
+    }
+    
+    art::Ptr<icarus::WaveformBaseline> baselinePtr
+      = metaToBaseline.assPtr(origMetaPtr);
+    if (!baselinePtr) {
+      // this warning suggests either a violation of the assumptions or wrong
+      // configuration.
+      mf::LogProblem{ fLogCategory }
+        << "Waveform '" << fWaveformTag.encode() << "' #" << wavePtr.key()
+        << " (" << meta << ") couldn't be matched to any baseline.";
+      continue;
+    }
+    
+    art::Ptr<icarus::WaveformRMS> RMSptr
+      { waveformRMShandle, baselinePtr.key() };
+    
+    waveToBaseline.addSingle(wavePtr, std::move(baselinePtr));
+    waveToRMS.addSingle(wavePtr, std::move(RMSptr));
+    if (fRecreateMetaAssns)
+      waveToMeta.addSingle(wavePtr, std::move(origMetaPtr));
+    
+  } // for
+  
+  //
+  // send the data products to the event
+  //
+  event.put(moveToUniquePtr(waveToBaseline));
+  event.put(moveToUniquePtr(waveToRMS));
+  if (fRecreateMetaAssns) event.put(moveToUniquePtr(waveToMeta));
+  
+} // icarus::trigger::ReassociatePMTbaselines::produce()
+
+
+//------------------------------------------------------------------------------
+bool
+icarus::trigger::ReassociatePMTbaselines::OpDetWaveformMetaSorter::operator()
+  (sbn::OpDetWaveformMeta const& a, sbn::OpDetWaveformMeta const& b)
+  const noexcept
+{
+  if (a.channel != b.channel) return a.channel < b.channel;
+  if (a.startTime != b.startTime) return a.startTime < b.startTime;
+  return a.endTime < b.endTime;
+} // icarus::trigger::ReassociatePMTbaselines::OpDetWaveformMetaSorter::operator()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(icarus::trigger::ReassociatePMTbaselines)
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/PMT/RequireOnBeamWaveforms_module.cc
+++ b/icaruscode/PMT/RequireOnBeamWaveforms_module.cc
@@ -1,0 +1,551 @@
+/**
+ * @file   RequireOnBeamWaveforms_module.cc
+ * @brief  Module requiring the presence of waveforms.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   August 31, 2023
+ *
+ */
+
+// ICARUS/LArSoft libraries
+#include "icaruscode/IcarusObj/OpDetWaveformMeta.h"
+#include "icarusalg/Utilities/AtomicPassCounter.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
+#include "lardataalg/DetectorInfo/DetectorTimings.h" // DetectorClocksWithUnits
+#include "lardataalg/Utilities/quantities/spacetime.h" // nanoseconds, ...
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "lardataobj/RawData/OpDetWaveform.h"
+#include "lardataobj/RawData/TriggerData.h"
+
+// framework libraries
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Core/SharedFilter.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Utilities/InputTag.h"
+#include "canvas/Utilities/Exception.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Atom.h"
+#include "cetlib_except/exception.h"
+// 
+// C/C++ standard libraries
+#include <algorithm> // std::count()
+#include <optional>
+#include <vector>
+#include <string>
+#include <cstddef> // std::size_t
+
+
+//------------------------------------------------------------------------------
+/**
+ * @brief Requires the presence of one waveform per PMT covering beam gate time.
+ *
+ * This module passes only the events with one optical detector waveform
+ * per channel covering the beam gate opening time.
+ * 
+ * It attempts to read optical detector metadata and, failing that, falls back
+ * to the waveforms themselves.
+ * 
+ * Optionally, the availability of the waveforms is also verified
+ * (`ForceWaveformPresence`). With this option, if a waveform is not available
+ * it is considered like it were missing completely.
+ * 
+ * Note that the timestamp in the waveforms is assumed to be on the same scale
+ * as the beam gate opening time, and, where it matters, expressed in
+ * microseconds.
+ * 
+ *
+ * Configuration parameters
+ * =========================
+ *
+ * * `WaveformTag` (input tag, optional): tag of the optical detector waveforms;
+ *   if not specified, optical detector waveforms are not read at all
+ *   (unless `ForceWaveformPresence` is set).
+ * * `WaveformMetaTag` (input tag, optional): tag of the optical detector
+ *   waveform metadata; if empty, metadata is not used, and if not specified,
+ *   the value of `WaveformTag` is used instead; in both special cases,
+ *   `WaveformTag` must be specified.
+ * * `TriggerTag` (input tag, optional): data product to use to learn when the
+ *   beam gate was opened; if omitted, `DetectorClocksService` is used instead.
+ * * `WaveformMetaAssnsTag` (input tag, default: like `WaveformMetaTag`): tag of
+ *   the association between waveforms and their metadata. Normally, this is the
+ *   same as the tag of the metadata itself, but in some old data that was not
+ *   the case (`ReassociatePMTbaselines` would reassociate the existing one).
+ * * `ForceWaveformPresence` (flag, default: `false`): if set, waveforms from
+ *   `WaveformTag` are always read even when the check is performed with
+ *   metadata; this detects the case where optical detector waveforms _were_
+ *   present but have since been dropped.
+ * * `ThrowOnFailure` (string, default: empty): if non-empty, instead of just
+ *   returning `false`, when an event does not qualify, an exception is thrown
+ *   with the category specified here, which can then be handled by _art_'s
+ *   scheduler "service".
+ * * `MissingChannels` (sequence of numbers, default: empty): the channels in
+ *   this list are allowed not to be present.
+ * * `LogCategory` (string, default: `RequireOnBeamWaveforms`): message facility
+ *   stream name where to write console messages to.
+ *
+ * 
+ * Service dependencies
+ * =====================
+ * 
+ * * `Geometry`: to learn how many channels we are looking for.
+ * * `DetectorClocksService`: depending on configuration, to get the beam
+ *    opening time and for optical tick duration.
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * * `std::vector<raw::OpDetWaveform>` (`WaveformTag`, if specified): the
+ *   waveforms which must have been present (and, if required, available).
+ * * `std::vector<sbn::OpDetWaveformMeta>` (`WaveformTagMeta`, if specified):
+ *   the metadata of the waveforms which must be present.
+ * * `std::vector<raw::Trigger>` (`TriggerTag`, if specified) to read the beam
+ *   gate opening time.
+ * * `art::Assns<sbn::OpDetWaveformMeta, raw::OpDetWaveform>` (`WaveformTagMeta`
+ *   if `ForceWaveformPresence` is set and metadata is used) to verify the
+ *   availability of waveforms.
+ * 
+ * 
+ * Output data products
+ * =====================
+ * 
+ * None.
+ * 
+ */
+class RequireOnBeamWaveforms: public art::SharedFilter {
+  
+    public:
+  
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::OptionalAtom<art::InputTag> WaveformTag{
+      Name{ "WaveformTag" },
+      Comment{ "optical detector waveform data product to be checked" }
+      };
+    
+    fhicl::OptionalAtom<art::InputTag> WaveformMetaTag{
+      Name{ "WaveformMetaTag" },
+      Comment{ "optical detector waveform metadata product to be checked" }
+      };
+    
+    fhicl::Atom<art::InputTag> TriggerTag{
+      Name{ "TriggerTag" },
+      Comment{ "trigger data product to use to discover the beam gate time" },
+      art::InputTag{}
+      };
+    
+    fhicl::OptionalAtom<art::InputTag> WaveformMetaAssnsTag{
+      Name{ "WaveformMetaAssnsTag" },
+      Comment{ "optical detector waveform and metadata associations" }
+      };
+    
+    fhicl::Atom<bool> ForceWaveformPresence{
+      Name{ "ForceWaveformPresence" },
+      Comment{ "ensures waveforms are available in the input file" },
+      false
+      };
+    
+    fhicl::Sequence<raw::Channel_t> MissingChannels{
+      Name{ "MissingChannels" },
+      Comment{ "" },
+      std::vector<raw::Channel_t>{}
+      };
+    
+    fhicl::Atom<std::string> ThrowOnFailure{
+      Name{ "ThrowOnFailure" },
+      Comment{ "if criteria are not met throw exception with this category" },
+      ""
+      };
+    
+    fhicl::Atom<std::string> LogCategory{
+      Name{ "LogCategory" },
+      Comment{ "name of the message facility stream used by the module" },
+      "RequireOnBeamWaveforms"
+      };
+    
+  }; // Config
+  
+  using Parameters = art::SharedFilter::Table<Config>;
+  
+  
+  RequireOnBeamWaveforms
+    (Parameters const& params, art::ProcessingFrame const&);
+  
+  /// Evaluate the filtering logic.
+  virtual bool filter(art::Event& event, art::ProcessingFrame const&) override;
+  
+  /// Prints a summary.
+  virtual void endJob(art::ProcessingFrame const&) override;
+  
+    private:
+  
+  using microsecond = util::quantities::points::microsecond;
+  using nanoseconds = util::quantities::intervals::nanoseconds;
+  
+  // --- BEGIN -- Configuration parameters -------------------------------------
+  
+  art::InputTag const fWaveformTag; ///< Input waveform data product.
+  
+  art::InputTag const fWaveformMetaTag; ///< Input waveform metadata product.
+  
+  art::InputTag const fTriggerTag; ///< Data product for beam gate.
+  
+  art::InputTag const fWaveformMetaAssnsTag; ///< Input waveform/metadata assns.
+  
+  bool const fForceWaveformPresence; ///< Whether to always read waveforms.
+  
+  /// Category of the exception to throw on failure (empty: does not throw).
+  std::string const fThrowOnFailure;
+  
+  std::string const fLogCategory; ///< Name of message facility stream.
+  
+  // --- END ---- Configuration parameters -------------------------------------
+  
+  // --- BEGIN -- Caches -------------------------------------------------------
+  
+  /// Bits of required channels (index is channel number).
+  std::vector<bool> const fRequiredChannelMask;
+  
+  std::ptrdiff_t const fNRequired; ///< Number of channels needed on beam.
+  
+  // --- END ---- Caches -------------------------------------------------------
+  
+  /// Count of passed and seen events.
+  icarus::ns::util::AtomicPassCounter<> fPassed;
+  
+  /// Reads the beam gate opening time from `DetectorClocksService`.
+  microsecond beamGateTimeFromService(art::Event const& event) const;
+  
+  /// Reads the beam gate opening time from the configured trigger data product.
+  microsecond beamGateTimeFromData(art::Event const& event) const;
+
+  /// Returns a mask with positions of the missing channels set to `true`.
+  std::vector<bool> missingFromMetadata(
+    microsecond beamGateTime,
+    std::vector<sbn::OpDetWaveformMeta> const& metadata,
+    art::FindOneP<raw::OpDetWaveform> const* toWaveforms = nullptr
+    ) const;
+
+
+  /// Returns a mask with positions of the missing channels set to `true`.
+  std::vector<bool> missingFromWaveforms(
+    microsecond beamGateTime,
+    std::vector<raw::OpDetWaveform> const& waveforms,
+    nanoseconds clockTick
+    ) const;
+  
+  /// Composes and returns the list of channels to require.
+  static std::vector<bool> buildRequiredChannelList
+    (std::vector<raw::Channel_t> const& skipChannels = {});
+  
+  
+}; // class RequireOnBeamWaveforms
+
+
+//------------------------------------------------------------------------------
+
+RequireOnBeamWaveforms::RequireOnBeamWaveforms
+  (Parameters const& params, art::ProcessingFrame const&)
+  : art::SharedFilter{ params }
+  // configuration
+  , fWaveformTag          { params().WaveformTag().value_or(art::InputTag{}) }
+  , fWaveformMetaTag      { params().WaveformMetaTag().value_or(fWaveformTag) }
+  , fTriggerTag           { params().TriggerTag() }
+  , fWaveformMetaAssnsTag
+    { params().WaveformMetaAssnsTag().value_or(fWaveformMetaTag) }
+  , fForceWaveformPresence{ params().ForceWaveformPresence() }
+  , fThrowOnFailure       { params().ThrowOnFailure() }
+  , fLogCategory          { params().LogCategory() }
+  // caches
+  , fRequiredChannelMask{ buildRequiredChannelList(params().MissingChannels()) }
+  , fNRequired{
+      std::count
+        (fRequiredChannelMask.begin(), fRequiredChannelMask.end(), true)
+      }
+{
+  
+  async<art::InEvent>();
+  
+  //
+  // configuration check
+  //
+  if (fWaveformTag.empty() && fWaveformMetaTag.empty()) {
+    throw art::Exception{ art::errors::Configuration }
+      << "At least one of '" << params().WaveformTag.name() << "' and '"
+      << params().WaveformMetaTag.name() << "' must be specified non-empty.\n";
+  }
+  
+  
+  //
+  // consume declaration
+  //
+  if (!fWaveformMetaTag.empty()) {
+    consumes<std::vector<sbn::OpDetWaveformMeta>>(fWaveformMetaTag);
+    if (!fWaveformTag.empty())
+      mayConsume<std::vector<raw::OpDetWaveform>>(fWaveformTag);
+    if (fForceWaveformPresence) {
+      consumes<art::Assns<sbn::OpDetWaveformMeta, raw::OpDetWaveform>>
+        (fWaveformMetaTag);
+    }
+  }
+  else {
+    assert(!fWaveformTag.empty());
+    consumes<std::vector<raw::OpDetWaveform>>(fWaveformTag);
+  }
+  
+  if (!fTriggerTag.empty()) consumes<std::vector<raw::Trigger>>(fTriggerTag);
+  
+  
+  //
+  // dump configuration
+  //
+  mf::LogInfo log{ fLogCategory };
+  log << "Configuration:";
+  if (!fWaveformMetaTag.empty()) {
+    log << "\n * check performed on waveform metadata '"
+      << fWaveformMetaTag.encode() << "'";
+    if (!fWaveformTag.empty()) {
+      log << "\n   * if not available, check is performed on waveforms '"
+        << fWaveformTag.encode() << "'";
+    }
+  }
+  else {
+    log << "\n * check performed on waveforms '"
+      << fWaveformTag.encode() << "'";
+  }
+  if (fForceWaveformPresence) {
+    log
+      << "\n * presence of target waveforms checked (via metadata association '"
+      << fWaveformMetaAssnsTag.encode() << "')";
+  }
+  if (fTriggerTag.empty()) {
+    log << "\n * beam gate time from DetectorClocksService";
+  }
+  else {
+    log << "\n * beam gate time from trigger data product '"
+      << fTriggerTag.encode() << "'";
+  }
+  log << "\n * requiring the presence of " << fNRequired << " channels";
+  if (!fThrowOnFailure.empty())
+    log << "\n * if an event fails the criteria, throw an exception of category '" << fThrowOnFailure << "'";
+  
+  
+} // RequireOnBeamWaveforms::RequireOnBeamWaveforms()
+
+
+//------------------------------------------------------------------------------
+std::vector<bool> RequireOnBeamWaveforms::buildRequiredChannelList
+  (std::vector<raw::Channel_t> const& skipChannels /* = {} */)
+{
+  std::vector<bool> mask
+    (lar::providerFrom<geo::Geometry>()->MaxOpChannel(), true);
+  
+  // they will be never missed
+  for (raw::Channel_t const channel: skipChannels) mask[channel] = false;
+  
+  return mask;
+} // RequireOnBeamWaveforms::buildRequiredChannelList()
+
+
+//------------------------------------------------------------------------------
+bool RequireOnBeamWaveforms::filter
+  (art::Event& event, art::ProcessingFrame const&)
+{
+  
+  std::vector<std::size_t> WaveformIndices;
+  std::vector<bool> missingWaveforms;
+  
+  //
+  // discover the time
+  //
+  microsecond const beamGateTime = fTriggerTag.empty()
+    ? beamGateTimeFromService(event): beamGateTimeFromData(event);
+  
+  if (!fWaveformMetaTag.empty()) {
+    auto waveformMetadata
+      = event.getHandle<std::vector<sbn::OpDetWaveformMeta>>(fWaveformMetaTag);
+    if (waveformMetadata) {
+      
+      auto const toWaveforms = fForceWaveformPresence
+        ? std::make_optional<art::FindOneP<raw::OpDetWaveform>>
+          (waveformMetadata, event, fWaveformMetaAssnsTag)
+        : std::nullopt
+        ;
+      
+      missingWaveforms = missingFromMetadata
+        (beamGateTime, *waveformMetadata, toWaveforms? &*toWaveforms: nullptr);
+      
+    }
+    else {
+      mf::LogTrace{ fLogCategory } << "Waveform metadata '"
+        << fWaveformMetaTag.encode() << "' not available.";
+    }
+  }
+  
+  if (missingWaveforms.empty()) {
+    if (fWaveformTag.empty()) {
+      throw art::Exception{ art::errors::ProductNotFound }
+        << "Waveform metadata '" << fWaveformMetaTag.encode()
+        << "' not available and no waveform tag was configured!\n";
+    }
+    
+    detinfo::DetectorClocksWithUnits const detClocks{
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event)
+      };
+    
+    
+    missingWaveforms = missingFromWaveforms(
+      beamGateTime,
+      event.getProduct<std::vector<raw::OpDetWaveform>>(fWaveformTag),
+      detClocks.OpticalClockPeriod()
+      );
+  }
+  
+  
+  //
+  // draw conclusions
+  //
+  unsigned int const nMissing
+    = std::count(missingWaveforms.begin(), missingWaveforms.end(), true);
+  bool const accepted = (nMissing == 0);
+  
+  fPassed.add(accepted);
+  
+  if (!accepted) {
+    mf::LogInfo{ fLogCategory }
+      << event.id() << ": " << nMissing << "/" << fNRequired << " '"
+      << fWaveformTag.encode()
+      << "' optical detector waveforms did not meet the on-beam requirements.";
+    
+    if (!fThrowOnFailure.empty()) {
+      throw cet::exception{ fThrowOnFailure }
+        << event.id() << ": " << nMissing << "/" << fNRequired << " '"
+      << fWaveformTag.encode()
+      << "' optical detector waveforms did not meet the on-beam requirements\n";
+    }
+  }
+  
+  return accepted;
+  
+} // RequireOnBeamWaveforms::filter()
+
+
+//------------------------------------------------------------------------------
+void RequireOnBeamWaveforms::endJob(art::ProcessingFrame const&) {
+  
+  if (fPassed.failed() > 0) {
+    mf::LogInfo{ fLogCategory }
+      << fPassed.failed() << "/" << fPassed.total()
+      << " events failed the requirements.";
+  }
+  
+} // RequireOnBeamWaveforms::endJob()
+
+
+//------------------------------------------------------------------------------
+auto RequireOnBeamWaveforms::beamGateTimeFromService
+  (art::Event const& event) const -> microsecond
+{
+  detinfo::DetectorClocksWithUnits const detClocks{
+    art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event)
+    };
+  return detClocks.BeamGateTime();
+} // RequireOnBeamWaveforms::beamGateTimeFromService()
+
+
+//------------------------------------------------------------------------------
+auto RequireOnBeamWaveforms::beamGateTimeFromData(art::Event const& event) const
+  -> microsecond
+{
+  assert(!fTriggerTag.empty());
+  auto const& triggers
+    = event.getProduct<std::vector<raw::Trigger>>(fTriggerTag);
+  if (triggers.empty()) {
+    throw cet::exception("RequireOnBeamWaveforms")
+      << "No triggers in '" << fTriggerTag.encode() << "'!\n";
+  }
+  return microsecond::castFrom(triggers.front().BeamGateTime());
+} // RequireOnBeamWaveforms::beamGateTimeFromData()
+
+
+//------------------------------------------------------------------------------
+std::vector<bool> RequireOnBeamWaveforms::missingFromMetadata(
+  microsecond beamGateTime,
+  std::vector<sbn::OpDetWaveformMeta> const& metadata,
+  art::FindOneP<raw::OpDetWaveform> const* toWaveforms /* = nullptr */
+) const {
+  
+  std::vector<bool> missingWaveforms{ fRequiredChannelMask };
+  
+  for (auto const& [ iWaveform, waveformMeta ]: util::enumerate(metadata)) {
+    
+    // we could also check the on-beam flag here (`withBeamGate()`),
+    // but it may not be reliable for the original simulation waveforms
+    // (when metadata is created, beam gate time might be not known yet)
+    
+    if (!waveformMeta.includes(beamGateTime.value())) continue;
+    
+    if (fForceWaveformPresence) {
+      assert(toWaveforms);
+      
+      art::Ptr<raw::OpDetWaveform> const waveform = toWaveforms->at(iWaveform);
+      
+      if (waveform.isNull()) {
+        throw art::Exception{ art::errors::LogicError }
+          << "Metadata #" << iWaveform
+          << " is not associated to any waveform!\n";
+      }
+      if (!waveform.isAvailable()) continue; // like if we hadn't found it
+    }
+    
+    // found
+    if (waveformMeta.channel < missingWaveforms.size())
+      missingWaveforms[waveformMeta.channel] = false;
+    
+  } // for
+  
+  return missingWaveforms;
+} // RequireOnBeamWaveforms::missingFromMetadata()
+
+
+//------------------------------------------------------------------------------
+std::vector<bool> RequireOnBeamWaveforms::missingFromWaveforms(
+  microsecond beamGateTime, std::vector<raw::OpDetWaveform> const& waveforms,
+  nanoseconds clockTick
+) const {
+  
+  std::vector<bool> missingWaveforms{ fRequiredChannelMask };
+  
+  for (raw::OpDetWaveform const& waveform: waveforms) {
+    
+    // check: contains beam gate
+    microsecond const startTime{ waveform.TimeStamp() };
+    microsecond const endTime{ startTime + clockTick * waveform.size() };
+    if ((beamGateTime < startTime) || (beamGateTime >= endTime)) continue;
+    
+    // that was enough
+    if (waveform.ChannelNumber() < missingWaveforms.size())
+      missingWaveforms[waveform.ChannelNumber()] = false;
+    
+  } // for
+  
+  return missingWaveforms;
+} // RequireOnBeamWaveforms::missingFromWaveforms()
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(RequireOnBeamWaveforms)
+
+
+//------------------------------------------------------------------------------
+

--- a/icaruscode/PMT/Trigger/Algorithms/SlidingWindowPatternAlg.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/SlidingWindowPatternAlg.cxx
@@ -283,7 +283,8 @@ auto icarus::trigger::SlidingWindowPatternAlg::applyWindowPattern(
       );
     mfLogTrace() << "  opposite [#" << winTopology.opposite << "]: "
       << compactdump(gateAt(winTopology.opposite))
-      << "\n  => " << compactdump(trigPrimitive);
+      << "\n  opposite >= " << pattern.minInOppositeWindow << ": "
+        << compactdump(trigPrimitive);
   } // if
   
   // add main plus opposite window requirement (if any)
@@ -293,7 +294,8 @@ auto icarus::trigger::SlidingWindowPatternAlg::applyWindowPattern(
       (discriminate(*mainPlusOpposite, pattern.minSumInOppositeWindows));
     mfLogTrace() << "  sum [+ #" << winTopology.opposite << "]: "
       << compactdump(*mainPlusOpposite)
-      << "\n  => " << compactdump(trigPrimitive);
+      << "\n  sum >= " << pattern.minSumInOppositeWindows << ": "
+        << compactdump(trigPrimitive);
     
   } // if
   

--- a/icaruscode/PMT/Trigger/Algorithms/TriggerGateBuilder.h
+++ b/icaruscode/PMT/Trigger/Algorithms/TriggerGateBuilder.h
@@ -148,6 +148,9 @@ class icarus::trigger::TriggerGateBuilder {
      */
     GateData_t gates() && { return std::move(fGates); }
     
+    /// Returns the gate for the specified waveform `channel`, `nullptr` if n/a.
+    triggergate_t const* getGateFor(raw::Channel_t const channel) const;
+    
     /// Returns (and creates, if necessary) the gate for the specified waveform.
     triggergate_t& gateFor(raw::OpDetWaveform const& waveform);
     
@@ -166,6 +169,12 @@ class icarus::trigger::TriggerGateBuilder {
       private:
     ADCCounts_t fThreshold; ///< The threshold for all the gates.
     GateData_t fGates; ///< All the gates, at most one per channel.
+    
+    /// Returns an iterator to the gate for `channel`, `fGates.end()` if none.
+    auto findGateFor(raw::Channel_t const channel);
+    
+    /// Returns an iterator to the gate for `channel`, `fGates.end()` if none.
+    auto findGateFor(raw::Channel_t const channel) const;
     
   }; // class TriggerGates
   // --- END Data types --------------------------------------------------------

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -7,6 +7,7 @@ art_make_library(
     "WriteBeamGateInfo_module.cc"
     "FixBeamGateInfo_module.cc"
     "DiscriminatePMTwaveformsByChannel_module.cc"
+    "DiscriminatedAdderSignal_module.cc"
     "MajorityTriggerSimulation_module.cc"
     "SlidingWindowTrigger_module.cc"
     "SlidingWindowTriggerSimulation_module.cc"
@@ -82,9 +83,10 @@ cet_build_plugin(LVDSgates art::module LIBRARIES ${MODULE_LIBRARIES})
 
 cet_build_plugin(WriteBeamGateInfo art::module LIBRARIES
   lardataobj::Simulation
+  lardata::Utilities
   larcorealg::headers
   lardataalg::headers
-  ) 
+  )
 
 cet_build_plugin(FixBeamGateInfo art::module LIBRARIES
   lardataobj::Simulation
@@ -94,25 +96,43 @@ cet_build_plugin(FixBeamGateInfo art::module LIBRARIES
 
 cet_build_plugin(DiscriminatePMTwaveformsByChannel art::module
                 LIBRARIES
-		icaruscode::PMT_Trigger_Algorithms
-		sbnobj::ICARUS_PMT_Trigger_Data
-		sbnobj::ICARUS_PMT_Data
-		sbnobj::Common_PMT_Data
-		icaruscode::PMT_Trigger_Utilities
-		icaruscode::PMT_Algorithms
-		lardataobj::RawData
-		lardata::Utilities
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
-		larcore::Geometry_Geometry_service
-		art::Framework_Services_Registry
-		art::Framework_Principal
-		art::Framework_Core
-		canvas::canvas
-		messagefacility::MF_MessageLogger
-		fhiclcpp::fhiclcpp
-		cetlib_except::cetlib_except
-		ROOT::Core
-		) 
+  icaruscode::PMT_Trigger_Algorithms
+  sbnobj::ICARUS_PMT_Trigger_Data
+  sbnobj::ICARUS_PMT_Data
+  sbnobj::Common_PMT_Data
+  icaruscode::PMT_Trigger_Utilities
+  icaruscode::PMT_Algorithms
+  lardataobj::RawData
+  lardata::Utilities
+  lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+  larcore::Geometry_Geometry_service
+  art::Framework_Services_Registry
+  art::Framework_Principal
+  art::Framework_Core
+  canvas::canvas
+  messagefacility::MF_MessageLogger
+  fhiclcpp::fhiclcpp
+  cetlib_except::cetlib_except
+  ROOT::Core
+  )
+
+cet_build_plugin(DiscriminatedAdderSignal art::module
+  LIBRARIES
+    icaruscode::PMT_Trigger_Algorithms
+    icaruscode::PMT_Trigger_Utilities
+    icaruscode::PMT_Algorithms
+    icaruscode::IcarusObj
+    sbnobj::ICARUS_PMT_Trigger_Data
+    sbnobj::ICARUS_PMT_Data
+    lardata::headers
+    larcore::headers
+    lardataalg::DetectorInfo
+    lardataalg::headers
+    larcorealg::Geometry
+    larcorealg::CoreUtils
+    lardataobj::RawData
+    art::Framework_Services_Registry
+  )
 
 cet_build_plugin(SlidingWindowTrigger art::module
                 LIBRARIES
@@ -149,12 +169,6 @@ cet_build_plugin(MajorityTriggerSimulation art::module
 		art_root_io::TFileService_service
 		art_root_io::tfile_support
 		art::Framework_Services_Registry
-		art::Framework_Principal
-		art::Framework_Core
-		canvas::canvas
-		messagefacility::MF_MessageLogger
-		fhiclcpp::fhiclcpp
-		cetlib_except::cetlib_except
 		ROOT::Hist
 		ROOT::Core
 		) 

--- a/icaruscode/PMT/Trigger/DiscriminatedAdderSignal_module.cc
+++ b/icaruscode/PMT/Trigger/DiscriminatedAdderSignal_module.cc
@@ -1,0 +1,1437 @@
+/**
+ * @file   DiscriminatedAdderSignal_module.cc
+ * @brief  Module to put together and discriminate adder signals.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   July 6, 2023
+ */
+
+
+// ICARUS libraries
+#include "icaruscode/PMT/Trigger/Algorithms/SlidingWindowDefinitionAlg.h"
+#include "icaruscode/PMT/Trigger/Algorithms/TriggerGateBuilder.h"
+#include "icaruscode/PMT/Trigger/Algorithms/TriggerTypes.h" // ADCCounts_t
+#include "icaruscode/PMT/Trigger/Utilities/TriggerGateOperations.h" // GateOps
+#include "icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h"
+#include "icaruscode/PMT/Algorithms/OpDetWaveformMetaUtils.h" // OpDetWaveformMetaMaker
+#include "icaruscode/IcarusObj/OpDetWaveformMeta.h"
+#include "icarusalg/Utilities/TimeIntervalConfig.h" // icarus::...::TimeInterval
+#include "icarusalg/Utilities/GroupByIndex.h"
+#include "sbnobj/ICARUS/PMT/Trigger/Data/OpticalTriggerGate.h"
+#include "sbnobj/ICARUS/PMT/Data/WaveformBaseline.h"
+
+// LArSoft libraries
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
+#include "lardataalg/DetectorInfo/DetectorTimings.h"
+#include "lardataalg/Utilities/intervals_fhicl.h" // for microseconds parameters
+#include "lardataalg/Utilities/quantities/electromagnetism.h" // millivolt
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "larcorealg/CoreUtils/zip.h"
+#include "larcorealg/CoreUtils/values.h" // util::const_values()
+#include "larcorealg/CoreUtils/StdUtils.h" // util::to_string()
+#include "lardataobj/RawData/OpDetWaveform.h"
+
+// framework libraries
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/SharedProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Persistency/Common/PtrMaker.h"
+#include "art/Utilities/make_tool.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+#include "canvas/Persistency/Common/FindOne.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Utilities/InputTag.h"
+#include "cetlib/maybe_ref.h"
+#include "cetlib_except/exception.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/types/OptionalTable.h"
+#include "fhiclcpp/types/OptionalSequence.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/ParameterSet.h"
+
+// C/C++ standard libraries
+#include <iomanip>
+#include <algorithm> // std::transform()
+#include <numeric> // std::accumulate()
+#include <iterator> // std::back_inserter(), std::iterator_traits
+#include <utility> // std::move(), std::pair
+#include <functional> // std::mem_fn()
+#include <memory> // std::unique_ptr
+#include <map>
+#include <valarray>
+#include <vector>
+#include <string>
+#include <optional>
+#include <cassert>
+
+
+//------------------------------------------------------------------------------
+using namespace util::quantities::time_literals;
+
+//------------------------------------------------------------------------------
+namespace icarus::trigger { class DiscriminatedAdderSignal; }
+
+/**
+ * @brief Produces discriminated optical waveforms for PMT adders.
+ * 
+ * This module produces a "discriminated waveform" for each adder module and
+ * for each configured threshold, via an algorithm of the class of
+ * `icarus::trigger::TriggerGateBuilder` (`TriggerGateBuilder` configuration
+ * parameter).
+ * 
+ * The input is PMT optical waveforms: this module composes them into added
+ * analogue signals, then discriminates them.
+ * No distortion is applied to the PMT waveforms before or after the addition.
+ * 
+ * Thresholds are ultimately chosen by the tool in charge of actually running
+ * the discrimination algorithm. Out of the thresholds that this algorithm
+ * produces, it is possible to choose only a subset of them
+ * (`SelectThresholds`).
+ * 
+ * 
+ * Output data products
+ * =====================
+ * 
+ * * `std::vector<raw::OpDetWaveform>`, `std::vector<icarus::WaveformBaseline>`
+ *   and their one-to-one associations (only if `SaveWaveforms` is set):
+ *   waveforms from the adders; in this emulation, the waveforms are
+ *   "reproduced" from the already digitized PMT waveforms, in contrast with
+ *   the hardware which performs an analogue sum.
+ *   The channel number is unique on each of them, but it has no set meaning
+ *   beyond that.
+ *   In addition, a baseline object is saved for each waveform (their baseline
+ *   is `0` by construction since they originate from baseline-subtracted PMT
+ *   waveforms), and an association
+ *   `art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>`between them
+ *   (which is trivial since the two data products are
+ *   @ref LArSoftProxyDefinitionParallelData "parallel").
+ * * `std::vector<sbn::OpDetWaveformMeta>` (only if `SavePMTcoverage` is set):
+ *   parallel to the `std::vector<raw::OpDetWaveform>` data product, each entry
+ *   in the collection is matched with the corresponding one in the adder
+ *   waveform collection; if `SaveWaveforms` is set, an association
+ *   `art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>` is also produced
+ *   (which is also trivial since the two data products are
+ *   @ref LArSoftProxyDefinitionParallelData "parallel").
+ * * for each threshold _thr_ (in ADC counts), data products are created with
+ *   an instance name equivalent to the threshold (e.g. for a threshold of 700
+ *   ADC counts, the data product instance name will be `"700"`):
+ *     * a data product of type
+ *       `std::vector<icarus::trigger::OpticalTriggerGate::GateData_t>`,
+ *       with one entry per adder module; each gate object has as index in the
+ *       vector the number of the optical channel;
+ *     * an _art_ association, one trigger gate data to many optical waveforms,
+ *       of each trigger gate data (as above) with all the optical waveforms
+ *       which contributed to it; the order of the association pairs is the same
+ *       as the one of the trigger gate data, i.e. by channel, and some trigger
+ *       gate data entries may be not associated to any waveform and therefore
+ *       they can not be listed in the association; association pairs within
+ *       the same optical channel are sorted by optical waveform timestamp;
+ *       the type of the association is
+ *       `art::Assns<icarus::trigger::OpticalTriggerGate::GateData_t, raw::OpDetWaveform>`.
+ *       If `SaveMetaAssns` is set, also an association
+ *       art::Assns<icarus::trigger::OpticalTriggerGate::GateData_t, sbn::OpDetWaveformMeta>`
+ *       (just like the previous one, but associating to the waveform metadata
+ *       instead of the waveform itself).
+ *     * if `SaveWaveforms` is set, an association
+ *       `art::Assns<icarus::trigger::OpticalTriggerGate::GateData_t, raw::OpDetWaveform>`
+ *       to the adder waveforms;
+ *       this will have the string `adder` appended to the instance name, to
+ *       distinguish it from the associations to the PMT waveforms.
+ *     * if `SavePMTcoverage` is set, an association
+ *       `art::Assns<icarus::trigger::OpticalTriggerGate::GateData_t, sbn::OpDetWaveformMeta>`
+ *       to the adder waveform metadata; this will have the string `adders`
+ *       appended to the instance name, for consistency with the associations
+ *       of the same trigger gate objects to the PMT waveforms.
+ * 
+ * 
+ * Input data products
+ * ====================
+ * 
+ * * `std::vector<raw::OpDetWaveform>` (`WaveformTag`): a single waveform for
+ *   each recorded optical detector activity; the activity belongs to a single
+ *   channel, but there may be multiple waveforms on the same channel. The time
+ *   stamp is expected to be from the
+ *   @ref DetectorClocksElectronicsTime "electronics time scale" and therefore
+ *   expressed in microseconds.
+ * * `art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>` (`BaselineTag`):
+ *   the baseline associated to each of the input waveforms.
+ * * `art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>` (`WaveformTag`;
+ *   only if `SaveMetaAssns` is set): associations between the input waveforms
+ *   and their metadata (will be used to create associations to the
+ *   discriminated waveforms).
+ * 
+ * 
+ * Service requirements
+ * ---------------------
+ * 
+ * The following services are _required_:
+ * 
+ * * `Geometry` (for window definition)
+ * * an implementation of `detinfo::DetectorClocksService`
+ * * _art_ message facility
+ * 
+ * 
+ * Configuration parameters
+ * =========================
+ * 
+ * A terse description of the parameters is printed by running
+ * `lar --print-description DiscriminatedAdderSignal`.
+ * 
+ * * `WaveformTag` (input tag): the data product containing all optical
+ *   detector waveforms.
+ * * `BaselineTag` (input tag): the data product containing the association
+ *   between each input waveform (`WaveformTag`) and its estimated baseline.
+ * * `WaveformMetaTag` (input tag, optional): the data product containing the
+ *   association between each input waveform (`WaveformTag`) and its metadata;
+ *   if omitted, the tag from `WaveformTag` is used.
+ * * `AmplitudeScale` (real number, default: `1.0`): how much to scale each
+ *   input waveform.
+ * * `TimeInterval` (table, optional): limits the time range of the adders to
+ *   the specified time interval; all time points are _relative to the beam gate
+ *   opening time_. No more than two of the following must be specified:
+ *     * `Start` (time, default: ages ago): start from this time point.
+ *     * `End` (time, default: ages in the future): end at this time point.
+ *     * `Duration` (time, default: ages): duration of the time interval.
+ * * `MissingChannels` (list of integers): list of the PMT channel numbers
+ *   (as reported in the `WaveformTag` input collection) to be excluded.
+ *   Note that in the hardware bad channels may be included in the adder input.
+ * 
+ * * `TriggerGateBuilder` (tool configuration): configuration of the _art_ tool
+ *   used to discriminate the optional waveforms; the tool interface is
+ *   `icarus::trigger::TriggerGateBuilder`.
+ * * `SelectThresholds` (sequence of ADC thresholds): if specified, only the
+ *   waveforms discriminated with the thresholds in this list will be saved
+ *   by the module; if not specified, all the thresholds produced by the
+ *   algorithm will be saved. @note If a requested threshold is not eventually
+ *   produced by the algorithm, an exception will be thrown by the module.
+ * 
+ * * `ChannelOffset` (integer, default: `15000`): this offset is added to the
+ *   channel number of the waveforms of the adders.
+ * * `ChannelsPerAdder` (positive integer, default: `15`): PMT are added in
+ *   groups of this many into each adder channel. The PMT are split in walls
+ *   and then grouped longitudinally. This number must be a divisor of the
+ *   number of PMT on the wall (e.g. in ICARUS there are 90 PMT, so this value
+ *   can only be 1, 2, 3, 5, 6, 9, 10, 15, 18, 30, 45 or 90).
+ * * `SaveWaveforms` (flag, default: `false`): if set, the waveforms from the
+ *   adders are saved, otherwise only the discriminated waveforms are.
+ * * `SavePMTcoverage` (flag, default: `true`): produces a collection of
+ *   `sbn::OpDetWaveformMeta` representing each of the output waveforms; trigger
+ *   tools can use this information in place for the more space-hungry waveforms
+ *   for further processing.
+ * * `SaveMetaAssns` (flag, default: `true`): if set, an association between the
+ *   metadata of the input waveforms (from `WaveformTag`) and the discriminated
+ *   waveforms is also saved.
+ * * `LogCategory` (string, default: `"DiscriminatedAdderSignal"`): label
+ *   for the category of messages in the console output; this is the label
+ *   that can be used for filtering messages via MessageFacility service
+ *   configuration.
+ * 
+ * 
+ */
+class icarus::trigger::DiscriminatedAdderSignal: public art::SharedProducer {
+  
+    public:
+  
+  using microseconds = util::quantities::intervals::microseconds;
+  
+  /// The type of data produced for a single channel.
+  using TriggerGateData_t = icarus::trigger::OpticalTriggerGate::GateData_t;
+  
+  
+  // --- BEGIN Configuration ---------------------------------------------------
+  struct Config {
+    
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    
+    fhicl::Atom<art::InputTag> WaveformTag{
+      Name{ "WaveformTag" },
+      Comment{ "input tag of digitized optical waveform data product" }
+      };
+    
+    fhicl::Atom<art::InputTag> BaselineTag{
+      Name{ "BaselineTag" },
+      Comment{ "input tag for associations between waveforms and baselines" }
+      };
+    
+    fhicl::OptionalAtom<art::InputTag> WaveformMetaTag{
+      Name{ "WaveformMetaTag" },
+      Comment{
+        "input tag for associations between waveforms and metadata"
+        " [default: as WaveformTag]"
+        }
+      };
+    
+    fhicl::Atom<float> AmplitudeScale{
+      Name{ "AmplitudeScale" },
+      Comment{ "scale factor applied to each sample of all input waveforms" },
+      1.0 // default value
+      };
+    
+    fhicl::DelegatedParameter TriggerGateBuilder_{
+      Name{ "TriggerGateBuilder" },
+      Comment{
+        "parameters for generating trigger gates from optical channel output"
+        }
+      };
+    
+    icarus::ns::fhicl::TimeIntervalOptionalTable<microseconds> TimeInterval{
+      Name{ "TimeInterval" },
+      Comment{ "limit the adder time to this interval, relative to beam gate" }
+      };
+    
+    fhicl::OptionalSequence<raw::ADC_Count_t> SelectThresholds{
+      Name{ "SelectThresholds" },
+      Comment{ "thresholds to save (default: all those produced by algorithm)" }
+      };
+    
+    fhicl::Sequence<raw::Channel_t> MissingChannels{
+      Name{ "MissingChannels" },
+      Comment("do not include the specified channels [default: all included]"),
+      std::vector<raw::Channel_t>{}
+      };
+    
+    fhicl::Atom<bool> SaveWaveforms{
+      Name{ "SaveWaveforms" },
+      Comment{ "write a raw::OpDetWaveform for each of the adder boards" },
+      false
+      };
+    
+    fhicl::Atom<bool> SavePMTcoverage{
+      Name{ "SavePMTcoverage" },
+      Comment
+        { "write a sbn::OpDetWaveformMeta collection for adder waveforms" },
+      true
+      };
+    
+    fhicl::Atom<bool> SaveMetaAssns{
+      Name{ "SaveMetaAssns" },
+      Comment{
+        "write associations between discriminated waveforms"
+        " and their input metadata"
+      },
+      true
+      };
+    
+    fhicl::Atom<int> ChannelOffset{
+      Name{ "ChannelOffset" },
+      Comment{ "offset added to the channel number of the adder waveforms" },
+      15000
+      };
+    
+    fhicl::Atom<unsigned int> ChannelsPerAdder{
+      Name{ "ChannelsPerAdder" },
+      Comment{ "number of PMT channels in each adder" },
+      15
+      };
+    
+    fhicl::Atom<std::string> LogCategory{
+      Name{ "LogCategory" },
+      Comment{ "tag of the module output to console via message facility" },
+      "DiscriminatedAdderSignal"
+      };
+    
+  }; // struct Config
+  
+  using Parameters = art::SharedProducer::Table<Config>;
+  
+  // --- END Configuration -----------------------------------------------------
+  
+  
+  explicit DiscriminatedAdderSignal
+    (Parameters const& config, art::ProcessingFrame const& frame);
+  
+  
+  // --- BEGIN Framework hooks -------------------------------------------------
+  
+  /// Creates the data products.
+  virtual void produce(art::Event& event, art::ProcessingFrame const&) override;
+  
+  // --- END Framework hooks ---------------------------------------------------
+  
+  
+    private:
+  
+  using electronics_time = detinfo::timescales::electronics_time;
+  using WaveformWithBaseline = icarus::trigger::WaveformWithBaseline;
+  
+  /// Time interval from an unspecified reference.
+  using RelTimeInterval_t = icarus::ns::util::TimeInterval<microseconds>;
+  
+  /// Time interval in electronics time.
+  using TimeInterval_t = icarus::ns::util::TimeInterval<electronics_time>;
+  
+  /// Map of waveform information records per channel.
+  using WaveformsByChannel_t
+    = icarus::ns::util::GroupByIndex<WaveformWithBaseline>;
+  
+  /// Conversion from ADC# to mV for an ADC sampling 2 V with 14 bits.
+  static constexpr double mVperADC = 2'000. / (1<<14);
+  
+  
+  // --- BEGIN Configuration variables -----------------------------------------
+  
+  art::InputTag const fWaveformTag; ///< Input optical waveform tag.
+  
+  art::InputTag const fBaselineTag; ///< Input waveform baseline tag.
+  
+  art::InputTag const fWaveformMetaTag; ///< Input waveform metadata tag.
+  
+  float const fAmplitudeScale; ///< Scale factor for input waveform amplitude.
+  
+  RelTimeInterval_t const fTimeInterval; ///< Range of time to create adders on.
+  
+  /// Thresholds selected for saving, and their instance name.
+  std::map<icarus::trigger::ADCCounts_t, std::string> fSelectedThresholds;
+  
+  std::vector<raw::Channel_t> const fMissingChannels; ///< Channels to skip.
+  
+  bool const fSaveWaveforms; ///< Whether to save `raw::OpDetWaveform`.
+  
+  bool const fSavePMTcoverage; ///< Whether to save `sbn::OpDetWaveformMeta`.
+  
+  bool const fSaveMetaAssns; ///< Whether to save input waveform associations.
+  
+  int const fAdderChannelOffset; ///< Channel number offset for adder waveforms.
+  
+  unsigned int const fChannelsPerAdder; ///< Channels per adder.
+  
+  
+  std::string const fLogCategory; ///< Category name for the console output stream.
+  
+  // --- END Configuration variables -------------------------------------------
+  
+  
+  // --- BEGIN Algorithms ------------------------------------------------------
+  
+  /// Algorithms to simulate trigger gates out of optical channel output.
+  std::unique_ptr<icarus::trigger::TriggerGateBuilder> fTriggerGateBuilder;
+  
+  // --- END Algorithms --------------------------------------------------------
+  
+  
+  // --- BEGIN Service variables -----------------------------------------------
+  
+  geo::GeometryCore const& fGeom; ///< Cached geometry service provider.
+  
+  microseconds const fOpticalTick; ///< Duration of an optical tick.
+  
+  // --- END Service variables -------------------------------------------------
+  
+  
+  /// Suffix used for the instance name of some data products.
+  static std::string const AdderDataProductSuffix;
+  
+  /// Suffix used for the instance name of some data products.
+  static std::string const PMTDataProductSuffix;
+  
+  
+  /**
+   * @brief Returns the samples of a waveform added from the specified ones.
+   * @param timeInterval the interval to constrain the waveform into
+   * @param waveforms the list of waveforms (plus baseline) to include
+   * @param channel (default: max possible value) channel number to assign
+   * @return the added waveform and the list of the contributing waveforms
+   * 
+   * The returned waveform starts at either `timeInterval.start` or the
+   * earliest of the specified waveform start times. Likewise, the waveform ends
+   * at either `timeInterval.end` or the latest of the waveform end times.
+   * 
+   * The input waveforms are assumed to be grouped by channel: each entry in
+   * `waveforms` is assumed to be the list of pointers to information records
+   * for all the relevant waveform on the same channel (empty lists are ignored,
+   * and there is no way to know which channel they might have belonged to).
+   * 
+   * This function uses `computeTimeInterval()` to determine the actual time
+   * interval that the added waveform needs to cover, and it performs the
+   * addition with `addWaveformsInInterval()`. See the documentation of those
+   * methods for additional details.
+   * The returned list includes all and only the waveforms which have at least
+   * one sample in the requested time interval.
+   */
+  std::pair<raw::OpDetWaveform, std::vector<WaveformWithBaseline const*>>
+  makeAdderWaveform(
+    TimeInterval_t const& timeInterval,
+    std::vector<std::vector<WaveformWithBaseline const*>> const& waveforms,
+    raw::Channel_t channel = std::numeric_limits<raw::Channel_t>::max()
+    ) const;
+  
+  /**
+   * @brief Removes the channels configured as missing from a `channelList`.
+   * @param channels the list of channels (see the description)
+   * @return `channels` list except for the "missing" ones
+   */
+  void removeChannels(std::vector<raw::Channel_t>& channels) const;
+  
+  /// Returns whether `channel` is in the configured missing channel list.
+  bool isMissingChannel(raw::Channel_t channel) const;
+  
+  /**
+   * @brief Returns the time interval where the `waveforms` should be added.
+   * @param waveforms the input waveforms, grouped by channel
+   * @param timeInterval the interval outside we are not interested in adding
+   * @return a time interval where addition should happen
+   * 
+   * The `waveforms` are specified as lists of pointers to waveform information
+   * records, each list pertaining a single channel.
+   * The information used from the record is the timestamp and the number of
+   * samples, both learnt from the optical waveform object.
+   * 
+   * The returned interval is guaranteed to be fully covered with data from all
+   * the channels in the input, and it never extends beyond `timeInterval`.
+   * It is possible that there is no sample available at all, in which case the
+   * returned interval is empty (starting and ending at `timeInterval.start`).
+   */
+  TimeInterval_t computeTimeInterval(
+    std::vector<std::vector<WaveformWithBaseline const*>> const& waveforms,
+    TimeInterval_t const& timeInterval
+    ) const;
+  
+  
+  /**
+   * @brief Returns the samples of a waveform added from the specified ones.
+   * @param timeInterval the interval to fill
+   * @param waveforms the list of waveforms (plus baseline) to include
+   * @param channel (default: max possible value) channel number to assign
+   * @return the added waveform and the list of the contributing waveforms
+   * 
+   * The returned waveform exactly covers the `timeInterval`.
+   * The input waveforms are assumed to be grouped by channel: each entry in
+   * `waveforms` is assumed to be the list of pointers to information records
+   * for all the relevant waveform on the same channel (empty lists are ignored,
+   * and there is no way to know which channel they might have belonged to).
+   * The returned list includes all and only the waveforms which have at least
+   * one sample in the requested time interval.
+   * 
+   * It is assumed that for each channel _one_ of the input `waveforms` covers
+   * the whole `timeInterval`.
+   */
+  std::pair<std::valarray<float> , std::vector<WaveformWithBaseline const*>>
+  addWaveformsInInterval(
+    TimeInterval_t const& timeInterval,
+    std::vector<std::vector<WaveformWithBaseline const*>> const& waveforms,
+    raw::Channel_t channel = std::numeric_limits<raw::Channel_t>::max()
+    ) const;
+
+  /// Packs the specified `samples` at `startTime` into a `raw::OpDetWaveform`.
+  template <typename Samples>
+  raw::OpDetWaveform packWaveform
+    (raw::Channel_t channel, electronics_time startTime, Samples const& samples)
+    const;
+
+  /// Returns the interval covered by the `waveform`, in electronics time.
+  TimeInterval_t waveformTimeCoverage(raw::OpDetWaveform const& waveform) const;
+  
+  /**
+   * @brief Returns the PMT channel composition of each adder window.
+   * @param geom LArSoft geometry service provider
+   * @return a list of adder windows, each with it list of contributing channels
+   * 
+   * Windows are defined as groups of 15 channels.
+   * The `MissingChannels` are not included in any window.
+   */
+  icarus::trigger::TriggerWindowDefs_t createAdderWindows
+    (geo::GeometryCore const& geom) const;
+  
+  /// Returns a map channel -> waveforms on that channel.
+  /// If `waveformInfo` changes, the returned map becomes invalid.
+  static WaveformsByChannel_t groupByChannel
+    (std::vector<WaveformWithBaseline> const& waveformInfo);
+  
+  /// Returns the number of optical ticks from `start` to `stop`.
+  template <typename StartTime, typename StopTime>
+  std::ptrdiff_t tickDistance(StartTime start, StopTime time) const;
+  
+  /// Returns a crude baseline estimation at the first `interval` and at the
+  /// last one. The baseline is just the arithmetic average.
+  /// This method takes the `begin` and `end` iterator to the waveform data.
+  template <typename BIter, typename EIter>
+  std::pair<double, double> computeSimpleBaselines
+    (BIter begin, EIter end, microseconds interval) const;
+  
+  /// Returns a crude baseline estimation at the first `interval` and at the
+  /// last one. The baseline is just the arithmetic average.
+  /// This method takes the whole `waveform` data collection.
+  template <typename Waveform>
+  std::pair<double, double> computeSimpleBaselines
+    (Waveform const& added, microseconds interval) const;
+  
+  /// Converts an ADC count into voltage of a 14 bit ADC, 2 V peak-to-peak.
+  template <typename T>
+  static constexpr util::quantities::millivolt to_mV
+    (util::quantities::counts_as<T> ADC)
+    { return (double(ADC.value()) / (1<<14)) * util::quantities::volt{ 2.0 }; }
+  
+}; // icarus::trigger::DiscriminatedAdderSignal
+
+
+
+//------------------------------------------------------------------------------
+//--- Implementation
+//------------------------------------------------------------------------------
+namespace {
+  
+  /// Appends a copy of all the elements of `src` into `dest`. Returns `dest`.
+  template <typename DestColl, typename SrcColl>
+  DestColl& append(DestColl& dest, SrcColl const& src);
+  
+  /// Moves all the elements of `src` at the end of `dest`. Returns `dest`.
+  template <typename DestColl, typename SrcColl>
+  DestColl& append(DestColl& dest, SrcColl&& src);
+  
+  /// Returns a `std::vector` with the results of `op` on each of `src`.
+  // C++20: this is probably a single range operation
+  template <typename SrcColl, typename Func>
+  auto transformColl(SrcColl const& src, Func&& op)
+    {
+      using Result_t = std::decay_t
+        <decltype(op(std::declval<typename SrcColl::value_type>()))>;
+      using DestColl = std::vector<Result_t>;
+      DestColl dest;
+      std::transform(begin(src), end(src), back_inserter(dest), op);
+      return dest;
+    } // transformColl()
+  
+  
+  template <typename T>
+  std::unique_ptr<T> moveToUniquePtr(T& obj)
+    { return std::make_unique<T>(std::move(obj)); }
+  
+  /// Returns a copy of the collection `coll`, sorted by `std::sort()`.
+  template <typename Coll>
+  Coll sorted(Coll coll)
+    {
+      Coll sortedColl{ coll };
+      std::sort(begin(sortedColl), end(sortedColl));
+      return sortedColl;
+    }
+  
+} // local namespace
+
+
+//------------------------------------------------------------------------------
+//--- icarus::trigger::DiscriminatedAdderSignal
+//------------------------------------------------------------------------------
+std::string const
+icarus::trigger::DiscriminatedAdderSignal::AdderDataProductSuffix{ "adder" }; 
+std::string const
+icarus::trigger::DiscriminatedAdderSignal::PMTDataProductSuffix{ "" };
+
+
+//------------------------------------------------------------------------------
+icarus::trigger::DiscriminatedAdderSignal::DiscriminatedAdderSignal
+  (Parameters const& config, art::ProcessingFrame const& frame)
+  : art::SharedProducer{ config }
+  // configuration
+  , fWaveformTag       { config().WaveformTag()      }
+  , fBaselineTag       { config().BaselineTag()      }
+  , fWaveformMetaTag   { config().WaveformMetaTag().value_or(fWaveformTag) }
+  , fAmplitudeScale    { config().AmplitudeScale()   }
+  , fTimeInterval
+    {
+      icarus::ns::fhicl::makeTimeInterval(config().TimeInterval())
+        .value_or(RelTimeInterval_t{})
+    }
+  , fMissingChannels   { sorted(config().MissingChannels()) }
+  , fSaveWaveforms     { config().SaveWaveforms()    }
+  , fSavePMTcoverage   { config().SavePMTcoverage()  }
+  , fSaveMetaAssns     { config().SaveMetaAssns()    }
+  , fAdderChannelOffset{ config().ChannelOffset()    }
+  , fChannelsPerAdder  { config().ChannelsPerAdder() }
+  , fLogCategory       { config().LogCategory()      }
+  , fTriggerGateBuilder{
+      art::make_tool<icarus::trigger::TriggerGateBuilder>
+        (config().TriggerGateBuilder_.get<fhicl::ParameterSet>())
+    }
+  // service cache
+  , fGeom              { *lar::providerFrom<geo::Geometry>() }
+  , fOpticalTick       {
+    detinfo::makeDetectorClocksWithUnits
+      (art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob())
+      .OpticalClockPeriod()
+    }
+{
+  async<art::InEvent>();
+  
+  //
+  // optional configuration parameters
+  //
+  if (fTimeInterval.empty()) {
+    throw art::Exception{ art::errors::Configuration }
+      << "The '" << config().TimeInterval.name()
+      << "' parameters configures an empty time interval [ "
+      << fTimeInterval.start << " -- " << fTimeInterval.stop << " ]\n";
+  }
+  
+  //
+  // configuration post-processing
+  //
+  std::vector<raw::ADC_Count_t> selectedThresholds;
+  if (!config().SelectThresholds(selectedThresholds)) {
+    std::vector<ADCCounts_t> const& allThresholds
+      = fTriggerGateBuilder->channelThresholds();
+    
+    if (allThresholds.empty()) {
+      throw art::Exception{ art::errors::Configuration }
+        << "Trigger building algorithm reports no threshold!\n"
+        << "Check the configuration of `TriggerGateBuilder` tool.\n";
+    }
+    selectedThresholds = transformColl
+      (allThresholds, std::mem_fn(&icarus::trigger::ADCCounts_t::value));
+  }
+  else if (selectedThresholds.empty()) {
+    throw art::Exception{ art::errors::Configuration }
+      << "Configured to save no thresholds!\n"
+      << "Add values to the `SelectThresholds` configuration parameter.\n";
+  }
+  
+  for (auto const& threshold: selectedThresholds) {
+    fSelectedThresholds[icarus::trigger::ADCCounts_t{threshold}]
+      = util::to_string(threshold);
+  }
+  
+  {
+    mf::LogInfo log(fLogCategory);
+    log << "Configuration:"
+      << "\n * time interval: [ "
+        << fTimeInterval.start << " - " << fTimeInterval.stop << " ]"
+      << "\n * selected thresholds:"
+      ;
+    for (auto const& [ threshold, instance ]: fSelectedThresholds) {
+      log << " " << threshold << " ADC = " << to_mV(threshold)
+        << " (\"" << instance << "\")";
+    }
+  } // nameless block
+  
+  //
+  // declaration of input
+  //
+  consumes<std::vector<raw::OpDetWaveform>>(fWaveformTag);
+  consumes<art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>>
+    (fBaselineTag);
+  if (fSaveMetaAssns) {
+    consumes<art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>>
+      (fWaveformMetaTag);
+  }
+  
+  //
+  // declaration of output
+  //
+  
+  if (fSaveWaveforms) {
+    produces<std::vector<raw::OpDetWaveform>>();
+    produces<std::vector<icarus::WaveformBaseline>>();
+    produces<art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>>();
+  }
+  if (fSavePMTcoverage) {
+    produces<std::vector<sbn::OpDetWaveformMeta>>();
+    if (fSaveWaveforms)
+      produces<art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta>>();
+  }
+  for (std::string const& instanceName: util::const_values(fSelectedThresholds))
+  {
+    produces<std::vector<TriggerGateData_t>>(instanceName);
+    produces<art::Assns<TriggerGateData_t, raw::OpDetWaveform>>
+      (instanceName + PMTDataProductSuffix);
+    if (fSaveMetaAssns) {
+      produces<art::Assns<TriggerGateData_t, sbn::OpDetWaveformMeta>>
+        (instanceName + PMTDataProductSuffix);
+    }
+    if (fSaveWaveforms) {
+      produces<art::Assns<TriggerGateData_t, raw::OpDetWaveform>>
+        (instanceName + AdderDataProductSuffix);
+    } // if saving waveforms
+    if (fSavePMTcoverage) {
+      produces<art::Assns<TriggerGateData_t, sbn::OpDetWaveformMeta>>
+        (instanceName + AdderDataProductSuffix);
+    } // if saving waveform metadata
+  } // for thresholds
+  
+} // icarus::trigger::DiscriminatedAdderSignal::DiscriminatedAdderSignal()
+
+
+//------------------------------------------------------------------------------
+void icarus::trigger::DiscriminatedAdderSignal::produce
+  (art::Event& event, art::ProcessingFrame const&)
+{
+  
+  //
+  // set up the algorithm to create the trigger gates
+  //
+  detinfo::DetectorTimings const detTimings {
+    art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(event)
+    };
+  fTriggerGateBuilder->resetup(detTimings);
+  mf::LogDebug{ fLogCategory }
+    << "Trigger at " << detTimings.TriggerTime() << ", "
+    << (detTimings.TriggerTime() - detTimings.BeamGateTime())
+    << " after beam gate opened at " << detTimings.BeamGateTime();
+  
+  //
+  // prepare input
+  //
+  auto const& waveformHandle
+    = event.getValidHandle<std::vector<raw::OpDetWaveform>>(fWaveformTag);
+  auto const& waveforms = *waveformHandle;
+  
+  // retrieve the baseline information
+  art::FindOne<icarus::WaveformBaseline> const waveformBaselines
+    { waveformHandle, event, fBaselineTag };
+  
+  // attach to each waveform additional information: baseline
+  std::vector<WaveformWithBaseline> waveformInfo;
+  waveformInfo.reserve(waveforms.size());
+  for (auto const& [ iWaveform, waveform ]: util::enumerate(waveforms)) {
+    cet::maybe_ref<icarus::WaveformBaseline const> const baseline
+      { waveformBaselines.at(iWaveform) };
+    if (!baseline) {
+      throw art::Exception{ art::errors::NotFound }
+        << "No baseline ('" << fBaselineTag.encode()
+        << "') found for waveform #" << iWaveform << " (channel="
+        << waveform.ChannelNumber() << " time=" << waveform.TimeStamp()
+        << ").\n";
+    }
+    waveformInfo.emplace_back(&waveform, &(baseline.ref()));
+  }
+  
+  // returns a art pointer to the waveform of `wi`
+  auto PMTwaveformInfoPtr
+    = [handle=waveformHandle, firstWF=&(waveformHandle->front())]
+      (WaveformWithBaseline const* wi)
+    {
+      return art::Ptr<raw::OpDetWaveform>(handle, wi->waveformPtr() - firstWF);
+    };
+  
+  mf::LogDebug{ fLogCategory }
+    << "Addition of " << waveforms.size() << " PMT waveforms from '"
+    << fWaveformTag.encode() << "' with baselines from '"
+    << fBaselineTag.encode() << "'";
+  
+  //
+  // define the time interval
+  //
+  TimeInterval_t const timeInterval{
+    detTimings.BeamGateTime() + fTimeInterval.start,
+    detTimings.BeamGateTime() + fTimeInterval.stop
+    };
+  
+  //
+  // define the adder windows in terms of contributing channels;
+  // this implicitly defines the channel number
+  //
+  icarus::trigger::TriggerWindowDefs_t const adderChannels
+    = createAdderWindows(fGeom);
+  
+  //
+  // create adder waveforms
+  //
+  // We need to create it in a format that `TriggerGateBuilder::build()`
+  // is happy with, that is a pointer to waveform plus pointer to baseline;
+  // even if the baselines are all `0`, we need them in a stable data object
+  
+  WaveformsByChannel_t const waveformInfoByChannel
+    = groupByChannel(waveformInfo);
+  
+  auto const isMissing = [&missing=fMissingChannels](raw::Channel_t channel)
+    { return std::binary_search(missing.cbegin(), missing.cend(), channel); };
+  std::vector<raw::OpDetWaveform> adderWaveforms;
+  std::vector<icarus::WaveformBaseline> adderWaveformBaselines; // quite a dummy
+  std::vector<WaveformWithBaseline> adderWaveformInfo;
+  std::vector<std::vector<art::Ptr<raw::OpDetWaveform>>>
+    adderWaveformContribPtrs;
+  // preallocate all the space we need
+  adderWaveforms.reserve(adderChannels.size());
+  adderWaveformBaselines.reserve(adderChannels.size());
+  for (auto const& [ window, windowChannels ]: util::enumerate(adderChannels)) {
+    
+    raw::Channel_t const adderChannel = fAdderChannelOffset + window;
+    
+    mf::LogTrace log{ fLogCategory };
+    log << "Collecting waveforms for adder channel " << adderChannel << " from "
+      << windowChannels.size() << " channels on window " << window << ":";
+    std::vector<std::vector<WaveformWithBaseline const*>> inputWaveforms;
+    for (raw::Channel_t const ch: windowChannels) {
+      if (isMissing(ch)) {
+        // these should have been already filtered out by `createAdderWindows()`
+        log << " (!" << ch << ")";
+        continue;
+      }
+      inputWaveforms.push_back(waveformInfoByChannel[ch]);
+      log << " " << ch;
+      if (auto nCh = waveformInfoByChannel[ch].size(); nCh != 1)
+        log << " [x" << nCh << "]";
+    }
+    
+    auto [ waveform, waveformContribs ] = makeAdderWaveform
+      (timeInterval, inputWaveforms, adderChannel);
+    
+    adderWaveforms.push_back(std::move(waveform));
+    adderWaveformBaselines.emplace_back(0);
+    // the preallocation of the two vectors guarantees that the pointers
+    // are not going to be invalidated by a vector resize
+    adderWaveformInfo.emplace_back
+      (&adderWaveforms.back(), &adderWaveformBaselines.back());
+    
+    std::vector<art::Ptr<raw::OpDetWaveform>> waveformContribPtrs
+      = transformColl(waveformContribs, PMTwaveformInfoPtr);
+    
+    adderWaveformContribPtrs.push_back(std::move(waveformContribPtrs));
+    
+  } // for adder windows
+  
+  //
+  // discrimination (all thresholds at once)
+  //
+  
+  // this is a collection where each entry (of type `TriggerGates`) contains
+  // the complete set of trigger gates for an event for a given threshold.
+  std::vector<icarus::trigger::TriggerGateBuilder::TriggerGates>
+    triggerGatesByThreshold = fTriggerGateBuilder->build(adderWaveformInfo);
+  
+  using TriggerGates_t = icarus::trigger::TriggerGateBuilder::TriggerGates;
+  
+  { // nameless block
+    mf::LogTrace log(fLogCategory);
+    log << "Trigger gates from " << triggerGatesByThreshold.size()
+      << " thresholds:\n";
+    for (TriggerGates_t const& triggerGates: triggerGatesByThreshold)
+      triggerGates.dump(log);
+    
+  } // nameless block
+  
+  // fix the channels in the gates: they contain the adder waveform channel,
+  // we want the contributing PMT channels
+  // (also because that will be needed when simulating a trigger)
+  std::vector<std::pair<ADCCounts_t, std::vector<TriggerGateData_t>>>
+    adderGatesAndThresholds;
+  adderGatesAndThresholds.reserve(triggerGatesByThreshold.size());
+  for (TriggerGates_t& triggerGates: triggerGatesByThreshold) {
+    std::vector<TriggerGateData_t> thresholdAdders;
+    for(
+      auto const& [ adderWaveform, contribs ]
+      : util::zip(adderWaveforms, adderWaveformContribPtrs)
+    ) {
+      assert(triggerGates.getGateFor(adderWaveform)); // must already exist
+      
+      // tracking is used to keep a record of contributing waveforms from the
+      // same channel; this does not apply here because only the adder "channel"
+      // is contributing, and only with a single waveform (if we wished to
+      // emulate trigger primitives from adders, it would be a  different story)
+      // ... so we drop tracking without looking back
+      
+      TriggerGateData_t gate; // no channel list yet  // ... so we drop it
+      // this assigns only the gate data ("levels"), not affecting its channels
+      gate = std::move(triggerGates.gateFor(adderWaveform).gate().gateLevels());
+      // we want to set the list of channels in the trigger gate
+      // to the one of the contributing PMT channels (not the adder "channel")
+      for (art::Ptr<raw::OpDetWaveform> const& waveform: contribs)
+        gate.addChannel(waveform->ChannelNumber());
+      
+      thresholdAdders.push_back(std::move(gate));
+    } // for discriminated adder
+    
+    adderGatesAndThresholds.emplace_back
+      (triggerGates.threshold(), std::move(thresholdAdders));
+    
+  } // for threshold
+  
+  
+  //
+  // prepare output
+  //
+  auto const makeAdderPtr = fSaveWaveforms
+    ? std::optional<art::PtrMaker<raw::OpDetWaveform>>{ event }: std::nullopt;
+  auto const makeAdderMetaPtr = fSavePMTcoverage
+    ? std::optional<art::PtrMaker<sbn::OpDetWaveformMeta>>{ event }
+    : std::nullopt;
+  
+  // more input: needed only to save associations to input waveform metadata
+  std::optional<art::FindOneP<sbn::OpDetWaveformMeta>> waveformToMeta
+    = fSaveMetaAssns
+    ? std::make_optional<art::FindOneP<sbn::OpDetWaveformMeta>>
+      (waveformHandle, event, fWaveformMetaTag)
+    : std::nullopt
+    ;
+  for (auto& [ thr, discrGates ]: adderGatesAndThresholds) {
+    
+    // find the threshold and its label, if we care of it
+    auto const iThr = fSelectedThresholds.find(thr);
+    if (iThr == fSelectedThresholds.end()) continue; // not interested
+    
+    std::string const& instanceName = iThr->second;
+    art::PtrMaker<TriggerGateData_t> const makeGatePtr(event, instanceName);
+    
+    art::Assns<TriggerGateData_t, raw::OpDetWaveform> discrToAdderContrib;
+    art::Assns<TriggerGateData_t, sbn::OpDetWaveformMeta>
+      discrToAdderContribMeta;
+    art::Assns<TriggerGateData_t, raw::OpDetWaveform> discrToAdder;
+    art::Assns<TriggerGateData_t, sbn::OpDetWaveformMeta> discrToAdderMeta;
+    for(
+      auto const& [ iAdder, contribs ]
+      : util::enumerate(adderWaveformContribPtrs)
+    ) {
+      art::Ptr<TriggerGateData_t> const gatePtr{ makeGatePtr(iAdder) };
+      
+      // associations: discriminated adder waveforms <=> input waveforms
+      discrToAdderContrib.addMany(gatePtr, contribs);
+      // associations: discriminated adder waveforms <=> input waveform metadata
+      if (fSaveMetaAssns) {
+        assert(waveformToMeta);
+        for (art::Ptr<raw::OpDetWaveform> const& contribPtr: contribs) {
+          discrToAdderContribMeta.addSingle
+            (gatePtr, waveformToMeta->at(contribPtr.key()));
+        }
+      }
+      
+      // associations: discriminated adder waveforms <=> adder waveforms
+      if (fSaveWaveforms) {
+        assert(makeAdderPtr);
+        discrToAdder.addSingle(gatePtr, (*makeAdderPtr)(iAdder));
+      }
+      
+      // associations: discriminated adder waveforms <=> adder waveform metadata
+      if (fSavePMTcoverage) {
+        assert(makeAdderMetaPtr);
+        discrToAdderMeta.addSingle(gatePtr, (*makeAdderMetaPtr)(iAdder));
+      }
+      
+    } // for adder waveforms
+    
+    event.put(
+      moveToUniquePtr(discrToAdderContrib), instanceName + PMTDataProductSuffix
+      );
+    
+    if (fSaveMetaAssns) {
+      event.put(
+        moveToUniquePtr(discrToAdderContribMeta),
+        instanceName + PMTDataProductSuffix
+        );
+    }
+    
+    if (fSaveWaveforms) {
+      event.put
+        (moveToUniquePtr(discrToAdder), instanceName + AdderDataProductSuffix);
+    }
+    
+    if (fSavePMTcoverage) {
+      event.put(
+        moveToUniquePtr(discrToAdderMeta), instanceName + AdderDataProductSuffix
+        );
+    }
+
+    // discriminated adder waveforms
+    event.put(moveToUniquePtr(discrGates), instanceName);
+    
+  } // for all extracted thresholds
+  
+  if (fSavePMTcoverage) {
+    assert(makeAdderMetaPtr);
+    
+    if (fSaveWaveforms) {
+      assert(adderWaveformMeta.size() == adderWaveforms.size());
+      assert(makeAdderPtr);
+      
+      art::PtrMaker<icarus::WaveformBaseline> const makeAdderBaselinePtr
+        { event };
+      
+      // associations: adder waveforms <=> adder waveform metadata,
+      //                               <=> adder waveform baselines
+      art::Assns<raw::OpDetWaveform, sbn::OpDetWaveformMeta> adderWaveformAssns;
+      art::Assns<raw::OpDetWaveform, icarus::WaveformBaseline>
+        adderWaveformBaselineAssns;
+      for (std::size_t const i: util::counter(adderWaveforms.size())) {
+        art::Ptr<raw::OpDetWaveform> const adderPtr = (*makeAdderPtr)(i);
+        adderWaveformAssns.addSingle(adderPtr, (*makeAdderMetaPtr)(i));
+        adderWaveformBaselineAssns.addSingle(adderPtr, makeAdderBaselinePtr(i));
+      }
+      event.put(moveToUniquePtr(adderWaveformBaselines));
+      event.put(moveToUniquePtr(adderWaveformAssns));
+      event.put(moveToUniquePtr(adderWaveformBaselineAssns));
+      
+    } // if also save adder waveforms
+    
+    // adder waveform metadata
+    std::vector<sbn::OpDetWaveformMeta> adderWaveformMeta
+     = transformColl(adderWaveforms, sbn::OpDetWaveformMetaMaker{ detTimings });
+    event.put(moveToUniquePtr(adderWaveformMeta));
+    
+  } // if save metadata
+  
+  if (fSaveWaveforms) {
+    // adder waveforms
+    event.put(moveToUniquePtr(adderWaveforms));
+  }
+  
+} // icarus::trigger::DiscriminatedAdderSignal::produce()
+
+
+//------------------------------------------------------------------------------
+void icarus::trigger::DiscriminatedAdderSignal::removeChannels
+  (std::vector<raw::Channel_t>& channels) const
+{
+  auto isMissing
+    = [this](raw::Channel_t channel){ return isMissingChannel(channel); };
+  auto itEnd = std::remove_if(channels.begin(), channels.end(), isMissing);
+  channels.erase(itEnd, channels.end());
+} // icarus::trigger::DiscriminatedAdderSignal::removeChannels()
+
+
+//------------------------------------------------------------------------------
+bool icarus::trigger::DiscriminatedAdderSignal::isMissingChannel
+  (raw::Channel_t channel) const
+{
+  return std::binary_search
+    (fMissingChannels.cbegin(), fMissingChannels.cend(), channel);
+}
+
+
+//------------------------------------------------------------------------------
+auto icarus::trigger::DiscriminatedAdderSignal::makeAdderWaveform(
+  TimeInterval_t const& timeInterval,
+  std::vector<std::vector<WaveformWithBaseline const*>> const& waveforms,
+  raw::Channel_t channel /* = std::numeric_limits<raw::Channel_t>::max() */
+) const
+  -> std::pair<raw::OpDetWaveform, std::vector<WaveformWithBaseline const*>>
+{
+  
+  // decide the time range: largest sub-interval of timeInterval where all the
+  // input waveforms have information.
+  TimeInterval_t const adderTimeInterval
+    = computeTimeInterval(waveforms, timeInterval);
+  auto [ added, contribs ]
+    = addWaveformsInInterval(adderTimeInterval, waveforms, channel);
+  
+  raw::OpDetWaveform waveform
+    = packWaveform(channel, timeInterval.start, added);
+  
+  {
+    auto const [ startBaseline, endBaseline ]
+      = computeSimpleBaselines(added, 500_ns);
+    float const peak
+      = startBaseline - *std::min_element(begin(added), end(added));
+    mf::LogTrace log{ fLogCategory };
+    log << "Adder waveform CH=" << waveform.ChannelNumber()
+      << " created from " << contribs.size() << " waveforms: "
+      << waveform.size() << " samples starting at timestamp="
+      << waveform.TimeStamp();
+    if (!waveform.empty()) {
+      auto const [ itMinADC, itMaxADC ]
+        = std::minmax_element(waveform.cbegin(), waveform.cend());
+      electronics_time const minTime = timeInterval.start
+        + fOpticalTick * std::distance(waveform.cbegin(), itMinADC);
+      log << ", range [ " << *itMaxADC << " to " << *itMinADC
+        << " ] ADC (peak at " << minTime << ")";
+    }
+    log << "\n  adder baseline at start " << startBaseline
+      << " ADC, at end " << endBaseline << " ADC, peak: "
+      << peak << " ADC = " << to_mV(util::quantities::counts_f{ peak });
+  }
+  
+  return { std::move(waveform), std::move(contribs) };
+  
+} // icarus::trigger::DiscriminatedAdderSignal::makeAdderWaveform()
+
+
+//------------------------------------------------------------------------------
+auto icarus::trigger::DiscriminatedAdderSignal::computeTimeInterval(
+  std::vector<std::vector<WaveformWithBaseline const*>> const& waveforms,
+  TimeInterval_t const& timeInterval
+) const -> TimeInterval_t {
+  /*
+   * If we are willing to make up data (e.g. assigning samples of value `0` to
+   * the ticks that are not covered by any waveform in a channel), we can then
+   * exactly will the required `timeInterval`, with the caveat that we need
+   * still to supply the limits that the `timeInterval` does not specify
+   * (e.g. if `timeInterval.end` is "infinite", we may replace it with the last
+   * waveform time end).
+   * 
+   * If we are not willing to make up data, then we need to trim the allowed
+   * interval so that all channels have data in it. This is a more complicate
+   * choice in that it requires an "and" of all the coverage in each channel,
+   * in conjunction with the required `timeInterval`, and this and may also end
+   * up being not contiguous, in which case a choice must be made since only a
+   * single contiguous interval is accepted (with the premise above that we
+   * don't want to fill the gaps with made up data).
+   */
+  using TimeCoverage_t = icarus::trigger::TriggerGateData
+    <electronics_time, detinfo::timescales::time_interval>;
+  
+  //
+  // 1. determine all the time sub-intervals within `timeInterval` covered by
+  //    all channels
+  //
+  TimeCoverage_t coverage;
+  coverage.setOpeningAt(TimeCoverage_t::MinTick, 1U); // start always open
+
+  mf::LogTrace{ fLogCategory } << "Coverage within " << timeInterval
+    << " (only channels narrowing it are listed):";
+  for (std::vector<WaveformWithBaseline const*> const& chWaveforms: waveforms) {
+    
+    TimeCoverage_t chCoverage;
+    
+    for (WaveformWithBaseline const* wi: chWaveforms) {
+      TimeInterval_t wInterval = waveformTimeCoverage(wi->waveform());
+      assert(!wInterval.empty());
+      
+      // trim to the allowed` timeInterval`; we don't assume `wi` time ordering
+      wInterval.intersect(timeInterval);
+      if (wInterval.empty()) continue;
+      
+      chCoverage.openBetween(wInterval.start, wInterval.stop);
+    } // for waveforms in channel
+    
+    if (chWaveforms.empty()) {
+      mf::LogTrace{ fLogCategory } << " - no waveform in channel";
+    }
+    else if (chCoverage != coverage) {
+      mf::LogTrace{ fLogCategory } << " - channel "
+        << chWaveforms.front()->waveform().ChannelNumber()
+        << " with " << chWaveforms.size() << " waveforms => " << chCoverage;
+    }
+    coverage = icarus::trigger::GateOps::Mul(coverage, chCoverage);
+    
+  } // for channels
+  mf::LogTrace{ fLogCategory } << "Total coverage from " << waveforms.size()
+    << " channels: " << coverage;
+  
+  //
+  // 2. if there are multiple non-contiguous sub-intervals, pick the widest one
+  //
+  auto nextWindow
+    = [](TimeCoverage_t const& coverage, TimeInterval_t const& prev)
+    {
+      TimeInterval_t next;
+      next.start = coverage.findOpen(1, prev.stop);
+      if (next.start == TimeCoverage_t::MaxTick) return TimeInterval_t{};
+      next.stop = coverage.findClose(1, next.start);
+      return next;
+    };
+  
+  TimeInterval_t interval{ timeInterval.start };
+  auto duration = interval.duration();
+  TimeInterval_t runningWindow{ TimeCoverage_t::MinTick };
+  while (true) {
+    runningWindow = nextWindow(coverage, runningWindow);
+    if (runningWindow.empty()) break; // no more openings left
+    assert(runningWindow.end != TimeCoverage_t::MaxTick);
+    
+    auto const windowDuration = runningWindow.duration();
+    if (duration > windowDuration) continue; // smaller window, discarded
+    duration = windowDuration;
+    interval = runningWindow;
+  } // while
+  
+  return interval;
+} // icarus::trigger::DiscriminatedAdderSignal::computeTimeInterval()
+
+
+//------------------------------------------------------------------------------
+auto icarus::trigger::DiscriminatedAdderSignal::addWaveformsInInterval(
+  TimeInterval_t const& timeInterval,
+  std::vector<std::vector<WaveformWithBaseline const*>> const& waveforms,
+  raw::Channel_t channel /* = std::numeric_limits<raw::Channel_t>::max() */
+) const
+  -> std::pair<std::valarray<float> , std::vector<WaveformWithBaseline const*>>
+{
+  
+  std::size_t const nSamples = timeInterval.empty()
+    ? 0: tickDistance(timeInterval.start, timeInterval.stop);
+  
+  std::valarray<float> added(0.0f, nSamples);
+  std::vector<WaveformWithBaseline const*> used;
+  
+  mf::LogTrace{ fLogCategory } << "Building adder waveform CH=" << channel
+    << ", " << nSamples << " sample long, at interval " << timeInterval
+    << " from " << waveforms.size() << " channels";
+  
+  for (std::vector<WaveformWithBaseline const*> const& chWaveforms: waveforms) {
+    
+    for (WaveformWithBaseline const* wi: chWaveforms) {
+      
+      TimeInterval_t const wfCoverage = waveformTimeCoverage(wi->waveform());
+      
+      if (!wfCoverage.contains(timeInterval.start)) continue;
+      // in this approach, we assume that one of the selected waveforms covers
+      // the whole interval (if it were more, there would be a gap, and this
+      // algorithm should have carved an interval where no channel has gaps)
+      assert(wfCoverage.contains(timeInterval.stop));
+      
+      // add (minus baseline)
+      std::ptrdiff_t const startSample
+        = tickDistance(wfCoverage.start, timeInterval.start);
+      
+      auto itSample = std::next(wi->waveform().cbegin(), startSample);
+      for (float& sample: added) sample += *(itSample++);
+      
+      if (wi->hasBaseline()) added -= wi->baseline().baseline();
+      
+      { // --- BEGIN -- DEBUG --------------------------------------------------
+        auto const [ startBaseline, endBaseline ]
+          = computeSimpleBaselines(wi->waveform(), 500_ns);
+        auto const itLowest
+          = std::min_element(wi->waveform().begin(), wi->waveform().end());
+        raw::ADC_Count_t const lowest = *itLowest;
+        electronics_time const lowestTime = wfCoverage.start
+          + fOpticalTick * std::distance(wi->waveform().begin(), itLowest);
+        mf::LogTrace log{ fLogCategory };
+        log << " - from ch=" << std::setw(3) << wi->waveform().ChannelNumber()
+          << ", " << wfCoverage
+          << ", sample=" << std::setw(5) << startSample << ", baseline: ";
+        if (wi->hasBaseline()) {
+          double const baseline = wi->baseline().baseline();
+          log << std::setw(7) << std::setprecision(6) << std::left << baseline
+            << " ADC, diff of local start="
+            << std::showpos << std::setprecision(2) << std::setw(7) << std::left
+              << (startBaseline - baseline) << " ADC, end="
+            << std::showpos << std::setprecision(2) << std::setw(7) << std::left
+              << (endBaseline - baseline) << " ADC, peak amplitude: "
+            << std::defaultfloat << std::setprecision(6) << std::setw(8)
+            << (baseline - lowest) << " ADC at time " << lowestTime;
+        }
+        else {
+          log << "n/a, local start=" << std::setw(7) << std::setprecision(1)
+            << startBaseline << " ADC, end="
+            << std::setw(7) << std::setprecision(1) << endBaseline << " ADC"
+            << " ADC, lowest point: " << lowest << " ADC at time "
+            << lowestTime;
+        }
+      } // --- END ---- DEBUG --------------------------------------------------
+      
+      used.push_back(wi); // track
+      break; // this waveform has full coverage as per above, no more needed
+    } // for waveforms in channel
+    
+    if (chWaveforms.empty()) {
+      mf::LogTrace{ fLogCategory } << " - empty input collection!";
+    }
+    else if (used.empty()
+      || (
+        chWaveforms.front()->waveform().ChannelNumber()
+        != used.back()->waveform().ChannelNumber()
+      )
+    ) {
+      mf::LogTrace{ fLogCategory } << " - none of the " << chWaveforms.size()
+        << " waveforms of channel "
+        << chWaveforms.front()->waveform().ChannelNumber()
+        << " falls in the requested interval";
+    }
+    
+  } // for channels
+  
+  added *= fAmplitudeScale;
+  
+  return { std::move(added), std::move(used) };
+  
+} // icarus::trigger::DiscriminatedAdderSignal::addWaveformsInInterval()
+
+
+//------------------------------------------------------------------------------
+template <typename Samples>
+raw::OpDetWaveform icarus::trigger::DiscriminatedAdderSignal::packWaveform
+  (raw::Channel_t channel, electronics_time startTime, Samples const& samples)
+  const
+{
+  using std::size, std::begin, std::end;
+  
+  raw::TimeStamp_t const timeStamp
+    = startTime.convertInto<util::quantities::points::microsecond>().value();
+  raw::OpDetWaveform waveform{
+      timeStamp     /* timestamp */
+    , channel       /* channel */
+    , size(samples)  /* length */
+    };
+  
+  // float -> short
+  std::transform
+    (begin(samples), end(samples), back_inserter(waveform), std::roundf);
+  
+  return waveform;
+} // icarus::trigger::DiscriminatedAdderSignal::packWaveform()
+
+
+//------------------------------------------------------------------------------
+auto icarus::trigger::DiscriminatedAdderSignal::waveformTimeCoverage
+  (raw::OpDetWaveform const& waveform) const -> TimeInterval_t
+{
+  electronics_time const start
+    { util::quantities::microsecond{ waveform.TimeStamp() } };
+  return TimeInterval_t{ start, start + waveform.size() * fOpticalTick };
+}
+
+
+//------------------------------------------------------------------------------
+icarus::trigger::TriggerWindowDefs_t
+icarus::trigger::DiscriminatedAdderSignal::createAdderWindows
+  (geo::GeometryCore const& geom) const
+{
+  icarus::trigger::SlidingWindowDefinitionAlg makeWindows{ geom };
+  
+  icarus::trigger::TriggerWindowDefs_t windows
+    = makeWindows(fChannelsPerAdder, fChannelsPerAdder);
+  
+  for (TriggerWindowChannels_t& window: windows)
+    removeChannels(window);
+  
+  return windows;
+} // icarus::trigger::DiscriminatedAdderSignal::createAdderWindows()
+
+
+//------------------------------------------------------------------------------
+auto icarus::trigger::DiscriminatedAdderSignal::groupByChannel
+  (std::vector<icarus::trigger::WaveformWithBaseline> const& waveformInfo)
+  -> WaveformsByChannel_t
+{
+  auto waveformChannel = [](icarus::trigger::WaveformWithBaseline const& wi)
+    { return static_cast<std::size_t>(wi.waveform().ChannelNumber()); };
+  return icarus::ns::util::GroupByIndex{ waveformInfo, waveformChannel };
+} // icarus::trigger::DiscriminatedAdderSignal::groupByChannel()
+
+
+//------------------------------------------------------------------------------
+template <typename StartTime, typename StopTime>
+std::ptrdiff_t icarus::trigger::DiscriminatedAdderSignal::tickDistance
+  (StartTime start, StopTime stop) const
+{
+  return static_cast<std::ptrdiff_t>(std::trunc((stop - start) / fOpticalTick));
+}
+
+
+//------------------------------------------------------------------------------
+template <typename BIter, typename EIter>
+auto icarus::trigger::DiscriminatedAdderSignal::computeSimpleBaselines
+  (BIter begin, EIter end, microseconds interval) const
+  -> std::pair<double, double>
+{
+  assert(interval >= 0_us);
+  std::ptrdiff_t const nSamples
+    = std::min(tickDistance(0_us, interval), std::distance(begin, end));
+  return {
+    std::accumulate(begin, begin + nSamples, 0.0) / nSamples,
+    std::accumulate(end - nSamples, end, 0.0) / nSamples
+  };
+} // icarus::trigger::DiscriminatedAdderSignal::computeSimpleBaselines(Iter)
+
+
+//------------------------------------------------------------------------------
+template <typename Waveform>
+auto icarus::trigger::DiscriminatedAdderSignal::computeSimpleBaselines
+  (Waveform const& waveform, microseconds interval) const
+  -> std::pair<double, double>
+{
+  using std::begin, std::end;
+  return computeSimpleBaselines(begin(waveform), end(waveform), interval);
+} // icarus::trigger::DiscriminatedAdderSignal::computeSimpleBaselines(Waveform)
+
+
+//------------------------------------------------------------------------------
+DEFINE_ART_MODULE(icarus::trigger::DiscriminatedAdderSignal)
+
+
+//------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/SlidingWindowTrigger_module.cc
+++ b/icaruscode/PMT/Trigger/SlidingWindowTrigger_module.cc
@@ -17,7 +17,6 @@
 #include "icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h"
 #include "icaruscode/PMT/Algorithms/PMTverticalSlicingAlg.h"
 #include "icaruscode/IcarusObj/OpDetWaveformMeta.h" // sbn::OpDetWaveformMeta
-#include "icarusalg/Utilities/FHiCLutils.h" // util::fhicl::getOptionalValue()
 
 // LArSoft libraries
 #include "lardata/Utilities/NestedIterator.h" // lar::double_fwd_const_iterator
@@ -417,8 +416,7 @@ icarus::trigger::SlidingWindowTrigger::SlidingWindowTrigger
   : art::EDProducer(config)
   // configuration
   , fWindowSize(config().WindowSize())
-  , fWindowStride
-    (util::fhicl::getOptionalValue(config().Stride).value_or(fWindowSize))
+  , fWindowStride(config().Stride().value_or(fWindowSize))
   , fWindowChannels(defineWindows())
   , fEnabledWindows(makeEnabledWindowIndices(
      fWindowChannels.size(),

--- a/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
+++ b/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
@@ -1593,7 +1593,7 @@ std::uint64_t icarus::trigger::TriggerSimulationOnGates::TimestampToUTC
   (art::Timestamp const& ts)
 {
   return static_cast<std::uint64_t>(ts.timeHigh())
-    + static_cast<std::uint64_t>(event.time().timeLow()) * 1'000'000'000ULL;
+    + static_cast<std::uint64_t>(ts.timeLow()) * 1'000'000'000ULL;
 } // icarus::trigger::TriggerSimulationOnGates::TimestampToUTC()
 
 

--- a/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
+++ b/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
@@ -923,11 +923,19 @@ icarus::trigger::TriggerSimulationOnGates::TriggerSimulationOnGates
     log << "\nConfigured " << fADCthresholds.size() << " thresholds (ADC):";
     for (auto const& [ thresholdTag, dataTag ]: fADCthresholds)
       log << "\n * " << thresholdTag << " (from '" << dataTag.encode() << "')";
+#if 0 // TODO restore after adoption of https://github.com/LArSoft/lardataalg/pull/44
     log << "\nOther parameters:"
       << "\n * trigger time resolution: " << fTriggerTimeResolution
       << "\n * input beam gate reference time: "
         << util::StandardSelectorFor<util::TimeScale>{}
           .get(fBeamGateReference).name()
+#else
+    util::StandardSelectorFor<util::TimeScale> const timeScaleSelector;
+    log << "\nOther parameters:"
+      << "\n * trigger time resolution: " << fTriggerTimeResolution
+      << "\n * input beam gate reference time: "
+        << timeScaleSelector.get(fBeamGateReference).name()
+#endif
       ;
     if (fDeadTime == std::numeric_limits<nanoseconds>::max())
       log << "\n * only one trigger per beam gate (infinite dead time)";
@@ -1544,11 +1552,21 @@ auto icarus::trigger::TriggerSimulationOnGates::toBeamGateTime(
         (detinfo::timescales::simulation_time{ time });
       break;
     default:
+#if 0 // TODO restore after adoption of https://github.com/LArSoft/lardataalg/pull/44
       throw art::Exception{ art::errors::Configuration }
         << "Conversion of times from reference '"
         << util::StandardSelectorFor<util::TimeScale>{}
           .get(fBeamGateReference).name()
         << "' not supported.\n";
+#else
+    {
+      util::StandardSelectorFor<util::TimeScale> const timeScaleSelector;
+      throw art::Exception{ art::errors::Configuration }
+        << "Conversion of times from reference '"
+        << timeScaleSelector.get(fBeamGateReference).name()
+        << "' not supported.\n";
+    }
+#endif
   } // switch
   
   return time_es - detTimings.BeamGateTime();

--- a/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
+++ b/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
@@ -767,6 +767,9 @@ class icarus::trigger::TriggerSimulationOnGates
   /// Fills an `EventAux_t` from the information found in the argument.
   static EventAux_t extractEventInfo(art::Event const& event);
   
+  /// Converts a standard _art_ timestamp into an UTC time [ns]
+  static std::uint64_t TimestampToUTC(art::Timestamp const& ts);
+  
   /// Returns the ID of the cryostat the specified window belongs to.
   static geo::CryostatID WindowCryostat
     (icarus::trigger::WindowChannelMap::WindowInfo_t const& winfo)
@@ -1579,10 +1582,19 @@ auto icarus::trigger::TriggerSimulationOnGates::extractEventInfo
   (art::Event const& event) -> EventAux_t
 {
   return {
-      event.time().value()  // time
-    , event.event()         // event
+      TimestampToUTC(event.time()) // time
+    , event.event()                // event
     };
 } // icarus::trigger::TriggerSimulationOnGates::extractEventInfo()
+
+
+//------------------------------------------------------------------------------
+std::uint64_t icarus::trigger::TriggerSimulationOnGates::TimestampToUTC
+  (art::Timestamp const& ts)
+{
+  return static_cast<std::uint64_t>(ts.timeHigh())
+    + static_cast<std::uint64_t>(event.time().timeLow()) * 1'000'000'000ULL;
+} // icarus::trigger::TriggerSimulationOnGates::TimestampToUTC()
 
 
 //------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
+++ b/icaruscode/PMT/Trigger/TriggerSimulationOnGates_module.cc
@@ -16,10 +16,11 @@
 #include "icaruscode/PMT/Trigger/Algorithms/TriggerTypes.h" // ADCCounts_t
 #include "icaruscode/PMT/Trigger/Algorithms/details/TriggerInfo_t.h"
 #include "icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h" // FillTriggerGates()
+#include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()...
+#include "icarusalg/Utilities/CommonChoiceSelectors.h" // util::TimeScale...
 #include "icarusalg/Utilities/PlotSandbox.h"
 #include "icarusalg/Utilities/ROOTutils.h" // util::ROOT
 #include "icarusalg/Utilities/BinningSpecs.h"
-#include "icaruscode/Utilities/DetectorClocksHelpers.h" // makeDetTimings()...
 #include "icarusalg/Utilities/FixedBins.h"
 #include "icarusalg/Utilities/PassCounter.h"
 #include "icarusalg/Utilities/mfLoggingClass.h"
@@ -72,7 +73,7 @@
 
 // C/C++ standard libraries
 #include <ostream>
-#include <algorithm> // std::fill()
+#include <algorithm> // std::fill(), std::any_of()
 #include <map>
 #include <vector>
 #include <iterator> // std::make_move_iterator()
@@ -80,6 +81,7 @@
 #include <string>
 #include <atomic>
 #include <optional>
+#include <functional> // std::mem_fn()
 #include <utility> // std::pair<>, std::move()
 #include <cmath> // std::ceil()
 #include <cstddef> // std::size_t
@@ -126,6 +128,10 @@ namespace icarus::trigger { class TriggerSimulationOnGates; }
  * Configuration
  * ==============
  * 
+ * Run `lar --print-description TriggerSimulationOnGates` for a configuration
+ * example and terse explanations (it will also include the full list of
+ * available options for multiple choice parameters like `BeamGateReference`).
+ * 
  * * `TriggerGatesTag` (string, mandatory): name of the module instance which
  *     produced the trigger primitives to be used as input; it must not include
  *     any instance name, as the instance names will be automatically added from
@@ -160,6 +166,11 @@ namespace icarus::trigger { class TriggerSimulationOnGates; }
  *     a `sbn::bits::triggerSource` mask reflecting the content of the input
  *     beam gate bits, which basically can distinguish only between BNB, NuMI
  *     and others, "unknown" (see also `daq::TriggerDecoder` tool).
+ * * `BeamGateReference` (text, default: `BeamGate`): time reference of the
+ *     input gates in the data product defined by `BeamGates`. By LArSoft
+ *     standard, that is simulation time in Monte Carlo, which is mirrored in
+ *     data by the hardware beam gate time (although the latter allows a margin
+ *     around the beam spill opening a bit before neutrinos are expected).
  * * `DeadTime` (time, default: forever): when looking for sequences of
  *     triggers, ignore this much time after every trigger found. This applies
  *     only within each requested gate: a trigger at the very end of a gate
@@ -425,6 +436,12 @@ class icarus::trigger::TriggerSimulationOnGates
       Comment("bits to be set in the trigger object as beam identifier")
       };
 
+    fhicl::Atom<util::TimeScale> BeamGateReference {
+      Name{ "BeamGateReference" },
+      Comment{ "time scale the beam gates refer to" },
+      util::TimeScale::BeamGate
+      };
+    
     fhicl::Atom<bool> EmitEmpty {
       Name("EmitEmpty"),
       Comment("produce a trigger object even for gates with no firing trigger"),
@@ -550,6 +567,8 @@ class icarus::trigger::TriggerSimulationOnGates
   WindowPattern const fPattern;
   
   art::InputTag const fBeamGateTag; ///< Data product of beam gates to simulate.
+  
+  util::TimeScale const fBeamGateReference; ///< Reference time of beam gates.
   
   /// Bits for the beam gate being simulated.
   std::optional<std::uint32_t> fBeamBits;
@@ -717,6 +736,20 @@ class icarus::trigger::TriggerSimulationOnGates
   /// Prints the summary of fired triggers on screen.
   void printSummary() const;
   
+  /**
+   * @brief Converts a time into beam gate time.
+   * @param time the time to be converted
+   * @param detTimings detector timings helper
+   * @return delay from the start of beam gate opening time to `time`
+   * 
+   * The time value is assumed to be in the reference as `fBeamGateReference`
+   * and converted into the beam gate time scale.
+   */
+  nanoseconds toBeamGateTime(
+    util::quantities::nanosecond time,
+    detinfo::DetectorTimings const& detTimings
+    ) const;
+
   /// Creates and returns a 1D histogram filled with `binnedContent`.
   TH1* makeHistogramFromBinnedContent(
     PlotSandbox_t& plots,
@@ -801,6 +834,7 @@ icarus::trigger::TriggerSimulationOnGates::TriggerSimulationOnGates
   // configuration
   , fPattern              (config().Pattern())
   , fBeamGateTag          (config().BeamGates())
+  , fBeamGateReference    (config().BeamGateReference())
   , fBeamBits             (config().BeamBits())
   , fEmitEmpty            (config().EmitEmpty())
   , fExtraInfo            (config().ExtraInfo())
@@ -890,7 +924,11 @@ icarus::trigger::TriggerSimulationOnGates::TriggerSimulationOnGates
     for (auto const& [ thresholdTag, dataTag ]: fADCthresholds)
       log << "\n * " << thresholdTag << " (from '" << dataTag.encode() << "')";
     log << "\nOther parameters:"
-      << "\n * trigger time resolution: " << fTriggerTimeResolution;
+      << "\n * trigger time resolution: " << fTriggerTimeResolution
+      << "\n * input beam gate reference time: "
+        << util::StandardSelectorFor<util::TimeScale>{}
+          .get(fBeamGateReference).name()
+      ;
     if (fDeadTime == std::numeric_limits<nanoseconds>::max())
       log << "\n * only one trigger per beam gate (infinite dead time)";
     else {
@@ -984,8 +1022,8 @@ void icarus::trigger::TriggerSimulationOnGates::produce(art::Event& event)
     log << "\n * threshold " << thrTag << ": ";
     icarus::ns::util::PassCounter gateResults;
     for (std::vector<WindowTriggerInfo_t> const& triggerInfo: triggers) {
-      if (triggerInfo.empty()) continue;
-      gateResults.add(triggerInfo.front().info.fired());
+      gateResults.add(std::any_of(triggerInfo.cbegin(), triggerInfo.cend(),
+        std::mem_fn(&WindowTriggerInfo_t::info)));
     }
     log << gateResults.passed() << "/" << gateResults.total()
       << " gates triggered"; // ... at least once
@@ -1303,8 +1341,9 @@ auto icarus::trigger::TriggerSimulationOnGates::produceForThreshold(
     std::vector<WindowTriggerInfo_t> triggerInfos;
     
     // relative to the beam gate time (also simulation time for MC);
-    nanoseconds start{ beamGate.Start() };
-    nanoseconds const stop{ beamGate.Start() + beamGate.Width() };
+    nanoseconds start{ toBeamGateTime
+      (util::quantities::nanosecond{ beamGate.Start() }, detTimings) };
+    nanoseconds const stop{ start + nanoseconds{ beamGate.Width() } };
     
     while (start < stop) {
       
@@ -1477,6 +1516,44 @@ void icarus::trigger::TriggerSimulationOnGates::printSummary() const {
   } // for
   
 } // icarus::trigger::TriggerSimulationOnGates::printSummary()
+
+
+//------------------------------------------------------------------------------
+auto icarus::trigger::TriggerSimulationOnGates::toBeamGateTime(
+  util::quantities::nanosecond time, detinfo::DetectorTimings const& detTimings
+) const
+  -> nanoseconds
+{
+  // currently (LArSoft v09_77_00) `detinfo::DetectorTimings` does not support
+  // beam gate timescale conversion, so we need to do it "by hand" from...
+  // electronics time, as usual
+  
+  detinfo::timescales::electronics_time time_es;
+  switch (fBeamGateReference) {
+    case util::TimeScale::Electronics:
+      time_es = detinfo::timescales::electronics_time{ time };
+      break;
+    case util::TimeScale::BeamGate:
+      return nanoseconds{ time };
+    case util::TimeScale::Trigger:
+      time_es = detTimings.toElectronicsTime
+        (detinfo::timescales::trigger_time{ time });
+      break;
+    case util::TimeScale::Simulation:
+      time_es = detTimings.toElectronicsTime
+        (detinfo::timescales::simulation_time{ time });
+      break;
+    default:
+      throw art::Exception{ art::errors::Configuration }
+        << "Conversion of times from reference '"
+        << util::StandardSelectorFor<util::TimeScale>{}
+          .get(fBeamGateReference).name()
+        << "' not supported.\n";
+  } // switch
+  
+  return time_es - detTimings.BeamGateTime();
+  
+} // icarus::trigger::TriggerSimulationOnGates::rebaseTime()
 
 
 //------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h
+++ b/icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h
@@ -499,7 +499,9 @@ icarus::trigger::transformIntoOpticalTriggerGate(Gates&& gates) {
   
   std::vector<TriggerGateData_t> gateData;
 
-  for (TriggerGateData_t& gate: icarus::trigger::gatesIn(gates))
+  // this function also captures a `Gate const& gates`, which would yield to
+  // const `gate` in this loop: `auto&&` matches it as exactly as it can
+  for (auto&& gate: icarus::trigger::gatesIn(gates))
     gateData.push_back(std::move(gate));
   
   return gateData;

--- a/icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h
+++ b/icaruscode/PMT/Trigger/Utilities/TriggerDataUtils.h
@@ -219,7 +219,7 @@ namespace icarus::trigger {
   
   // ---------------------------------------------------------------------------
   /**
-   * @brief Creates a gate object out of trigger gate data products.
+   * @brief Creates gate objects out of trigger gate data products.
    * @tparam OpDetInfo type of the associated waveforms
    * @param gates collection of data from all the gates
    * @param gateToWaveformInfo association between each gate and its waveforms
@@ -228,8 +228,9 @@ namespace icarus::trigger {
    *
    * Objects like `icarus::trigger::TrackedOpticalTriggerGate` include the gate
    * level information plus the connections to the source objects (waveforms).
-   * This structure is complicate enoug that they are not saved directly into an
-   * _art_ event. Rather, they are diced into pieces and the pieces are stored.
+   * These objects are complicate enough that they are not saved directly into
+   * an _art_ event. Rather, they are diced into pieces and the pieces are
+   * stored.
    * 
    * This function stitches the pieces and returns back an object like
    * `icarus::trigger::TrackedOpticalTriggerGate`.

--- a/icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h
+++ b/icaruscode/PMT/Trigger/Utilities/TriggerGateDataFormatting.h
@@ -105,6 +105,12 @@ std::ostream& icarus::trigger::details::operator<<
   else out << "no channel";
   out << "] " << gate.gateLevels();
   
+  if (unsigned int const maxTime = gate.findMaxOpen(); maxTime != gate.MaxTick)
+  {
+    unsigned int const maxOpening = gate.openingCount(maxTime);
+    out << " (maximum: " << maxOpening << " at " << maxTime << ")";
+  }
+  
   return out;
 } // icarus::trigger::operator<< (GateWrapper)
 

--- a/icaruscode/PMT/Trigger/dump_triggergatedata_icarus.fcl
+++ b/icaruscode/PMT/Trigger/dump_triggergatedata_icarus.fcl
@@ -21,63 +21,42 @@
 
 process_name: DumpTriggerGateData
 
-services: {
+services.message.destinations: {
   
-  message: {
-    destinations: {
-      
-      # grab all the "DumpTriggerGateData" messages and put them in DumpTriggerGateData.log
-      LogGates: {
-        append: false
-        categories: {
-          DumpTriggerGateData: { limit: -1 }
-          default: { limit: 0 }
-        }
-        filename: "DumpTriggerGateData.log"
-        threshold: "INFO"
-        type: "file"
-      } # LogGates
-      
-      LogStandardOut: {
-        categories: {
-          DumpTriggerGateData: { limit: 0 }
-          default: {}
-        }
+  # grab all the "DumpTriggerGateData" messages and put them in DumpTriggerGateData.log
+  LogGates: {
+    append: false
+    categories: {
+      DumpTriggerGateData: { limit: -1 }
+      default: { limit: 0 }
+    }
+    filename: "DumpTriggerGateData.log"
+    threshold: "INFO"
+    type: "file"
+  } # LogGates
+  
+  LogStandardOut: {
+    categories: {
+      DumpTriggerGateData: { limit: 0 }
+      default: {}
+    }
 #         threshold: "WARNING"
-        threshold: "DEBUG"
-        type: "cout"
-      } # LogStandardOut
-      
-    } # destinations
-  } # message
-} # services
-
-
-source: {
-  module_type: RootInput
-  maxEvents:  -1            # number of events to read
-} # source
-
-
-physics: {
-  producers:{}
-  filters:  {}
-  analyzers: {
-    dumptriggergatedata: {
-      module_type:  DumpTriggerGateData
-      
-      # specify the input tag of the raw::OpDetWaveform producer
-      TriggerGateDataTag: "discrimopdaq:100"
-      
-      # output category ("TriggerGateDataTag" by default), useful for filtering (see above)
-      OutputCategory: "DumpTriggerGateData"
-      
-    } # dumptriggergatedata
-  } # analyzers
+    threshold: "DEBUG"
+    type: "cout"
+  } # LogStandardOut
   
-  dumpers:  [ dumptriggergatedata ]
-  
-  trigger_paths: []
-  end_paths:     [ dumpers ]
-} # physics
+} # services.message.destinations
 
+
+physics.analyzers.dumptriggergatedata: {
+  module_type:  DumpTriggerGateData
+  
+  # specify the input tag of the raw::OpDetWaveform producer
+  TriggerGateDataTag: "discrimopdaq:100"
+  
+  # output category ("TriggerGateDataTag" by default), useful for filtering (see above)
+  OutputCategory: "DumpTriggerGateData"
+  
+} # physics.analyzers.dumptriggergatedata
+
+physics.dumpers:  [ dumptriggergatedata ]

--- a/icaruscode/PMT/Trigger/run_addertriggersimulation_icarus_data.fcl
+++ b/icaruscode/PMT/Trigger/run_addertriggersimulation_icarus_data.fcl
@@ -1,0 +1,269 @@
+#
+# File:    run_addertriggersimulation_icarus_data.fcl
+# Purpose: Runs the simulation of ICARUS adder triggers.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    July 5, 2023
+# Version: 1.0
+#
+# This is a top-level configuration that can be run directly.
+#
+# This job reads the already digitized PMT waveforms, creates added "analogue"
+# waveforms, discriminates them and computes a trigger logic on them.
+#
+#
+# Output
+# -------
+#
+# * `std::vector<raw::Trigger>`, `sbn::ExtraTriggerInfo` (very partial):
+#   the time at which the trigger from adders would have happened.
+#
+# Required inputs
+# ----------------
+#
+#  * optical detector readout: `daqPMT`
+#
+#
+# Required services
+# ------------------
+#
+#  * GeometryService
+#  * DetectorClocksService
+#
+#
+# Changes
+# --------
+# 
+# 20230705 (petrillo@slac.stanford.edu) [v1.0]
+# :   original version
+#
+
+#include "services_common_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+#include "trigger_emulation_icarus.fcl"
+
+
+BEGIN_PROLOG
+
+adderTrigSimTemplate: {
+  
+  module_type: TriggerSimulationOnGates
+  
+  TriggerGatesTag: "pmtaddertriggerwindows"
+  
+#  Thresholds: [ @local::icarus_triggergate_basic.SelectedAdderThreshold ]  # from trigger_icarus.fcl
+  Thresholds: @local::icarus_triggergate_basic.AdderThresholds  # from trigger_icarus.fcl
+  
+  Pattern: @local::icarus_triggergate_basic.SelectedAdderPattern  # from trigger_icarus.fcl
+  
+  BeamGates:         daqTrigger
+  BeamGateReference: trigger
+  
+  # we set the bits with a magic value
+  BeamBits: 0x800000
+  
+  # do not produce "non-triggers" (triggers which did not fire)
+  EmitEmpty: false
+  
+  # "infinite" dead time: we only keep the first trigger
+  DeadTime: @erase
+  
+  # disable the retriggering bit, which won't make sense in a 2 ms gate
+  RetriggeringBit: 64
+  
+  # use bit 20 for triggers on cryostat 0, bit 21 for the ones on cryostat 1
+  CryostatFirstBit: 20
+  
+  # this should probably be 12 or 24 ns
+  TriggerTimeResolution: "8 ns"
+  
+  # name of the category used for the output
+  LogCategory: "TriggerSimulationOnGates"
+  
+} # adderTrigSimTemplate
+
+
+processWaveforms: [
+    pmtbaselinesonbeam
+  , requireOnBeam
+  , pmtadderthr
+]
+
+
+END_PROLOG
+
+
+# ------------------------------------------------------------------------------
+process_name: AdderTrg
+
+
+# ------------------------------------------------------------------------------
+services: {
+  
+  # this provides: file service, random management (unused),
+  #                Geometry, detector properties and clocks
+  @table::icarus_common_services
+  
+  # currently unused (remove the line if they start mattering):
+  LArPropertiesService:      @erase
+  DetectorPropertiesService: @erase
+  
+} # services
+
+# services.scheduler.FailPath: [ "WaveformRequirementsNotMet" ]
+# services.scheduler.SkipEvent: [ "WaveformRequirementsNotMet" ]
+
+# ------------------------------------------------------------------------------
+physics: {
+  
+  producers: {
+    
+    # --------------------------------------------------------------------------
+    pmtbaselinesonbeam: {
+      module_type: ReassociatePMTbaselines
+      
+      # baselines:
+      #  * pmtconfigbaselines: from readout configuration
+      #  * pmtbaselines:       from waveform content
+      
+      OriginalWaveformTag: daqPMT
+      WaveformTag:         daqPMTonbeam
+      BaselineTag:         pmtbaselines
+      
+      RecreateMetaAssns:   true
+    
+    } # pmtbaselinesonbeam
+    
+    
+    pmtadderthr: {
+      module_type: DiscriminatedAdderSignal
+      
+      WaveformTag: daqPMTonbeam
+      
+      # bug fix: daqPMTonbeam did not save the correct associations, 
+      # `ReassociatePMTbaselines` is fixing that (via `RecreateMetaAssns` above)
+      WaveformMetaTag: pmtbaselinesonbeam
+      
+      # limit the discrimination buffer to this interval (just to save memory);
+      # times are relative to the beam gate
+      TimeInterval: {
+        Start: "-4 us"
+        End:  "+16 us"
+      }
+      
+      # adders take away 5% of PMT signal, our input is 95% of that signal,
+      # so we need a 0.05/0.95 factor here:
+      AmplitudeScale: 0.05263
+      
+      # the actual adders include all the PMT, unconditionally
+      MissingChannels: []
+      
+      BaselineTag: pmtbaselinesonbeam
+      
+      # list of thresholds to consider
+      TriggerGateBuilder: {
+        tool_type: FixedTriggerGateBuilderTool
+        
+        ChannelThresholds: @local::icarus_triggergate_basic.AdderThresholds  # from trigger_icarus.fcl
+        
+        # minimum duration of a trigger gate
+        GateDuration: "1 us"
+      }
+      
+      SaveWaveforms: true
+      
+      LogCategory: DiscriminatedAdderSignal
+      
+    } # pmtadderthr
+    
+    
+    pmtaddertriggerwindows: {
+      module_type:     "SlidingWindowTrigger"
+      
+      TriggerGatesTag: "pmtadderthr"
+      Thresholds:      @local::icarus_triggergate_basic.AdderThresholds  # from trigger_icarus.fcl
+      
+      # the PMT channels are plugged into the adders even if "missing"
+      # MissingChannels: @local::icarus_trigger_channel_ignore
+      
+      # size and stride are in PMT units
+      Stride:          15
+      WindowSize:      15
+      
+    } # pmtaddertriggerwindows
+    
+    
+    emuAdderTrig: {
+                       @table::adderTrigSimTemplate
+      TriggerGatesTag: pmtaddertriggerwindows
+      
+    } # emuAdderTrig
+    
+    # --------------------------------------------------------------------------
+    
+  } # producers
+  
+  filters: {
+    requireOnBeam: {
+      module_type:           RequireOnBeamWaveforms
+
+      WaveformTag:           daqPMTonbeam        # check waveforms directly, so:
+      TriggerTag:            daqTrigger
+      WaveformMetaAssnsTag:  pmtbaselinesonbeam  # ... superfluous
+      ForceWaveformPresence: true                # ... also superfluous
+      # ThrowOnFailure:       "WaveformRequirementsNotMet"
+      MissingChannels:      @local::icarus_trigger_channel_ignore
+    }
+  } # filters
+  
+  trigger: [
+      @sequence::processWaveforms
+    , pmtaddertriggerwindows
+    , emuAdderTrig
+    ]
+  output: [ rootoutput ]
+  
+  trigger_paths: [ trigger ]
+  end_paths:     [ output ]
+  
+} # physics
+
+
+outputs.rootoutput: @local::icarus_rootoutput # from rootoutput_icarus.fcl
+outputs.rootoutput.SelectEvents: [ trigger ]
+outputs.rootoutput.outputCommands: [
+    "drop *"
+#  , "keep *_*_*_stage0"
+#  , "drop *_roifinder_*_stage0"
+  , "keep *_daqTrigger_*_stage0"
+  , "keep *_pmtconfigbaselines_*_stage0"
+  , "keep *_pmtbaselines_*_stage0"
+  , "keep sbn::OpDetWaveformMetas_*_*_stage0"
+  , "keep *_daqPMTonbeam_*_stage0"
+  , "keep *_*_*_AdderTrg"
+  ]
+
+
+# ##############################################################################
+#
+# add debug output to its own file
+#
+services.message.destinations.AdderTrigSimLog: {
+  type:       file
+  filename:  "AdderTrigSim.log"
+  threshold:  DEBUG
+  categories: {
+    DiscriminatedAdderSignal: { limit: -1 }
+    TriggerSimulationOnGates: { limit: -1 }
+    default:                  { limit: 0 }
+  }
+} # services.messages.destinations.AdderTrigSimLog
+
+services.message.destinations.DebugLog: {
+  type:       file
+  filename:  "debug.log"
+  threshold:  DEBUG
+  categories: {
+    default:    { limit: -1 }
+  }
+} # services.messages.destinations.DebugLog
+

--- a/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_emulation_icarus.fcl
@@ -30,9 +30,9 @@
 # Configuration parameters
 # -------------------------
 # 
-# The following parameters can be overridden by setting them with `@ignore:`
-# before including this configuration file. Unless otherwise specified,
-# the default definition is in `trigger_icarus.fcl`.
+# The following parameters can be overridden by setting them with
+# `@protect_ignore:` before including this configuration file. Unless otherwise
+# specified, the default definition is in `trigger_icarus.fcl`.
 # 
 # * icarus_triggergate_basic.ChannelThresholds: the set of thresholds emulated
 #     in the trigger.

--- a/icaruscode/PMT/Trigger/trigger_icarus.fcl
+++ b/icaruscode/PMT/Trigger/trigger_icarus.fcl
@@ -86,6 +86,9 @@ icarus_triggergate_basic.Baseline: 15000
 # This is the primary PMT discrimination threshold, chosen for the hardware.
 icarus_triggergate_basic.SelectedThreshold: 400 # ADC
 
+# This is the primary PMT adder discrimination threshold (in ADC equivalent).
+icarus_triggergate_basic.SelectedAdderThreshold: 492  # 60 mV x (2^14 / 2 V) => 491.52 ADC#
+
 
 # thresholds for channel trigger gate opening [ADC counts]
 # in this default, we have a 1-photoelectron threshold, a loose-but-reachable
@@ -101,6 +104,14 @@ icarus_triggergate_basic.ChannelThresholds:
 # (V1730B) will open a gate signal for some amount of time in order to evaluate
 # the LVDS pair signal. This value determines that amount of time.
 icarus_triggergate_basic.PMTdiscrGateWidth: "160 ns"
+
+
+# adder signal emulation builds upon digitized waveforms;
+# discrimination thresholds need to be compared to a SPR of ~3.75 mV (as above)
+# that in an adder becomes ~3.7 mV x0.05 = 0.187 mV.
+# The thresholds chosen here are:         [ 320,      533,     1067     ] photoelectrons or
+#                                         [ "60 mV", "100 mV", "200 mV" ]
+icarus_triggergate_basic.AdderThresholds: [ 492,      819,     1638     ]
 
 
 #
@@ -206,9 +217,6 @@ icarus_dynamictriggergate: {
   tool_type: DynamicTriggerGateBuilderTool
   
   ChannelThresholds: @local::icarus_triggergate_basic.ChannelThresholds
-  
-  # minimum duration of a trigger gate
-  GateDuration: @local::icarus_triggergate_basic.PMTdiscrGateWidth
   
 } # icarus_dynamictriggergate
 
@@ -404,6 +412,7 @@ icarus_triggergate_basic.patterns.S10: {
 
 icarus_triggergate_basic.SelectedPattern: @local::icarus_triggergate_basic.patterns.S5
 icarus_triggergate_basic.SelectedPrimitivePattern: @local::icarus_triggergate_basic.patterns.S10
+icarus_triggergate_basic.SelectedAdderPattern: @local::icarus_triggergate_basic.patterns.M1
 
 
 

--- a/icaruscode/Utilities/IcarusObjectSelectors.h
+++ b/icaruscode/Utilities/IcarusObjectSelectors.h
@@ -12,7 +12,6 @@
 
 
 #include "sbnobj/Common/CRT/CRTPMTMatching.hh"
-#include <map> // until https://github.com/LArSoft/lardataalg/pull/41
 #include "lardataalg/Utilities/MultipleChoiceSelection.h"
 
 


### PR DESCRIPTION
This extensive pull request includes several updates and bug fixes for trigger emulation support.
Highlights:
1. Support for emulation on `Stage0` files: the information available for on-beam trigger emulation is fragmented: a module copies out the subset of the PMT waveforms that includes the beam gate; but some information associate to the original waveforms are not reassociated to the new ones. This PR introduces both some fixes and some mitigation for the existing data.
2. Support for adder bit decoding: the decoder relies on a convention to store adder bits into new `sbn::ExtraTriggerInfo` data members introduced in SBNSoftware/sbnobj#96.
3. New software to simulate the adder boards, the discrimination of their signal and the trigger logics.

One fix that is not included is in the trigger decoder, which promises a `sim::BeamGateInfo` in one time scale (standard) but it delivers it in another. That will be subject of a different PR.

Review of this PR is tricky... @jzettle is the usual victim. I am not sure who else might want to take a look to it.

This PR also depends on another on SBNSoftware/icarusalg which is going to be opened soon.

#### Commit descriptions

Many commits have further details of the changes; I copy their comments here for convenience of the reviewers:

* commit dce7a998964a24b23005587e8b418f353bdc9713
Date:   Thu Sep 14 01:45:45 2023 -0500

    TriggerSimulationOnGates: workaround for bug of util::MultiChoiceSelector
    
    To be reverted or otherwise removed when lardataalg PR #44 is adopted.

* commit 38ce11e2b104dcfab1942d5098b775c220ede15c
Date:   Thu Sep 14 00:27:04 2023 -0500

    First support for adder trigger emulation
    
    No configuration is provided yet though.

* commit e6ab640333cd7b089260ec2c986ad28bd92141fa
Date:   Thu Sep 14 00:23:02 2023 -0500

    Updated support for trigger emulation on data
    
    Syntax of LVDSgates threshold configuration has been uniformed to the other
    module (even if the interpretation under the hood has still to be different).
    TriggerSimulationOnGates can specify which time reference the gates use.
    This is necessary because it turns out that the trigger decoder is erroneously
    using the trigger time instead of the standard beam gate time
    (this will be the subject of a different fix; the change is necessary to
    correctly emulate triggers in the already decoded data).

* commit bfd23ddfce9bc5009d6dfec84a7e9cad82cb4664
Date:   Wed Sep 13 21:52:31 2023 -0500

    Removed some obsolete workarounds.

* commit 4a6f97f310255f7cc0a5b00f8d1a83d0cac9fdd2
Date:   Wed Sep 13 21:43:20 2023 -0500

    PMT and trigger support for Stage0/Stage1 data
    
    It was decided that Stage0 data would only serialize the PMT waveforms around the beam gate,
    and these waveforms are a new data product from the point of view of the framework.
    To make most of the algorithm still work, additional information must be saved.
    That includes making proper associations of the existing data with the new waveforms
    (like baselines) and/or recreate it for them (e.g. metadata).
    This commit introduces a module to perform a reassociation of the new waveforms
    to the existing baseline data product, in case it was not there yet (it actually was,
    but bugged; the bug is fixed with a previous commit, but the existing data suffers from it),
    a new filter module to verify that the waveforms are actually there (workaround for
    incomplete events) and adds resiliency to one of the trigger algorithms in case
    of missing data as well.

* commit ac852655960e1b1d5c1c9743f6fdaa15eb8b7cf3
Date:   Wed Sep 13 20:42:28 2023 -0500

    A few trigger code documentation updates

* commit 6216f727d000716c36a85d445f33d5ff3efb5766
Date:   Wed Sep 13 20:35:40 2023 -0500

    PMTverticalSlicingAlg returns slices sorted in the standard LArSoft way
    
    Order in x used to be reversed by chance.

* commit bfeb53b06e56da8976415417496d9234c91c98e6
Date:   Wed Sep 13 20:32:11 2023 -0500

    TriggerGateBuilder bug fix: support for missing channels (silently failed before)

* commit 2113d1dffe06c56da17acef4211a035c75686b69
Date:   Wed Sep 13 20:28:07 2023 -0500

    Updates to runFilesFromSAM.sh and sortDataLoggerFiles.py scripts
    
    * runFilesFromSAM.sh: allows ignoring up to some number of errors
    * sortDataLoggerFiles.py: support for calibration files with potentially duplicate files
      (files resolved by timestamp in the name, with no guarantee against name collision)

* commit 6acdebc53f7842a4f79c5257c5a628ee5160074a
Date:   Wed Sep 13 20:19:51 2023 -0500

    PMTWaveformBaselinesFromChannelData: groupByChannel moved to its own file
    
    Now called `groupByIndex` in `icarusalg`.
    Also fixed a non-constantness bug.

* commit fb65ca8ddc5a9613ed9376fc8524b8e37a8a26df
Date:   Wed Sep 13 20:18:28 2023 -0500

    CopyBeamTimePMTwaveforms module bug fix: waveform associations were broken
