### PR TITLE
Beginning fcl paths for ICARUS detector variation samples

### DIFF
--- a/fcl/CMakeLists.txt
+++ b/fcl/CMakeLists.txt
@@ -9,5 +9,6 @@ add_subdirectory(caf)
 add_subdirectory(services)
 add_subdirectory(utilities)
 add_subdirectory(compatibility)
+add_subdirectory(syst_variations)
 
 install_fhicl()

--- a/fcl/syst_variations/CMakeLists.txt
+++ b/fcl/syst_variations/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()

--- a/fcl/syst_variations/caf_variations_standard.fcl
+++ b/fcl/syst_variations/caf_variations_standard.fcl
@@ -1,0 +1,3 @@
+#include "cafmakerjob_icarus_detsim2d.fcl"
+
+process_name: CAFmakerVar

--- a/fcl/syst_variations/cosmics_g4_icarus_2xsce.fcl
+++ b/fcl/syst_variations/cosmics_g4_icarus_2xsce.fcl
@@ -1,0 +1,5 @@
+#include "g4_step2_simulate.fcl"
+
+services.SpaceChargeService.InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_DoubleCharge_voxelTH3.root"
+
+process_name: G4step2Var

--- a/fcl/syst_variations/detsim_variations_standard.fcl
+++ b/fcl/syst_variations/detsim_variations_standard.fcl
@@ -1,0 +1,3 @@
+#include "detsim_2d_icarus_fitFR.fcl"
+
+process_name: DetSimVar

