### PR TITLE
Use run number for TPC calibration

### DIFF
--- a/icaruscode/TPC/Calorimetry/NormalizeTPCSQL_tool.cc
+++ b/icaruscode/TPC/Calorimetry/NormalizeTPCSQL_tool.cc
@@ -99,7 +99,7 @@ icarus::calo::NormalizeTPCSQL::ScaleInfo icarus::calo::NormalizeTPCSQL::GetScale
 double icarus::calo::NormalizeTPCSQL::Normalize(double dQdx, const art::Event &e, 
     const recob::Hit &hit, const geo::Point_t &location, const geo::Vector_t &direction, double t0) {
   // Get the info
-  ScaleInfo i = GetScaleInfo(e.time().timeHigh());
+  ScaleInfo i = GetScaleInfo(e.id().runID().run());
 
   // Lookup the TPC, cryo
   unsigned tpc = hit.WireID().TPC;

--- a/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
+++ b/icaruscode/TPC/Calorimetry/NormalizeYZSQL_tool.cc
@@ -216,7 +216,7 @@ const icarus::calo::NormalizeYZSQL::ScaleInfo& icarus::calo::NormalizeYZSQL::Get
 double icarus::calo::NormalizeYZSQL::Normalize(double dQdx, const art::Event &e, 
     const recob::Hit &hit, const geo::Point_t &location, const geo::Vector_t &direction, double t0) {
   // Get the info
-  ScaleInfo const& i = GetScaleInfo(e.time().timeHigh());
+  ScaleInfo const& i = GetScaleInfo(e.id().runID().run());
 
   // compute itpc
   int cryo = hit.WireID().Cryostat;

--- a/icaruscode/TPC/Calorimetry/normtools_icarus.fcl
+++ b/icaruscode/TPC/Calorimetry/normtools_icarus.fcl
@@ -58,8 +58,8 @@ yznorm_sql: {
   Verbose: false
 }
 
-icarus_calonormtools: [@local::driftnorm, @local::yznorm, @local::tpcgain]
-# icarus_calonormtools: [@local::driftnorm_sql, @local::yznorm_sql, @local::tpcgain_sql]
+#icarus_calonormtools: [@local::driftnorm, @local::yznorm, @local::tpcgain]
+ icarus_calonormtools: [@local::driftnorm_sql, @local::yznorm_sql, @local::tpcgain_sql]
 
 # Gain with angular dep. recombination
 # Assume equal on planes -- this is __wrong__ -- will need to be fixed when they are calibrated


### PR DESCRIPTION
- We are passing time stamp to TPC dqdx and YZ calibration DB querying; drift correction module was correctly using run number. 
- Using SQL db as default for TPC calibration