### PR TITLE
Update the drift velocity in the WireCell simparams.jsonnet

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/icarus/simparams.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/simparams.jsonnet
@@ -12,7 +12,7 @@ base {
     // Electron lifetime
     lifetime : 3.5*wc.ms,
     // Electron drift speed, assumes a certain applied E-field
-    drift_speed : 1.5756*wc.mm/wc.us, // at 500 V/cm
+    drift_speed : 1.572*wc.mm/wc.us, // at 500 V/cm
   },
   daq: super.daq {
 

--- a/icaruscode/TPC/ICARUSWireCell/icarus/simparams.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/simparams.jsonnet
@@ -12,7 +12,7 @@ base {
     // Electron lifetime
     lifetime : 3.5*wc.ms,
     // Electron drift speed, assumes a certain applied E-field
-    drift_speed : 1.572*wc.mm/wc.us, // at 500 V/cm
+    drift_speed : 1.5714*wc.mm/wc.us, // at 500 V/cm
   },
   daq: super.daq {
 


### PR DESCRIPTION
This PR updates the `drift_speed` within `icaruscode/TPC/ICARUSWireCell/icarus/simparams.jsonnet` to reflect measurements by @gputnam (see [SBN-doc-23346-v1](https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=23346&filename=driftV.pdf&version=1)).

See also [icarusalg PR #81](https://github.com/SBNSoftware/icarusalg/pull/81)

#### Question for reviewers: 
Here, I am using a value based on the measurement for the West cryostat. Since I don't believe the drift speed can be set for each cryostat independently, would it be better to choose a value somewhere between the two measured drift speeds of each cryostat?