### PR TITLE
Update to data-based calibration for ICARUS MCS reco

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -15,7 +15,7 @@
 #include "eventweight_genie_systtools.fcl"
 #include "eventweight_flux_sbn.fcl"
 #include "mcreco.fcl"
-#include "mcsproducer.fcl"
+#include "mcsproducer_icarus.fcl"
 #include "rangeproducer.fcl"
 #include "crthitconverter_producer.fcl"
 #include "flashmatch_simple_icarus.fcl"
@@ -96,8 +96,8 @@ standard_crtt0producer_cryoW.PFParticleLabel: ["pandoraGausCryoW"]
 recoana_caf_preprocess_producers: {
   mcreco: @local::standard_mcreco
 
-  pandoraTrackMCSCryoE: @local::mcs_sbn
-  pandoraTrackMCSCryoW: @local::mcs_sbn
+  pandoraTrackMCSCryoE: @local::mcs_icarus_mc
+  pandoraTrackMCSCryoW: @local::mcs_icarus_mc
 
   pandoraTrackRangeCryoE: @local::range_sbn
   pandoraTrackRangeCryoW: @local::range_sbn

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -31,6 +31,13 @@ physics.producers.cafmaker.GenLabel: ""
 physics.producers.cafmaker.SimChannelLabel: ""
 physics.producers.cafmaker.SystWeightLabels: []
 
+# use different angular resolution for MCS in data
+physics.producers.pandoraTrackMCSCryoE: @local::mcs_icarus_data
+physics.producers.pandoraTrackMCSCryoE.TrackLabel: pandoraTrackGausCryoE
+
+physics.producers.pandoraTrackMCSCryoW: @local::mcs_icarus_data
+physics.producers.pandoraTrackMCSCryoW.TrackLabel: pandoraTrackGausCryoW
+
 physics.producers.cafmaker.TriggerLabel: "daqTrigger" # the general configuration, for MC, has a different one (see also https://github.com/SBNSoftware/icaruscode/issues/556)
 
 #include "icarus_data_recombination.fcl"


### PR DESCRIPTION
For NuMI backport release. Depends on https://github.com/SBNSoftware/sbncode/pull/439.