### PR TITLE
Add a CRT Hit flag to categorize side CRT Z position rectonstruction

### DIFF
--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -588,7 +588,7 @@ namespace crt {
 	  fZErrHit = hit.z_err;
 	  fT0Hit   = hit.ts0_ns;
 	  fT1Hit   = hit.ts1_ns;
-	  fHitFlag = hit.ts0_s_corr;
+	  fHitFlag = 0; //default flag = 0, only fill var. below for side CRT hits
 	  fNHitFeb  = hit.feb_id.size();
 	  fHitTotPe = hit.peshit;
 	  int mactmp = hit.feb_id[0];
@@ -636,6 +636,11 @@ namespace crt {
 		   fHitChan[arrpos]=thisHit[k].first;
                 }
              }
+	     // Load in CRTHitFlag for side CRT Hits only  
+	     // hit.ts0_s_corr was an unused variable in the sbn/common/CRTHit.h, repurposed this var for the hit flag to classify side CRT Z-position reconstruction 
+	     // if hitFlags are filled, hit.ts0_s_corr should be < 7, or else a timestamp is saved in ts0_s_corr
+	     if (hit.ts0_s_corr < 7) fHitFlag = hit.ts0_s_corr; 
+	     //
 	  }
 	  int chantmp = (*ittmp).second[0].first;
 	  

