### PR TITLE
Workflow to enable ML File Production with refactored LArG4

### DIFF
--- a/fcl/g4/larg4_icarus.fcl
+++ b/fcl/g4/larg4_icarus.fcl
@@ -8,6 +8,7 @@
 #include "PDFastSim_icarus.fcl"
 #include "icarus_genericCRT.fcl"
 #include "mcreco.fcl"
+#include "g4inforeducer.fcl"
 
 process_name: G4
 
@@ -47,6 +48,10 @@ physics:
     # Truth-level reconstruction
     mcreco: @local::standard_mcreco
 
+    # needs to run right after largeant
+    sedlite:    @local::sbn_largeant_info_reducer 
+
+
     # Generic CRT
     genericcrt: @local::icarus_genericCRT
 
@@ -59,6 +64,7 @@ physics:
             , ionization
             , pdfastsim
             , simdrift
+            , sedlite
             , mcreco
             , genericcrt
           ]
@@ -73,8 +79,22 @@ physics:
   end_paths: [ stream1 ]
 }
 
+# Store MCParticleLite in G4 to store dropped particles from KeepEMShowerDaughters: false
+physics.producers.largeant.StoreDroppedMCParticles: false
+#services.ParticleListAction.KeepDroppedParticlesInVolumes: ["volDetEnclosure"] 
+
+# ------------------------------------------------------------------------------
+# Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
 physics.producers.mcreco.G4ModName: "simdrift"
+physics.producers.mcreco.SimChannelLabel: "sedlite"
 physics.producers.mcreco.MCParticleLabel: "largeant"
-physics.producers.mcreco.SimChannelLabel: "simdrift"
+physics.producers.mcreco.UseSimEnergyDepositLite: true
+physics.producers.mcreco.UseSimEnergyDeposit: false
+physics.producers.mcreco.IncludeDroppedParticles: false
+physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
+
+#info reducer
+physics.producers.sedlite.SimEnergyDepositLabel: "largeant:LArG4DetectorServicevolTPCActive"
+physics.producers.sedlite.useOrigTrackID: true #needed since origTrackID not filled for sedlite in SBND
 
 outputs.rootoutput: @local::icarus_rootoutput

--- a/fcl/g4/larg4_icarus_intime.fcl
+++ b/fcl/g4/larg4_icarus_intime.fcl
@@ -21,15 +21,21 @@ physics.producers.ionandscintouttime: @local::icarus_ionandscint
 physics.producers.pdfastsimouttime: @local::icarus_pdfastsim_pvs
 physics.producers.simdriftouttime: @local::icarus_simdrift
 physics.producers.genericcrtouttime: @local::icarus_genericCRT
+physics.producers.sedliteouttime: @local::sbn_largeant_info_reducer
 
 # Set the appropriate input labels, to run geant4 only on the outtime cosmics
 physics.producers.simdriftintime.SimulationLabel: "ionandscintintime:priorSCE"
 physics.producers.genericcrtintime.LArG4Label: "larg4intime"
 physics.producers.larg4outtime.inputCollections: [ "GenInTimeSorter:outtime" ]
+physics.producers.larg4outtime.FillSimEnergyDeposits: true
+physics.producers.larg4outtime.EnergyDepositInstanceLabels: ["LArG4DetectorServicevolTPCActive"]
 physics.producers.ionandscintouttime.InputModuleLabels: ["larg4outtime"]
 physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE"
 physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime:priorSCE"
 physics.producers.genericcrtouttime.LArG4Label: "larg4outtime"
+#info reducer
+physics.producers.sedliteouttime.SimEnergyDepositLabel: "larg4outtime:LArG4DetectorServicevolTPCActive"
+physics.producers.sedliteouttime.useOrigTrackID: true #needed since origTrackID not filled for sedlite in SBND
 
 # Add a process that merges the MCParticles
 physics.producers.largeant: @local::icarus_merge_sim_sources
@@ -57,6 +63,9 @@ physics.producers.pdfastsim: @local::icarus_merge_sim_sources
 physics.producers.pdfastsim.FillSimPhotons: true
 physics.producers.pdfastsim.InputSourcesLabels: [ "pdfastsimintime", "pdfastsimouttime"]
 
