### PR TITLE
Added cosmic distance variable

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -25,6 +25,8 @@
 #include "sbn_stub.fcl"
 #include "transfer_flashmatch_producer.fcl"
 #include "crtt0producer_icarus.fcl"
+#include "showercosmicdistanceproducer.fcl"
+
 
 BEGIN_PROLOG
 
@@ -108,6 +110,9 @@ recoana_caf_preprocess_producers: {
   pandoraCRTMatchCryoE: @local::standard_crtt0producer_cryoE
   pandoraCRTMatchCryoW: @local::standard_crtt0producer_cryoW
 
+  ShowerCosmicDistCryoE: @local::showerCosmicDist_sbn
+  ShowerCosmicDistCryoW: @local::showerCosmicDist_sbn
+
   # crtconvhit: @local::crthitconverter_icarus
   rns: { module_type: "RandomNumberSaver" }
   genieweight: @local::sbn_eventweight_genie
@@ -120,6 +125,10 @@ recoana_caf_preprocess_producers.pandoraTrackMCSCryoE.TrackLabel: pandoraTrackGa
 recoana_caf_preprocess_producers.pandoraTrackMCSCryoW.TrackLabel: pandoraTrackGausCryoW
 recoana_caf_preprocess_producers.pandoraTrackRangeCryoE.TrackLabel: pandoraTrackGausCryoE
 recoana_caf_preprocess_producers.pandoraTrackRangeCryoW.TrackLabel: pandoraTrackGausCryoW
+recoana_caf_preprocess_producers.ShowerCosmicDistCryoE.ShowerLabel: SBNShowerGausCryoE
+recoana_caf_preprocess_producers.ShowerCosmicDistCryoW.ShowerLabel: SBNShowerGausCryoW
+recoana_caf_preprocess_producers.ShowerCosmicDistCryoE.PandoraLabel: pandoraGausCryoE
+recoana_caf_preprocess_producers.ShowerCosmicDistCryoW.PandoraLabel: pandoraGausCryoW
 
 recoana_caf_preprocess_producers.pandoraPidGausCryoE.TrackModuleLabel: "pandoraTrackGausCryoE"
 recoana_caf_preprocess_producers.pandoraPidGausCryoE.CalorimetryModuleLabel: "pandoraCaloGausCryoE"
@@ -239,8 +248,10 @@ caf_preprocess_sequence: [ mcreco,
     # Track Momentum Estimation
     pandoraTrackMCSCryoE, pandoraTrackMCSCryoW, 
     pandoraTrackRangeCryoE, pandoraTrackRangeCryoW,
-    pandoraCRTMatchCryoE, pandoraCRTMatchCryoW
+    pandoraCRTMatchCryoE, pandoraCRTMatchCryoW,
     # TODO: rns??
+    # Shower
+    ShowerCosmicDistCryoE, ShowerCosmicDistCryoW
     ]
 
 caf_preprocess_data_sequence: [
@@ -252,8 +263,10 @@ caf_preprocess_data_sequence: [
     # Track Momentum Estimation
     pandoraTrackMCSCryoE, pandoraTrackMCSCryoW,
     pandoraTrackRangeCryoE, pandoraTrackRangeCryoW,
-    pandoraCRTMatchCryoE, pandoraCRTMatchCryoW
+    pandoraCRTMatchCryoE, pandoraCRTMatchCryoW,
     # TODO: rns??
+    # Shower
+    ShowerCosmicDistCryoE, ShowerCosmicDistCryoW
     ]
 
 caf_preprocess_evtw_sequence: [@sequence::caf_preprocess_sequence, rns, genieweight, fluxweight]
@@ -295,7 +308,7 @@ cafmaker.RecoTrackLabel:    "pandoraTrackGaus"
 cafmaker.RecoShowerLabel:   "SBNShowerGaus"
 cafmaker.ShowerRazzleLabel: "" # unavailable
 cafmaker.RecoShowerSelectionLabel: "" # unavailable
-cafmaker.ShowerCosmicDistLabel: "" # unavailable
+cafmaker.ShowerCosmicDistLabel: "ShowerCosmicDist" 
 cafmaker.TrackCaloLabel:    "pandoraCaloGaus"
 cafmaker.TrackChi2PidLabel: "pandoraPidGaus"
 cafmaker.TrackScatterClosestApproachLabel: "" # unavailable


### PR DESCRIPTION
This PR changes one of the fcl files to enable that we save a variable that calculates the shortest distance from a shower to the nearest cosmic onto cafs. Currently, this variable goes unfilled in cafs but is calculated at the stage1 level, so I made changes to the cafemake_def.fcl file in order to start storing these values.