### PR TITLE
drop the new compressed fragments

### DIFF
--- a/fcl/reco/Stage0/Run1/stage0_run1_icarus.fcl
+++ b/fcl/reco/Stage0/Run1/stage0_run1_icarus.fcl
@@ -17,6 +17,7 @@ physics.end_paths:     [ outana, streamROOT ]
 # Drop the artdaq format files on output
 outputs.rootOutput.outputCommands: [
     "keep *_*_*_*",
+    "drop artdaq::Fragments_*_*_ICARUSReprocessRaw",
     "drop *_*_*_DAQ*",
     "drop *_ophituncorrected_*_*",
     "drop raw::OpDetWaveforms_daqPMT__*",

--- a/fcl/reco/Stage0/Run1/stage0_run1_raw_icarus.fcl
+++ b/fcl/reco/Stage0/Run1/stage0_run1_raw_icarus.fcl
@@ -5,4 +5,4 @@
 #include "stage0_run1_icarus.fcl"
 
 # Drop the artdaq format files on output
-outputs.rootOutput.outputCommands:  ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.rootOutput.outputCommands:  ["keep *_*_*_*", "drop artdaq::Fragments_*_*_ICARUSReprocessRaw", "drop *_*_*_DAQ*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]

--- a/fcl/reco/Stage0/Run1/stage0_run1_rawpmt_icarus.fcl
+++ b/fcl/reco/Stage0/Run1/stage0_run1_rawpmt_icarus.fcl
@@ -18,7 +18,7 @@ physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamROOT ]
 
 # Drop the artdaq format files on output
-outputs.rootOutput.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
+outputs.rootOutput.outputCommands:         ["keep *_*_*_*", "drop artdaq::Fragments_*_*_ICARUSReprocessRaw", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*" ]
 
 ## Modify the event selection for the purity analyzers
 physics.analyzers.purityinfoana0.SelectEvents:    [ path ]

--- a/fcl/reco/Stage0/Run1/stage0_run1_wc_icarus.fcl
+++ b/fcl/reco/Stage0/Run1/stage0_run1_wc_icarus.fcl
@@ -16,7 +16,7 @@ physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamCommon ]
 
 # Drop the artdaq format files on output
-outputs.rootOutput.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*", "drop *_decon2Droi*_*_*", "drop *_roifindr_*_*" ]
+outputs.rootOutput.outputCommands:         ["keep *_*_*_*", "drop artdaq::Fragments_*_*_ICARUSReprocessRaw", "drop *_*_*_DAQ*", "drop *_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop *_decon1DroiTPC*_*_*", "drop *_decon2Droi*_*_*", "drop *_roifindr_*_*" ]
 
 # Override the hit finder input 
 physics.producers.gaushitTPCWW.CalDataModuleLabel: "roifinder2d:PHYSCRATEDATATPCWW"

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus.fcl
@@ -23,6 +23,7 @@ physics.end_paths:     [ outana, streamROOT ]
 # Keep the Trigger fragment
 outputs.rootOutput.outputCommands: [
     "keep *_*_*_*", 
+    "drop artdaq::Fragments_*_*_ICARUSReprocessRaw",
     "drop *_*_*_DAQ*",
     "drop *_ophituncorrected_*_*",
     "drop raw::OpDetWaveforms_daqPMT__*",

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus_crtpmtonly.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus_crtpmtonly.fcl
@@ -22,6 +22,7 @@ physics.end_paths:     [ streamROOT ]
 # Keep the Trigger fragment
 outputs.rootOutput.outputCommands: [
     "keep *_*_*_*", 
+    "drop artdaq::Fragments_*_*_ICARUSReprocessRaw",
     "drop *_*_*_DAQ*",
     "drop *_ophituncorrected_*_*",
     "drop raw::OpDetWaveforms_daqPMT__*",

--- a/fcl/reco/Stage0/Run2/stage0_run2_raw_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_raw_icarus.fcl
@@ -8,4 +8,4 @@
 # Drop all output from the TPC decoder stage
 # Drop all output from the 1D deconvolution stage
 # Drop the recob::Wire output from the roifinder (but keep the ChannelROIs)
-outputs.rootOutput.outputCommands:         ["keep *_*_*_*", "drop *_*_*_DAQ*", "drop recob::Wire*_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop recob::Wire*_roifinder_*_*" ]
+outputs.rootOutput.outputCommands:         ["keep *_*_*_*", "drop artdaq::Fragments_*_*_ICARUSReprocessRaw", "drop *_*_*_DAQ*", "drop recob::Wire*_daqTPCROI_*_*", "drop *_decon1droi_*_*", "drop recob::Wire*_roifinder_*_*" ]

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_crtpmtfilter_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_crtpmtfilter_icarus.fcl
@@ -24,6 +24,7 @@ outputs.out1.SelectEvents: [ reco ]
 # Drop all output from the 2D deconvolution stage
 # Drop the recob::Wire output from the roifinder2d (but keep the ChannelROIs)
 outputs.rootOutput.outputCommands:         ["keep *_*_*_*", 
+                                            "drop artdaq::Fragments_*_*_ICARUSReprocessRaw",
                                             "drop *_*_*_DAQ*", 
                                             "drop *_daqTPCROI_*_*", 
                                             "drop *_decon1droi_*_*", 

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus.fcl
@@ -23,6 +23,7 @@ physics.end_paths:     [ outana, streamROOT ]
 # Drop the recob::Wire output from the roifinder2d (but keep the ChannelROIs)
 # Keep the Trigger fragment
 outputs.rootOutput.outputCommands:         ["keep *_*_*_*", 
+                                            "drop artdaq::Fragments_*_*_ICARUSReprocessRaw",
                                             "drop *_*_*_DAQ*", 
                                             "drop *_daqTPCROI_*_*", 
                                             "drop *_decon1droi_*_*", 

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_raw_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_raw_icarus.fcl
@@ -10,6 +10,7 @@
 # Drop all output from the 2D deconvolution stage
 # Drop the recob::Wire output from the roifinder2d (but keep the ChannelROIs)
 outputs.rootOutput.outputCommands:         ["keep *_*_*_*", 
+                                            "drop artdaq::Fragments_*_*_ICARUSReprocessRaw",
                                             "drop *_*_*_DAQ*", 
                                             "drop recob::Wire*_daqTPCROI_*_*", 
                                             "drop *_decon1droi_*_*", 


### PR DESCRIPTION
This PR adds the drop of the artdaq::Fragments produced by the new compression algorithm (icarus_produce_compressed_job.fcl) to all the stage0 fcl files that were previously dropping DAQ data.