### PR TITLE
Change trigger efficiency NTuple hit-level dE/dx information to output of standard calorimetry modules

### DIFF
--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
@@ -1145,7 +1145,7 @@ sbn::selHitInfo sbn::TimeTrackTreeStorage::makeHit(const recob::Hit &hit,
         hinfo.oncalo = true;
         hinfo.pitch = c->TrkPitchVec()[i_calo];
         hinfo.dqdx = c->dQdx()[i_calo];
-        hinfo.dEdx = dEdx_calc(hinfo.dqdx, fMODA, fMODB, fWion, fEfield);
+        hinfo.dEdx = c->dEdx()[i_calo];
         hinfo.rr = sortRange(c->ResidualRange()[i_calo]);
         break;
       } // for i_calo

--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
@@ -342,30 +342,6 @@ public:
       Comment("label for output messages of this module instance"),
       "TimeTrackTreeStorage" // default
       };
-
-    fhicl::Atom<float> MODA {
-      Name("MODA"),
-      Comment("first recombination parameter for dE/dx calculations"),
-      0.930 //default
-      };
-    
-    fhicl::Atom<float> MODB {
-      Name("MODB"),
-      Comment("second recombination parameter for dE/dx calculations"),
-      0.212
-      };
-    
-    fhicl::Atom<float> Wion {
-      Name("Wion"),
-      Comment("work function for recombination"),
-      0.0000236016
-      };
-    
-    fhicl::Atom<float> Efield {
-      Name("Efield"),
-      Comment("Electric field in kV/cm"),
-      0.5
-      };
     
     fhicl::Atom<bool> ForceDowngoing {
       Name("ForceDowngoing"),
@@ -396,12 +372,6 @@ public:
                           const std::vector<anab::Calorimetry const*> &calo,
                           const geo::GeometryCore *geo);
 
-  float dEdx_calc(float dQdx, 
-                  float A,
-                  float B,
-                  float Wion,
-                  float E);
-
   void analyze(art::Event const& e) override;
   
   void endJob() override;
@@ -424,10 +394,6 @@ private:
   art::InputTag const fFlashProducer;
   art::InputTag const fCRTMatchProducer;
   std::string const fLogCategory;
-  float const fMODA;
-  float const fMODB;
-  float const fWion;
-  float const fEfield;
   bool const fForceDowngoing; ///< Whether to force all tracks to be downgoing.
   int const fCalorimetryPlaneNumber; ///< Which plane to use for calorimetry.
   
@@ -1155,22 +1121,6 @@ sbn::selHitInfo sbn::TimeTrackTreeStorage::makeHit(const recob::Hit &hit,
   
   return hinfo;
 }
-
-float sbn::TimeTrackTreeStorage::dEdx_calc(float dQdx,
-                                           float A,
-                                           float B,
-                                           float Wion,
-                                           float E) 
-{
-  float LAr_density_gmL = 1.389875; //LAr density in g/cm^3
-  float alpha = A;
-  float beta = B/(LAr_density_gmL*E);
-  float dEdx = ((std::exp(dQdx*Wion*beta) - alpha)/beta)*3.278;
- 
-  return dEdx;
-  
-}
-
 
 sbn::selCRTInfo sbn::TimeTrackTreeStorage::extractCRTinfoFor(
   art::Ptr<recob::Track> const& trackPtr, art::Event const& event,

--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorageCRT_module.cc
@@ -553,10 +553,6 @@ sbn::TimeTrackTreeStorage::TimeTrackTreeStorage(Parameters const& p)
   , fFlashProducer    { p().FlashProducer() }
   , fCRTMatchProducer { p().CRTMatchingProducer() }
   , fLogCategory      { p().LogCategory() }
-  , fMODA             { p().MODA() }
-  , fMODB             { p().MODB() }
-  , fWion             { p().Wion() }
-  , fEfield           { p().Efield() }
   , fForceDowngoing    { p().ForceDowngoing() }
   , fCalorimetryPlaneNumber { p().CalorimetryPlane() }
   // algorithms
@@ -1309,5 +1305,4 @@ auto sbn::TimeTrackTreeStorage::distanceFromTimeRange
 
 // -----------------------------------------------------------------------------
 DEFINE_ART_MODULE(sbn::TimeTrackTreeStorage)
-
 

--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
@@ -376,10 +376,6 @@ sbn::TimeTrackTreeStorage::TimeTrackTreeStorage(Parameters const& p)
   , fTriggerProducer  { p().TriggerProducer() }
   , fFlashProducer    { p().FlashProducer() }
   , fLogCategory      { p().LogCategory() }
-  , fMODA             { p().MODA() }
-  , fMODB             { p().MODB() }
-  , fWion             { p().Wion() }
-  , fEfield           { p().Efield() }
   , fForceDowngoing    { p().ForceDowngoing() }
   // algorithms
   , fPMTwalls         { computePMTwalls() }

--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
@@ -748,7 +748,7 @@ sbn::selHitInfo sbn::TimeTrackTreeStorage::makeHit(const recob::Hit &hit,
         hinfo.oncalo = true;
         hinfo.pitch = c->TrkPitchVec()[i_calo];
         hinfo.dqdx = c->dQdx()[i_calo];
-        hinfo.dEdx = dEdx_calc(hinfo.dqdx, fMODA, fMODB, fWion, fEfield);
+        hinfo.dEdx = c->dEdx()[i_calo];
         hinfo.rr = c->ResidualRange()[i_calo];
         break;
       } // for i_calo

--- a/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
+++ b/icaruscode/Analysis/trigger/TimeTrackTreeStorage_module.cc
@@ -258,30 +258,6 @@ public:
       Comment("label for output messages of this module instance"),
       "TimeTrackTreeStorage" // default
       };
