### PR TITLE
Feature/cerati crtpmtfilter fcl

### DIFF
--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus_crtpmtfilter.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus_crtpmtfilter.fcl
@@ -1,0 +1,41 @@
+###
+## This fhicl file is used to filter events that do not pass the "medium" level
+## of the CRT-PMT filter. Only events passing are saved, in the same RAW format as before.
+## A second root file is saved with the CRT-PMT information for all events,
+## to allow studies on the filter performance.
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: CrtPmtFilter
+
+## Define the path we'll execute
+physics.path:     [ @sequence::icarus_stage0_data_crtpmtfilter_noTPC ]
+
+physics.filters.crtpmtmatchingfilter.FilterLevel: "medium"
+
+outputs.rootOutput.dataTier: "raw"
+outputs.rootOutput.outputCommands: [
+    "drop *_*_*_*", 
+    "keep *_*_*_DAQ*"]
+
+outputs.rootOutputNoFilt: {
+      checkFileName: false
+      compressionLevel: 1
+      dataTier: "reconstructed"
+      fileName: "%ifb_%tc-%p_unfilt.root"
+      fileProperties: {
+         maxInputFiles: 1
+      }
+      module_type: "RootOutput"
+      outputCommands: [
+         "keep *_*_*_CrtPmtFilter"
+      ]
+      saveMemoryObjectThreshold: 0
+   }
+
+physics.streamROOTNoFilt: [ "rootOutputNoFilt" ]
+
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ streamROOT, streamROOTNoFilt ]
+
+

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus_crtpmtfilter.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus_crtpmtfilter.fcl
@@ -1,41 +1,34 @@
 ###
 ## This fhicl file is used to filter events that do not pass the "medium" level
-## of the CRT-PMT filter. Only events passing are saved, in the same RAW format as before.
-## A second root file is saved with the CRT-PMT information for all events,
-## to allow studies on the filter performance.
+## of the CRT-PMT filter. Events passing are saved in the same RAW format as before.
+## For events that fail, the TPC information is dropped while the CRT-PMT information
+## is saved for all events, to allow studies on the filter performance.
 ##
+
 #include "stage0_icarus_driver_common.fcl"
 
 process_name: CrtPmtFilter
 
+daq: {
+  FragmentsLabelVec: [ "daq:PHYSCRATEDATATPCEE:DAQEVB09", "daq:PHYSCRATEDATATPCEW:DAQEVB09", "daq:PHYSCRATEDATATPCWE:DAQEVB09", "daq:PHYSCRATEDATATPCWW:DAQEVB09"]
+  module_type: "CopyDaqICARUSTPC"
+}
+
+physics.producers.daq: @local::daq
+
 ## Define the path we'll execute
-physics.path:     [ @sequence::icarus_stage0_data_crtpmtfilter_noTPC ]
+physics.path:     [ @sequence::icarus_stage0_data_crtpmtfilter_noTPC, daq ]
 
 physics.filters.crtpmtmatchingfilter.FilterLevel: "medium"
 
 outputs.rootOutput.dataTier: "raw"
+outputs.rootOutput.SelectEvents: []
 outputs.rootOutput.outputCommands: [
-    "drop *_*_*_*", 
-    "keep *_*_*_DAQ*"]
-
-outputs.rootOutputNoFilt: {
-      checkFileName: false
-      compressionLevel: 1
-      dataTier: "reconstructed"
-      fileName: "%ifb_%tc-%p_unfilt.root"
-      fileProperties: {
-         maxInputFiles: 1
-      }
-      module_type: "RootOutput"
-      outputCommands: [
-         "keep *_*_*_CrtPmtFilter"
+         "keep *_*_*_*",
+         "drop *_daq_PHYSCRATEDATATPC*_*",
+         "drop *_*_*_CrtPmtFilter",
+         "keep *_daq_*_CrtPmtFilter"
       ]
-      saveMemoryObjectThreshold: 0
-   }
-
-physics.streamROOTNoFilt: [ "rootOutputNoFilt" ]
 
 physics.trigger_paths: [ path ]
