### PR TITLE
add data integrity filter to recompression fcl

### DIFF
--- a/icaruscode/TPC/Compression/icarus_produce_compressed_job.fcl
+++ b/icaruscode/TPC/Compression/icarus_produce_compressed_job.fcl
@@ -20,7 +20,12 @@ physics:
     daq: @local::standard_producecompressed
   }
 
-  reproProduce: [ daq ]
+  filters:
+  {
+    filterdataintegrity: { module_type: "FilterDataIntegrity"}
+  }
+
+  reproProduce: [ filterdataintegrity, daq ]
 
   stream1: [ out1 ]
 
@@ -35,6 +40,7 @@ outputs:
   {
     module_type: RootOutput
     fileName: "icarus_reproduced_out.root"
+    SelectEvents: ["reproProduce"]
     outputCommands: [ "keep *_*_*_*",
                       "drop *_daq_PHYSCRATEDATATPC??_DAQEVB??" ]
   }


### PR DESCRIPTION
This PR adds the data integrity filter to the recompression fcl. This is needed to avoid failures for files where some events have corrupted daq information.