### PR TITLE
This commit fixes a bug in the CRT-PMT matching analyzer module. 

### DIFF
--- a/icaruscode/CRT/CRTPMTMatchingAna_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingAna_module.cc
@@ -246,6 +246,7 @@ class icarus::crt::CRTPMTMatchingAna : public art::EDAnalyzer {
   double fOpFlashTime_us;  // Time of the optical Flash w.r.t. Global Trigger
   double fOpFlashTimehit_us;
   double fOpFlashTimeAbs;
+  int fnOpHitAboveThreshold; // Number of Optical Hits above threshold
   bool fInTime;  // Was the OpFlash in beam spill time?
   bool fInTime_gate;
   bool fInTime_beam;
@@ -495,9 +496,12 @@ void icarus::crt::CRTPMTMatchingAna::analyze(art::Event const& e) {
       }
       geo::Point_t flash_pos = flashCentroid.middlePoint();
       // t_m = t_m / nPMTsTriggering; // unused
+      // F. Poppi: I will leave this commented in case we want to revert it to the original A. Scarpelli suggestion. 
+      // I'd rather have this as a variable to cut when doing the analysis.
+      /*if (nPMTsTriggering < fnOpHitToTrigger) {
       if (nPMTsTriggering < fnOpHitToTrigger) {
         continue;
-      }
+      }*/
       bool inTime = flashInTime(firstTime, m_gate_type, m_trigger_gate_diff, m_gate_width);
       fRelGateTime = m_trigger_gate_diff + (tAbsflash - 1500) * 1e3;
       fInTime_gate = false;
@@ -518,6 +522,7 @@ void icarus::crt::CRTPMTMatchingAna::analyze(art::Event const& e) {
       // Now get the CRT. Search the CRT Hits within -100 from the flash time
       //  for the future a differentiation between Top and Side and some
       //  considerations based on the proximity of the light are necessary
+      fnOpHitAboveThreshold=nPMTsTriggering;
       icarus::crt::MatchedCRT CRTmatches =
           CRTHitmatched(firstTime, flash_pos, crtHitList, 0.1);
       int TopEn = 0, TopEx = 0, SideEn = 0, SideEx = 0;

--- a/icaruscode/CRT/CRTPMTMatchingAna_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingAna_module.cc
@@ -347,6 +347,7 @@ icarus::crt::CRTPMTMatchingAna::CRTPMTMatchingAna(fhicl::ParameterSet const& p)
   fMatchTree->Branch("opHit_z", &fOpHitZ);
   fMatchTree->Branch("opHit_t", &fOpHitT);
   fMatchTree->Branch("opHit_amplitude", &fOpHitA);
+  fMatchTree->Branch("nOpHitOverThreshold", &fnOpHitAboveThreshold);
   fMatchTree->Branch("inTime", &fInTime);
   fMatchTree->Branch("inTime_beam", &fInTime_beam);
   fMatchTree->Branch("inTime_gate", &fInTime_gate);


### PR DESCRIPTION
Previously there was the requirment for a certain number of opHits to be above threshold to consider the flash valid. The bug did not initialze some vectors when the nopHitAboveThreshold was lower then the requirments. Since in the future threshold will change, I removed the strong skipping-the-flash condition and I added the number of opHits above threhsold as a variabile for the analyzers to cut on.  This PR was previously approved by reviewe.