### PR TITLE
New tags for Run 3 laser corrections

### DIFF
--- a/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
+++ b/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
@@ -6,7 +6,7 @@ BEGIN_PROLOG
 
 ICARUS_Calibration_GlobalTags: {
   @table::TPC_CalibrationTags_Oct2023
-  @table::PMT_CalibrationTags_Run2_Dec2023
+  @table::PMT_CalibrationTags_Run3_Dec2023
   @table::CRT_CalibrationTags_Oct2023
 }
 

--- a/fcl/configurations/calibration_database_PMT_TagSets_icarus.fcl
+++ b/fcl/configurations/calibration_database_PMT_TagSets_icarus.fcl
@@ -14,7 +14,7 @@ PMT_CalibrationTags_Run1: {
 }
 
 # These are the standard tags for analyses on Run 1 and Run 2 data (as of August 2023)
-# These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
+# These tagged versions of the databases contain tables relevant for Run 1 and Run 2.
 # Notes: 
 #  - No cosmics corrections are available for Run 2
 #  - Laser and cable corrections do not cover the entire Run 2 period
@@ -25,7 +25,7 @@ PMT_CalibrationTags_Run2_August2023: {
 }
 
 # These are the standard tags for analyses on Run 1 and Run 2 data (as of September 2023)
-# These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
+# These tagged versions of the databases contain tables relevant for Run 1 and Run 2.
 # Notes: 
 #  - No cosmics corrections are available for Run 2
 PMT_CalibrationTags_Run2_Sept2023: {
@@ -35,13 +35,24 @@ PMT_CalibrationTags_Run2_Sept2023: {
 }
 
 # These are the standard tags for analyses on Run 1 and Run 2 data (as of December 2023)
-# These tagged versions of the databases only contain tables relevant for Run 1 and Run 2.
+# These tagged versions of the databases contain tables relevant for Run 1 and Run 2.
 # Notes: 
 #  - Updated cable delays with new phase offsets
 #  - Full laser and cosmics corrections for all Run 2.
 PMT_CalibrationTags_Run2_Dec2023: {
   pmt_cables_delays_data:    "v2r3"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628, run>=9773 and run>=10369
   pmt_laser_timing_data:     "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773
+  pmt_cosmics_timing_data:   "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773 
+}
+
+# These are the standard tags for analyses on Run 1, Run 2 and future Run 3 data (as of December 2023)
+# These tagged versions of the databases contain tables relevant for Run 1, Run 2 and Run 3.
+# Notes: 
+#   - New cable delays (mapping changes, upgrades to laser distribution)
+#   - New laser table for the beginning of Run 3 (new signal cables)
+PMT_CalibrationTags_Run3_Dec2023: {
+  pmt_cables_delays_data:    "v2r4"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628, run>=9773, run>=10369 and run>=10865
+  pmt_laser_timing_data:     "v2r2"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628, run>=9773 and run>=10908
   pmt_cosmics_timing_data:   "v2r1"  # tables for run>=0 (null), run>=8046, run>=9301, run>=9628 and run>=9773 
 }
 


### PR DESCRIPTION
This PR updates the PMT calibration database tags to pick up the most recent corrections which should cover the beginning of Run 3. In particular:

- Cable delays are updated given the summer work on the laser system (`v2r4`).
- New laser corrections are included following the replacement of the signal cables and the new gain equalization (`v2r2`).

**Note**: This change requires a concurrent release of `icarus_data` containing the updated database files.

-------

@PetrilloAtWork Addressing here your comment from below: the cosmics-based corrections downstream are computed starting from the laser-correct ophit times and added on top. Assuming they get invalidated if you change the laser corrections is a conservative assumption we make. Comparing actual data, the issue is not as bad as we have claimed in the past. If you look at the plot below, you can see the cosmics residuals from run 9595 (first calibration period of RUN-2) corrected with: the correct cosmics corrections for that period (green), cosmics corrections from a wrong RUN-2 period (blue) and cosmics corrections from RUN-1 (orange). No relevant hardware change between green and blue, several between green and orange (adders + new voltages). Despite the laser corrections having changed, the same cosmics corrections could be applied but the price you pay are longer tails.
![CORRECTION_VALIDITY_TEST](https://github.com/SBNSoftware/icaruscode/assets/64699641/a1f1a1d5-16a7-41ff-af8d-b2ea2b95bc0d)
