### PR TITLE
Storing all tracks in Calibration Ntuple

### DIFF
--- a/fcl/reco/Stage1/Run1/stage1_multiTPC_icarus_gauss_alltracks_ntuple.fcl
+++ b/fcl/reco/Stage1/Run1/stage1_multiTPC_icarus_gauss_alltracks_ntuple.fcl
@@ -1,37 +1,4 @@
-#include "stage1_icarus_driver_common.fcl"
-
-process_name: stage1
-
-physics.reco: [ @sequence::icarus_filter_cluster3D,
-		@sequence::icarus_pandora_Gauss,
-		@sequence::icarus_reco_fm,
-                @sequence::icarus_crttrack,
-		@sequence::icarus_crtt0match,
-                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
-
-physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
-physics.trigger_paths:     [ reco ]
-physics.end_paths:         [ outana, stream1 ]
-outputs.out1.fileName:     "%ifb_%tc-%p.root"
-outputs.out1.dataTier:     "reconstructed"
-outputs.out1.SelectEvents: [ reco ]
-outputs.out1.outputCommands: [
-  "keep *_*_*_*",
-  "drop *_caloskimCalorimetryCryoE_*_*",
-  "drop *_caloskimCalorimetryCryoW_*_*"
-]
-
-# Disabled Space-Charge service for calorimetry
-services.SpaceChargeService: {
-    EnableCalEfieldSCE: false
-    EnableCalSpatialSCE: false
-    EnableCorrSCE: false
-    EnableSimEfieldSCE: false
-    EnableSimSpatialSCE: false
-    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
-    RepresentationType: "Voxelized_TH3"
-    service_provider: "SpaceChargeServiceICARUS"
-}
+#include "stage1_multiTPC_icarus_gauss.fcl"
 
 physics.analyzers.caloskimE.SelectionTools: [ ]
 physics.analyzers.caloskimW.SelectionTools: [ ]
@@ -40,22 +7,4 @@ physics.analyzers.caloskimE:       @local::caloskim_cryoe_goldentracks_not0
 physics.analyzers.caloskimW:       @local::caloskim_cryow_goldentracks_not0
 physics.analyzers.caloskimE.HitRawDigitsTickCollectWidth: 0
 physics.analyzers.caloskimW.HitRawDigitsTickCollectWidth: 0
-
-
-services.message.destinations :
-{
-  STDCOUT:
-  {
-     type:      "cout"      #tells the message service to output this destination to cout
-     threshold: "WARNING"     #tells the message service that this destination applies to WARNING and higher level messages
-     categories:
-     {
-       Cluster3D:
-       {
-         limit: -1
-         reportEvery: 1
-       }
-     }
-  }
-}
 

--- a/fcl/reco/Stage1/Run1/stage1_multiTPC_icarus_gauss_alltracks_ntuple.fcl
+++ b/fcl/reco/Stage1/Run1/stage1_multiTPC_icarus_gauss_alltracks_ntuple.fcl
@@ -1,0 +1,61 @@
+#include "stage1_icarus_driver_common.fcl"
+
+process_name: stage1
+
+physics.reco: [ @sequence::icarus_filter_cluster3D,
+		@sequence::icarus_pandora_Gauss,
+		@sequence::icarus_reco_fm,
+                @sequence::icarus_crttrack,
+		@sequence::icarus_crtt0match,
+                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
+
+physics.outana:            [ caloskimE, caloskimW, simpleLightAna, CRTDataAnalysis]
+physics.trigger_paths:     [ reco ]
+physics.end_paths:         [ outana, stream1 ]
+outputs.out1.fileName:     "%ifb_%tc-%p.root"
+outputs.out1.dataTier:     "reconstructed"
+outputs.out1.SelectEvents: [ reco ]
+outputs.out1.outputCommands: [
+  "keep *_*_*_*",
+  "drop *_caloskimCalorimetryCryoE_*_*",
+  "drop *_caloskimCalorimetryCryoW_*_*"
+]
+
+# Disabled Space-Charge service for calorimetry
+services.SpaceChargeService: {
+    EnableCalEfieldSCE: false
+    EnableCalSpatialSCE: false
+    EnableCorrSCE: false
+    EnableSimEfieldSCE: false
+    EnableSimSpatialSCE: false
+    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
+    RepresentationType: "Voxelized_TH3"
+    service_provider: "SpaceChargeServiceICARUS"
+}
+
+physics.analyzers.caloskimE.SelectionTools: [ ]
+physics.analyzers.caloskimW.SelectionTools: [ ]
+
+physics.analyzers.caloskimE:       @local::caloskim_cryoe_goldentracks_not0
+physics.analyzers.caloskimW:       @local::caloskim_cryow_goldentracks_not0
+physics.analyzers.caloskimE.HitRawDigitsTickCollectWidth: 0
+physics.analyzers.caloskimW.HitRawDigitsTickCollectWidth: 0
+
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"     #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       Cluster3D:
+       {
+         limit: -1
+         reportEvery: 1
+       }
+     }
+  }
+}
+