--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -229,7 +229,7 @@ namespace crt {
     int       fHitMod;
     int       fNHitFeb;
     float     fHitTotPe;
-
+    double    fHitFlag; // CRT Hit flag for side CRT Z reconstruction
     //CRT-PMT Matching vars
     int          fMatchEvent;///< Event number.
     int          fMatchRun;///< Run number.
@@ -404,6 +404,7 @@ namespace crt {
     fHitNtuple->Branch("gate_crt_diff",&m_gate_crt_diff, "gate_crt_diff/l");
     fHitNtuple->Branch("crt_global_trigger",&m_crt_global_trigger,"crt_global_trigger/l");
     fHitNtuple->Branch("crtGT_trig_diff",&m_crtGT_trig_diff,"crtGT_trig_diff/L");
+    fHitNtuple->Branch("hitFlag", &fHitFlag, "hitFlag/D");
     
     // Define the branches of our CRTPMTMatch ntuple
     fCRTPMTNtuple->Branch("event", &fMatchEvent, "event/I");
@@ -587,7 +588,7 @@ namespace crt {
 	  fZErrHit = hit.z_err;
 	  fT0Hit   = hit.ts0_ns;
 	  fT1Hit   = hit.ts1_ns;
-	   
+	  fHitFlag = hit.ts0_s_corr;
 	  fNHitFeb  = hit.feb_id.size();
 	  fHitTotPe = hit.peshit;
 	  int mactmp = hit.feb_id[0];

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -342,13 +342,13 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
 // Function to make filling a CRTHit a bit faster
 sbn::crt::CRTHit CRTHitRecoAlg::FillCRTHit(
     vector<uint8_t> tfeb_id, map<uint8_t, vector<pair<int, float>>> tpesmap,
-    float peshit, uint64_t time0, Long64_t time1, int plane, double x,
+    float peshit, double flag, uint64_t time0, Long64_t time1, int plane, double x,
     double ex, double y, double ey, double z, double ez, string tagger) {
   CRTHit crtHit;
   crtHit.feb_id = tfeb_id;
   crtHit.pesmap = tpesmap;
   crtHit.peshit = peshit;
-  crtHit.ts0_s_corr = time0 / 1'000'000'000;
+  crtHit.ts0_s_corr = flag;
   crtHit.ts0_ns = time0 % 1'000'000'000;
   crtHit.ts0_ns_corr = time0;
   crtHit.ts1_ns =
@@ -460,7 +460,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeTopHit(
 
   // no channels above threshold? return empty hit
   if (nabove == 0 || !findx || !findz)
-    return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
+    return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
 
   // hitpos*=1.0/petot; //hit position weighted by deposited charge
   // hitpos*=1.0/nabove;
@@ -497,9 +497,9 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeTopHit(
   // T0 reset events
   if ((sum < 10000 && thit1 < 2'001'000 && thit1 > 2'000'000) ||
       data->IsReference_TS1() || data->IsReference_TS0())
-    return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
+    return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
 
-  CRTHit hit = FillCRTHit({mac}, pesmap, petot, thit, thit1, plane,
+  CRTHit hit = FillCRTHit({mac}, pesmap, petot, 0, thit, thit1, plane,
                           hitpoint.X(), hitpointerr[0], hitpoint.Y(),
                           hitpointerr[1], hitpoint.Z(), hitpointerr[2], region);
 
@@ -545,7 +545,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeBottomHit(art::Ptr<CRTData> data) {
   }
 
   // no channels above threshold? return empty hit
-  if (nabove == 0) return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
+  if (nabove == 0) return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
 
   hitpos *= 1.0 / petot;  // hit position weighted by deposited charge
   geo::AuxDetGeo::LocalPoint_t const hitlocal{hitpos.X(), 0., 0.};
@@ -560,7 +560,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeBottomHit(art::Ptr<CRTData> data) {
   hitpointerr[1] = adGeo.HalfHeight();
   hitpointerr[2] = adsGeo.Length() / sqrt(12);
 
-  CRTHit hit = FillCRTHit({mac}, pesmap, petot, thit, thit, plane, hitpoint.X(),
+  CRTHit hit = FillCRTHit({mac}, pesmap, petot, 0, thit, thit, plane, hitpoint.X(),
                           hitpointerr[0], hitpoint.Y(), hitpointerr[1],
                           hitpoint.Z(), hitpointerr[2], region);
 
@@ -576,7 +576,18 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
 
   vector<uint8_t> macs;
   map<uint8_t, vector<pair<int, float>>> pesmap;
-
+  
+  double flag = 0.;// Flag for Side CRT Hits to destinguish between good and bad 
+                   //  reconstructed positions. - AH on 2/3/2023, see docdb 29972
+                   /* Note on flag variables: 
+		      flag = 0 : OK z position 
+		      flag = 1 : single ended readout on same end on inner and outer layers 
+		      flag = 2 : timestamps on opposite ends of module are >50 ns apart 
+		      flag = 3 : reco z position beyond length of module
+		      flag = 4 : single ended readout on one layer, OK z position 
+		      flag = 5 : reco z position in exact center of module 
+		      flag = 6 : single ended readout on opposite ends on inner and outer layers 
+		   */
   struct infoA {
     uint8_t mac5s;
     int channel;
@@ -592,7 +603,14 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
     TVector3 pos;
     int strip;
   };
-
+  /*struct info{
+    uint8_t mac5s; 
+    int channel;
+    uint64_t t0;
+    TVector3 pos;
+    int strip;
+    };
+    info infoA, infoB;*/
   vector<infoA> informationA;
   vector<infoA> informationB;
 
@@ -885,7 +903,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
       mf::LogInfo("CRTHitRecoAlg: ") << "no channels above threshold!" << '\n';
     if (layID.size() < 2 && fVerbose)
       mf::LogInfo("CRTHitRecoAlg: ") << "no coincidence found" << '\n';
-    return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
+    return FillCRTHit({}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "");
   }
 
   //-----------------------------------------------------------
@@ -1156,15 +1174,10 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
 
   ttrigs.resize(
       std::distance(ttrigs.begin(), std::unique(ttrigs.begin(), ttrigs.end())));
-  // thit = std::reduce(ttrigs.begin(), ttrigs.end()) / (uint64_t)ttrigs.size();
-  // thit = std::accumulate(ttrigs.begin(), ttrigs.end()) /
-  // (uint64_t)ttrigs.size();
-
+  
   t1trigs.resize(std::distance(t1trigs.begin(),
                                std::unique(t1trigs.begin(), t1trigs.end())));
-  //    t1hit = std::reduce(t1trigs.begin(), t1trigs.end()) /
-  //    (uint64_t)t1trigs.size(); t1hit = std::accumulate(t1trigs.begin(),
-  //    t1trigs.end()) / (uint64_t)t1trigs.size();
+  
   if (!ttrigs.empty()) {
     uint64_t const offset = ttrigs[0];
     int64_t rel_thit = 0;
@@ -1232,7 +1245,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   Long64_t thit1 = (Long64_t)(thit - GlobalTrigger[(int)macs.at(0)]);
 
   // generate hit
-  CRTHit hit = FillCRTHit(macs, pesmap, petot, thit, thit1, plane, hitpoint[0],
+  CRTHit hit = FillCRTHit(macs, pesmap, petot, flag, thit, thit1, plane, hitpoint[0],
                           hitpointerr[0], hitpoint[1], hitpointerr[1],
                           hitpoint[2], hitpointerr[2], region);
 

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -1005,11 +1005,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
 	float zaxixpos = 0.5 * (int64_t(t1_1 - t1_2) / fPropDelay);
 	posA = adsGeo.GetCenter() + geo::Zaxis() * zaxixpos;
 
-	if(zaxixpos!=0){
-	  
-	  
-	}
-	//
+	
 	if (fVerbose) 
 	  mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
 	    << "---\n\tFEB A: (mac_1,mac_2 = " << (int)infn.mac5s << "," 
@@ -1058,6 +1054,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   if (fVerbose) 
     mf::LogInfo("CRTHitRecoAlg")
       << "zposA_vec.size = " << zposA_vec.size() << "\n";
+  // if mutliple FEB coincidences on single layer, take average of all reco'd z-positions 
   if (zposA_vec.size() > 1){
     if (fVerbose) std::cout << "Z pos = ";
     for(float i_zpos : zposA_vec){
@@ -1124,12 +1121,11 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
 	  mf::LogInfo("CRTHitRecoAlg: ")
             << "t1: " << t2_1 << ", t2:" << t2_2
             << ", deltat : " << int64_t(t2_1 - t2_2) << '\n';
-	// if (foutCSVFile) filecsv << plane << "\t"<<  int64_t(t2_1 - t2_2) <<
-	// "\n";
+	// if (foutCSVFile) filecsv << plane << "\t"<<  int64_t(t2_1 - t2_2) << "\n";
+
 	float zaxixpos = 0.5 * (int64_t(t2_1 - t2_2) / fPropDelay);
 	posB = adsGeo.GetCenter() + geo::Zaxis() * zaxixpos;
 
-	//posB = adsGeo.GetCenter() + geo::Zaxis() * zaxixpos;
 	if (fVerbose)
 	  mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
 	    << "---\n\tFEB B: (mac_1,mac_2 = " << (int)infn.mac5s << "," 
@@ -1177,7 +1173,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   if (fVerbose) 
     mf::LogInfo("CRTHitRecoAlg")
       << "zposB_vec.size = " << zposB_vec.size() << "\n";
-  // if zposA_vec.size > 1, average the values in vect                                                 
+   // if mutliple FEB coincidences on single layer, take average of all reco'd z-positions 
   if (zposB_vec.size() > 1){
     if (fVerbose) std::cout << "Z pos = (";
     for(float i_zpos : zposB_vec){

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -940,8 +940,8 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   uint64_t t1_2 = -5; //layer 1: T0 for FEB on North end of module (odd mac5), E+W walls
   uint64_t t2_1 = -5; //layer 2: T0 for FEB on South end of module (even mac5), E+W walls
   uint64_t t2_2 = -5; //layer 2: T0 for FEB on North end of module (odd mac5), E+W walls
-  int mac5_1 = -5; //layer 1 mac5 (used to check for hits that cross module,)
-  int mac5_2 = -5; //layer 2 mac5 
+  int mac5_1 = -555; //layer 1 mac5 (used to check for hits that cross module,)
+  int mac5_2 = -555; //layer 2 mac5 
   geo::Point_t center;
   //if multiple pairs of FEBs contribute on a layer, take average of all reco'd z pos 
   // (store them in vector and take avg.)
@@ -958,7 +958,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
     zrange_max = center.Z() + adsGeo.HalfLength();
 
     if (fVerbose)
-      mf::LogInfo("CRTHitRecoAlg: ")
+      mf::LogInfo("CRTHitRecoAlg:")
           << "A type ----------> time: " << (long long int)infn.t0 << " ,macs "
           << (int)infn.mac5s  //<< '\n';
           << " ,chal " << infn.channel << " ,  position " << infn.pos[2]
@@ -1080,13 +1080,14 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
     zrange_max = center.Z() + adsGeo.HalfLength();
 
     if (fVerbose)
-      mf::LogInfo("CRTHitRecoAlg: ") << " B type ----------> time: " << infn.t0
+      mf::LogInfo("CRTHitRecoAlg:") << " B type ----------> time: " << infn.t0
                                      << " ,macs " << (int)infn.mac5s  //<< '\n';
                                      << " ,chal " << infn.channel
                                      << " ,  position " << infn.pos[2] << '\n';
 
-    if ((int)infn.mac5s != (int)informationB[i + 1].mac5s and
-        i < (int)informationB.size() - 1) {
+    if (((int)infn.mac5s != (int)informationB[i + 1].mac5s and
+	 i < (int)informationB.size() - 1) || (flag == 1 || flag == 4)) {
+      if(flag == 4 and i > 0) continue;
       layer2 = true;
       mac5_2 = (int)infn.mac5s;
       t0_2 = (uint64_t)infn.t0;
@@ -1195,6 +1196,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
       (int)informationB.size()==1 and 
       (crossfeb == 7 or crossfeb == 5) and //if opp ended readouts and cross feb
       region!="South" && region!="North"){ 
+    std::cout << "mac1, mac2 = " << mac5_1 << ", " << mac5_2 << "\n";
     flag = 6;
     int z_pos = 0.5*(int64_t(t0_1 - t0_2)/fPropDelay);
     // Check if FEB hits contributing to crossfeb hit are over 54ns apart
@@ -1253,7 +1255,8 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
       mf::LogInfo("CRTHitRecoAlg: ")
           << "hello hi namaskar,  hitpos z " << hitpos[2] << '\n';
     // side crt and only single layer match
-  }*/ else if (layer1 && region != "South" && region != "North") {  // && nx==1){
+    }*/ 
+  else if (layer1 && region != "South" && region != "North") {  // && nx==1){
     hitpos.SetZ(posA.Z());
     hitpos.SetX(hitpos.X() * 1.0 / nx);
     hitpos.SetY(hitpos.Y() * 1.0 / nx);

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -164,7 +164,7 @@ class icarus::crt::CRTHitRecoAlg {
   // Function to make filling a CRTHit a bit faster
   CRTHit FillCRTHit(vector<uint8_t> tfeb_id,
                     map<uint8_t, vector<pair<int, float>>> tpesmap,
-                    float peshit, uint64_t time0, Long64_t time1, int plane,
+                    float peshit, double flag, uint64_t time0, Long64_t time1, int plane,
                     double x, double ex, double y, double ey, double z,
                     double ez, string tagger);
 

--- a/icaruscode/CRT/CRTUtils/CRTTrackRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTTrackRecoAlg.cc
@@ -249,7 +249,7 @@ sbn::crt::CRTHit CRTTrackRecoAlg::DoAverage(vector<art::Ptr<sbn::crt::CRTHit>> h
   }
 
   // Create a hit
-  sbn::crt::CRTHit crtHit = hitAlg.FillCRTHit(hits[0]->feb_id, hits[0]->pesmap, hits[0]->peshit, 
+  sbn::crt::CRTHit crtHit = hitAlg.FillCRTHit(hits[0]->feb_id, hits[0]->pesmap, hits[0]->peshit, 0, 
                                   (ts0_ns/nhits)*1e-3, (ts1_ns/nhits)*1e-3, hits[0]->plane, xpos/nhits, (xmax-xmin)/2,
                                   ypos/nhits, (ymax-ymin)/2., zpos/nhits, (zmax-zmin)/2., tagger);
 


### PR DESCRIPTION
This PR adds a CRT Hit flag to help identify some cases where the Z-position reconstruction for side CRT hits isnt so good.
The Side CRT Hit are made of coincidences between inner and outer layers, with two layers being readout on opposite ends by two different FEBs (For East and West Side CRT walls *only*, North and South Side CRT walls use cut modules and readout on a single end). 
In some cases, the Side CRT Hit Z position can be reconstructed off the bounds of the module wall, due to the FEB readouts on opposite ends being too far apart in time (T0 on inner and outer layers being > 54ns apart). There are some other cases where the Side CRT Z-Position is defaulted to the center of the module, which is also flagged here. 
This PR is able to flag the badly reconstructed Z-positions (flag = 1,2,3) so the analyzer can choose whether or not to remove those CRT Hits entirely,  which one might want to do if the analysis is CRT position dependent.
We can use the CRT light signal amplitude (PE) to help assign a better Z position for these flagged CRT Hits, but this will have to wait for a new PR. 