### PR TITLE
apply offset to simulated CRT Hit times as the CRT Hits are being produced

### DIFF
--- a/fcl/caf/cafmakerjob_icarus.fcl
+++ b/fcl/caf/cafmakerjob_icarus.fcl
@@ -50,7 +50,9 @@ physics:
 # MCT0Offset for MC ()
 # ref1 : https://github.com/SBNSoftware/icaruscode/blob/v09_37_02_01/icaruscode/CRT/crtsimmodules_icarus.fcl#L11
 # ref2 : https://github.com/SBNSoftware/icaruscode/blob/v09_64_01/icaruscode/CRT/crttruehitproducer.fcl#L8
-physics.producers.cafmaker.CRTSimT0Offset: @local::standard_icarus_crtsimalg.GlobalT0Offset
+# physics.producers.cafmaker.CRTSimT0Offset: @local::standard_icarus_crtsimalg.GlobalT0Offset
+# instead, apply this^ offset in CRTHitRecoAlg.cc, see https://github.com/SBNSoftware/icaruscode/pull/660
+
 # Blinding not needed for MC
 physics.producers.cafmaker.CreateBlindedCAF: false
 # MC times are already measured w.r.t. the beam gate

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -478,7 +478,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeTopHit(
   // //Obsolete
   double corr = 0;
   if (findz == true && findx == true) corr = TopCRT_TimingCorr[sector];
-  thit -= (int64_t)round(corr);
+  thit -= (uint64_t)round(corr);
   thit1 -= (int64_t)round(corr);
 
   auto const hitpoint =

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -2,22 +2,7 @@
 #include <algorithm>
 #include "larcore/CoreUtils/ServiceUtil.h"  // lar::providerFrom()
 using namespace icarus::crt;
-/*
-//----------------------------------------------------------------------
-CRTHitRecoAlg::CRTHitRecoAlg(const Config& config){
-  this->reconfigure(config);
-  fChannelMap = art::ServiceHandle<icarusDB::IICARUSChannelMap const>{}.get();
-  fGeometryService  = lar::providerFrom<geo::Geometry>();
-  fCrtutils = new CRTCommonUtils();
-}
 
-//---------------------------------------------------------------------
-CRTHitRecoAlg::CRTHitRecoAlg(){
-  fChannelMap = art::ServiceHandle<icarusDB::IICARUSChannelMap const>{}.get();
-  fGeometryService = lar::providerFrom<geo::Geometry>();
-  fCrtutils = new CRTCommonUtils();
-}
-*/
 CRTHitRecoAlg::CRTHitRecoAlg(const fhicl::ParameterSet& pset)
     : CRTHitRecoAlg() {
   this->reconfigure(pset);
@@ -27,28 +12,8 @@ CRTHitRecoAlg::CRTHitRecoAlg()
     : fGeometryService(lar::providerFrom<geo::Geometry>()),
       fChannelMap(
           art::ServiceHandle<icarusDB::IICARUSChannelMap const>{}.get()) {}
-/*
+
 //---------------------------------------------------------------------
-void CRTHitRecoAlg::reconfigure(const Config& config){
-    fVerbose = config.Verbose();
-    fUseReadoutWindow = config.UseReadoutWindow();
-    fQPed = config.QPed();
-    fQSlope = config.QSlope();
-    fPropDelay = config.PropDelay();
-    fPEThresh = config.PEThresh();
-    ftopGain = config.topGain();
-    ftopPed = config.topPed();
-    fSiPMtoFEBdelay = config.SiPMtoFEBdelay();
-    fCoinWindow = config.CoinWindow();
-    fCrtWindow = config.CrtWindow();
-    foutCSVFile = config.outCSVFile();
-    fCSVFile = config.CSVFile();
-    fData = config.Data();
-    if (foutCSVFile)
-      filecsv.open(fCSVFile.c_str());
-    return;
-}
-*/
 void CRTHitRecoAlg::reconfigure(const fhicl::ParameterSet& pset) {
   fVerbose = pset.get<bool>("Verbose", false);
   fUseReadoutWindow = pset.get<bool>("UseReadoutWindow", false);
@@ -64,25 +29,18 @@ void CRTHitRecoAlg::reconfigure(const fhicl::ParameterSet& pset) {
   fCSVFile = pset.get<std::string>("CSVFile", "");
   fData = pset.get<bool>("Data", false);
   if (!fCSVFile.empty()) filecsv.open(fCSVFile);
-  /*{
-    std::vector<std::vector<int32_t> > T1delays =
-  pset.get<std::vector<std::vector<int32_t> > >("FEB_T1delay_side");
-    std::vector<std::vector<int32_t> > T0delays =
-  pset.get<std::vector<std::vector<int32_t> > >("FEB_T0delay_side"); for(auto
-  feb : T1delays) { int32_t mac = feb[0]; int32_t d   = feb[1];
-      FEB_T1delay_side[mac] = d;
-    }
-    for(auto feb : T0delays) {
-      int32_t mac = feb[0];
-      int32_t d   = feb[1];
-      FEB_T0delay_side[mac] = d;
-    }
-  }*/
-
   return;
 }
 
 //---------------------------------------------------------------------------------------
+// Preselect CRTData to be constructed into a CRT Hit 
+// 1. look for CRTData within +/- 3ms (fCrtWindow) of trigger timestamp
+// 2. filtering 
+// -- Side CRTs filter out low PEs (values < fPEThresh) and hits that are not a 
+//    T0 or T1 reference hit (if its a T0 or T1 reset event, they can have low PE..)
+// -- Bottom CRT Hit reco also using fPEThresh, probably need to be revisited
+// -- Top CRT does not require additional filtering here
+// 
 vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(
     const vector<art::Ptr<CRTData>>& crtList, uint64_t trigger_timestamp) {
   if (fVerbose)
@@ -102,7 +60,7 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(
                                     trigger_timestamp)) > fCrtWindow))
       continue;
 
-    if (type == 'm') {
+    if (type == 'm') { // 'm' = MINOS, Side CRTs
       for (int chan = 0; chan < 32; chan++) {
         std::pair<double, double> const chg_cal =
             fChannelMap->getSideCRTCalibrationMap((int)crtList[febdat_i]->fMac5,
@@ -120,13 +78,13 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(
               << chg_cal.first << ", " << chg_cal.second << ","
               << crtList[febdat_i]->fAdc[chan] << "," << pe << ")\n";
       }
-    } else if (type == 'c') {
+    } else if (type == 'c') { // 'c' = CERN, Top CRTs
       for (int chan = 0; chan < 32; chan++) {
         // float pe = (crtList[febdat_i]->fAdc[chan]-fQPed)/fQSlope;
         // if(pe<=fPEThresh) continue;
         presel = true;
       }
-    } else if (type == 'd') {
+    } else if (type == 'd') { //'d' = Double Chooz, Bottom CRTs
       for (int chan = 0; chan < 64; chan++) {
         float pe = (crtList[febdat_i]->fAdc[chan] - fQPed) / fQSlope;
         if (pe <= fPEThresh) continue;
@@ -139,7 +97,6 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(
   }
   mf::LogInfo("CRTHitRecoAlg:")
       << "Found " << crtdata.size() << " after preselection " << '\n';
-  // std::cout<<trigger_timestamp<<std::endl;
   return crtdata;
 }
 
@@ -160,30 +117,22 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
 
   // sort by the time
   std::sort(crtList.begin(), crtList.end(), compareBytime);
+  // Below is the calculation of the Global Trigger timestamp from the T1 reset
+  // currently only done for top CRT T1 reset values
+  // TODO: Validate side CRT global trigger timestamp reconstruction to be used 
+  // for the reference for side CRT hits, currently a couple ns off. -AH 01/19/2024
 
   // Load Delays map for Top CRT
   CRT_delay_map const FEB_delay_map = LoadFEBMap();
   std::vector<std::pair<int, ULong64_t>> CRTReset;
   ULong64_t TriggerArray[305] = {0};
-  // Note: I still need to validate the Side CRT GT, so for now we will just use
-  // the top values - will be revisited, want to store seperate
-  //       values for the different timing chains once understood better. - AH
-  //       12/01/2022
-  // Vectors to store CRT Resets. Note: West and North Side CRTs are on the West
-  // timing rack, East and South Side CRTs are on East timing rack
-  /*std::vector<std::pair<int,ULong64_t>> CRTReset_top;
-  std::vector<std::pair<int,ULong64_t>> CRTReset_side_west;
-  std::vector<std::pair<int,ULong64_t>> CRTReset_side_east;
-  ULong64_t TriggerArray_top[232]={0};
-  ULong64_t TriggerArray_side_west[94]={0};
-  ULong64_t TriggerArray_side_east[94]={0};*/
-
+  
   for (size_t crtdat_i = 0; crtdat_i < crtList.size(); crtdat_i++) {
     uint8_t mac = crtList[crtdat_i]->fMac5;
     int adid = fCrtutils.MacToAuxDetID(mac, 0);
     char type = fCrtutils.GetAuxDetType(adid);
     string region = fCrtutils.GetAuxDetRegion(adid);
-    // int plane =fCrtutils.AuxDetRegionNameToNum(region); //3 seperate GTs
+    
     // For the time being, Only Top CRT delays are loaded, nothing to do for
     // Side CRT yet
     if (type == 'c' && crtList[crtdat_i]->IsReference_TS1()) {
@@ -192,33 +141,9 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
                                   FEB_delay_map.at((int)mac + 73).T1_delay;
       TriggerArray[(int)mac] = Ts0T1ResetEvent;
       CRTReset.emplace_back((int)mac, Ts0T1ResetEvent);  // single GT
-      /*TriggerArray_top[(int) mac]=Ts0T1ResetEvent;
-      CRTReset_top.emplace_back((int) mac,Ts0T1ResetEvent);*///3 seperate GTs
     }
-    /*if (type == 'm' && crtList[crtdat_i]->IsReference_TS1()) {
-      try
-        {
-          ULong64_t Ts0T1ResetEvent = crtList[crtdat_i]->fTs0 +
-    FEB_T0delay_side.at(mac) - FEB_T1delay_side.at(mac); if(plane == 40 || plane
-    == 41 || plane == 42 || plane == 47){//CRT T1 reset on West/North
-            TriggerArray_side_west[(int) mac]=Ts0T1ResetEvent;
-            CRTReset_side_west.emplace_back((int) mac,Ts0T1ResetEvent);
-          }
-          else{
-            TriggerArray_side_east[(int) mac]=Ts0T1ResetEvent;
-            CRTReset_side_east.emplace_back((int) mac,Ts0T1ResetEvent);
-          }
-        }
-      catch(std::out_of_range& e)
-        {
-          throw art::Exception(art::errors::Configuration)
-            << "MAC address " << mac << " not found in the FEB_delay array!!!
-    Please update FEB_delay FHiCL file \n";
-        }
-    }*/
   }
-  // std::cout << "------\nCreateCRTHits::Trigger timestamp =
-  // "<<trigger_timestamp<<"\n------\n";
+
   const int trigger_offset =
       60;  // Average distance between Global Trigger and Trigger_timestamp (ns)
            // TODO: Make configurable parameter
@@ -232,47 +157,7 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
   for (int i = 0; i < 305; i++) {
     if (TriggerArray[i] == 0) TriggerArray[i] = GlobalTrigger;
   }
-  // std::cout<<"Global Trigger "<<GlobalTrigger<<std::endl; //single GT
-  /*
-  //Global Trigger Calculation for Top CRT
-  const int trigger_offset= 60; //Average distance between Global Trigger and
-  Trigger_timestamp (ns) ULong64_t GlobalTrigger_top= trigger_timestamp; if
-  (!CRTReset_top.empty()) GlobalTrigger_top = GetMode(CRTReset_top);
-  //Add average difference between trigger_timestamp and Global trigger
-  else GlobalTrigger_top=GlobalTrigger_top-trigger_offset;// In this event, the
-  T1 Reset was probably "vetoed" by the T0 Reset for (int i=0; i<232; i++){ if
-  (TriggerArray_top[i]==0) TriggerArray_top[i]=GlobalTrigger_top;
-  }
-  //std::cout<<"------\nCreateCRTHits::Mode Top CRT Global Trigger
-  ="<<GlobalTrigger_top<<"\n------\n";
-
-  //Global Trigger Calculation for West/North Side CRTs
-  ULong64_t GlobalTrigger_side_west= trigger_timestamp;
-  if (!CRTReset_side_west.empty()) GlobalTrigger_side_west =
-  GetMode(CRTReset_side_west);
-  //Add average difference between trigger_timestamp and Global trigger
-  else GlobalTrigger_side_west=GlobalTrigger_side_west-trigger_offset;// In this
-  event, the T1 Reset was probably "vetoed" by the T0 Reset for (int i=0; i<94;
-  i++){ if (TriggerArray_side_west[i]==0)
-  TriggerArray_side_west[i]=GlobalTrigger_side_west;
-  }
-  //std::cout<<"------\nCreateCRTHits::Mode Side West CRT Global Trigger
-  ="<<GlobalTrigger_side_west<<"\n------\n";
-
-  //Global Trigger Calculation for East/South Side CRTs
-  ULong64_t GlobalTrigger_side_east= trigger_timestamp;
-  if (!CRTReset_side_east.empty()) GlobalTrigger_side_east =
-  GetMode(CRTReset_side_east);
-  //Add average difference between trigger_timestamp and Global trigger
-  else GlobalTrigger_side_east=GlobalTrigger_side_east-trigger_offset;// In this
-  event, the T1 Reset was probably "vetoed" by the T0 Reset for (int i=0; i<94;
-  i++){ if (TriggerArray_side_east[i]==0)
-  TriggerArray_side_east[i]=GlobalTrigger_side_east;
-  }
-  //std::cout<<"------\nCreateCRTHits::Mode Side East CRT Global Trigger
-  ="<<GlobalTrigger_side_east<<"\n------\n";
-  */ //3 seperate GTs
-
+  
   // loop over time-ordered CRTData
   for (size_t febdat_i = 0; febdat_i < crtList.size(); febdat_i++) {
     uint8_t mac = crtList[febdat_i]->fMac5;
@@ -321,7 +206,7 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
 
     if (type == 'm') sideRegionToIndices[region].push_back(febdat_i);
 
-  }  // loop over CRTData products
+  }  // End loop over time-ordered CRTData products
 
   vector<size_t> unusedDataIndex;
   for (auto const& regIndices : sideRegionToIndices) {
@@ -333,9 +218,10 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
     vector<size_t> indices = regIndices.second;
 
     if (fVerbose)
-      mf::LogInfo("CRTHitRecoAlg: ")
-          << "number of hits associated to this region : " << indices.size()
-          << '\n';
+      mf::LogInfo("CRTHitRecoAlg: ")  
+	<< "\n-------------------------\nCreateCRTHits: found " 
+	<< indices.size() << " side CRT hits in region " << regIndices.first 
+	<< "\n----------\n";
 
     for (size_t index_i = 0; index_i < indices.size(); index_i++) {
       dataIds.clear();
@@ -404,16 +290,7 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
           uint8_t imac = (int)crtList[indices[index_i]]->fMac5;
           int adid = fCrtutils.MacToAuxDetID(imac, 0);
           string region = fCrtutils.GetAuxDetRegion(adid);
-          // int plane =fCrtutils.AuxDetRegionNameToNum(region); //3 seperate GT
-          CRTHit hit = MakeSideHit(coinData, TriggerArray);  // single GT
-          /*CRTHit hit;
-          if(plane == 40 || plane == 41 || plane == 42 || plane == 47){//CRT T1
-          reset on West/North hit = MakeSideHit(coinData,
-          TriggerArray_side_west);
-          }
-          else{
-            hit = MakeSideHit(coinData, TriggerArray_side_east);
-          }*/ //3 seperate GT
+          CRTHit hit = MakeSideHit(coinData, TriggerArray);  // using top CRT GT
 
           if (IsEmptyHit(hit)) {
             unusedDataIndex.push_back(indices[index_i]);
@@ -441,7 +318,7 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
   }        // loop over side CRTData products
 
   if (fVerbose) {
-    mf::LogInfo("CRT") << returnHits.size() << " CRT hits produced!" << '\n'
+    mf::LogInfo("CRTHitRecoAlg") << returnHits.size() << " CRT hits produced!" << '\n'
                        << "  nHitC: " << nHitC << " , nHitD: " << nHitD
                        << " , nHitM: " << nHitM << '\n'
                        << "  nMisC: " << nMissC << " , nMisD: " << nMissD
@@ -449,8 +326,8 @@ vector<pair<sbn::crt::CRTHit, vector<int>>> CRTHitRecoAlg::CreateCRTHits(
     auto cts = regCounts.begin();
     mf::LogInfo("CRT") << " CRT Hits by region" << '\n';
     while (cts != regCounts.end()) {
-      mf::LogInfo("CRT") << "reg: " << (*cts).first
-                         << " , hits: " << (*cts).second << '\n';
+      std::cout << "reg: " << (*cts).first
+		<< " , hits: " << (*cts).second << '\n';
       cts++;
     }
   }  // if Verbose
@@ -696,7 +573,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   vector<uint8_t> macs;
   map<uint8_t, vector<pair<int, float>>> pesmap;
 
-  struct infoA {
+  struct info {
     uint8_t mac5s;
     int channel;
     uint64_t t0;
@@ -704,22 +581,12 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
     int strip;
   };
 
-  struct infoB {
-    uint8_t mac5s;
-    int channel;
-    uint64_t t0;
-    TVector3 pos;
-    int strip;
-  };
-
-  vector<infoA> informationA;
-  vector<infoA> informationB;
+  vector<info> informationA, informationB;
 
   int adid = fCrtutils.MacToAuxDetID(coinData[0]->fMac5, 0);  // module ID
   auto const& adGeo = fGeometryService->AuxDet(adid);         // module
-  string region = fCrtutils.GetAuxDetRegion(adid);
-  int plane = fCrtutils.AuxDetRegionNameToNum(region);
-
+  string region = fCrtutils.GetAuxDetRegion(adid);            //region name
+  int plane = fCrtutils.AuxDetRegionNameToNum(region);        //region code (ranges from 30-50)
   double hitpoint[3], hitpointerr[3];
   TVector3 hitpos(0., 0., 0.);
 
@@ -741,7 +608,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
 
   uint64_t southt0_v = -999, southt0_h = -999;
 
-  // loop over FEBs
+  // loop over coinData to group FEBs into inner or outer layers (febA or febB)
   for (auto const& data : coinData) {
     if (adid == (int)fCrtutils.MacToAuxDetID((int)data->fMac5, 0)) {
       febA.push_back(data->fMac5);
@@ -1027,21 +894,19 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   //---------------------------------------------------------------------
   // std::ofstream o(filename.c_str());
 
-  geo::Point_t posA;
-  geo::Point_t posB;
-  bool layer1 = false;
-  bool layer2 = false;
+  geo::Point_t posA, posB;
+  bool layer1 = false, layer2 = false;
 
   geo::Point_t crossfebpos;
 
-  uint64_t t0_1 = -5;
-  uint64_t t0_2 = -5;
-  uint64_t t1_1 = -5;
-  uint64_t t1_2 = -5;
-  uint64_t t2_1 = -5;
-  uint64_t t2_2 = -5;
-  int mac5_1 = -5;
-  int mac5_2 = -5;
+  uint64_t t0_1 = -5; // T0 for infoA, layer1
+  uint64_t t0_2 = -5; // T0 for infoB, layer2
+  uint64_t t1_1 = -5; //layer 1: T0 for FEB on South end of module (even mac5), E+W walls
+  uint64_t t1_2 = -5; //layer 1: T0 for FEB on North end of module (odd mac5), E+W walls
+  uint64_t t2_1 = -5; //layer 2: T0 for FEB on South end of module (even mac5), E+W walls
+  uint64_t t2_2 = -5; //layer 2: T0 for FEB on North end of module (odd mac5), E+W walls
+  int mac5_1 = -555;  //layer 1 mac5 (used to check for hits that cross module)
+  int mac5_2 = -555;  //layer 2 mac5 (used to check for hits that cross module)
   geo::Point_t center;
 
   for (auto const& infn : informationA) {

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -489,10 +489,8 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeTopHit(
   hitpointerr[2] = adsGeo.HalfWidth1() * 2 / sqrt(12);
   // thit1 = (Long64_t)(thit-GlobalTrigger[(int)mac+73]);
   if (fData) thit1 = (Long64_t)(thit - GlobalTrigger[(int)mac]);
-  else {
-    thit1 = thit - fGlobalT0Offset;
-    std::cout << "thit1 = thit - fGlobalT0Offset = " << thit << " - " << fGlobalT0Offset << " = " << thit1 << "\n";
-  }
+  else thit1 = thit - fGlobalT0Offset;
+
   // Remove T1 Reset event not correctly flagged, remove T1 reset events, remove
   // T0 reset events
   if ((sum < 10000 && thit1 < 2'001'000 && thit1 > 2'000'000) ||
@@ -1223,10 +1221,8 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   //Long64_t thit1 = (Long64_t)(thit - GlobalTrigger[(int)macs.at(0)]);
   Long64_t thit1;
   if (fData) thit1=(Long64_t)(thit-GlobalTrigger[(int)macs.at(0)]);
-  else {
-    thit1 = thit - fGlobalT0Offset;
-    std::cout << "thit1 = thit - fGlobalT0Offset = " << thit << " - " << fGlobalT0Offset << " = " << thit1 << "\n";
-  }
+  else thit1 = thit - fGlobalT0Offset;
+
   // generate hit
   CRTHit hit = FillCRTHit(macs, pesmap, petot, thit, thit1, plane, hitpoint[0],
                           hitpointerr[0], hitpoint[1], hitpointerr[1],

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -28,6 +28,7 @@ void CRTHitRecoAlg::reconfigure(const fhicl::ParameterSet& pset) {
   fCrtWindow = pset.get<uint64_t>("CrtWindow", 0.);
   fCSVFile = pset.get<std::string>("CSVFile", "");
   fData = pset.get<bool>("Data", false);
+  fGlobalT0Offset = pset.get<double>("GlobalT0Offset",0.);
   if (!fCSVFile.empty()) filecsv.open(fCSVFile);
   return;
 }

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -76,79 +76,7 @@ class icarus::crt::CRTHitRecoAlg {
  public:
   using CRTData = icarus::crt::CRTData;
   using CRTHit = sbn::crt::CRTHit;
-  /*//OLD
-  struct Config {
-    using Name = fhicl::Name;
-    using Comment = fhicl::Comment;
-    fhicl::Atom<bool> UseReadoutWindow {
-      Name("UseReadoutWindow"),
-        Comment("Only reconstruct hits within readout window")
-        };
-    fhicl::Atom<double> QPed {
-      Name("QPed"),
-        Comment("Pedestal offset [ADC]")
-        };
-    fhicl::Atom<double> QSlope {
-      Name("QSlope"),
-        Comment("Pedestal slope [ADC/photon]")
-        };
-    fhicl::Atom<bool> Verbose {
-      Name("Verbose"),
-        Comment("Output verbosity")
-        };
-    fhicl::Atom<bool> Data {
-      Name("Data"),
-        Comment("choose data/mc")
-        };
-    fhicl::Atom<bool> outCSVFile {
-      Name("outCSVFile"),
-        Comment("Output a csv file")
-        };
-    fhicl::Atom<std::string> CSVFile {
-      Name("CSVFile"),
-        Comment("file name for output CSV File")
-        };
-    fhicl::Atom<double> PropDelay {
-      Name("PropDelay"),
-        Comment("group velocity in WLS fiber [ns/cm]")
-        };
-    fhicl::Atom<double> PEThresh {
-      Name("PEThresh"),
-        Comment("threshold in photoelectrons above which charge amplitudes used
-  in hit reco")
-        };
-    fhicl::Atom<double> topGain {
-      Name("topGain"),
-        Comment("Dummy Gain value for Top CRT")
-        };
-    fhicl::Atom<double> topPed {
-      Name("topPed"),
-        Comment("Dummy Pedestal value for Top CRT")
-        };
-    fhicl::Atom<uint64_t> SiPMtoFEBdelay {
-      Name("SiPMtoFEBdelay"),
-        Comment("Delay for SiPM to FEB signal correction 11.6 [ns]")
-        };
-    fhicl::Atom<uint64_t> CoinWindow {
-      Name("CoinWindow"),
-        Comment("window for finding side CRT trigger coincidences [ns]")
-        };
-    fhicl::Atom<uint64_t> CrtWindow {
-      Name("CrtWindow"),
-        Comment("window for looking data [ns]")
-        };
-  };//Config
-
-  //OLD constructors
-  CRTHitRecoAlg(const Config& config);
-  CRTHitRecoAlg(const fhicl::ParameterSet& pset) :
-    CRTHitRecoAlg{fhicl::Table<Config>{pset}()} {}
-  CRTHitRecoAlg();
-
-  //OLD configure module from fcl file
-  void reconfigure(const Config& config);*/
-
-  // new constructors
+  
   explicit CRTHitRecoAlg(const fhicl::ParameterSet& pset);
   CRTHitRecoAlg();
   void reconfigure(const fhicl::ParameterSet& pset);
@@ -191,6 +119,7 @@ class icarus::crt::CRTHitRecoAlg {
   uint64_t fCrtWindow;  ///< Looking data window within trigger timestamp [ns]
   std::ofstream filecsv;
   bool fData;  ///< look for only data
+  double fGlobalT0Offset;  ///< Offset to be applied to MC CRT hit times.
   const icarusDB::IICARUSChannelMap* fChannelMap = nullptr;
 
   // Given top CRTData product, produce CRTHit

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -120,6 +120,9 @@ class icarus::crt::CRTHitRecoAlg {
   std::ofstream filecsv;
   bool fData;  ///< look for only data
   double fGlobalT0Offset;  ///< Offset to be applied to MC CRT hit times.
+  // See DocDB 34763 for CRT Time distributions before and after this 
+  // fGlobalT0Offset parameter was moved to the  CRTHitRecoAlg.
+
   const icarusDB::IICARUSChannelMap* fChannelMap = nullptr;
 
   // Given top CRTData product, produce CRTHit

--- a/icaruscode/CRT/crthitproducer.fcl
+++ b/icaruscode/CRT/crthitproducer.fcl
@@ -15,6 +15,7 @@ standard_crthitrecoalg:
     CrtWindow:            3e6    # time window for looking data within trigger timestamp [ns]
     outCSVFile:           false  # write the information in to a csv file
     Data:                 true   # for data
+    GlobalT0Offset:       0      # offset to be applied for MC only, 0 for data.
     CSVFile:              "data.csv" # dump time difference between both end readouts.
 
 }

--- a/icaruscode/CRT/crtsimhitproducer.fcl
+++ b/icaruscode/CRT/crtsimhitproducer.fcl
@@ -15,6 +15,7 @@ standard_crtsimhitrecoalg:
     CrtWindow:            3e6    # time window for looking data within trigger timestamp [ns]
     outCSVFile:           false  # write the information in to a csv file
     Data:                 false  # for data
+    GlobalT0Offset:       1.6e6         # offset to be applied to simulated CRT Hit times to ensure times are centered around 0. [ns]
     CSVFile:              "data.csv" # dump time difference between both end readouts.  			   
 }
 


### PR DESCRIPTION
This pull request applies fGlobalT0Offset, a fhicl parameter that should be applied to simulated CRT Hit times only, to the CRTHitProducer. This offset gets [added to the true time in the CRTDetSimAlg](https://github.com/SBNSoftware/icaruscode/blob/develop/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc#L616) before passing the true time to a timestamp generator. This offset should be subtracted back off so the simulated CRT Hit distribution is centered around 0, ranging from -1.5 ms to +1.5 ms. 
This offset is currently applied to the simulated CRT Hit times in the CAFs and the CRT-PMT Matching producer, but is not applied to _all_ simulated CRT hit times (for ex., this offset is missing in calibration ntuples). This is a flaw in the workflow; we should have this offset applied as high up in the chain as possible, as the CRT Hits are being made, so that the CRT hit time distribution looks the same regardless of what type of file is being looked at (see [docdb 34586](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=34586) for more info).

Keeping this PR as a draft while I continue to validate my changes and ask for reviews from reviewers.