--- a/fcl/reco/Stage1/Run2/stage1_run2_icarus_alltracks_ntuple.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_icarus_alltracks_ntuple.fcl
@@ -1,0 +1,66 @@
+#include "stage1_icarus_driver_common.fcl"
+
+process_name: stage1
+
+physics.reco: [ @sequence::icarus_filter_cluster3D,
+                @sequence::icarus_pandora_Gauss,
+                @sequence::icarus_reco_fm,
+                @sequence::icarus_tpcpmtbarycentermatch,
+                @sequence::icarus_crttrack,
+                @sequence::icarus_crtt0match,
+                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
+
+physics.outana:            [ @sequence::icarus_analysis_modules ]
+physics.trigger_paths:     [ reco ]
+physics.end_paths:         [ outana, stream1 ]
+outputs.out1.fileName:     "%ifb_%tc-%p.root"
+outputs.out1.dataTier:     "reconstructed"
+outputs.out1.SelectEvents: [ reco ]
+outputs.out1.outputCommands: [
+  "keep *_*_*_*",
+  "drop *_caloskimCalorimetryCryoE_*_*",
+  "drop *_caloskimCalorimetryCryoW_*_*"
+]
+
+# Disabled Space-Charge service for calorimetry
+services.SpaceChargeService: {
+    EnableCalEfieldSCE: false
+    EnableCalSpatialSCE: false
+    EnableCorrSCE: false
+    EnableSimEfieldSCE: false
+    EnableSimSpatialSCE: false
+    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
+    RepresentationType: "Voxelized_TH3"
+    service_provider: "SpaceChargeServiceICARUS"
+}
+
+physics.analyzers.caloskimE.SelectionTools: [ ]
+physics.analyzers.caloskimW.SelectionTools: [ ]
+
+physics.analyzers.caloskimE:       @local::caloskim_cryoe_goldentracks_not0
+physics.analyzers.caloskimW:       @local::caloskim_cryow_goldentracks_not0
+physics.analyzers.caloskimE.HitRawDigitsTickCollectWidth: 0
+physics.analyzers.caloskimW.HitRawDigitsTickCollectWidth: 0
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       Cluster3DICARUS:
+       {
+         limit: 5
+         reportEvery: 1
+       }
+       SnippetHit3D:
+       {
+         limit: 5
+         reportEvery: 1
+       }
+     }
+  }
+}
+

--- a/fcl/reco/Stage1/Run2/stage1_run2_icarus_alltracks_ntuple.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_icarus_alltracks_ntuple.fcl
@@ -1,38 +1,4 @@
-#include "stage1_icarus_driver_common.fcl"
-
-process_name: stage1
-
-physics.reco: [ @sequence::icarus_filter_cluster3D,
-                @sequence::icarus_pandora_Gauss,
-                @sequence::icarus_reco_fm,
-                @sequence::icarus_tpcpmtbarycentermatch,
-                @sequence::icarus_crttrack,
-                @sequence::icarus_crtt0match,
-                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW]
-
-physics.outana:            [ @sequence::icarus_analysis_modules ]
-physics.trigger_paths:     [ reco ]
-physics.end_paths:         [ outana, stream1 ]
-outputs.out1.fileName:     "%ifb_%tc-%p.root"
-outputs.out1.dataTier:     "reconstructed"
-outputs.out1.SelectEvents: [ reco ]
-outputs.out1.outputCommands: [
-  "keep *_*_*_*",
-  "drop *_caloskimCalorimetryCryoE_*_*",
-  "drop *_caloskimCalorimetryCryoW_*_*"
-]
-
-# Disabled Space-Charge service for calorimetry
-services.SpaceChargeService: {
-    EnableCalEfieldSCE: false
-    EnableCalSpatialSCE: false
-    EnableCorrSCE: false
-    EnableSimEfieldSCE: false
-    EnableSimSpatialSCE: false
-    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
-    RepresentationType: "Voxelized_TH3"
-    service_provider: "SpaceChargeServiceICARUS"
-}
+#include "stage1_run2_icarus.fcl"
 
 physics.analyzers.caloskimE.SelectionTools: [ ]
 physics.analyzers.caloskimW.SelectionTools: [ ]
@@ -42,25 +8,4 @@ physics.analyzers.caloskimW:       @local::caloskim_cryow_goldentracks_not0
 physics.analyzers.caloskimE.HitRawDigitsTickCollectWidth: 0
 physics.analyzers.caloskimW.HitRawDigitsTickCollectWidth: 0
 
-services.message.destinations :
-{
-  STDCOUT:
-  {
-     type:      "cout"      #tells the message service to output this destination to cout
-     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
-     categories:
-     {
-       Cluster3DICARUS:
-       {
-         limit: 5
-         reportEvery: 1
-       }
-       SnippetHit3D:
-       {
-         limit: 5
-         reportEvery: 1
-       }
-     }
-  }
-}
 


### PR DESCRIPTION
This PR is intended to include two new FCL files in the Stage1 reconstructions which allow to store all the tracks in the Calibration Ntuple and not only the CC ones.