### PR TITLE
restore legacy G4

### DIFF
--- a/fcl/detsim/SBNNoise/multitpc_detsim_icarus_sbnnoise.fcl
+++ b/fcl/detsim/SBNNoise/multitpc_detsim_icarus_sbnnoise.fcl
@@ -113,3 +113,9 @@ outputs:
  }
 }
 
+#legacy G4 configs
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
+physics.producers.crtdaq.G4ModuleLabel: "largeant"
+physics.producers.opdaq.InputModule: "largeant"
+i

--- a/fcl/detsim/SBNNoise/multitpc_detsim_icarus_sbnnoise.fcl
+++ b/fcl/detsim/SBNNoise/multitpc_detsim_icarus_sbnnoise.fcl
@@ -118,4 +118,3 @@ services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
 services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
 physics.producers.crtdaq.G4ModuleLabel: "largeant"
 physics.producers.opdaq.InputModule: "largeant"
-i

--- a/fcl/detsim/commissioning/run4642like_detsim_icarus.fcl
+++ b/fcl/detsim/commissioning/run4642like_detsim_icarus.fcl
@@ -69,3 +69,8 @@ physics: {
 outputs: {
   rootoutput: @local::icarus_rootoutput
 }
+
+#legacy G4 configs
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
+physics.producers.opdaq.InputModule: "largeant"

--- a/fcl/detsim/commissioning/run4759like_detsim_icarus.fcl
+++ b/fcl/detsim/commissioning/run4759like_detsim_icarus.fcl
@@ -69,3 +69,8 @@ physics: {
 outputs: {
   rootoutput: @local::icarus_rootoutput
 }
+
+#legacy G4 configs
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
+physics.producers.opdaq.InputModule: "largeant"

--- a/fcl/detsim/detsim_1d_icarus.fcl
+++ b/fcl/detsim/detsim_1d_icarus.fcl
@@ -93,3 +93,9 @@ physics.producers.daq3.TPCVec:              [ [1, 2], [1, 3] ]
 
 # ------------------------------------------------------------------------------
 outputs.rootoutput: @local::icarus_rootoutput
+
+#legacy G4 configs
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
+physics.producers.crtdaq.G4ModuleLabel: "largeant"
+physics.producers.opdaq.InputModule: "largeant"

--- a/fcl/detsim/detsim_2d_icarus.fcl
+++ b/fcl/detsim/detsim_2d_icarus.fcl
@@ -10,7 +10,8 @@ services: {
   @table::icarus_detsim_services
   #FileCatalogMetadata:  @local::art_file_catalog_mc
 } # services
-
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
 
 physics: {
 

--- a/fcl/detsim/detsim_2d_icarus.fcl
+++ b/fcl/detsim/detsim_2d_icarus.fcl
@@ -10,8 +10,6 @@ services: {
   @table::icarus_detsim_services
   #FileCatalogMetadata:  @local::art_file_catalog_mc
 } # services
-services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
-services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
 
 physics: {
 
@@ -35,6 +33,9 @@ outputs: {
   rootoutput: @local::icarus_rootoutput
 }
 
+#legacy G4 configs
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
 physics.producers.daq.wcls_main.configs: ["pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet"]
 physics.producers.crtdaq.G4ModuleLabel: "largeant"
 physics.producers.opdaq.InputModule: "largeant"

--- a/fcl/detsim/detsim_2d_icarus.fcl
+++ b/fcl/detsim/detsim_2d_icarus.fcl
@@ -34,3 +34,7 @@ physics: {
 outputs: {
   rootoutput: @local::icarus_rootoutput
 }
+
+physics.producers.daq.wcls_main.configs: ["pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet"]
+physics.producers.crtdaq.G4ModuleLabel: "largeant"
+physics.producers.opdaq.InputModule: "largeant"

--- a/fcl/detsim/detsim_2d_icarus_diff-10.fcl
+++ b/fcl/detsim/detsim_2d_icarus_diff-10.fcl
@@ -1,38 +1,4 @@
-#include "services_icarus_simulation.fcl"
-#include "detsimmodules_wirecell_ICARUS.fcl"
-#include "opdetsim_pmt_icarus.fcl"
-#include "crtsimmodules_icarus.fcl"
-#include "rootoutput_icarus.fcl"
-
-process_name: DetSim
-
-services: {
-  @table::icarus_detsim_services
-  #FileCatalogMetadata:  @local::art_file_catalog_mc
-} # services
-
-
-physics: {
-
-  producers: {
-    crtdaq:         @local::icarus_crtsim
-     opdaq:         @local::icarus_simpmt
-       daq:         @local::icarus_simwire_wirecell
-
-       rns:         { module_type: "RandomNumberSaver" }
-  } # producers
-  
-  simulate: [ rns, opdaq, daq, crtdaq ]
-  
-  # define the output stream, there could be more than one if using filters
-  stream:  [ rootoutput ]
-
-} # physics
-
-
-outputs: {
-  rootoutput: @local::icarus_rootoutput
-}
+#include "detsim_2d_icarus.fcl"
 
 # Field Responce input customisation
 # physics.producers.daq.wcls_main.params.files_fields: "icarus_testFR_1.json.bz2"

--- a/fcl/detsim/detsim_2d_icarus_diff10.fcl
+++ b/fcl/detsim/detsim_2d_icarus_diff10.fcl
@@ -1,38 +1,4 @@
-#include "services_icarus_simulation.fcl"
-#include "detsimmodules_wirecell_ICARUS.fcl"
-#include "opdetsim_pmt_icarus.fcl"
-#include "crtsimmodules_icarus.fcl"
-#include "rootoutput_icarus.fcl"
-
-process_name: DetSim
-
-services: {
-  @table::icarus_detsim_services
-  #FileCatalogMetadata:  @local::art_file_catalog_mc
-} # services
-
-
-physics: {
-
-  producers: {
-    crtdaq:         @local::icarus_crtsim
-     opdaq:         @local::icarus_simpmt
-       daq:         @local::icarus_simwire_wirecell
-
-       rns:         { module_type: "RandomNumberSaver" }
-  } # producers
-  
-  simulate: [ rns, opdaq, daq, crtdaq ]
-  
-  # define the output stream, there could be more than one if using filters
-  stream:  [ rootoutput ]
-
-} # physics
-
-
-outputs: {
-  rootoutput: @local::icarus_rootoutput
-}
+#include "detsim_2d_icarus.fcl"
 
 # Field Responce input customisation
 # physics.producers.daq.wcls_main.params.files_fields: "icarus_testFR_1.json.bz2"

--- a/fcl/detsim/detsim_2d_icarus_fitFR.fcl
+++ b/fcl/detsim/detsim_2d_icarus_fitFR.fcl
@@ -1,3 +1,4 @@
 #include "detsim_2d_icarus.fcl"
 
 physics.producers.daq: @local::icarus_simwire_wirecell_fitSR
+physics.producers.daq.wcls_main.configs: ["pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet"]

--- a/fcl/detsim/detsim_2d_icarus_refactored.fcl
+++ b/fcl/detsim/detsim_2d_icarus_refactored.fcl
@@ -1,5 +1,34 @@
-#include "detsim_2d_icarus.fcl"
+#include "services_icarus_simulation.fcl"
+#include "detsimmodules_wirecell_ICARUS.fcl"
+#include "opdetsim_pmt_icarus.fcl"
+#include "crtsimmodules_icarus.fcl"
+#include "rootoutput_icarus.fcl"
 
-physics.producers.daq.wcls_main.configs: ["pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-refactored.jsonnet"]
-physics.producers.crtdaq.G4ModuleLabel: "genericcrt"
-physics.producers.opdaq.InputModule: "pdfastsim"
+process_name: DetSim
+
+services: {
+  @table::icarus_detsim_services
+  #FileCatalogMetadata:  @local::art_file_catalog_mc
+} # services
+
+physics: {
+
+  producers: {
+    crtdaq:         @local::icarus_crtsim
+     opdaq:         @local::icarus_simpmt
+       daq:         @local::icarus_simwire_wirecell
+
+       rns:         { module_type: "RandomNumberSaver" }
+  } # producers
+
+  simulate: [ rns, opdaq, daq, crtdaq ]
+
+  # define the output stream, there could be more than one if using filters
+  stream:  [ rootoutput ]
+
+} # physics
+
+
+outputs: {
+  rootoutput: @local::icarus_rootoutput
+}

--- a/fcl/g4/standard_g4_icarus.fcl
+++ b/fcl/g4/standard_g4_icarus.fcl
@@ -36,7 +36,8 @@ process_name: G4
 
 # ------------------------------------------------------------------------------
 services: @local::icarus_g4_services
-
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
 
 # ------------------------------------------------------------------------------
 physics:

--- a/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
@@ -70,3 +70,6 @@ outputs.out1.SelectEvents: [ "simulate" ]
 outputs.out1.fileName:	"prodcorsika_protononly_intime_icarus_numi_%tc-%p.root"
 
 process_name: CosmicsCorsikaProtonGenAndG4InTime
+
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"

--- a/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
@@ -70,6 +70,3 @@ outputs.out1.SelectEvents: [ "simulate" ]
 outputs.out1.fileName:	"prodcorsika_protononly_intime_icarus_numi_%tc-%p.root"
 
 process_name: CosmicsCorsikaProtonGenAndG4InTime
-
-services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
-services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"

--- a/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_icarus_bnb.fcl
@@ -136,3 +136,6 @@ physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
 
 # Store MCParticleLite in G4 to store dropped particles from KeepEMShowerDaughters: false
 physics.producers.larg4intime.StoreDroppedMCParticles: true
+
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"

--- a/fcl/reco/ForCITests/reco_icarus_driver_common.fcl
+++ b/fcl/reco/ForCITests/reco_icarus_driver_common.fcl
@@ -80,3 +80,5 @@ services.message.destinations :
      }
   }
 }
+
+physics.producers.mcophit.SimPhotonsProducer: "largeant"

--- a/fcl/reco/Stage0/Run1/stage0_run1_icarus_mc.fcl
+++ b/fcl/reco/Stage0/Run1/stage0_run1_icarus_mc.fcl
@@ -49,3 +49,5 @@ physics.analyzers.purityinfoana1.SelectEvents: [ path ]
 physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 
+# restore legacy G4 labels
+physics.producers.mcophit.SimPhotonsProducer: "largeant"

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus_mc.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus_mc.fcl
@@ -54,7 +54,5 @@ physics.analyzers.purityinfoana1.SelectEvents: [ path ]
 physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 
-# restore legacy G4 gdml and label
+# restore legacy G4 labels
 physics.producers.mcophit.SimPhotonsProducer: "largeant"
-services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
-services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus_mc.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus_mc.fcl
@@ -54,3 +54,7 @@ physics.analyzers.purityinfoana1.SelectEvents: [ path ]
 physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 
+# restore legacy G4 gdml and label
+physics.producers.mcophit.SimPhotonsProducer: "largeant"
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"

--- a/fcl/reco/Stage0/Run2/stage0_run2_icarus_mc_refactored.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_icarus_mc_refactored.fcl
@@ -1,3 +1,56 @@
-#include "stage0_run2_icarus_mc.fcl"
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_mc_defs.fcl"
+#include "stage0_icarus_driver_common.fcl"
 
-physics.producers.mcophit.SimPhotonsProducer: "pdfastsim"
+process_name: MCstage0
+
+## Add the MC module to the list of producers
+physics.producers: {  @table::icarus_stage0_producers
+                      @table::icarus_stage0_mc_producers
+                   }
+
+## Use the following to run the full defined stage0 set of modules
+physics.path: [   @sequence::icarus_stage0_mc_PMT,
+                  MCDecodeTPCROI,
+                  @sequence::icarus_stage0_multiTPC,
+                  simChannelROI,
+                  @sequence::icarus_stage0_mc_crt
+              ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamROOT ]
+
+# Drop data products that are no longer needed, but make sure to keep important items!
+# For example, we need to drop the RawDigits from the detector simulation stage but want to keep the SimChannel info from WireCell...
+outputs.rootOutput.outputCommands: ["keep *_*_*_*", "drop *_daq*_*_*", "drop *_MCDecodeTPCROI_*_*", "drop *_decon1droi_*_*", "drop recob::Wire*_roifinder_*_*", "keep *_daq_simpleSC_*"]
+
+# Set the expected input for ophit
+physics.producers.ophit.InputModule: "opdaq"
+
+# Note the default assumption is that our detector simulation input will come from the WireCell 2D drift simulation, a la 'daq'
+# If we are running the 1D drift simulation we need to switch to using:
+# `physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq3:PHYSCRATEDATATPCWW","daq2:PHYSCRATEDATATPCWE","daq1:PHYSCRATEDATATPCEW","daq0:PHYSCRATEDATATPCEE"]`
+#
+physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq:TPCWW","daq:TPCWE","daq:TPCEW","daq:TPCEE"]
+physics.producers.MCDecodeTPCROI.OutInstanceLabelVec: ["PHYSCRATEDATATPCWW", "PHYSCRATEDATATPCWE", "PHYSCRATEDATATPCEW", "PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:        ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+
+physics.producers.simChannelROI.SimChannelLabelVec:  ["daq:simpleSC"]
+physics.producers.simChannelROI.OutInstanceLabelVec: ["All"]
+
+physics.producers.decon2droiEE.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCEE"
+physics.producers.decon2droiEW.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCEW"
+physics.producers.decon2droiWE.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWE"
+physics.producers.decon2droiWW.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWW"
+
+## Need overrides for the purity monitor
+physics.analyzers.purityinfoana0.SelectEvents: [ path ]
+physics.analyzers.purityinfoana1.SelectEvents: [ path ]
+physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_mc.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_mc.fcl
@@ -93,3 +93,6 @@ physics.producers.decon2droiEE.wcls_main.structs.shaping2: 1.3
 physics.producers.decon2droiEW.wcls_main.structs.shaping2: 1.3  
 physics.producers.decon2droiWE.wcls_main.structs.shaping2: 1.3  
 physics.producers.decon2droiWW.wcls_main.structs.shaping2: 1.3  
+
+# restore legacy G4 labels
+physics.producers.mcophit.SimPhotonsProducer: "largeant"

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_testgauss_icarus_mc.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_testgauss_icarus_mc.fcl
@@ -61,3 +61,5 @@ physics.analyzers.purityinfoana1.SelectEvents: [ path ]
 physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
 
+# restore legacy G4 labels
+physics.producers.mcophit.SimPhotonsProducer: "largeant"

--- a/fcl/reco/Stage1/Run1/stage1_multiTPC_icarus_gauss_MC.fcl
+++ b/fcl/reco/Stage1/Run1/stage1_multiTPC_icarus_gauss_MC.fcl
@@ -12,7 +12,7 @@ process_name: MCstage1
 physics.producers: {
             @table::icarus_stage1_producers
 
-            mcophit:                        @local::ICARUSMCOpHit
+            #mcophit:                        @local::ICARUSMCOpHit
             mcopflashTPC0:                  @local::ICARUSMCOpFlashTPC0
             mcopflashTPC1:                  @local::ICARUSMCOpFlashTPC1
             mcopflashTPC2:                  @local::ICARUSMCOpFlashTPC2

--- a/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_icarus_MC.fcl
@@ -30,7 +30,7 @@ services.ParticleInventoryService:  @local::standard_particleinventoryservice
 physics.producers: {
             @table::icarus_stage1_producers
 
-            mcophit:                        @local::ICARUSMCOpHit
+            #mcophit:                        @local::ICARUSMCOpHit
             mcopflashTPC0:                  @local::ICARUSMCOpFlashTPC0
             mcopflashTPC1:                  @local::ICARUSMCOpFlashTPC1
             mcopflashTPC2:                  @local::ICARUSMCOpFlashTPC2

--- a/icaruscode/CRT/CRTGeoObjectSorter.cxx
+++ b/icaruscode/CRT/CRTGeoObjectSorter.cxx
@@ -25,6 +25,10 @@ namespace geo{
     // assume volume name is "volAuxDet<subsystem>module###<region>"
     std::string modulePrefix = "module";
 
+    //keep compatibility with legacy g4
+    ad1name.erase(std::remove(ad1name.begin(), ad1name.end(), '_'), ad1name.end());
+    ad2name.erase(std::remove(ad2name.begin(), ad2name.end(), '_'), ad2name.end());
+
     int ad1Num = atoi( ad1name.substr(ad1name.find(modulePrefix)+modulePrefix.length(),3).c_str() );
     int ad2Num = atoi( ad2name.substr(ad2name.find(modulePrefix)+modulePrefix.length(), 3).c_str() );
 
@@ -42,6 +46,10 @@ namespace geo{
     // assume volume name is "volAuxDetSensitive<subsystem>module###(<cut<###>,top or bot>)strip##"
     std::string modulePrefix = "module";
     std::string stripPrefix = "strip";
+
+    //keep compatibility with legacy g4
+    ad1name.erase(std::remove(ad1name.begin(), ad1name.end(), '_'), ad1name.end());
+    ad2name.erase(std::remove(ad2name.begin(), ad2name.end(), '_'), ad2name.end());
 
     int ad1Num = atoi( ad1name.substr(ad1name.find(modulePrefix)+modulePrefix.length(), 3).c_str() );
     int ad2Num = atoi( ad2name.substr(ad2name.find(modulePrefix)+modulePrefix.length(), 3).c_str() );

--- a/icaruscode/CRT/CRTUtils/CRTCommonUtils.cc
+++ b/icaruscode/CRT/CRTUtils/CRTCommonUtils.cc
@@ -610,6 +610,9 @@ string CRTCommonUtils::AuxDetNameToRegion(string name) {
     }
     base+="module###";
 
+    //keep compatibility with legacy g4
+    name.erase(std::remove(name.begin(), name.end(), '_'), name.end());
+
     //module name has 2 possible formats
     //  volAuxDet_<subsystem>_module_###_<region>
     //  volAuxDet_<subsystem>_module_###_cut###_<region>

--- a/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
@@ -496,7 +496,7 @@ namespace icarus{
 	      path += "/";
 	    }
 	  }
-	  if (path.find(adGeo.Name())!=std::string::npos && path.find("strip"+stripn)!=std::string::npos) break;
+	  if (path.find(adsGeo.TotalVolume()->GetName())!=std::string::npos) break;
 	  else path = "";
 	}
 

--- a/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
@@ -488,6 +488,9 @@ namespace icarus{
 	string stripn = std::to_string(adsid);
 	if (stripn.length()==1) stripn = "0"+stripn;
 
+	// whether we are using the "legacy" geometry naming scheme
+	bool const isLegacy = std::string(adsGeo.TotalVolume()->GetName()).find("_")!=std::string::npos;
+
         string path = "";
 	for (size_t ip=0;ip<paths.size();ip++) {
 	  for (size_t inode=0; inode<paths.at(ip).size(); inode++) {
@@ -497,7 +500,7 @@ namespace icarus{
 	    }
 	  }
 	  if ( (path.find(adGeo.Name())!=std::string::npos && path.find("strip"+stripn)!=std::string::npos) || //refactored
-	       (std::string(adsGeo.TotalVolume()->GetName()).find("_")!=std::string::npos && path.find(adsGeo.TotalVolume()->GetName())!=std::string::npos) ) //legacy
+	       (isLegacy && path.find(adsGeo.TotalVolume()->GetName())!=std::string::npos) ) //legacy
 	    break;
 	  else path = "";
 	}

--- a/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
@@ -496,7 +496,7 @@ namespace icarus{
 	      path += "/";
 	    }
 	  }
-	  if (path.find(adsGeo.TotalVolume()->GetName())!=std::string::npos) break;
+	  if ( (path.find(adGeo.Name())!=std::string::npos && path.find("strip"+stripn)!=std::string::npos) || path.find(adsGeo.TotalVolume()->GetName())!=std::string::npos) break;
 	  else path = "";
 	}
 

--- a/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTDetSimAlg.cc
@@ -496,7 +496,9 @@ namespace icarus{
 	      path += "/";
 	    }
 	  }
-	  if ( (path.find(adGeo.Name())!=std::string::npos && path.find("strip"+stripn)!=std::string::npos) || path.find(adsGeo.TotalVolume()->GetName())!=std::string::npos) break;
+	  if ( (path.find(adGeo.Name())!=std::string::npos && path.find("strip"+stripn)!=std::string::npos) || //refactored
+	       (std::string(adsGeo.TotalVolume()->GetName()).find("_")!=std::string::npos && path.find(adsGeo.TotalVolume()->GetName())!=std::string::npos) ) //legacy
+	    break;
 	  else path = "";
 	}
 

--- a/icaruscode/CRT/crtsimmodules_icarus.fcl
+++ b/icaruscode/CRT/crtsimmodules_icarus.fcl
@@ -85,7 +85,7 @@ icarus_crtsim:
 {
   module_type: "icaruscode/CRT/CRTDetSim"
 
-  G4ModuleLabel: "largeant"
+  G4ModuleLabel: "genericcrt"
 
   DetSimAlg: @local::standard_icarus_crtsimalg
 }

--- a/icaruscode/PMT/OpReco/driver/gen_protons.fcl
+++ b/icaruscode/PMT/OpReco/driver/gen_protons.fcl
@@ -121,3 +121,8 @@ services.message.destinations :
      }
   }
 }
