### PR TITLE
Update PMT calibration tags for full Run-2 corrections

### DIFF
--- a/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
+++ b/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
@@ -6,7 +6,7 @@ BEGIN_PROLOG
 
 ICARUS_Calibration_GlobalTags: {
   @table::TPC_CalibrationTags_Oct2023
-  @table::PMT_CalibrationTags_Run2_Sept2023
+  @table::PMT_CalibrationTags_Run2_Dec2023
   @table::CRT_CalibrationTags_Oct2023
 }
 

--- a/fcl/configurations/calibration_database_PMT_TagSets_icarus.fcl
+++ b/fcl/configurations/calibration_database_PMT_TagSets_icarus.fcl
@@ -34,4 +34,15 @@ PMT_CalibrationTags_Run2_Sept2023: {
   pmt_cosmics_timing_data:   "v2r0"  # tables for run>=0 (null), run>=8046 and run>=9301 (null) 
 }
 
+# These are the standard tags for analyses on Run 1 and Run 2 data (as of December 2023)
+# These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
+# Notes: 
+#  - Updated cable delays with new phase offsets
+#  - Full laser and cosmics corrections for all Run 2.
+PMT_CalibrationTags_Run2_Dec2023: {
+  pmt_cables_delays_data:    "v2r3"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628, run>=9773 and run>=10369
+  pmt_laser_timing_data:     "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
+  pmt_cosmics_timing_data:   "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773 
+}
+
 END_PROLOG


### PR DESCRIPTION
This PR updates the PMT calibration tags to pick-up the latest timing corrections.
In particular, the update includes:

- New cable delays for Run-2, adding phase offsets to single digitizers and updating the mapping after the summer activities (`v2r3`).
- New cosmics corrections for Run-2 (`v2r1`).

**Note**: This change requires a concurrent release of `icarus_data` containing the updated databases.