-physics.end_paths:     [ streamROOT, streamROOTNoFilt ]
-
-
+physics.end_paths:     [ streamROOT ]

--- a/icaruscode/Decode/CMakeLists.txt
+++ b/icaruscode/Decode/CMakeLists.txt
@@ -106,6 +106,14 @@ cet_build_plugin(DumpTrigger art::module LIBRARIES
   lardataalg::DetectorInfo
   )
 
+cet_build_plugin(CopyDaqICARUSTPC art::module LIBRARIES
+  sbnobj::Common_Trigger
+  artdaq_core::artdaq-core_Data
+  messagefacility::MF_MessageLogger
+  fhiclcpp::fhiclcpp
+  cetlib_except::cetlib_except
+  )
+
 install_headers()
 install_fhicl()
 install_source()

--- a/icaruscode/Decode/CopyDaqICARUSTPC_module.cc
+++ b/icaruscode/Decode/CopyDaqICARUSTPC_module.cc
@@ -1,0 +1,81 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       CopyDaqICARUSTPC
+// Plugin Type: producer (Unknown Unknown)
+// File:        CopyDaqICARUSTPC_module.cc
+//
+// Generated at Tue Nov  7 13:07:45 2023 by Giuseppe Cerati using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "sbnobj/Common/Trigger/ExtraTriggerInfo.h"
+// #include "sbnobj/Common/Trigger/BeamBits.h"
+// #include "sbnobj/Common/PMT/Data/PMTconfiguration.h" // sbn::PMTconfiguration
+// #include "sbndaq-artdaq-core/Overlays/Common/CAENV1730Fragment.hh"
+// #include "sbndaq-artdaq-core/Overlays/FragmentType.hh" // sbndaq::FragmentType
+#include "artdaq-core/Data/Fragment.hh"
+
+#include <memory>
+
+namespace {
+
+  /// Moves the content of `data` into a `std::unique_ptr`.
+  template <typename T>
+  std::unique_ptr<T> moveToUniquePtr(T& data)
+    { return std::make_unique<T>(std::move(data)); }
+
+} // local namespace
+
+class CopyDaqICARUSTPC;
+
+class CopyDaqICARUSTPC : public art::EDProducer {
+public:
+  explicit CopyDaqICARUSTPC(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  CopyDaqICARUSTPC(CopyDaqICARUSTPC const&) = delete;
+  CopyDaqICARUSTPC(CopyDaqICARUSTPC&&) = delete;
+  CopyDaqICARUSTPC& operator=(CopyDaqICARUSTPC const&) = delete;
+  CopyDaqICARUSTPC& operator=(CopyDaqICARUSTPC&&) = delete;
+
+  // Required functions.
+  void produce(art::Event& e) override;
+
+private:
+
+  // Declare member data here.
+  std::vector<art::InputTag> const fInputTags;
+};
+
+
+CopyDaqICARUSTPC::CopyDaqICARUSTPC(fhicl::ParameterSet const& p)
+  : EDProducer{p},
+  fInputTags(p.get<std::vector<art::InputTag>>("FragmentsLabelVec"))
+{
+  for (art::InputTag const& inputTag: fInputTags) {
+    consumes<artdaq::Fragments>(inputTag);
+    produces<artdaq::Fragments>(inputTag.instance());
+  }
+}
+
+void CopyDaqICARUSTPC::produce(art::Event& e)
+{
+  for (art::InputTag const& inputTag: fInputTags) {
+     auto const& thisHandle = e.getHandle<artdaq::Fragments>(inputTag);
+     artdaq::Fragments frags = *thisHandle;
+     e.put(moveToUniquePtr(frags), inputTag.instance());
+  }  
+}
+
+DEFINE_ART_MODULE(CopyDaqICARUSTPC)


### PR DESCRIPTION
This PR adds a fcl to run the CRT-PMT filter and copy forward the TPC RAW data only for events that pass the filter.
A producer module to make this copy is added as well.

The goal is to be able to reduce the size of the RAW data we need to process, starting from the data we already collected and currently store on disk.