+
+#legacy G4 configs
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
+physics.producers.opdaq.InputModule: "largeant"

--- a/icaruscode/PMT/OpReco/driver/run_opflash_debugger.fcl
+++ b/icaruscode/PMT/OpReco/driver/run_opflash_debugger.fcl
@@ -82,3 +82,6 @@ services.message.destinations :
      }
   }
 }
+
+# restore legacy G4 labels
+physics.producers.mcophit.SimPhotonsProducer: "largeant"

--- a/icaruscode/PMT/OpReco/driver/run_opflash_electron.fcl
+++ b/icaruscode/PMT/OpReco/driver/run_opflash_electron.fcl
@@ -132,3 +132,6 @@ services.message.destinations :
      }
   }
 }
+
+# restore legacy G4 labels
+physics.producers.mcophit.SimPhotonsProducer: "largeant"

--- a/icaruscode/PMT/OpReco/driver/run_opflash_protons.fcl
+++ b/icaruscode/PMT/OpReco/driver/run_opflash_protons.fcl
@@ -132,3 +132,6 @@ services.message.destinations :
      }
   }
 }
+
+# restore legacy G4 labels
+physics.producers.mcophit.SimPhotonsProducer: "largeant"

--- a/icaruscode/PMT/OpReco/driver/study_ophit_singlep.fcl
+++ b/icaruscode/PMT/OpReco/driver/study_ophit_singlep.fcl
@@ -111,3 +111,8 @@ services.message.destinations :
      }
   }
 }
