### PR TITLE
Update to the CRT calibration Ntuple

### DIFF
--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -218,6 +218,8 @@ namespace crt {
     float    fZErrHit; ///< stat error of CRT hit reco Z (cm)
     uint64_t    fT0Hit; ///< hit time w.r.t. PPS
     Long64_t    fT1Hit; ///< hit time w.r.t. global trigger
+    float     fHitPE[32];
+    int       fHitMac[32];
     int       fHitReg; ///< region code of CRT hit
     int       fHitSubSys;
     int       fNHit; ///< number of CRT hits for this event
@@ -379,6 +381,8 @@ namespace crt {
     fHitNtuple->Branch("zErr",        &fZErrHit,     "zErr/F");
     fHitNtuple->Branch("t0",          &fT0Hit,       "t0/l");
     fHitNtuple->Branch("t1",          &fT1Hit,       "t1/L");
+    fHitNtuple->Branch("PEs",         &fHitPE,       "PEs[32]/F");
+    fHitNtuple->Branch("Macs",        &fHitMac,       "Mac[32]/I");
     fHitNtuple->Branch("region",      &fHitReg,      "region/I");  
     //    fHitNtuple->Branch("tagger",      &ftagger,      "tagger/C");  
     fHitNtuple->Branch("subSys",      &fHitSubSys,   "subSys/I");
@@ -583,7 +587,8 @@ namespace crt {
 	  int mactmp = hit.feb_id[0];
 	  fHitReg  = fCrtutils->AuxDetRegionNameToNum(fCrtutils->MacToRegion(mactmp));
 	  fHitSubSys =  fCrtutils->MacToTypeCode(mactmp);
-	  
+	  std::fill( std::begin( fHitPE ), std::end( fHitPE ), 0 );
+	  std::fill( std::begin( fHitMac ), std::end( fHitMac ), 0 );
 	  m_gate_crt_diff = m_gate_start_timestamp - hit.ts0_ns;
 	  m_crt_global_trigger = hit.ts0_ns - hit.ts1_ns;
 	  m_crtGT_trig_diff = m_crt_global_trigger - (m_trigger_timestamp%1'000'000'000);//'''						      
@@ -594,7 +599,13 @@ namespace crt {
 	     mf::LogError("CRTDataAnalysis") << "mactmp = " << mactmp << std::endl;
 	     mf::LogError("CRTDataAnalysis") << "could not find mac in pesmap!" << std::endl;
 	    continue;
-	  }	  
+	  }
+          if(fHitSubSys==0){
+      	     for(int k=0; k<32; k++){
+		fHitPE[k]=ittmp.at(k).second;
+                fHitMac[k]=0;	
+  	     }	  
+	  }
 	  int chantmp = (*ittmp).second[0].first;
 	  
 	  fHitMod  = fCrtutils->MacToAuxDetID(mactmp, chantmp);

--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -218,6 +218,7 @@ namespace crt {
     float    fZErrHit; ///< stat error of CRT hit reco Z (cm)
     uint64_t    fT0Hit; ///< hit time w.r.t. PPS
     Long64_t    fT1Hit; ///< hit time w.r.t. global trigger
+    int       fHitNChan;
     float     fHitPE[32];
     int       fHitMac[32];
     int	      fHitChan[32];
@@ -372,6 +373,8 @@ namespace crt {
     fDAQNtuple->Branch("gate_start_timestamp", &m_gate_start_timestamp, "gate_start_timestamp/l");
 
     // Define the branches of our SimHit n-tuple
+    fHitNtuple->Branch("run",         &fDetRun,      "run/I");
+    fHitNtuple->Branch("subrun",      &fDetSubRun,   "subrun/I");
     fHitNtuple->Branch("event",       &fHitEvent,    "event/I");
     fHitNtuple->Branch("nHit",        &fNHit,        "nHit/I");
     fHitNtuple->Branch("x",           &fXHit,        "x/F");
@@ -382,6 +385,7 @@ namespace crt {
     fHitNtuple->Branch("zErr",        &fZErrHit,     "zErr/F");
     fHitNtuple->Branch("t0",          &fT0Hit,       "t0/l");
     fHitNtuple->Branch("t1",          &fT1Hit,       "t1/L");
+    fHitNtuple->Branch("NChan",       &fHitNChan,       "nChan/I");
     fHitNtuple->Branch("PEs",         &fHitPE,       "PEs[32]/F");
     fHitNtuple->Branch("Macs",        &fHitMac,      "Mac[32]/I");
     fHitNtuple->Branch("Chans",       &fHitChan,     "Chans[32]/I");
@@ -603,13 +607,15 @@ namespace crt {
 	     mf::LogError("CRTDataAnalysis") << "could not find mac in pesmap!" << std::endl;
 	    continue;
 	  }
+	  fHitNChan=0;
           if(fHitSubSys==0){
 	     std::map<uint8_t, std::vector<std::pair<int,float>>>::const_iterator it;
 	     for (it = hit.pesmap.begin(); it!=hit.pesmap.end();it++){
 		std::vector<std::pair<int,float>> thisHit = it->second;
 		int hitsize = (int) thisHit.size();
 	     	for(int k=0; k< hitsize; k++){
-			fHitPE[thisHit[k].first]=thisHit[k].second;
+		   fHitPE[thisHit[k].first]=thisHit[k].second;
+		   if(thisHit[k].second>1) fHitNChan++;
 		}	
   	     }
 	  } else if (fHitSubSys==1) {
@@ -618,6 +624,7 @@ namespace crt {
 	     for (it = hit.pesmap.begin(); it!=hit.pesmap.end();it++){
                 std::vector<std::pair<int,float>> thisHit = it->second;
                 int hitsize = (int) thisHit.size();
+		fHitNChan+=hitsize;
                 for(int k=0; k< hitsize; k++){
 		   arrpos++;
 		   if(arrpos>=32) continue;

--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -615,6 +615,8 @@ namespace crt {
 		int hitsize = (int) thisHit.size();
 	     	for(int k=0; k< hitsize; k++){
 		   fHitPE[thisHit[k].first]=thisHit[k].second;
+		   fHitChan[thisHit[k].first]=thisHit[k].first;
+		   fHitMac[thisHit[k].first]=(int)it->first;
 		   if(thisHit[k].second>1) fHitNChan++;
 		}	
   	     }


### PR DESCRIPTION
This PR includes a new feature to the CRT Hit calibration ntuple.
Originally only the sum of the PEs in one CRT Hit was stored in the HitTree. This PR includes 3 new branches (arrays of size 32) to the HitTree.
1st Branch is PEs, for the Top CRT (for which all the 32 channels of the FEB are recorded) each index of the PEs array correspond to the channel of the FEB, the entry is the corresponding calibrated PE value. The Side CRTs only store information of the channels that are actively part of the reconstructed CRT Hit, this is due to how the Side CRT works (multiple channels from different FEB participate in a hit). For the Side CRT you loose correspondance between channel and index, this is nonetheless fixed with the inclusion of a 2nd branch (array): Chans.
2nd Branch is Chans: for the Top CRT, since it is not needed, it is filled with default value (-1). For the Side CRT each index correspond to the same index of PEs and Macs branch. Stores information of the channel number.
3rd Branch is Macs:  for the Top CRT, since it is not needed, it is filled with default value (-1). For the Side CRT each index correspond to the same index of PEs and Chans branch. Stores information of the Mac that is associated with the i-th channel, i-th pe.