-
-    fhicl::Atom<float> MODA {
-      Name("MODA"),
-      Comment("first recombination parameter for dE/dx calculations"),
-      0.930 //default
-      };
-    
-    fhicl::Atom<float> MODB {
-      Name("MODB"),
-      Comment("second recombination parameter for dE/dx calculations"),
-      0.212
-      };
-    
-    fhicl::Atom<float> Wion {
-      Name("Wion"),
-      Comment("work function for recombination"),
-      0.0000236016
-      };
-    
-    fhicl::Atom<float> Efield {
-      Name("Efield"),
-      Comment("Electric field in kV/cm"),
-      0.5
-      };
     
     fhicl::Atom<bool> ForceDowngoing {
       Name("ForceDowngoing"),
@@ -302,12 +278,6 @@ public:
                           const std::vector<art::Ptr<anab::Calorimetry>> &calo,
                           const geo::GeometryCore *geo);
 
-  float dEdx_calc(float dQdx, 
-                  float A,
-                  float B,
-                  float Wion,
-                  float E);
-
   void analyze(art::Event const& e) override;
   
   void endJob() override;
@@ -327,10 +297,6 @@ private:
   art::InputTag const fTriggerProducer;
   art::InputTag const fFlashProducer;
   std::string const fLogCategory;
-  float const fMODA;
-  float const fMODB;
-  float const fWion;
-  float const fEfield;
   bool const fForceDowngoing; ///< Whether to force all tracks to be downgoing.
   
   // --- END ---- Configuration parameters -------------------------------------
@@ -757,21 +723,6 @@ sbn::selHitInfo sbn::TimeTrackTreeStorage::makeHit(const recob::Hit &hit,
   }
   
   return hinfo;
-}
-
-float sbn::TimeTrackTreeStorage::dEdx_calc(float dQdx,
-                                           float A,
-                                           float B,
-                                           float Wion,
-                                           float E) 
-{
-  float LAr_density_gmL = 1.389875; //LAr density in g/cm^3
-  float alpha = A;
-  float beta = B/(LAr_density_gmL*E);
-  float dEdx = ((std::exp(dQdx*Wion*beta) - alpha)/beta)*3.278;
- 
-  return dEdx;
-  
 }
 
 

--- a/icaruscode/Analysis/trigger/createtree_timed_tracks_icarus.fcl
+++ b/icaruscode/Analysis/trigger/createtree_timed_tracks_icarus.fcl
@@ -35,10 +35,6 @@ timetracktreestorage_base: {
   module_type: "TimeTrackTreeStorage"
   BeamGateProducer: "daqTrigger"
   TriggerProducer:  "daqTrigger"
-  MODA: 0.930
-  MODB: 0.212
-  Wion: 0.0000236016
-  Efield: 0.5
   ForceDowngoing: true
 }
 

--- a/icaruscode/Analysis/trigger/magic_raw_to_triggeremu_icarus_Run1_data.fcl
+++ b/icaruscode/Analysis/trigger/magic_raw_to_triggeremu_icarus_Run1_data.fcl
@@ -76,11 +76,6 @@ gatesFromTracks_icarus: {
 t0TreeStore_icarus: {
 
   @table::timetracktreestorage_base
-  
-  MODA: 0.930
-  MODB: 0.212
-  Wion: 0.0000236016
-  Efield: 0.5
   ForceDowngoing: true
   
 } # t0TreeStore_icarus


### PR DESCRIPTION
One-line change to trigger efficiency modules to extract the hit-level dE/dx information from the standard calorimetry modules in the NTuples used for the trigger efficiency analyses instead of a homebrew function in the module. Tested extensively that the production works and values are output using the production branch v09_72_00_05p04 by Riccardo Triozzi and shown to work. Can test again directly with this version if requested by review.