--- a/fcl/syst_variations/g4_step1_simulate.fcl
+++ b/fcl/syst_variations/g4_step1_simulate.fcl
@@ -1,0 +1,120 @@
+#
+# Purpose: Processes generated Monte Carlo events through GEANT4 detector simulation
+# 
+# 
+# Input
+# ------
+# 
+# * all `simb::MCTruth` collection data products are used as input
+# 
+# 
+# Output
+# -------
+# 
+# * `largeant` ("legacy" `LArG4` module):
+#     * `simb::MCParticle` collection: all initial, intermediate and final
+#       particles propagated through the detector (exceptions apply)
+#     * `sim::SimEnergyDeposit` collections: `TPCActive` and `Others`
+#     * `sim::SimChannel` collection: ionisation drifted to TPC channels
+#     * `sim::SimPhoton` collection: scintillation photons converting into PMT
+#     * `sim::AuxDetSimChannel` collection: hits from auxiliary detectors (CRT)
+# * `ionization` (`sim::SimEnergyDeposit` collection)
+#
+
+
+# ------------------------------------------------------------------------------
+#include "services_icarus_simulation.fcl"
+#include "largeantmodules_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+#include "g4inforeducer.fcl"
+#include "mcreco.fcl"
+
+
+# ------------------------------------------------------------------------------
+process_name: G4step1
+
+
+# ------------------------------------------------------------------------------
+services: @local::icarus_g4_services
+
+
+# ------------------------------------------------------------------------------
+physics:
+{
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  producers:
+  {
+    largeant:   @local::icarus_largeant
+    ionization: {
+                  module_type: "larsim/ElectronDrift/ShiftEdepSCE"
+                  EDepTag:     "largeant:TPCActive"
+                  MakeAnaTree: false
+                }
+    sedlite:    @local::sbn_largeant_info_reducer # needs to run right after largeant
+         
+    # Saving MC information needed for the ML effort
+    mcreco:     @local::standard_mcreco
+
+    rns:        { module_type: "RandomNumberSaver" }
+  }
+
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  #simulate: [ rns, largeant, ionization, sedlite, mcreco ]
+  simulate: [ rns, largeant ]
+  stream:   [ rootoutput ]
+
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  
+} # physics
+
+# Store MCParticleLite in G4 to store dropped particles from KeepEMShowerDaughters: false
+physics.producers.largeant.StoreDroppedMCParticles: true
+
+# ------------------------------------------------------------------------------
+
+# Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
+#physics.producers.mcreco.SimChannelLabel: "sedlite"
+#physics.producers.mcreco.MCParticleLabel: "largeant"
+#physics.producers.mcreco.MCParticleLiteLabel: "largeant"
+#physics.producers.mcreco.UseSimEnergyDeposit: false
+#physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
+#physics.producers.mcreco.UseSimEnergyDepositLite: true
+#physics.producers.mcreco.IncludeDroppedParticles: true
+
+outputs.rootoutput: @local::icarus_rootoutput
+
+services.LArG4Parameters.ParticleKineticEnergyCut: 0.0005
+physics.producers.largeant.KeepParticlesInVolumes: [ "volCryostat" ]
+
+# ------------------------------------------------------------------------------
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+      ## Turning off the spewing of warnings coming from these two modules
+       SimDriftElectrons:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       McReco:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       default:
+       {
+         limit: 5  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/fcl/syst_variations/g4_step2_simulate.fcl
+++ b/fcl/syst_variations/g4_step2_simulate.fcl
@@ -1,0 +1,118 @@
+#
+# Purpose: Processes generated Monte Carlo events through GEANT4 detector simulation
+# 
+# 
+# Input
+# ------
+# 
+# * all `simb::MCTruth` collection data products are used as input
+# 
+# 
+# Output
+# -------
+# 
+# * `largeant` ("legacy" `LArG4` module):
+#     * `simb::MCParticle` collection: all initial, intermediate and final
+#       particles propagated through the detector (exceptions apply)
+#     * `sim::SimEnergyDeposit` collections: `TPCActive` and `Others`
+#     * `sim::SimChannel` collection: ionisation drifted to TPC channels
+#     * `sim::SimPhoton` collection: scintillation photons converting into PMT
+#     * `sim::AuxDetSimChannel` collection: hits from auxiliary detectors (CRT)
+# * `ionization` (`sim::SimEnergyDeposit` collection)
+#
+
+
+# ------------------------------------------------------------------------------
+#include "services_icarus_simulation.fcl"
+#include "largeantmodules_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+#include "g4inforeducer.fcl"
+#include "mcreco.fcl"
+#include "enable_spacecharge_icarus.fcl"
+
+# ------------------------------------------------------------------------------
+process_name: G4step2
+
+
+# ------------------------------------------------------------------------------
+services: @local::icarus_g4_services
+
+
+# ------------------------------------------------------------------------------
+physics:
+{
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  producers:
+  {
+    largeant:   @local::icarus_largeant
+    ionization: {
+                  module_type: "larsim/ElectronDrift/ShiftEdepSCE"
+                  EDepTag:     "largeant:TPCActive"
+                  MakeAnaTree: false
+                }
+    sedlite:    @local::sbn_largeant_info_reducer # needs to run right after largeant
+         
+    # Saving MC information needed for the ML effort
+    mcreco:     @local::standard_mcreco
+
+    rns:        { module_type: "RandomNumberSaver" }
+  }
+
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  #simulate: [ rns, largeant, ionization, sedlite, mcreco ]
+  simulate: [ rns, ionization, sedlite, mcreco ] 
+  stream:   [ rootoutput ]
+
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  
+} # physics
+
+# Store MCParticleLite in G4 to store dropped particles from KeepEMShowerDaughters: false
+physics.producers.largeant.StoreDroppedMCParticles: true
+
+# ------------------------------------------------------------------------------
+
+# Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
+physics.producers.mcreco.SimChannelLabel: "sedlite"
+physics.producers.mcreco.MCParticleLabel: "largeant"
+physics.producers.mcreco.MCParticleLiteLabel: "largeant"
+physics.producers.mcreco.UseSimEnergyDeposit: false
+physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
+physics.producers.mcreco.UseSimEnergyDepositLite: true
+physics.producers.mcreco.IncludeDroppedParticles: true
+
+outputs.rootoutput: @local::icarus_rootoutput
+
+
+# ------------------------------------------------------------------------------
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+      ## Turning off the spewing of warnings coming from these two modules
+       SimDriftElectrons:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       McReco:
+       {
+         limit: 0
+         reportEvery: 0
+       }
+       default:
+       {
+         limit: 5  #don't print anything at the infomsg level except the explicitly named categories
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/fcl/syst_variations/larcv_variations_standard.fcl
+++ b/fcl/syst_variations/larcv_variations_standard.fcl
@@ -1,0 +1,3 @@
+#include "larcv_icarus.fcl"
+
+process_name: larcvVar

--- a/fcl/syst_variations/scrub_stages_variation.fcl
+++ b/fcl/syst_variations/scrub_stages_variation.fcl
@@ -1,0 +1,39 @@
+# This fcl purely removes products made in the post-G4step1 processes.
+# This allows for keeping the identical simulated event on the file and running
+# a variation of the downstream detector simulation / reconstruction.
+#
+# Author Jacob Zettlemoyer (jzettle@fnal.gov), originally implemented by H. Lay for SBND
+
+#include "rootoutput_icarus.fcl"
+
+process_name: Scrub
+
+source:
+{
+  module_type:   RootInput
+  inputCommands: [ "keep *_*_*_*",
+  		   "drop *_mcreco_*_*",
+		   "drop *_sedlite_*_*",
+		   "drop *_ionization_*_*",
+                   "drop *_*_*_DetSim",
+		   "drop *_*_*_MCstage0",
+                   "drop *_*_*_MCstage1" ]
+}
+
+outputs:
+{
+  out1:
+  {
+    compressionLevel: 1
+    dataTier: "simulated"
+    fileName: "Scrubbed_%tc.root"
+    module_type: "RootOutput"
+    saveMemoryObjectThreshold: 0
+  }
+}
+
+physics:
+{
+  stream1:   [ out1 ]
+  end_paths: [ stream1 ]
+}

--- a/fcl/syst_variations/stage0_variations_standard.fcl
+++ b/fcl/syst_variations/stage0_variations_standard.fcl
@@ -1,0 +1,3 @@
+#include "stage0_run2_icarus_mc.fcl"
+
+process_name: MCstage0Var

--- a/fcl/syst_variations/stage1_variations_standard.fcl
+++ b/fcl/syst_variations/stage1_variations_standard.fcl
@@ -1,0 +1,3 @@
+#include "stage1_run2_icarus_MC.fcl"
+
+process_name: MCstage1Var


### PR DESCRIPTION
Start of the idea for preparing for making ICARUS detector variation samples. This PR encapsulates the idea for these samples and creates a set of fcls to go back and take stage1 inputs and drop all products after the largeant part of the G4 stage. The fcls in here inelegantly split the G4 stage into two parts: one that runs the largeant step and one that runs the rest of the stage (happy to take suggestions on this). This is in order to preserve the G4 steps for a given event when we run detector variations along with the identical set of generated events.  Then there are fcl to rerun the original stages providing a template for the variations. These fcls exist solely due to the art requirement that a stage cannot include the same `process_name` or else it does not run. 

This PR is made now in order to help the production team test workflows using a tagged release working chiefly with Mateus Carneiro (who I don't clearly see in here). I tried to inform @SFBayLaser and @PetrilloAtWork (who I also tag as reviewers) so hopefully they are not too surprised. I will commit a better naming scheme as Gianluca requested privately. Other suggestions/thoughts are welcome.

In order to implement this scheme we would need to save the data products from the G4 stage up to and including the largeant step in the stage1 files which means saving those as well as part of a production. 
