### PR TITLE
New training based on bnb ICARUS simulations for track vs shower discrimination 

### DIFF
--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
@@ -323,13 +323,17 @@
     <OutputVertexListName>DaughterVertices3D</OutputVertexListName>
   </algorithm>
   <algorithm type = "LArBdtPfoCharacterisation">
+    <TrainingSetMode>false</TrainingSetMode>
+    <CaloHitListName>CaloHitList2D</CaloHitListName>
+    <MCParticleListName>Input</MCParticleListName>
+    <TrainingOutputFileName>BNBPfoCharTraining</TrainingOutputFileName>
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
     <PersistFeatures>true</PersistFeatures>
-    <MvaFileName>PandoraBdt_v08_33_00_SBND.xml</MvaFileName>
+    <MvaFileName>BNBPfoCharTraining_sdellepi_noHierarchy.xml</MvaFileName>
     <MvaName>PfoCharBDT</MvaName>
-    <MvaFileNameNoChargeInfo>PandoraBdt_v08_33_00_SBND.xml</MvaFileNameNoChargeInfo>
+    <MvaFileNameNoChargeInfo>BNBPfoCharTraining_sdellepi_noHierarchy.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
@@ -337,12 +341,13 @@
       <tool type = "LArThreeDPCAFeatureTool"/>
       <tool type = "LArThreeDOpeningAngleFeatureTool"/>
       <tool type = "LArThreeDChargeFeatureTool"/>
+      <tool type = "LArConeChargeFeatureTool"/>
     </FeatureTools>
     <FeatureToolsNoChargeInfo>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
       <tool type = "LArThreeDVertexDistanceFeatureTool"/>
       <tool type = "LArThreeDPCAFeatureTool"/>
-      <tool type = "LArThreeDOpeningAngleFeatureTool"/>
+      <tool type = "LArThreeDOpeningAngleFeatureTool"/>      
     </FeatureToolsNoChargeInfo>
   </algorithm>
   <algorithm type = "LArNeutrinoProperties">

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
@@ -331,9 +331,9 @@
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
     <PersistFeatures>true</PersistFeatures>
-    <MvaFileName>BNBPfoCharTraining_sdellepi_noHierarchy.xml</MvaFileName>
+    <MvaFileName>PandoraBdt_v09_72_01_ICARUS_pfochar_bnb.xml</MvaFileName>
     <MvaName>PfoCharBDT</MvaName>
-    <MvaFileNameNoChargeInfo>BNBPfoCharTraining_sdellepi_noHierarchy.xml</MvaFileNameNoChargeInfo>
+    <MvaFileNameNoChargeInfo>PandoraBdt_v09_72_01_ICARUS_pfochar_bnb.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>


### PR DESCRIPTION
This PR contains the new training for track vs shower discrimination in Pandora automatic reconstruction (i.e. LArBdtPfoCharacterisation) based on ICARUS bnb simulations (icaruscode v09_72_01) and including three new BDT variables.

This PR should also include changes to branches with the same name of the following repositories:
- feature/acampani_sdellepi_new_BdtPfoCharacterisation in sbnanaobj
- feature/acampani_sdellepi_new_BdtPfoCharacterisation in sbncode 
- the new BDT training .xml file  in icarus_data/icarus_data/PandoraMVAs/PandoraBdt_v09_72_01_ICARUS_pfochar_bnb.xml