+#Add a process that merges the dropped MCParticles
+physics.producers.sedlite: @local::icarus_merge_intime_dropped_mcparts
+
 # Add all these new modules to the simulate path
 physics.simulate: [ rns
                   ### Complete intime drift simulation and generic CRT
@@ -70,6 +79,7 @@ physics.simulate: [ rns
                   , pdfastsimouttime
                   , simdriftouttime
                   , genericcrtouttime
+                  , sedliteouttime
                   ### Merge the intime and outtime paths
                   , largeant
                   , ionization
@@ -78,6 +88,7 @@ physics.simulate: [ rns
                   , genericcrt
                   ### Do truth-level reconstruction
                   , mcreco
+                  , sedlite 
                   ]
 
 services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]

--- a/fcl/g4/larg4_services_icarus.fcl
+++ b/fcl/g4/larg4_services_icarus.fcl
@@ -46,6 +46,7 @@ icarus_particle_list_action:
   keepEMShowerDaughters: false             # If false, does not store electromagnetic shower daughter
                                            # particles in the MCParticles data product.
   storeTrajectories: true
+  KeepDroppedParticlesInVolumes: ["volTPCActive"] 
   keepGenTrajectories: ["generator"]       # list of generator labels for which we want to store
                                            # trajectory points.
   keepOnlyPrimaryFullTrajectories: false   # (defaults to false in larg4) If set to true, only

--- a/fcl/g4/mergesimsources_icarus.fcl
+++ b/fcl/g4/mergesimsources_icarus.fcl
@@ -47,4 +47,14 @@ icarus_merge_overlay_sim_sources : {
   AuxDetHitsInstanceLabels:    @local::largeant_crt_volumes
 }
 
+icarus_merge_intime_dropped_mcparts: 
+{
+    @table::icarus_merge_sim_sources
+    module_type: "MergeSimSourcesSBN"
+    InputSourcesLabels: ["larg4intime:droppedMCParticles","larg4outtime:droppedMCParticles"]
+    FillMCParticles: true
+    FillMCParticlesLite: false
+    FillMCParticlesAssociated: false
+}
+
 END_PROLOG

--- a/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
@@ -16,6 +16,7 @@
 #include "LArG4.fcl"
 #include "services_icarus_simulation.fcl"
 #include "larg4_services_icarus.fcl"
+#include "g4inforeducer.fcl"
 
 #include "prodcorsika_protononly_icarus.fcl"
 
@@ -38,6 +39,7 @@ physics.producers.loader: { module_type: "PhysListLoader" }
 physics.producers.larg4intime: @local::standard_larg4
 physics.producers.ionandscintintime: @local::icarus_ionandscint
 physics.producers.pdfastsimintime: @local::icarus_pdfastsim_pvs
+physics.producers.sedliteintime: @local::sbn_largeant_info_reducer
 
 # Add a filter on the geant4 intime output, based on sim photons
 physics.filters.timefilter: @local::icarus_timefilterssimphotonlitetime
@@ -47,6 +49,7 @@ physics.simulate: [ corsika
                   , GenInTimeSorter
                   , loader
                   , larg4intime
+                  , sedliteintime
                   , ionandscintintime
                   , pdfastsimintime
                   , beamgate
@@ -59,14 +62,20 @@ physics.producers.generator: @erase
 
 # Set the appropriate input labels
 physics.producers.larg4intime.inputCollections: ["GenInTimeSorter:intime"]
+physics.producers.larg4intime.FillSimEnergyDeposits: true
+physics.producers.larg4intime.EnergyDepositInstanceLabels: ["LArG4DetectorServicevolTPCActive"]
 physics.producers.ionandscintintime.InputModuleLabels: ["larg4intime"]
 physics.producers.pdfastsimintime.SimulationLabel: "ionandscintintime:priorSCE"
+physics.producers.sedliteintime.SimEnergyDepositLabel: "larg4intime:LArG4DetectorServicevolTPCActive"
+physics.producers.sedliteintime.useOrigTrackID: true #needed
+
 physics.filters.timefilter.SimPhotonsLiteCollectionLabel: "pdfastsimintime"
+
 
 services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]
 services.LArG4Parameters.UseLitePhotons: true
 
 outputs.out1.SelectEvents: [ "simulate" ]
-outputs.out1.fileName:	"prodcorsika_protononly_intime_icarus_numi_%tc-%p.root"
+outputs.out1.fileName:	"prodcorsika_protononly_intime_icarus_bnb_%tc-%p.root"
 
 process_name: CosmicsCorsikaProtonGenAndG4InTime


### PR DESCRIPTION
These additions to the refactored LArG4 fcls to enable the creation of data products needed by the ML reconstruction chain. This is a mimic of a similar SBND PR by @bear-is-asleep. 

The ML team has validated that this truth information is sufficient. 

This relies on a number of other PRs across a number of packages:

SBNCode: https://github.com/SBNSoftware/sbncode/pull/430
LArG4: https://github.com/LArSoft/larg4/pull/52
LArSim: https://github.com/LArSoft/larsim/pull/131

