### PR TITLE
Fixed the coherent noise scale factor (1.09 -> 1.0) to match data

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
+++ b/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
@@ -50,7 +50,7 @@ icarus_simwire_wirecell:
             # driftSpeed: 1.5756
             # Scaling Parameters from int and coh noise components
 	        int_noise_scale: 1.0
-	        coh_noise_scale: 1.09
+	        coh_noise_scale: 1.0
 
             # Gain and shaping time
             gain0: 14.9654 # mV/fC 


### PR DESCRIPTION
The inputs to the Wire Cell model were updated in a recent release of icarus_data. The existing parameter controlling the scale of the coherent noise in `detsimmodules_wirecell_ICARUS.fcl` was not updated to match data, which this PR does. 

Some context: previously, this scale factor was used to scale the coherent noise upwards to match data. This is no longer necessary as the noise model matches data with no fine-tuning of scale factors (all scales set to 1.0).

I have made a small sample with both the default and with the change in this PR and verified that this PR is needed to match the data sample that was used to generate the model. The plot below supports this claim (though it is not very presentable). Note that the average noise levels in data (listed below the plots) are only matched with the scale factor set to 1.0.

![image](https://github.com/SBNSoftware/icaruscode/assets/38986971/69a752b0-86ac-41c2-bc19-3d250256d2d5)
