### PR TITLE
Updated 2d simulation/deconvolution fhicl files for validation of pending 2024 release

### DIFF
--- a/fcl/detsim/detsim_2d_icarus.fcl
+++ b/fcl/detsim/detsim_2d_icarus.fcl
@@ -33,14 +33,3 @@ physics: {
 outputs: {
   rootoutput: @local::icarus_rootoutput
 }
-
-# Field Responce input customisation
-# physics.producers.daq.wcls_main.params.files_fields: "icarus_testFR_1.json.bz2"
-
-#
-# customisation
-#
-
-# we are suppressing channels with no signal in the TPC
-# physics.producers.daq.SuppressNoSignal: true
-

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus.fcl
@@ -42,6 +42,39 @@ physics.producers.gaushitTPCWE.CalDataModuleLabel:  "roifinder2d:PHYSCRATEDATATP
 physics.producers.gaushitTPCEW.CalDataModuleLabel:  "roifinder2d:PHYSCRATEDATATPCEW"
 physics.producers.gaushitTPCEE.CalDataModuleLabel:  "roifinder2d:PHYSCRATEDATATPCEE"
 
+# Add below as per Gray Putnam (should we move to jsonnet files?)
+physics.producers.decon2droiEE.wcls_main.structs.gain0: 10.2636323 
+physics.producers.decon2droiEW.wcls_main.structs.gain0: 10.2636323 
+physics.producers.decon2droiWE.wcls_main.structs.gain0: 10.2636323 
+physics.producers.decon2droiWW.wcls_main.structs.gain0: 10.2636323 
+
+
+physics.producers.decon2droiEE.wcls_main.structs.gain1: 12.1420344 
+physics.producers.decon2droiEW.wcls_main.structs.gain1: 12.1420344 
+physics.producers.decon2droiWE.wcls_main.structs.gain1: 12.1420344 
+physics.producers.decon2droiWW.wcls_main.structs.gain1: 12.1420344 
+
+physics.producers.decon2droiEE.wcls_main.structs.gain2: 13.0261362 
+physics.producers.decon2droiEW.wcls_main.structs.gain2: 13.0261362 
+physics.producers.decon2droiWE.wcls_main.structs.gain2: 13.0261362 
+physics.producers.decon2droiWW.wcls_main.structs.gain2: 13.0261362 
+
+
+physics.producers.decon2droiEE.wcls_main.structs.shaping0: 1.3  
+physics.producers.decon2droiEW.wcls_main.structs.shaping0: 1.3  
+physics.producers.decon2droiWE.wcls_main.structs.shaping0: 1.3  
+physics.producers.decon2droiWW.wcls_main.structs.shaping0: 1.3  
+
+physics.producers.decon2droiEE.wcls_main.structs.shaping1: 1.45  
+physics.producers.decon2droiEW.wcls_main.structs.shaping1: 1.45  
+physics.producers.decon2droiWE.wcls_main.structs.shaping1: 1.45  
+physics.producers.decon2droiWW.wcls_main.structs.shaping1: 1.45  
+
+physics.producers.decon2droiEE.wcls_main.structs.shaping2: 1.3  
+physics.producers.decon2droiEW.wcls_main.structs.shaping2: 1.3  
+physics.producers.decon2droiWE.wcls_main.structs.shaping2: 1.3  
+physics.producers.decon2droiWW.wcls_main.structs.shaping2: 1.3  
+
 services.message.destinations :
 {
   STDCOUT:

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_keepup.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_keepup.fcl
@@ -1,0 +1,17 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_run2_wc_icarus.fcl"
+
+## Add the purity monitor
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamROOT ]
+
+
+## Need overrides for the purity monitor
+physics.analyzers.purityinfoana0.SelectEvents: [ path ]
+physics.analyzers.purityinfoana1.SelectEvents: [ path ]
+physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_mc.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_mc.fcl
@@ -5,7 +5,7 @@
 #include "stage0_icarus_mc_defs.fcl"
 #include "stage0_icarus_driver_common.fcl"
 
-process_name: MCstage0
+process_name: MCstage0Test
 
 ## Add the MC module to the list of producers
 physics.producers: {  @table::icarus_stage0_producers
@@ -20,7 +20,7 @@ physics.path: [   @sequence::icarus_stage0_mc_PMT,
               ]
 
 ## boiler plate...
-physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.outana:        [ ]
 physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamROOT ]
 
@@ -30,7 +30,7 @@ outputs.rootOutput.outputCommands: ["keep *_*_*_*",
                                     "drop *_MCDecodeTPCROI_*_*", 
                                     "drop *_decon1droi_*_*", 
                                     "drop *_decon2Droi*_*_*", 
-                                    "drop recob::Wire*_roifinder_*_*", 
+                                    "drop recob::Wire*_roifinder*_*_*", 
                                     "keep *_daq_simpleSC_*" ]
 
 # Drop the daq format files on output, 
@@ -62,15 +62,44 @@ physics.producers.decon2droiEW.wcls_main.params.raw_input_label:  "MCDecodeTPCRO
 physics.producers.decon2droiWE.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWE"
 physics.producers.decon2droiWW.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWW"
 
+# Make sure ROI finder uses correct info
+physics.producers.roifinder2d.WireModuleLabelVec:  ["decon2droiWW:decon","decon2droiWE:decon","decon2droiEW:decon","decon2droiEE:decon"]
+
 # Override the hit finder input 
 physics.producers.gaushitTPCWW.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCWW"
 physics.producers.gaushitTPCWE.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCWE"
 physics.producers.gaushitTPCEW.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCEW"
 physics.producers.gaushitTPCEE.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCEE"
 
-## Need overrides for the purity monitor
-physics.analyzers.purityinfoana0.SelectEvents: [ path ]
-physics.analyzers.purityinfoana1.SelectEvents: [ path ]
-physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
-physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+# As per Gray Putname...
+physics.producers.decon2droiEE.wcls_main.structs.gain0: 10.2636323 
+physics.producers.decon2droiEW.wcls_main.structs.gain0: 10.2636323 
+physics.producers.decon2droiWE.wcls_main.structs.gain0: 10.2636323 
+physics.producers.decon2droiWW.wcls_main.structs.gain0: 10.2636323 
 
+
+physics.producers.decon2droiEE.wcls_main.structs.gain1: 12.1420344 
+physics.producers.decon2droiEW.wcls_main.structs.gain1: 12.1420344 
+physics.producers.decon2droiWE.wcls_main.structs.gain1: 12.1420344 
+physics.producers.decon2droiWW.wcls_main.structs.gain1: 12.1420344 
+
+physics.producers.decon2droiEE.wcls_main.structs.gain2: 13.0261362 
+physics.producers.decon2droiEW.wcls_main.structs.gain2: 13.0261362 
+physics.producers.decon2droiWE.wcls_main.structs.gain2: 13.0261362 
+physics.producers.decon2droiWW.wcls_main.structs.gain2: 13.0261362 
+
+
+physics.producers.decon2droiEE.wcls_main.structs.shaping0: 1.3  
+physics.producers.decon2droiEW.wcls_main.structs.shaping0: 1.3  
+physics.producers.decon2droiWE.wcls_main.structs.shaping0: 1.3  
+physics.producers.decon2droiWW.wcls_main.structs.shaping0: 1.3  
+
+physics.producers.decon2droiEE.wcls_main.structs.shaping1: 1.45  
+physics.producers.decon2droiEW.wcls_main.structs.shaping1: 1.45  
+physics.producers.decon2droiWE.wcls_main.structs.shaping1: 1.45  
+physics.producers.decon2droiWW.wcls_main.structs.shaping1: 1.45  
+
+physics.producers.decon2droiEE.wcls_main.structs.shaping2: 1.3  
+physics.producers.decon2droiEW.wcls_main.structs.shaping2: 1.3  
+physics.producers.decon2droiWE.wcls_main.structs.shaping2: 1.3  
+physics.producers.decon2droiWW.wcls_main.structs.shaping2: 1.3  

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_raw_icarus_mc.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_raw_icarus_mc.fcl
@@ -10,13 +10,13 @@
 # Drop all output from the 2D deconvolution stage
 # Drop the recob::Wire output from the roifinder2d (but keep the ChannelROIs)
 outputs.rootOutput.outputCommands:         ["keep *_*_*_*", 
-                                            "drop *_daq_*_*", 
-                                            "drop *_MCDecodeTPCROI_*_*", 
+                                            #"drop *_daq_*_*", # Temporarily remove
+                                            "drop *_MCDecodeTPCROI_*_*",
                                             "drop *_decon1droi_*_*", 
                                             "drop *_decon2droi*_*_*", 
                                             "drop recob::Wire*_roifinder_*_*",
                                             "drop recob::Wire*_roifinder2d_*_*",
-                                            "keep raw::RawDigit*_MCDecodeTPCROI_*_*",
-                                            "keep *_daq_simpleSC*_*" 
+                                            "keep raw::RawDigit*_MCDecodeTPCROI_*_*"
+                                            #"keep *_daq_simpleSC*_*"  # Temporarily remove
                                            ]
 

--- a/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
+++ b/icaruscode/Decode/DecoderTools/decoderTools_icarus.fcl
@@ -89,8 +89,9 @@ TPCNoiseFilter1DTool: {
     NSigmaForTrucation: 3.5
     StructuringElement: 16
     FilterWindow:       10
-    Threshold:          [12.0, 12.0, 12.0] #[8., 7.0 , 8.0] #[2.75, 2.75, 2.75] # changing threshold scheme from dynamic to static
+    Threshold:          [1.0,1.0,1.0]
     FilterModeVec:      ["e","g","d"]
+    LowFreqCorrection:  true
     UseFFTFilter:       false
     FFTSigmaVals:       [ [1.5,20.], [1.5,20.], [1.5,20.] ]
     FFTCutoffVals:      [ [8.,800.], [8.,800.], [4.0,800.] ]


### PR DESCRIPTION
These fhicl files are meant to be used for reprocessing Run 2 data and for MC simulations. These versions are to start validation and may be updated...