+
+#legacy G4 configs
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
+physics.producers.opdaq.InputModule: "largeant"

--- a/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
@@ -24,7 +24,7 @@ FakeFlash: {
 ICARUSMCOpHit: {
     module_type: "ICARUSMCOpHit"
     MergePeriod: 0.01
-    SimPhotonsProducer: "largeant"
+    SimPhotonsProducer: "pdfastsim"
     SPEArea: @local::SPE.Area
     SPEAmplitude: @local::SPE.Amplitude
 }

--- a/icaruscode/PMT/opdetsim_pmt_icarus.fcl
+++ b/icaruscode/PMT/opdetsim_pmt_icarus.fcl
@@ -8,7 +8,7 @@ BEGIN_PROLOG
 icarus_simpmt: 
 {
   module_type:               "SimPMTIcarus"
-  InputModule:               "largeant"
+  InputModule:               "pdfastsim"
   
   @table::icarus_pmtsimulationalg_standard
 }

--- a/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
+++ b/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
@@ -16,7 +16,7 @@ icarus_simwire_wirecell:
         // loglevels: ["magnify:debug"]
         plugins: ["WireCellPgraph", "WireCellGen","WireCellSio","WireCellRoot","WireCellLarsoft"]
         // needs to be found via your WIRECELL_PATH 
-        configs: ["pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet"]
+        configs: ["pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-refactored.jsonnet"]
         // Contract note: these exact "type:name" must be used to identify
         // the configuration data structures for these components in the Jsonnet.
         inputers: ["wclsSimDepoSetSource:electron"]


### PR DESCRIPTION
This PR is meant to restore the legacy G4 functionality (needs SBNSoftware/icarusalg#84).
The main problem is that the legacy G4 does not support multiple sensitive AuxDet volumes corresponding to a single logical volume (see e.g. https://github.com/LArSoft/larsim/blob/develop/larsim/LegacyLArG4/AuxDetReadoutGeometry.cxx#L139) and the refactored gdml uses a single logical volume for all strips in the same module type.

What we do in this PR is to:
* ensure that the volume name lookup works for both legacy and refactored gdml (with and without "_" in the volume names). See changes in icaruscode/CRT and icaruscode/CRT/CRTUtils
* all the other changes are to fcl files:
   * change the default fcls and input labels to the refactored g4, as it should be the new standard
   * ensure the legacy g4 and detsim use the legacy gdml and the legacy input labels
   * ensure the legacy stage0 fcl for MC use the legacy input label for mcophit (using the new gdml is fine for reco as the geometry is the same)
   * comment out mcophit from stage1 fcls as it is not used

What this PR does not do:
* move all the legacy fcls to a separate directory
* rename the refactored fcls to be the new standard (i.e. what production uses)
These should probably be done once there is consensus that we can use refactored for production.