### PR TITLE
Update TPC Channel Status database tags to v3r2

### DIFF
--- a/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
+++ b/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
@@ -5,7 +5,7 @@
 BEGIN_PROLOG
 
 ICARUS_Calibration_GlobalTags: {
-  @table::TPC_CalibrationTags_Oct2023
+  @table::TPC_CalibrationTags_Feb2024
   @table::PMT_CalibrationTags_Run3_Dec2023
   @table::CRT_CalibrationTags_Oct2023
 }

--- a/fcl/configurations/calibration_database_TPC_TagSets_icarus.fcl
+++ b/fcl/configurations/calibration_database_TPC_TagSets_icarus.fcl
@@ -4,7 +4,7 @@
 BEGIN_PROLOG
 
 ## Valid for Run A,1, and 2
-## - Files decoded with release __ to __ should use v3r1 
+## - Files decoded with release <v09_66_02 should use v3r1 
 TPC_CalibrationTags_Oct2023: {
 
   tpc_channelstatus_data: "v3r1"
@@ -16,7 +16,7 @@ TPC_CalibrationTags_Oct2023: {
 
 ## Valid for Run A,1, and 2
 ## - tpc_channelstatus_data updated to v3r2, where we reverted back "flange=WE20M AND board=1 or 5" to "Good" status.
-## - Files decoded with versions __ to __ should use v3r2
+## - Files decoded with release >=v09_66_02 should use v3r2
 TPC_CalibrationTags_Feb2024: {
 
   tpc_channelstatus_data: "v3r2"

--- a/fcl/configurations/calibration_database_TPC_TagSets_icarus.fcl
+++ b/fcl/configurations/calibration_database_TPC_TagSets_icarus.fcl
@@ -4,9 +4,22 @@
 BEGIN_PROLOG
 
 ## Valid for Run A,1, and 2
+## - Files decoded with release __ to __ should use v3r1 
 TPC_CalibrationTags_Oct2023: {
 
   tpc_channelstatus_data: "v3r1"
+  tpc_elifetime_data: "v2r1"
+  tpc_dqdxcalibration_data: "v2r1"
+  tpc_yz_correction_data: "v2r1"
+
+}
+
+## Valid for Run A,1, and 2
+## - tpc_channelstatus_data updated to v3r2, where we reverted back "flange=WE20M AND board=1 or 5" to "Good" status.
+## - Files decoded with versions __ to __ should use v3r2
+TPC_CalibrationTags_Feb2024: {
+
+  tpc_channelstatus_data: "v3r2"
   tpc_elifetime_data: "v2r1"
   tpc_dqdxcalibration_data: "v2r1"
   tpc_yz_correction_data: "v2r1"


### PR DESCRIPTION
Add and update TPC channel status db tag in TagSets and also update GlobalTag. `icarus_data` `v09_83_01` already contains this new tag.