### PR TITLE
Trigger decoder for adder triggers

### DIFF
--- a/fcl/reco/Stage0/Run2/partial/decodeTrigger_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/partial/decodeTrigger_icarus.fcl
@@ -1,4 +1,5 @@
 #include "services_common_icarus.fcl"
+#include "channelmapping_icarus.fcl"
 #include "rootoutput_icarus.fcl"
 #include "decoderdefs_icarus.fcl"
 
@@ -11,6 +12,7 @@ services: {
   
                      @table::icarus_geometry_services
   DetectorClocksService: @local::icarus_detectorclocks
+  IICARUSChannelMap: @local::icarus_channelmappinggservice  # from channelmapping_icarus.fcl
 }
 
 

--- a/icaruscode/Decode/ChannelMapping/ChannelMapDumper.cxx
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapDumper.cxx
@@ -168,12 +168,22 @@ void dumpPMTmapping(icarusDB::IICARUSChannelMapProvider const& mapping) {
       << " includes " << digitizerChannels.size()
       << " LArSoft channels between " << digitizerChannels.front().channelID
       << " and " << digitizerChannels.back().channelID
-      << " [board channel index in brackets]:";
-    Pager pager{ 8 };
+      << " [board channel info in brackets]:";
+    Pager pager{ 3 };
     for(auto const & chInfo: digitizerChannels) {
       if (pager.nextHasNewLine()) log << "\n     ";
-      log << " "  << std::setw(3) << chInfo.channelID
-        << " [" << std::setw(3) << chInfo.digitizerChannelNo << "]";
+      log << " " << std::setw(3) << chInfo.channelID
+        << " [" << chInfo.digitizerLabel << "@"
+        << std::setfill('0') << std::setw(2) << chInfo.digitizerChannelNo;
+      if (chInfo.hasLVDSinfo()) {
+        log << ", LVDS:" << chInfo.LVDSconnector << "-"
+          << std::setw(2) << chInfo.LVDSbit;
+      }
+      if (chInfo.hasAdderInfo()) {
+        log << ", adder:" << chInfo.adderConnector << "-"
+          << std::setw(2) << chInfo.adderBit;
+      }
+      log << "]";
     } // for channel
     
   } // for fragment

--- a/icaruscode/Decode/ChannelMapping/ChannelMapPostGres.cxx
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapPostGres.cxx
@@ -490,10 +490,12 @@ int icarusDB::ChannelMapPostGres::BuildPMTFragmentToDigitizerChannelMap
           << " on row " << row
           << ") retrieving LVDS connector from channel mapping database\n";
       }
-      auto const [ LVDSconnector, LVDSbit ]
-        = splitIntegers<2, unsigned short int>(*LVDSconnectorLabel, "-");
-      chInfo.LVDSconnector = LVDSconnector;
-      chInfo.LVDSbit = LVDSbit;
+      if (!LVDSconnectorLabel->empty() && (*LVDSconnectorLabel != "-")) {
+        auto const [ LVDSconnector, LVDSbit ]
+          = splitIntegers<2, unsigned short int>(*LVDSconnectorLabel, "-");
+        chInfo.LVDSconnector = LVDSconnector;
+        chInfo.LVDSbit = LVDSbit;
+      }
     }
     
     // adder connector and bit
@@ -505,10 +507,12 @@ int icarusDB::ChannelMapPostGres::BuildPMTFragmentToDigitizerChannelMap
           << " on row " << row
           << ") retrieving adder connector from channel mapping database\n";
       }
-      auto const [ adderConnector, adderBit ]
-        = splitIntegers<2, unsigned short int>(*adderConnectorLabel, "-");
-      chInfo.adderConnector = adderConnector;
-      chInfo.adderBit = adderBit;
+      if (!adderConnectorLabel->empty() && (*adderConnectorLabel != "-")) {
+        auto const [ adderConnector, adderBit ]
+          = splitIntegers<2, unsigned short int>(*adderConnectorLabel, "-");
+        chInfo.adderConnector = adderConnector;
+        chInfo.adderBit = adderBit;
+      }
     }
     
     // fill the map

--- a/icaruscode/Decode/ChannelMapping/ChannelMapPostGres.h
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapPostGres.h
@@ -1,7 +1,7 @@
 /**
  * @file   icaruscode/Decode/ChannelMapping/ChannelMapPostGres.h
  * @brief  Interface with ICARUS channel mapping PostGres database.
- * @author T. Usher (factorised by Gianluca Petrillo, petrillo@slac.stanford.edu)
+ * @author T. Usher (factorised by G. Petrillo, petrillo@slac.stanford.edu)
  * @see    icaruscode/Decode/ChannelMapping/ChannelMapPostGres.cxx
  */
 
@@ -12,6 +12,7 @@
 // ICARUS libraries
 #include "icaruscode/Decode/ChannelMapping/IChannelMapping.h"
 #include "icaruscode/Decode/ChannelMapping/RunPeriods.h"
+#include "icaruscode/Utilities/Expected.h"
 #include "icarusalg/Utilities/mfLoggingClass.h"
 
 // framework libraries
@@ -133,33 +134,6 @@ class icarusDB::ChannelMapPostGres
   virtual int BuildSideCRTCalibrationMap(SideCRTChannelToCalibrationMap&) const override;
 
     private:
-
-  /// Loosely based on C++-20 `std::expected`.
-  template <typename T, typename E = int>
-  class Expected {
-    std::variant<T, E> fValue;
-      public:
-    constexpr Expected(E e = E{}): fValue{ std::move(e) } {}
-    constexpr Expected(T t): fValue{ std::move(t) } {}
-    
-    Expected<T, E>& operator= (E e) { fValue = std::move(e); return *this; }
-    Expected<T, E>& operator= (T t) { fValue = std::move(t); return *this; }
-    template <typename... Args>
-    T& emplace(Args&&... args)
-      { return fValue.emplace(std::forward<Args>(args)...); }
-    
-    bool has_value() const { return std::holds_alternative<T>(fValue); }
-    
-    E code() const { return std::get<E>(fValue); }
-    T const& value() const { return std::get<T>(fValue); }
-    
-    operator T const& () const { return value(); }
-    T const& operator*() const { return value(); }
-    
-    explicit operator bool() const { return has_value(); }
-    
-  }; // Expected
-  
   
   // --- BEGIN --- Configuration parameters ------------------------------------
   
@@ -225,7 +199,7 @@ class icarusDB::ChannelMapPostGres
   /// Returns the string on the specified `column` of the `tuple`.
   /// @return the requested string, or an error code from libwda on error
   template <std::size_t BufferSize = 32>
-  static Expected<std::string> getStringFromTuple
+  static util::Expected<std::string> getStringFromTuple
     (details::WDATuple const& tuple, std::size_t column);
 
   /// Returns an exception object pre-approved with our signature.

--- a/icaruscode/Decode/ChannelMapping/ChannelMapSQLite.cxx
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapSQLite.cxx
@@ -450,11 +450,13 @@ int icarusDB::ChannelMapSQLite::buildPMTFragmentToDigitizerChannelMap_callback
   // input is C-strings; we force the other term of comparison to C++ strings
   using namespace std::string_literals;
   auto const [
-     LaserChannelColumn,   DigitizerChannelColumn, ChannelIDcolumn,
-     FragmentIDcolumn
+     LaserChannelColumn,     DigitizerChannelColumn, ChannelIDcolumn,
+     FragmentIDcolumn,       DigitizerLabelColumn,   LVDSconnectorColumn,
+     AdderConnectorColumn
   ] = icarus::ns::util::PositionFinder{ gsl::span{azColName, (unsigned) argc} }(
-    "light_fiber_label"s, "digitizer_ch_number"s, "channel_id"s,
-    "fragment_id"s
+    "light_fiber_label"s,   "digitizer_ch_number"s, "channel_id"s,
+    "fragment_id"s,         "digitizer_label"s,     "FPGA_connector_DIO"s,
+    "adder_connector_DIO"s
     );
   
   auto& fragmentToDigitizerChannelMap
@@ -462,7 +464,9 @@ int icarusDB::ChannelMapSQLite::buildPMTFragmentToDigitizerChannelMap_callback
   
   // Start extracting info
   unsigned int const fragmentID         = std::stol(argv[FragmentIDcolumn]);
-  unsigned int const digitizerChannelNo = std::stol(argv[DigitizerChannelColumn]);
+  std::string digitizerLabel            = argv[DigitizerLabelColumn];
+  unsigned int const digitizerChannelNo
+    = std::stol(argv[DigitizerChannelColumn]);
   unsigned int const channelID          = std::stol(argv[ChannelIDcolumn]);
 
   // Read the laser channel; format is `L-<number>`. <number> is int from [1-41]
@@ -476,10 +480,30 @@ int icarusDB::ChannelMapSQLite::buildPMTFragmentToDigitizerChannelMap_callback
       << "Failed to convert laser channel '" << laserChannelLabel
       << "' into a channel number for channel " << channelID << "!\n";
   }
+  
+  // PMT discriminated signal connector and bit
+  auto const [ LVDSconnector, LVDSbit ]
+    = (LVDSconnectorColumn < (std::size_t)argc)
+    ? splitIntegers<2, unsigned short int>(argv[LVDSconnectorColumn], "-")
+    : std::array
+      { PMTChannelInfo_t::NoConnector, PMTChannelInfo_t::NoConnectorBit }
+    ;
+  
+  // adder discriminated signal connector and bit
+  auto const [ adderConnector, adderBit ]
+    = (AdderConnectorColumn < (std::size_t)argc)
+    ? splitIntegers<2, unsigned short int>(argv[AdderConnectorColumn], "-")
+    : std::array
+      { PMTChannelInfo_t::NoConnector, PMTChannelInfo_t::NoConnectorBit }
+    ;
 
   // Fill the map
-  fragmentToDigitizerChannelMap[fragmentID].push_back
-    ({ digitizerChannelNo, channelID, laserChannel });
+  fragmentToDigitizerChannelMap[fragmentID].push_back({ // C++20: name members
+    std::move(digitizerLabel), digitizerChannelNo,
+    channelID, laserChannel,
+    LVDSconnector, LVDSbit,
+    adderConnector, adderBit
+    });
   
   return 0;
 } // ...::ChannelMapSQLite::buildPMTFragmentToDigitizerChannelMap_callback()

--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapDataTypes.h
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapDataTypes.h
@@ -71,6 +71,13 @@ namespace icarusDB {
       = std::numeric_limits<unsigned int>::max();
     static constexpr unsigned int NoLaserChannel
       = std::numeric_limits<unsigned int>::max();
+    static constexpr unsigned short int NoConnector
+      = std::numeric_limits<short int>::max();
+    static constexpr unsigned short int NoConnectorBit
+      = std::numeric_limits<short int>::max();
+    
+    /// Label of the digitizer this channel is on (e.g. `WW-TOP-A`).
+    std::string digitizerLabel;
     
     /// Number of the channel within its digitizer.
     unsigned int digitizerChannelNo = NoDigitizerChannel;
@@ -80,6 +87,25 @@ namespace icarusDB {
     
     /// Number of laser channel shining into this PMT.
     unsigned int laserChannelNo = NoLaserChannel;
+    
+    /// Number of the connector with the LVDS signal of this channel.
+    unsigned short int LVDSconnector = NoConnector;
+    
+    /// Number of the connector bit carrying the LVDS signal of this channel.
+    unsigned short int LVDSbit = NoConnectorBit;
+    
+    /// Number of the connector with the adder signal including this channel.
+    unsigned short int adderConnector = NoConnector;
+    
+    /// Number of the connector bit carrying the adder signal including this
+    /// channel.
+    unsigned short int adderBit = NoConnectorBit;
+    
+    /// Returns whether the LVDS connector bit information is available.
+    constexpr bool hasLVDSinfo() const { return LVDSbit != NoConnectorBit; }
+    
+    /// Returns whether the adder connector bit information is available.
+    constexpr bool hasAdderInfo() const { return adderBit != NoConnectorBit; }
     
     /// Sorting by channel ID.
     constexpr bool operator< (PMTChannelInfo_t const& other) const noexcept

--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProviderBase.h
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProviderBase.h
@@ -31,6 +31,21 @@ namespace icarusDB {
  * @tparam ChMapAlg type of channel mapping helper to be used
  * 
  * 
+ * Caches
+ * -------
+ * 
+ * This implementation relies on a database backend reading the full information
+ * from the database and caching the result, every time a new run period is
+ * requested. To help users who in turn cache information from this object to
+ * track whether _their_ caches are invalidated by such occurrences, this object
+ * uses the `util::CacheCounter` facility to version every cache.
+ * Users will want to use the `util::CacheGuard` tool to monitor the cache.
+ * Three caches are tracked, with tags `"TPC"`, `"PMT"` and `"CRT"`, plus
+ * the overall cache tracking (tagged with an empty name `""`).
+ * At the moment of writing, the three caches are actually updated all at the
+ * same times.
+ * 
+ * 
  * Configuration parameters
  * =========================
  * 

--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProviderBase.tcc
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProviderBase.tcc
@@ -29,6 +29,7 @@ icarusDB::ICARUSChannelMapProviderBase<ChMapAlg>::ICARUSChannelMapProviderBase
   , fDiagnosticOutput  { config.DiagnosticOutput() }
   , fChannelMappingAlg { config.ChannelMappingTool() }
 {
+  addCacheTags({ "TPC", "PMT", "CRT" }); // all caches updated at the same time
 }
 
 
@@ -265,13 +266,16 @@ void icarusDB::ICARUSChannelMapProviderBase<ChMapAlg>::readFromDatabase() {
 
   mfLogInfo() << "Building the channel mapping";
 
+  updateCacheID("TPC");
+  
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // TPC fragment-based mapping
   cet::cpu_timer theClockFragmentIDs;
   theClockFragmentIDs.start();
   fTPCFragmentToReadoutMap.clear();
-  if (fChannelMappingAlg.BuildTPCFragmentIDToReadoutIDMap(fTPCFragmentToReadoutMap))
-  {
+  if (
+   fChannelMappingAlg.BuildTPCFragmentIDToReadoutIDMap(fTPCFragmentToReadoutMap)
+  ) {
     throw myException()
       << "Cannot recover the TPC fragment ID channel map from the database.\n";
   }
@@ -311,6 +315,8 @@ void icarusDB::ICARUSChannelMapProviderBase<ChMapAlg>::readFromDatabase() {
     << ", Readout IDs time: " << readoutIDsTime;
   
   
+  updateCacheID("PMT");
+  
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // PMT channel mapping
   fPMTFragmentToDigitizerMap.clear();
@@ -330,6 +336,8 @@ void icarusDB::ICARUSChannelMapProviderBase<ChMapAlg>::readFromDatabase() {
     }
   }
   
+  
+  updateCacheID("CRT");
   
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // Side CRT channel mapping

--- a/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProviderBase.tcc
+++ b/icaruscode/Decode/ChannelMapping/ICARUSChannelMapProviderBase.tcc
@@ -408,7 +408,7 @@ constexpr unsigned int icarusDB::ICARUSChannelMapProviderBase<ChMapAlg>::PMTfrag
   
   // protest if this is a fragment not from the PMT;
   // but make an exception for old PMT fragment IDs (legacy)
-  assert(((fragmentID & ~0xFF) == 0x00) || ((fragmentID & ~0xFF) == 0x20));
+  assert(((fragmentID & ~0xFF) == 0x0000) || ((fragmentID & ~0xFF) == 0x2000));
   
   return fragmentID & 0xFF;
   

--- a/icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h
+++ b/icaruscode/Decode/ChannelMapping/IICARUSChannelMap.h
@@ -66,6 +66,14 @@ namespace icarusDB { class IICARUSChannelMap; };
 class icarusDB::IICARUSChannelMap
   : virtual public icarusDB::IICARUSChannelMapProvider
 {
+    public:
+  
+  /// Type of the service provider.
+  using provider_type = icarusDB::IICARUSChannelMapProvider;
+  
+  /// Returns the service provider.
+  provider_type const* provider() const { return this; }
+  
 };
 
 

--- a/icaruscode/Decode/ChannelMapping/IICARUSChannelMapProvider.h
+++ b/icaruscode/Decode/ChannelMapping/IICARUSChannelMapProvider.h
@@ -10,6 +10,7 @@
 // ICARUS libraries
 #include "icaruscode/Decode/ChannelMapping/RunPeriods.h"
 #include "icaruscode/Decode/ChannelMapping/ICARUSChannelMapDataTypes.h"
+#include "icaruscode/Utilities/CacheCounter.h"
 
 // C/C++ standard libraries
 #include <vector>
@@ -39,9 +40,12 @@ namespace icarusDB { class IICARUSChannelMapProvider; }
  * expected that implementations cache results in their final form and provide
  * direct access to that cache.
  * 
- * 
+ * The interface includes cache tracking support via `util::CacheCounter`.
+ * Implementations are expected to maintain the tracking of the cache with the
+ * default (empty) name; by default the cache will be always considered
+ * outdated.
  */
-class icarusDB::IICARUSChannelMapProvider {
+class icarusDB::IICARUSChannelMapProvider: public util::CacheCounter {
     
     public:
   

--- a/icaruscode/Decode/ChannelMapping/channelmapping_icarus.fcl
+++ b/icaruscode/Decode/ChannelMapping/channelmapping_icarus.fcl
@@ -14,7 +14,7 @@ ChannelMappingPostGres: {
 
 # for icarusDB::ChannelMapSQLite:
 ChannelMappingSQLite: {
-    DBFileName:         "ChannelMapICARUS_20230829.db"
+    DBFileName:         "ChannelMapICARUS_20240318.db"
     CalibDBFileName:    "crt_gain_reco_data"
     Tag:                @local::ICARUS_Calibration_GlobalTags.crt_gain_reco_data
 }

--- a/icaruscode/Decode/DecoderTools/CMakeLists.txt
+++ b/icaruscode/Decode/DecoderTools/CMakeLists.txt
@@ -27,6 +27,8 @@ set(        TOOL_LIBRARIES
                 icarus_signal_processing::Detection
                 icarus_signal_processing::Filters
                 icaruscode::TPC_Utilities_SignalShapingICARUSService_service
+                icaruscode::PMT_Trigger_Algorithms
+                icaruscode::Decode_ChannelMapping
                 icaruscode::Decode_DecoderTools
                 icaruscode::Decode_DecoderTools_Dumpers
                 icaruscode::Utilities

--- a/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TriggerDecoderV3_tool.cc
@@ -786,7 +786,7 @@ namespace daq
       locationMask = mask(sbn::triggerLocation::CryoEast);
     else if(triggerLocation == 2)
       locationMask = mask(sbn::triggerLocation::CryoWest);
-    else if(triggerLocation == 7)
+    else if(triggerLocation >= 3) // should be 7
       locationMask = mask(sbn::triggerLocation::CryoEast, sbn::triggerLocation::CryoWest);
     fTriggerExtra->triggerLocationBits = locationMask;
     

--- a/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.cxx
@@ -21,7 +21,6 @@
 #include "cetlib_except/exception.h"
 
 // C/C++ standard libraries
-#include <ostream>
 #include <algorithm> // std::sort()
 #include <iomanip> // std::dec, std::hex
 #include <cstdlib> // std::div()
@@ -29,29 +28,13 @@
 
 
 // -----------------------------------------------------------------------------
-// ---  icarus::trigger::LVDSbitID implementation
+// ---  icarus::trigger::PMTpairBitID implementation
 // -----------------------------------------------------------------------------
 std::ostream& icarus::trigger::operator<<
-  (std::ostream& out, LVDSbitID const& bit)
+  (std::ostream& out, PMTpairBitID const& bit)
 {
-  static constexpr char Side[] = "EW";
-  auto const fillch = out.fill(); // width is reset to 0, fill character is not
-  out << (bit.hasCryostat()? Side[bit.cryostat]: '?')
-    << '/' << (bit.hasPMTwall()? Side[bit.PMTwall]: '?')
-    << '/' << std::setw(2) << std::setfill('0') << bit.statusBit
-    << std::setfill(fillch);
-  return out;
+  return out << static_cast<PMTpairBitID::BaseID_t const&>(bit);
 }
-
-
-// -----------------------------------------------------------------------------
-auto icarus::trigger::LVDSbitID::fromIndex(Index_t index) -> LVDSbitID
-{
-  auto const [ cryostat, wb ]
-    = std::div(index, NPMTwallsPerCryostat * NStatusWordBits);
-  auto const [ wall, bit ] = std::div(wb, NStatusWordBits);
-  return { (std::size_t) cryostat, (std::size_t) wall, (StatusBit_t) bit };
-} // icarus::trigger::LVDSbitID::fromIndex()
 
 
 // -----------------------------------------------------------------------------
@@ -81,9 +64,22 @@ auto icarus::trigger::LVDSHWbitID::fromIndex(Index_t index) -> LVDSHWbitID {
 
 
 // -----------------------------------------------------------------------------
-// ---  icarus::trigger::PMTpairBitMap implementation
+// ---  icarus::trigger::LVDSbitMaps implementation
 // -----------------------------------------------------------------------------
-auto icarus::trigger::PMTpairBitMap::bitSource(LVDSbitID bit) const
+bool icarus::trigger::LVDSbitMaps::hasMap(Map map) const {
+  switch (map) {
+    case Map::PMTpairs: return !fLVDSinfoMap.empty();
+    case Map::Adders:   return !fAdderInfoMap.empty();
+    default:
+      throw Exception{ Errors::Error }
+        << "Logic error: hasMap() does not support map type #"
+        << static_cast<int>(map) << "!\n";
+  } // switch
+} // icarus::trigger::LVDSbitMaps::hasMap()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::trigger::LVDSbitMaps::bitSource(PMTpairBitID const& bit) const
   -> LVDSinfo_t
 {
   return fLVDSinfoMap.at(bit.index());
@@ -91,8 +87,16 @@ auto icarus::trigger::PMTpairBitMap::bitSource(LVDSbitID bit) const
 
 
 // -----------------------------------------------------------------------------
+auto icarus::trigger::LVDSbitMaps::bitSource(AdderBitID const& bit) const
+  -> AdderInfo_t
+{
+  return fAdderInfoMap.at(bit.index());
+}
+
+
+// -----------------------------------------------------------------------------
 std::vector<std::vector<raw::Channel_t>>
-icarus::trigger::PMTpairBitMap::channelPairs() const {
+icarus::trigger::LVDSbitMaps::channelPairs() const {
   
   std::vector<std::vector<raw::Channel_t>> pairs;
   for (LVDSinfo_t const& info: fLVDSinfoMap) {
@@ -102,18 +106,46 @@ icarus::trigger::PMTpairBitMap::channelPairs() const {
   return pairs;
 }
 
+
 // -----------------------------------------------------------------------------
-auto icarus::trigger::PMTpairBitMap::buildLVDSsourceMap
-  (icarusDB::IICARUSChannelMapProvider const& channelMap) const
-  -> std::vector<LVDSinfo_t>
+void icarus::trigger::LVDSbitMaps::buildAllMaps
+  (icarusDB::IICARUSChannelMapProvider const& channelMap)
 {
-  //
-  // get the LVDS connector/bit information channel by channel
-  //
+  buildMaps(channelMap, { Map::PMTpairs, Map::Adders });
+}
+
+
+// -----------------------------------------------------------------------------
+void icarus::trigger::LVDSbitMaps::buildMaps(
+  icarusDB::IICARUSChannelMapProvider const& channelMap,
+  std::initializer_list<Map> maps
+) {
+
+  fPMTchannelInfo = buildChannelInfo(channelMap);
+
+  for (Map map: maps) {
+    switch (map) {
+      case Map::PMTpairs:
+        fLVDSinfoMap = buildPMTpairSourceMap(channelMap);
+        break;
+      case Map::Adders:
+        fAdderInfoMap = buildAdderSourceMap(channelMap);
+        break;
+    } // switch
+  } // for
+  
+} // icarus::trigger::LVDSbitMaps::buildMaps()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::trigger::LVDSbitMaps::buildChannelInfo
+  (icarusDB::IICARUSChannelMapProvider const& channelMap) const
+  -> std::vector<LVDSchannel_t>
+{
   std::vector<LVDSchannel_t> PMTchannelDB;
   
-  mf::LogTrace debugLog{ "PMTpairBitMap" };
-  debugLog << "PMTpairBitMap::buildLVDSsourceMap() collecting channel info:";
+  mf::LogTrace debugLog{ "LVDSbitMaps" };
+  debugLog << "LVDSbitMaps::buildChannelInfo() collecting channel info:";
   
   for (unsigned int const fragmentID: util::counter(0x2000, 0x2018)) {
     if (!channelMap.hasPMTDigitizerID(fragmentID)) {
@@ -127,22 +159,22 @@ auto icarus::trigger::PMTpairBitMap::buildLVDSsourceMap
     ) {
       unsigned short int const cryostat = info.channelID / NChannelsPerCryostat;
       
-      if (!info.hasLVDSinfo()) {
-        throw Exception{ Errors::NoPairBitInformation }
-          << "PMT fragment ID 0x" << std::hex << fragmentID << std::dec
-          << " has no LVDS information in the channel mapping database.\n";
-      }
-      
       debugLog << "\n[#" << PMTchannelDB.size() << "] CH=" << info.channelID
         << " " << cryostat << "/" << info.LVDSconnector << "/" << info.LVDSbit;
       
+      LVDSHWbitID const PMTpairBit = info.hasLVDSinfo()
+        ? LVDSHWbitID{ cryostat, info.LVDSconnector, info.LVDSbit }
+        : LVDSHWbitID{}
+        ;
+      LVDSHWbitID const adderBit = info.hasAdderInfo()
+        ? LVDSHWbitID{ cryostat, info.adderConnector, info.adderBit }
+        : LVDSHWbitID{}
+        ;
+      
       PMTchannelDB.push_back(LVDSchannel_t{
           info.channelID        // .channel
-        , LVDSHWbitID{          // .LVDSsource
-            cryostat              // .cryostat
-          , info.LVDSconnector    // .connector
-          , info.LVDSbit          // .bit
-          }
+        , PMTpairBit            // .PMTpairSource
+        , adderBit              // .adderSource
         });
     } // for channel in fragment
   } // for fragment ID
@@ -151,9 +183,21 @@ auto icarus::trigger::PMTpairBitMap::buildLVDSsourceMap
   
   std::sort(PMTchannelDB.begin(), PMTchannelDB.end());
   
-  //
-  // fill the logic LVDS bit positions with their source information
-  //
+  return PMTchannelDB;
+  
+} // icarus::trigger::LVDSbitMaps::buildChannelInfo()
+
+
+// -----------------------------------------------------------------------------
+auto icarus::trigger::LVDSbitMaps::buildPMTpairSourceMap
+  (icarusDB::IICARUSChannelMapProvider const& channelMap) const
+  -> std::vector<LVDSinfo_t>
+{
+  // note that this function must support also the case where there is no PMT
+  // pair information in the channel mapping database, in which case all
+  // connector information will be "invalid" and protocol demands an empty map
+  
+  assert(fPMTchannelInfo.size() == NChannels); // insider knowledge...
   
   /*
    * The logic of the filling is a bit complicated. Class documentation explains
@@ -174,27 +218,29 @@ auto icarus::trigger::PMTpairBitMap::buildLVDSsourceMap
    *    track the channels we already covered when processing the other PMT
    *    channel of the pair, and skip them when met those LVDS bit again
    *  * the destination bit is also an ordered progression within the word,
-   *    but inverted: note in fact that if we inverted the position of the bits
-   *    in each 32-bit word
+   *    but inverted because the _most_ significant bit is assigned to the
+   *    _lowest_ channels
    */
-  std::vector<LVDSinfo_t> sourceMap{ LVDSbitID::NIndices() };
-  std::vector<LVDSbitID> HWtoLogicID{ LVDSHWbitID::NIndices() };
+  std::vector<LVDSinfo_t> sourceMap{ PMTpairBitID::NIndices() };
+  std::vector<PMTpairBitID> HWtoLogicID{ LVDSHWbitID::NIndices() };
   
   unsigned int nBits = 0;
-  for (LVDSchannel_t const& info: PMTchannelDB) { // in PMT channel order
+  for (LVDSchannel_t const& info: fPMTchannelInfo) { // in PMT channel order
     
-    LVDSHWbitID::Index_t const sourceIndex = info.LVDSsource.index();
+    if (!info.PMTpairSource) continue; // skip invalid
     
-    LVDSbitID logicBit = HWtoLogicID[sourceIndex];
+    LVDSHWbitID::Index_t const sourceIndex = info.PMTpairSource.index();
+    
+    PMTpairBitID logicBit = HWtoLogicID[sourceIndex];
     
     LVDSinfo_t* mapInfo = logicBit? &(sourceMap[logicBit.index()]): nullptr;
     if (!mapInfo) { // new bit: set the source
       // which logic bit to set:
-      logicBit.cryostat = info.LVDSsource.cryostat;
+      logicBit.cryostat = info.PMTpairSource.cryostat;
       assert(logicBit.cryostat == info.channel / NChannelsPerCryostat);
       logicBit.PMTwall
-        = info.channel / (NChannelsPerCryostat/LVDSbitID::NPMTwallsPerCryostat)
-        % LVDSbitID::NCryostats;
+        = info.channel/(NChannelsPerCryostat/PMTpairBitID::NPMTwallsPerCryostat)
+        % PMTpairBitID::NCryostats;
       logicBit.statusBit = 47 - (nBits++ % 48); // 0 => 47, 1 => 46,..., 47 => 0
       if (logicBit.statusBit >= 24)
         logicBit.statusBit += 8; // 0 => 0,..., 23 => 23, 24 => 32, 25 => 33,...
@@ -202,27 +248,29 @@ auto icarus::trigger::PMTpairBitMap::buildLVDSsourceMap
       assert(logicBit);
       HWtoLogicID[sourceIndex] = logicBit;
       mapInfo = &(sourceMap[logicBit.index()]);
-      mapInfo->source = info.LVDSsource;
+      mapInfo->ID = logicBit;
+      mapInfo->source = info.PMTpairSource;
     }
     assert(mapInfo);
-    assert(mapInfo->source == info.LVDSsource);
+    assert(mapInfo->source == info.PMTpairSource);
     
     mapInfo->channels.push_back(info.channel);
-    // check that they are sorted (the input list should be sorted already..._
+    // check that they are sorted (the input list should be sorted already...)
     assert((mapInfo->channels.size() == 1)
       || (
         mapInfo->channels[mapInfo->channels.size()-2]
         < mapInfo->channels[mapInfo->channels.size()-1]
       ));
     
-  } // for PMTchannelDB
+  } // for fPMTchannelInfo
   
   
   // --- BEGIN DEBUG -----
-  debugLog << "\nFinal map:";
+  mf::LogTrace debugLog{ "LVDSbitMaps" };
+  debugLog << "Final PMT pair bit map:";
   for (auto const& [ bit, info ]: util::enumerate(sourceMap)) {
-    debugLog << "\n[ " << std::setw(3) << bit << "] logic="
-      << LVDSbitID::fromIndex(bit) << " => HW=";
+    debugLog << "\n[" << std::setw(3) << bit << "] logic="
+      << PMTpairBitID::fromIndex(bit) << " => HW=";
     if (info.source) {
       debugLog << info.source << " (ix="
         << std::setw(3) << info.source.index() << ") "
@@ -237,14 +285,115 @@ auto icarus::trigger::PMTpairBitMap::buildLVDSsourceMap
   }
   // --- END DEBUG -------
   
-  assert(nBits == 192);
-  return sourceMap;
+  assert((nBits == 0) || (nBits == 192)); // 0 if no info in mapping database
+  return (nBits == 0)? std::vector<LVDSinfo_t>{}: sourceMap;
   
-} // icarus::trigger::PMTpairBitMap::buildLVDSsourceMap()
+} // icarus::trigger::LVDSbitMaps::buildPMTpairSourceMap()
 
 
 // -----------------------------------------------------------------------------
-std::string icarus::trigger::PMTpairBitMap::errorMessage(Errors code) {
+auto icarus::trigger::LVDSbitMaps::buildAdderSourceMap
+  (icarusDB::IICARUSChannelMapProvider const& channelMap) const
+  -> std::vector<AdderInfo_t>
+{
+  // note that this function must support also the case where there is no adder
+  // information in the channel mapping database, in which case all connector
+  // information will be "invalid" and the protocol demands an empty map
+  
+  assert(fPMTchannelInfo.size() == NChannels); // insider knowledge...
+  
+  /*
+   * The logic of the filling is a bit complicated. Class documentation explains
+   * it and shows it to be:
+   * 
+   * east cryostat, east wall: `0x0a000000'0A000000`, channel `0` the most
+   * significant bit in `a` (bit #58) and channel `45` the one in `A` (bit 26);
+   * east cryostat, west wall: `0x0a000000'0A000000`, channel `90` the most
+   * significant bit in `a` (bit #58) and channel `135` the one in `d` (bit 26);
+   * west cryostat, east wall: `0x0a000000'0A000000`, channel `180` the most
+   * significant bit in `a` (bit #58) and channel `225` the one in `d` (bit 26);
+   * west cryostat, west wall: `0x0a000000'0A000000`, channel `270` the most
+   * significant bit in `a` (bit #58) and channel `315` the one in `d` (bit 26).
+   * 
+   * How we get there:
+   *  * we sort the filling with an ordered progression of channels, lowest
+   *    first, and because adder bit are associated to 15 channels, we
+   *    track the channels we already covered when processing the other PMT
+   *    channels of the adder, and skip them when met those LVDS bit again
+   *  * the destination bit is also an ordered progression within the word,
+   *    but inverted because the _most_ significant bit is assigned to the
+   *    _lowest_ channels
+   */
+  std::vector<AdderInfo_t> sourceMap{ AdderBitID::NIndices() };
+  std::vector<AdderBitID> HWtoLogicID{ LVDSHWbitID::NIndices() };
+  
+  unsigned int nBits = 0;
+  for (LVDSchannel_t const& info: fPMTchannelInfo) { // in PMT channel order
+    
+    if (!info.adderSource) continue; // skip invalid
+    
+    LVDSHWbitID::Index_t const sourceIndex = info.adderSource.index();
+    
+    AdderBitID logicBit = HWtoLogicID[sourceIndex];
+    
+    AdderInfo_t* mapInfo = logicBit? &(sourceMap[logicBit.index()]): nullptr;
+    if (!mapInfo) { // new bit: set the source
+      // which logic bit to set:
+      logicBit.cryostat = info.adderSource.cryostat;
+      assert(logicBit.cryostat == info.channel / NChannelsPerCryostat);
+      logicBit.PMTwall
+        = info.channel / (NChannelsPerCryostat/AdderBitID::NPMTwallsPerCryostat)
+        % AdderBitID::NCryostats;
+      logicBit.statusBit = 5 - (nBits++ % 6); // 0/6/... => 5, 1/7/... => 4, ...
+      
+      assert(logicBit);
+      HWtoLogicID[sourceIndex] = logicBit;
+      mapInfo = &(sourceMap[logicBit.index()]);
+      mapInfo->ID = logicBit;
+      mapInfo->source = info.adderSource;
+    }
+    assert(mapInfo);
+    assert(mapInfo->source == info.adderSource);
+    
+    mapInfo->channels.push_back(info.channel);
+    // check that they are sorted (the input list should be sorted already...)
+    assert((mapInfo->channels.size() == 1)
+      || (
+        mapInfo->channels[mapInfo->channels.size()-2]
+        < mapInfo->channels[mapInfo->channels.size()-1]
+      ));
+    
+  } // for PMTchannelDB
+  
+  
+  // --- BEGIN DEBUG -----
+  mf::LogTrace debugLog{ "LVDSbitMaps" };
+  debugLog << "Final adder bit map:";
+  for (auto const& [ bit, info ]: util::enumerate(sourceMap)) {
+    debugLog << "\n[" << std::setw(3) << bit << "] logic="
+      << AdderBitID::fromIndex(bit) << " => HW=";
+    if (info.source) {
+      debugLog << info.source << " (ix="
+        << std::setw(3) << info.source.index() << ") "
+        << info.channels.size() << " channels {";
+      for (raw::Channel_t const channel: info.channels)
+        debugLog << " " << std::setw(3) << channel;
+      debugLog << " }";
+    }
+    else {
+      debugLog << "(invalid)";
+    }
+  }
+  // --- END DEBUG -------
+  
+  assert((nBits == 0) || (nBits == 24)); // 0 if no info in mapping database
+  return (nBits == 0)? std::vector<AdderInfo_t>{}: sourceMap;
+  
+} // icarus::trigger::LVDSbitMaps::buildAdderSourceMap()
+
+
+// -----------------------------------------------------------------------------
+std::string icarus::trigger::LVDSbitMaps::errorMessage(Errors code) {
   using namespace std::string_literals;
   switch (code) {
     case Errors::NoError:
@@ -257,12 +406,14 @@ std::string icarus::trigger::PMTpairBitMap::errorMessage(Errors code) {
       return "channel mapping database does not have PMT fragment information"s;
     case Errors::NoPairBitInformation:
       return "channel mapping database does not have PMT pair bit information"s;
+    case Errors::NoAdderBitInformation:
+      return "channel mapping database does not have adder bit information"s;
     case Errors::Unknown:
       return "unknown error"s;
     default:
       return "unexpected error code "s + std::to_string(static_cast<int>(code));
   } // switch
-} // icarus::trigger::PMTpairBitMap::errorMessage()
+} // icarus::trigger::LVDSbitMaps::errorMessage()
 
 
 // -----------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.cxx
+++ b/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.cxx
@@ -1,0 +1,268 @@
+/**
+ * @file   icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.cxx
+ * @brief  Utilities for mapping CAEN V1730B LVDS channels to PMT channels.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 10, 2024
+ * @see    icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.h
+ * 
+ */
+
+// library header
+#include "icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.h"
+
+// ICARUS libraries
+#include "icaruscode/Decode/ChannelMapping/IICARUSChannelMapProvider.h"
+#include "icaruscode/Decode/ChannelMapping/ICARUSChannelMapDataTypes.h"
+
+// framework libraries
+#include "larcorealg/CoreUtils/enumerate.h"
+#include "larcorealg/CoreUtils/counter.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "cetlib_except/exception.h"
+
+// C/C++ standard libraries
+#include <ostream>
+#include <algorithm> // std::sort()
+#include <iomanip> // std::dec, std::hex
+#include <cstdlib> // std::div()
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+// ---  icarus::trigger::LVDSbitID implementation
+// -----------------------------------------------------------------------------
+std::ostream& icarus::trigger::operator<<
+  (std::ostream& out, LVDSbitID const& bit)
+{
+  static constexpr char Side[] = "EW";
+  auto const fillch = out.fill(); // width is reset to 0, fill character is not
+  out << (bit.hasCryostat()? Side[bit.cryostat]: '?')
+    << '/' << (bit.hasPMTwall()? Side[bit.PMTwall]: '?')
+    << '/' << std::setw(2) << std::setfill('0') << bit.statusBit
+    << std::setfill(fillch);
+  return out;
+}
+
+
+// -----------------------------------------------------------------------------
+auto icarus::trigger::LVDSbitID::fromIndex(Index_t index) -> LVDSbitID
+{
+  auto const [ cryostat, wb ]
+    = std::div(index, NPMTwallsPerCryostat * NStatusWordBits);
+  auto const [ wall, bit ] = std::div(wb, NStatusWordBits);
+  return { (std::size_t) cryostat, (std::size_t) wall, (StatusBit_t) bit };
+} // icarus::trigger::LVDSbitID::fromIndex()
+
+
+// -----------------------------------------------------------------------------
+// ---  icarus::trigger::LVDSHWbitID implementation
+// -----------------------------------------------------------------------------
+std::ostream& icarus::trigger::operator<<
+  (std::ostream& out, LVDSHWbitID const& bit)
+{
+  if (!bit) return out << "<invl>";
+  auto const fillch = out.fill(); // width is reset to 0, fill character is not
+  out << bit.cryostat << '/' << bit.connector << '/'
+    << std::setw(2) << std::setfill('0') << bit.bit << std::setfill(fillch);
+  return out;
+}
+
+
+// -----------------------------------------------------------------------------
+auto icarus::trigger::LVDSHWbitID::fromIndex(Index_t index) -> LVDSHWbitID {
+  auto const [ cryostat, cb ] = std::div(index, NConnectorsPerCryostat * 32);
+  auto const [ connector, bit ] = std::div(cb, 32);
+  return {
+    (unsigned short int) cryostat,
+    (Connector_t) connector,
+    (ConnectorBit_t) bit
+    };
+} // icarus::trigger::LVDSHWbitID::fromIndex()
+
+
+// -----------------------------------------------------------------------------
+// ---  icarus::trigger::PMTpairBitMap implementation
+// -----------------------------------------------------------------------------
+auto icarus::trigger::PMTpairBitMap::bitSource(LVDSbitID bit) const
+  -> LVDSinfo_t
+{
+  return fLVDSinfoMap.at(bit.index());
+}
+
+
+// -----------------------------------------------------------------------------
+std::vector<std::vector<raw::Channel_t>>
+icarus::trigger::PMTpairBitMap::channelPairs() const {
+  
+  std::vector<std::vector<raw::Channel_t>> pairs;
+  for (LVDSinfo_t const& info: fLVDSinfoMap) {
+    if (!info.channels.empty()) pairs.push_back(info.channels);
+  }
+  
+  return pairs;
+}
+
+// -----------------------------------------------------------------------------
+auto icarus::trigger::PMTpairBitMap::buildLVDSsourceMap
+  (icarusDB::IICARUSChannelMapProvider const& channelMap) const
+  -> std::vector<LVDSinfo_t>
+{
+  //
+  // get the LVDS connector/bit information channel by channel
+  //
+  std::vector<LVDSchannel_t> PMTchannelDB;
+  
+  mf::LogTrace debugLog{ "PMTpairBitMap" };
+  debugLog << "PMTpairBitMap::buildLVDSsourceMap() collecting channel info:";
+  
+  for (unsigned int const fragmentID: util::counter(0x2000, 0x2018)) {
+    if (!channelMap.hasPMTDigitizerID(fragmentID)) {
+      throw Exception{ Errors::NoPMTfragment }
+        << "PMT fragment ID 0x" << std::hex << fragmentID << std::dec
+        << " not available in the channel mapping database.\n";
+    }
+    
+    for (icarusDB::PMTChannelInfo_t const& info
+      : channelMap.getPMTchannelInfo(fragmentID)
+    ) {
+      unsigned short int const cryostat = info.channelID / NChannelsPerCryostat;
+      
+      if (!info.hasLVDSinfo()) {
+        throw Exception{ Errors::NoPairBitInformation }
+          << "PMT fragment ID 0x" << std::hex << fragmentID << std::dec
+          << " has no LVDS information in the channel mapping database.\n";
+      }
+      
+      debugLog << "\n[#" << PMTchannelDB.size() << "] CH=" << info.channelID
+        << " " << cryostat << "/" << info.LVDSconnector << "/" << info.LVDSbit;
+      
+      PMTchannelDB.push_back(LVDSchannel_t{
+          info.channelID        // .channel
+        , LVDSHWbitID{          // .LVDSsource
+            cryostat              // .cryostat
+          , info.LVDSconnector    // .connector
+          , info.LVDSbit          // .bit
+          }
+        });
+    } // for channel in fragment
+  } // for fragment ID
+  
+  assert(PMTchannelDB.size() == NChannels); // insider knowledge...
+  
+  std::sort(PMTchannelDB.begin(), PMTchannelDB.end());
+  
+  //
+  // fill the logic LVDS bit positions with their source information
+  //
+  
+  /*
+   * The logic of the filling is a bit complicated. Class documentation explains
+   * it and shows it to be:
+   * 
+   * east cryostat, east wall: `0x00aAbBcC'00dDeEfF`, channel `0` the most
+   * significant bit in `a` (bit #55) and channel `45` the one in `d` (bit 23);
+   * east cryostat, west wall: `0x00aAbBcC'00dDeEfF`, channel `90` the most
+   * significant bit in `a` (bit #55) and channel `135` the one in `d` (bit 23);
+   * west cryostat, east wall: `0x00aAbBcC'00dDeEfF`, channel `180` the most
+   * significant bit in `a` (bit #55) and channel `225` the one in `d` (bit 23);
+   * west cryostat, west wall: `0x00aAbBcC'00dDeEfF`, channel `270` the most
+   * significant bit in `a` (bit #55) and channel `315` the one in `d` (bit 23).
+   * 
+   * How we get there:
+   *  * we sort the filling with an ordered progression of channels, lowest
+   *    first, and because most LVDS bit are associated to two channels, we
+   *    track the channels we already covered when processing the other PMT
+   *    channel of the pair, and skip them when met those LVDS bit again
+   *  * the destination bit is also an ordered progression within the word,
+   *    but inverted: note in fact that if we inverted the position of the bits
+   *    in each 32-bit word
+   */
+  std::vector<LVDSinfo_t> sourceMap{ LVDSbitID::NIndices() };
+  std::vector<LVDSbitID> HWtoLogicID{ LVDSHWbitID::NIndices() };
+  
+  unsigned int nBits = 0;
+  for (LVDSchannel_t const& info: PMTchannelDB) { // in PMT channel order
+    
+    LVDSHWbitID::Index_t const sourceIndex = info.LVDSsource.index();
+    
+    LVDSbitID logicBit = HWtoLogicID[sourceIndex];
+    
+    LVDSinfo_t* mapInfo = logicBit? &(sourceMap[logicBit.index()]): nullptr;
+    if (!mapInfo) { // new bit: set the source
+      // which logic bit to set:
+      logicBit.cryostat = info.LVDSsource.cryostat;
+      assert(logicBit.cryostat == info.channel / NChannelsPerCryostat);
+      logicBit.PMTwall
+        = info.channel / (NChannelsPerCryostat/LVDSbitID::NPMTwallsPerCryostat)
+        % LVDSbitID::NCryostats;
+      logicBit.statusBit = 47 - (nBits++ % 48); // 0 => 47, 1 => 46,..., 47 => 0
+      if (logicBit.statusBit >= 24)
+        logicBit.statusBit += 8; // 0 => 0,..., 23 => 23, 24 => 32, 25 => 33,...
+      
+      assert(logicBit);
+      HWtoLogicID[sourceIndex] = logicBit;
+      mapInfo = &(sourceMap[logicBit.index()]);
+      mapInfo->source = info.LVDSsource;
+    }
+    assert(mapInfo);
+    assert(mapInfo->source == info.LVDSsource);
+    
+    mapInfo->channels.push_back(info.channel);
+    // check that they are sorted (the input list should be sorted already..._
+    assert((mapInfo->channels.size() == 1)
+      || (
+        mapInfo->channels[mapInfo->channels.size()-2]
+        < mapInfo->channels[mapInfo->channels.size()-1]
+      ));
+    
+  } // for PMTchannelDB
+  
+  
+  // --- BEGIN DEBUG -----
+  debugLog << "\nFinal map:";
+  for (auto const& [ bit, info ]: util::enumerate(sourceMap)) {
+    debugLog << "\n[ " << std::setw(3) << bit << "] logic="
+      << LVDSbitID::fromIndex(bit) << " => HW=";
+    if (info.source) {
+      debugLog << info.source << " (ix="
+        << std::setw(3) << info.source.index() << ") "
+        << info.channels.size() << " channels {";
+      for (raw::Channel_t const channel: info.channels)
+        debugLog << " " << std::setw(3) << channel;
+      debugLog << " }";
+    }
+    else {
+      debugLog << "(invalid)";
+    }
+  }
+  // --- END DEBUG -------
+  
+  assert(nBits == 192);
+  return sourceMap;
+  
+} // icarus::trigger::PMTpairBitMap::buildLVDSsourceMap()
+
+
+// -----------------------------------------------------------------------------
+std::string icarus::trigger::PMTpairBitMap::errorMessage(Errors code) {
+  using namespace std::string_literals;
+  switch (code) {
+    case Errors::NoError:
+      return "no error"s;
+    case Errors::Error:
+      return "(unspecified) error"s;
+    case Errors::NoDatabase:
+      return "channel mapping database not configured"s;
+    case Errors::NoPMTfragment:
+      return "channel mapping database does not have PMT fragment information"s;
+    case Errors::NoPairBitInformation:
+      return "channel mapping database does not have PMT pair bit information"s;
+    case Errors::Unknown:
+      return "unknown error"s;
+    default:
+      return "unexpected error code "s + std::to_string(static_cast<int>(code));
+  } // switch
+} // icarus::trigger::PMTpairBitMap::errorMessage()
+
+
+// -----------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.h
+++ b/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.h
@@ -1,0 +1,450 @@
+/**
+ * @file   icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.h
+ * @brief  Utilities for mapping CAEN V1730B LVDS channels to PMT channels.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   March 10, 2024
+ * @see    icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.cxx
+ * 
+ */
+
+#ifndef ICARUSCODE_PMT_TRIGGER_ALGORITHMS_LVDSBITMAPS_H
+#define ICARUSCODE_PMT_TRIGGER_ALGORITHMS_LVDSBITMAPS_H
+
+// LArSoft and framework libraries
+#include "lardataobj/RawData/OpDetWaveform.h" // raw::Channel_t
+#include "cetlib_except/coded_exception.h"
+
+// C/C++ standard libraries
+#include <iosfwd> // std::ostream
+#include <vector>
+#include <string>
+#include <array>
+#include <limits>
+
+// -----------------------------------------------------------------------------
+// forward declarations
+namespace icarus::trigger {
+  
+  struct LVDSbitID;
+  struct LVDSHWbitID;
+  struct LVDSinfo_t;
+  
+  class PMTpairBitMap;
+  
+  std::ostream& operator<< (std::ostream& out, LVDSbitID const& bit);
+  std::ostream& operator<< (std::ostream& out, LVDSHWbitID const& bit);
+  
+} // namespace icarus::trigger
+
+namespace icarusDB { class IICARUSChannelMapProvider; }
+
+
+// -----------------------------------------------------------------------------
+/// Identifier of a "logical" LVDS bit
+/// following `sbn::ExtraTriggerInfo` convention.
+struct icarus::trigger::LVDSbitID {
+  
+  using StatusBit_t = unsigned short int; ///< Type for bit in the status word.
+  using Index_t = unsigned short int; ///< Type for LVDS bit ID index.
+  
+  /// How many cryostats in the detector.
+  static constexpr std::size_t NCryostats = 2;
+  
+  /// How many PMT walls per cryostat. Each has one status word.
+  static constexpr std::size_t NPMTwallsPerCryostat = 2;
+  
+  /// How many bits in a status word.
+  static constexpr unsigned short int NStatusWordBits = 64;
+  
+  
+  /// Special value to identify the absence of cryostat information.
+  static constexpr std::size_t NoCryostat
+    = std::numeric_limits<std::size_t>::max();
+  
+  /// Special value to identify the absence of PMT wall information.
+  static constexpr std::size_t NoPMTwall
+    = std::numeric_limits<std::size_t>::max();
+  
+  /// Special value to identify the absence of a status bit.
+  static constexpr StatusBit_t NoStatusBit
+    = std::numeric_limits<StatusBit_t>::max();
+  
+  /// Special value for an invalid bit index.
+  static constexpr Index_t InvalidIndex = std::numeric_limits<Index_t>::max();
+  
+  
+  // --- BEGIN ---  Data members  --------------------------------------------
+  
+  /// The cryostat the bit comes from (`sbn::ExtraTriggerInfo` convention).
+  std::size_t cryostat = NoCryostat;
+  
+  /// The PMT wall the bit comes from (`sbn::ExtraTriggerInfo` convention).
+  std::size_t PMTwall = NoPMTwall;
+  
+  /// The number of bit in the status word (`0` is the least significant one).
+  StatusBit_t statusBit = NoStatusBit;
+  
+  // --- END -----  Data members  --------------------------------------------
+  
+  /// Returns if the cryostat is set; ID is valid even if this is `false`.
+  constexpr bool hasCryostat() const { return cryostat != NoCryostat; }
+  
+  /// Returns if the PMT wall is set; ID is valid even if this is `false`.
+  constexpr bool hasPMTwall() const { return PMTwall != NoPMTwall; }
+  
+  /// Returns an "unique" index for this information.
+  /// Supports the absence of PMT wall or cryostat (not of bit).
+  constexpr Index_t index() const
+    {
+      if (!isValid()) return InvalidIndex;
+      std::size_t const nWalls = hasPMTwall()
+        ? (PMTwall + (hasCryostat()? cryostat: 0) * NPMTwallsPerCryostat): 0;
+      return statusBit + nWalls * NStatusWordBits;
+    }
+  
+  
+  /// Returns whether this ID is valid
+  /// (does not require `hasCryostat()` nor `hasPMTwall()`).
+  constexpr bool isValid() const { return statusBit != NoStatusBit; }
+  
+  /// Returns whether this ID is valid
+  /// (does not require `hasCryostat()` nor `hasPMTwall()`).
+  constexpr operator bool() const { return isValid(); }
+  
+  
+  /// Rebuilds an ID object from its index.
+  static LVDSbitID fromIndex(Index_t index);
+  
+  /// Returns the number of possible indices (`0` to `NIndices() - 1`).
+  static constexpr Index_t NIndices()
+    { return NCryostats * NPMTwallsPerCryostat * NStatusWordBits; }
+  
+}; // icarus::trigger::LVDSbitID
+
+
+// -----------------------------------------------------------------------------
+/// Identifier of a "hardware" LVDS bit featured in the PMT channel mapping
+/// databases.
+struct icarus::trigger::LVDSHWbitID {
+  
+  using Connector_t = unsigned short int; ///< Type for connector number.
+  using ConnectorBit_t = unsigned short int; ///< Type for connector bit.
+  using Index_t = unsigned short int; ///< Type for LVDS bit ID index.
+  
+  /// How many cryostats in the detector.
+  static constexpr unsigned short int NCryostats = LVDSbitID::NCryostats;
+  
+  /// How many 32-bit connectors come out of each cryostat.
+  static constexpr unsigned short int NConnectorsPerCryostat = 4;
+  
+  /// Special value to identify the absence of cryostat information.
+  static constexpr unsigned short int NoCryostat
+    = std::numeric_limits<unsigned short int>::max();
+  
+  /// Special value to identify the absence of a connector.
+  static constexpr Connector_t NoConnector
+    = std::numeric_limits<Connector_t>::max();
+  
+  /// Special value to identify the absence of a connector bit.
+  static constexpr ConnectorBit_t NoConnectorBit
+    = std::numeric_limits<ConnectorBit_t>::max();
+  
+  /// Special value for an invalid bit index.
+  static constexpr Index_t InvalidIndex = std::numeric_limits<Index_t>::max();
+  
+  
+  // --- BEGIN ---  Data members  --------------------------------------------
+  
+  /// The cryostat the bit comes from (`sbn::ExtraTriggerInfo` convention).
+  unsigned short int cryostat = NoCryostat;
+  
+  /// The number of connector within the appropriate wall.
+  Connector_t connector = NoConnector;
+  
+  /// The bit index within the 32-bit connector word (0 = least significant).
+  ConnectorBit_t bit = NoConnectorBit;
+  
+  // --- END -----  Data members  --------------------------------------------
+  
+  /// Returns if the cryostat is set; ID is valid even if this is `false`.
+  constexpr bool hasCryostat() const { return cryostat != NoCryostat; }
+  
+  /// Returns an "unique" index for this information.
+  constexpr Index_t index() const
+    {
+      return isValid()
+        ? ((hasCryostat()? (cryostat * NConnectorsPerCryostat * 32): 0)
+          + connector * 32 + bit)
+        : InvalidIndex;
+    }
+  
+  
+  /// Returns whether this ID is valid (does not require `hasCryostat()`).
+  constexpr bool isValid() const
+    { return (connector != NoConnector) && (bit != NoConnectorBit); }
+  
+  /// Returns whether this ID is valid (does not require `hasCryostat()`).
+  constexpr operator bool() const { return isValid(); }
+  
+  
+  /// Rebuilds an ID object from its index.
+  static LVDSHWbitID fromIndex(Index_t index);
+  
+  /// Returns the number of possible indices (`0` to `NIndices() - 1`).
+  static constexpr Index_t NIndices()
+    { return NCryostats * NConnectorsPerCryostat * 32; }
+  
+}; // icarus::trigger::LVDSHWbitID
+
+
+// -----------------------------------------------------------------------------
+/// Description of a (logical) LVDS bit and additional information
+/// (none so far).
+struct icarus::trigger::LVDSinfo_t {
+  
+  LVDSHWbitID source; ///< Identifier of the hardware LVDS bit feeding this one.
+  
+  std::vector<raw::Channel_t> channels; ///< PMT channels covered by this bit.
+  
+  /// Returns whether this information is fully valid (both channel and ID).
+  operator bool() const { return source; }
+  
+  /// Order operator: sorted after the LVDS index.
+  bool operator< (LVDSinfo_t const& other) const
+    { return source.index() < other.source.index(); }
+  
+}; // icarus::trigger::LVDSinfo_t
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Utility to build and maintain ICARUS trigger LVDS bit maps.
+ * 
+ * This object caches the relations between the LVDS bits. The maps include:
+ *  * from logic LVDS bit ID to hardware LVDS bit ID (see below).
+ * 
+ * Upon request, the following mappings may be added:
+ *  * from PMT channel to LVDS bit ID (logic), and vice versa.
+ * 
+ * 
+ * Maps are build based on the information from the PMT hardware channel
+ * mapping.
+ * 
+ * 
+ * 
+ * Mapping conventions
+ * --------------------
+ * 
+ * The logic mapping is described in `sbn::ExtraTriggerInfo::LVDSstatus`.
+ * Compared with that mapping, the LVDS bit ID are assigned so that
+ *  * the index of the ID, modulo 64 bits, matches the `LVDSstatus` words;
+ *  * cryostats and PMT walls of the IDs are honoured, so that they can be used
+ *    to directly adderss `LVDSstatus`.
+ * 
+ * This results in the following mapping, "first bit" meaning the most significant:
+ * 
+ * * east cryostat, east wall: `0x00aAbBcC'00dDeEfF`, channel `0` the most
+ *   significant bit in `a` (bit #55) and channel `45` the one in `d` (bit 23);
+ * * east cryostat, west wall: `0x00aAbBcC'00dDeEfF`, channel `90` the most
+ *   significant bit in `a` (bit #55) and channel `135` the one in `d` (bit 23);
+ * * west cryostat, east wall: `0x00aAbBcC'00dDeEfF`, channel `180` the most
+ *   significant bit in `a` (bit #55) and channel `225` the one in `d` (bit 23);
+ * * west cryostat, west wall: `0x00aAbBcC'00dDeEfF`, channel `270` the most
+ *   significant bit in `a` (bit #55) and channel `315` the one in `d` (bit 23).
+ * 
+ * 
+ * Naming conventions
+ * -------------------
+ * 
+ * Each PMT has a channel ID associated with a location; the relation between
+ * the channel number value and the position of the PMT is fixed by a
+ * convention (from LArSoft). This is a "logical" channel number.
+ * On the other side, each PMT has a unique identifier that was assigned by
+ * the ICARUS PMT Working Group and is used as key in an hardware database.
+ * This is the PMT hardware channel number. These two channel numbers may be
+ * (and in fact, are) different.
+ * A similar distinction is made of the LVDS signals.
+ * 
+ * * Eight LVDS signals with discriminated PMT pair information are emitted by
+ *   each CAEN V1730B PMT readout board. These bits are collected into four
+ *   64-bit words, one for each of the four PMT walls. The word values are
+ *   stored in `sbn::ExtraTriggerInfo`, which also defines the convention
+ *   relating each of the bits in the 64-bit words with the physical location of 
+ *   the PMT feeding the bit. This is equivalent to the logical PMT channel
+ *   number described above, and here we call it a "logical LVDS bit ID".
+ *   Analyzers will typically deal with this logical ID only. It is described by
+ *   `icarus::trigger::LVDSbitID` data type.
+ * * The assembly of the bits in hardware includes the combination of 8-bit
+ *   information from groups of three PMT readout boards, physically using LVDS
+ *   format and for that often just dubbed "the LVDS signals", via custom LVDS
+ *   boxes into 32-bit cables and connectors, with the excess 8 bits in each of
+ *   them partly used for other information.
+ *   Like in the case of single PMT, we define a "hardware LVDS bit ID"
+ *   representing the position of a bit in the 32-bit word in the connector,
+ *   and identifying the connector. The relation of these bits with the actual
+ *   PMT channels is encoded in the hardware database; analyzers typically don't
+ *   have to deal with them, because the trigger decoding software will
+ *   translate them into the `sbn::ExtraTriggerInfo` convention (using, in fact,
+ *   this `PMTpairBitMap` object for the mapping). The data type devoted to this
+ *   concept is `LVDSHWbitID`. Note that the NIM FPGA boards combine two 32-bit
+ *   connector words into 64-bit words for transportation. These 64-bit words
+ *   are stored in the trigger DAQ fragment. At first look, these 64-bit words
+ *   are similar  to the ones described in the previous bullet, but their bits
+ *   are in a different relation with the actual readout boards and PMT.
+ *   Also note that the decoding of these 64-bit words from the FPGA require,
+ *   on top oft he information from this mapping, the information of where each
+ *   connector is located within the word (hint: connectors 0 and 2 are stored
+ *   as the most significant 32-bit word, 1 and 3 as the least significant one).
+ *
+ */
+class icarus::trigger::PMTpairBitMap {
+  
+    public:
+  
+  // --- BEGIN --- Hard-coded geometry -----------------------------------------
+  /// @name Good old hard-coded ICARUS geometry.
+  /// @{
+  
+  /// Total number of PMT channels in the detector.
+  static constexpr unsigned int NChannels = 360;
+  
+  /// Number of PMT channels in each cryostat.
+  static constexpr unsigned int NChannelsPerCryostat = 180;
+  
+  /// Number of cryostats in the detector.
+  static constexpr std::size_t NCryostats = NChannels / NChannelsPerCryostat;
+  
+  ///@}
+  // --- END ----- Hard-coded geometry -----------------------------------------
+  
+  /// Error codes from this object. See `errorMessage()` code for descriptions.
+  enum class Errors {
+    NoError,              ///< No error condition.
+    Error,                ///< An unspecified error condition.
+    NoDatabase,           ///< No channel mapping database access.
+    NoPMTfragment,        ///< Missing a required PMT fragment information.
+    NoPairBitInformation, ///< No PMT pair bit information in the database.
+    Unknown               ///< Unknown error.
+  };
+  
+  /// Returns a predefined message describing the specified error `code`.
+  static std::string errorMessage(Errors code);
+  
+  /// Type of exception thrown by this object.
+  using Exception = cet::coded_exception<Errors, &errorMessage>;
+  
+  /// Default constructor: maps empty until `rebuild()` is called.
+  PMTpairBitMap() = default;
+  
+  /// Constructor: builds all the maps based on the specified PMT channel map.
+  PMTpairBitMap(icarusDB::IICARUSChannelMapProvider const& channelMap)
+    { buildAllMaps(channelMap); }
+  
+  
+  // --- BEGIN -----  Query interface  -----------------------------------------
+  /// @name Query interface.
+  /// @{
+  
+  /**
+   * @brief Returns the source bit for the specified encoded bit.
+   * @param bit ID of the logical LVDS bit to get the source information of
+   * @return the number of hardware connector and bit where to find the value
+   * @throws std::out_of_range if the specified bit is not in the map
+   * 
+   * The output `connector`/`bit` bits are sorted according to the prescription
+   * of `sbn::ExtraTriggerInfo`, which requires the least significant bit to
+   * have the most upstream PMT pair (i.e. the lowest channels).
+   * 
+   * The returned information includes:
+   *  * the cryostat the bit comes from (the same as the one in `bit`);
+   *  * the hardware connector number the bit comes from;
+   *  * the hardware bit (wire) in the connector which carries the `bit` value.
+   * 
+   * See `buildLVDSsourceMap()` for details of the mapping definitions.
+   */
+  LVDSinfo_t bitSource(LVDSbitID bit) const;
+  
+  
+  /**
+   * @brief Returns a list of channels paired in a single LVDS.
+   * @return a list of vectors of one or two PMT channel ID
+   * 
+   * This method recreates the pairing of PMT channels into LVDS bits.
+   * The order of the "pairs" follows the order of the logic bits.
+   * These "pairs" can actually contain either two or one ID; empty pairs
+   * (from invalid bits) are not included.
+   */
+  std::vector<std::vector<raw::Channel_t>> channelPairs() const;
+  
+  /// @}
+  // --- END -------  Query interface  -----------------------------------------
+  
+  
+  // --- BEGIN -----  Map updates  ---------------------------------------------
+  
+  /// Rebuilds all the LVDS maps based on the specified channel map status.
+  void rebuild(icarusDB::IICARUSChannelMapProvider const& channelMap)
+    { buildAllMaps(channelMap); }
+  
+  // --- END -------  Map updates  ---------------------------------------------
+  
+  
+    private:
+  
+  /// Description of a LVDS bit and association to a PMT channel.
+  /// @note This record does not include the logical LVDS bit ID it provides
+  ///       information of.
+  struct LVDSchannel_t {
+    
+    /// Special value identifying no channel set.
+    static constexpr raw::Channel_t NoChannel
+      = std::numeric_limits<raw::Channel_t>::max();
+    
+    raw::Channel_t channel = NoChannel; ///< ID of an associated PMT channel.
+    
+    LVDSHWbitID LVDSsource; ///< Identifier of the LVDS bit source.
+    
+    /// Returns an "unique" index for the LVDS source.
+    constexpr unsigned short int index() const { return LVDSsource.index(); }
+    
+    /// Returns whether this information is fully valid (both channel and ID).
+    operator bool() const { return (channel != NoChannel) && LVDSsource; }
+    
+    /// Order operator: sorted after the channel ID only.
+    bool operator< (LVDSchannel_t const& other) const
+      { return channel < other.channel; }
+    
+  }; // LVDSchannel_t
+
+
+  /// For each logic LVDS bit index, the HW LVDS ID and information are stored.
+  std::vector<LVDSinfo_t> fLVDSinfoMap;
+  
+  
+  /// Builds all the maps
+  void buildAllMaps(icarusDB::IICARUSChannelMapProvider const& channelMap)
+    {
+      fLVDSinfoMap = buildLVDSsourceMap(channelMap);
+    }
+  
+  /**
+   * @brief Builds the LVDS map connecting each bit to its hardware source.
+   * @param channelMap service provider to associate each PMT channel to LVDS
+   * @return a map
+   * 
+   * The map is multi-level. The first level is the cryostat index (up to
+   * `NCryostats - 1`), then for each cryostat a vector hosts in each index
+   * the information of the LVDS ID matching that index.
+   * The information includes the source in the hardware connector of the bit.
+   * 
+   */
+  std::vector<LVDSinfo_t> buildLVDSsourceMap
+    (icarusDB::IICARUSChannelMapProvider const& channelMap) const;
+  
+  
+}; // icarus::trigger::PMTpairBitMap
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_PMT_TRIGGER_ALGORITHMS_LVDSBITMAPS_H

--- a/icaruscode/TPC/Compression/producecompressedjob.fcl
+++ b/icaruscode/TPC/Compression/producecompressedjob.fcl
@@ -1,4 +1,5 @@
 #include "services_common_icarus.fcl"
+#include "channelmapping_icarus.fcl"
 
 #include "ProduceCompressed.fcl"
 
@@ -7,16 +8,7 @@ process_name: TestReprocessRaw
 services:
 {
   @table::icarus_basic_services
-  IICARUSChannelMap: {
-    ChannelMappingTool: {
-      CalibDBFileName: "crt_gain_reco_data"
-      DBFileName: "ChannelMapICARUS_20230829.db"
-      Tag: "v1r0"
-      tool_type: "ChannelMapSQLite"
-    }
-    DiagnosticOutput: false
-    service_provider: "ICARUSChannelMap"
-  }
+  IICARUSChannelMap: @local::icarus_channelmappinggservice
 }
 
 source:

--- a/icaruscode/Utilities/CacheCounter.h
+++ b/icaruscode/Utilities/CacheCounter.h
@@ -1,0 +1,283 @@
+/**
+ * @file   icaruscode/Utilities/CacheCounter.h
+ * @brief  Simple utility to track cache changes.
+ * @author Gianluca Petrillo (petrillo@slac.standord.edu)
+ * @date   March 11, 2024
+ * 
+ * This library is header only.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_CACHECOUNTER_H
+#define ICARUSCODE_UTILITIES_CACHECOUNTER_H
+
+// C/C++ standard libraries
+#include <map>
+#include <string>
+#include <initializer_list>
+#include <atomic>
+#include <stdexcept> // std::logic_error
+
+
+// -----------------------------------------------------------------------------
+namespace util {
+  class CacheCounter;
+  class CacheGuard;
+}
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Counter of cache versions.
+ * @see `util::CacheGuard`
+ * 
+ * This simple class contains an index of cache IDs.
+ * A cache ID is a number that represents the status of a cache.
+ * 
+ * Multiple caches are supported by a single object instance.
+ * Each cache is represented by a "tag", or name. The cache with empty name is
+ * special in that it represent the whole set of caches: when updating it, all
+ * the other cache IDs are also updated.
+ * 
+ * Note that the special ID value `NoCache` represents the idea that the cache
+ * is never up to date and always needs to be refreshed (functionally equivalent
+ * to not having any cache).
+ * 
+ * See `util::CacheGuard` for a usage example.
+ */
+class util::CacheCounter {
+  
+    public:
+  
+  using CacheID_t = unsigned long; ///< Type of cache identifier.
+  using CacheTag_t = std::string; ///< Type of cache name.
+  
+  /// ID specifying that cache is not present yet.
+  static constexpr CacheID_t NoCache = 0;
+  
+  /// Constructor: prepares the ID of the default cache tag.
+  CacheCounter() { fCacheID.emplace("", NoCache); }
+  
+  /// Constructor: prepares the ID of the caches with the specified tags.
+  CacheCounter(std::initializer_list<CacheTag_t> tags)
+    : CacheCounter{}
+    { addCacheTags(std::move(tags)); }
+  
+  /// Adds tags. The ID of existing ones are not changed.
+  void addCacheTags(std::initializer_list<CacheTag_t> tags)
+    { for (CacheTag_t const& tag: tags) fCacheID.emplace(tag, NoCache); }
+  
+  /// Returns the current ID of the cache with the specified tag.
+  CacheID_t cacheID(CacheTag_t const& tag) const { return fCacheID.at(tag); }
+  
+  /// Returns whether the specified tag is tracked.
+  bool hasTag(CacheTag_t const& tag) const { return fCacheID.count(tag) > 0; }
+  
+  /// Returns whether the cache `tag` was updated since it has `sinceID` ID.
+  bool wasCacheUpdatedSince(CacheTag_t const& tag, CacheID_t sinceID) const
+    { return cacheID(tag) > sinceID; }
+  
+  /// Returns whether the default cache was updated since it has `sinceID` ID.
+  bool wasCacheUpdatedSince(CacheID_t sinceID) const
+    { return wasCacheUpdatedSince({}, sinceID); }
+  
+  
+    protected:
+  
+  /// ID of the current caches.
+  mutable std::map<CacheTag_t, std::atomic<CacheID_t>> fCacheID;
+  
+  /// Increments the counter of the specified cache tag.
+  /// The default (empty) tag increments all.
+  CacheID_t updateCacheID(CacheTag_t const& cacheTag = "") const
+    {
+      if (cacheTag.empty()) {
+        for (auto& ID: fCacheID) if (!ID.first.empty()) ++(ID.second);
+      }
+      else ++fCacheID.at(""); // always update the default cache
+      return ++fCacheID.at(cacheTag); // return only the ID from the argument
+    }
+  
+}; // util::CacheCounter
+
+
+// -----------------------------------------------------------------------------
+/**
+ * @brief Tracks the status of a cache.
+ * @see `util::CacheCounter`
+ * 
+ * This class tracks the status of a cache, represented by an integer (ID).
+ * The cache is supposed to update (increment) that ID value each time it
+ * updates the cache content itself. This object tracks that ID and reports
+ * whether it has changed since the last time.
+ * 
+ * There are two elements of the interface:
+ *  * `update()` unconditionally acquires the current ID of the cache; it also
+ *      returns whether it's a new ID (like `wasUpdated()`).
+ *  * `wasUpdated()` compares the current cache ID to the one acquired by the
+ *      last `update()` call, and returns whether the current cache is newer.
+ * 
+ * While the cache ID can be any number, and the interface allows to directly
+ * provide the cache ID, nonetheless this class has a special relationship with
+ * `util::CacheCounter`: it can point to a specific tag name of any cache,
+ * or it can point to a specific cache and tag, with a simpler interface.
+ * If a `CacheGuard` object needs to track a specific cache or cache tag, that
+ * must be specified at  construction time.
+ * 
+ * Note that the object always starts with no update.
+ * 
+ * Also note that a cache ID of `util::CacheCounter::NoCache` is specially
+ * treated and a cache with that ID will never be considered up to date.
+ * 
+ * 
+ * Example
+ * --------
+ * 
+ * A database access class performs standard queries reading time-dependent
+ * data from a database. It caches the result of the query, and it updates
+ * the cache when a time is requested that is not the one present in the cache.
+ * This class also derives from `util::CacheCounter` to offer the cache updating
+ * track capability.
+ * 
+ * An analysis class uses the data from the database to produce results.
+ * It stores the small amount of data derived by the database that is needed
+ * for the computation, and it needs to refetch or recompute that data when
+ * its local cache is outdated. To do this it has a `util::CacheGuard` data
+ * member bound to the database access class above.
+ * 
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * class DatabaseQuery: public util::CacheCounter {
+ *   
+ *   bool fetchData()
+ *     {
+ *       // ...
+ *       return true;
+ *     }
+ *   
+ *   void updateCache() { if (fetchData()) updateCacheID(); }
+ *   
+ *     public:
+ *   
+ *   using Data_t = ... ;
+ *   
+ *   Data_t query();
+ *   
+ * };
+ * 
+ * DatabaseQuery DBquery;
+ * 
+ * 
+ * class DataUser {
+ *   
+ *   util::CacheGuard fDatabaseQueryCacheGuard;
+ *   DatabaseQuery::Data_t fCachedQueryResult;
+ *   
+ *   DatabaseQuery::Data_t const& queryResults()
+ *     {
+ *       if (fDatabaseQueryCacheGuard.update())
+ *         fCachedQueryResult = DBquery.query();
+ *       return fCachedQueryResult;
+ *     }
+ *   
+ *   
+ *     public:
+ *   
+ *   DataUser(): fDatabaseQueryCache{ DBquery } {}
+ *   
+ *   void compute()
+ *     {
+ *       DatabaseQuery::Data_t const& data = queryResults();
+ *       // ...
+ *     }
+ *   
+ * }; // DataUser
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * 
+ * 
+ */
+class util::CacheGuard {
+  
+  /// Pointer to the cache to monitor by default.
+  CacheCounter const* fDefaultCache = nullptr;
+  
+  /// Tag of the cache to monitor.
+  CacheCounter::CacheTag_t fCacheTag;
+  
+  /// The ID of the cache at the last check.
+  CacheCounter::CacheID_t fLastCacheID = CacheCounter::NoCache;
+  
+  /// Returns the default cache object, throwing `std::logic_error` if not set.
+  CacheCounter const& defaultCache() const
+    {
+      if (!fDefaultCache)
+        throw std::logic_error{ "util::CacheGuard default cache was not set." };
+      return *fDefaultCache;
+    }
+  
+  /// Changes the default cache.
+  void chooseCache(CacheCounter const* cache)
+    { fDefaultCache = cache; fLastCacheID = CacheCounter::NoCache; }
+  
+    public:
+  
+  /// Constructor: prepares monitoring of cache `tag`.
+  CacheGuard(CacheCounter::CacheTag_t tag = ""): fCacheTag{ std::move(tag) } {}
+  
+  /// Constructor: prepares monitoring of cache `tag` of the specified object.
+  CacheGuard(CacheCounter const& cache, CacheCounter::CacheTag_t tag = "")
+    : fDefaultCache{ &cache }, fCacheTag{ std::move(tag) } {}
+  
+  /// Changes the default cache.
+  void setCache(CacheCounter const& cache) { chooseCache(&cache); }
+  
+  /// Removes the default cache.
+  void unsetCache() { chooseCache(nullptr); }
+  
+  
+  /// Returns the ID of the cache at the last update.
+  CacheCounter::CacheID_t lastUpdateID() const { return fLastCacheID; }
+  
+  
+  /// @{
+  
+  /// Returns whether the cache, which has `cacheID` ID, was updated since the
+  /// last `update()` call.
+  bool wasUpdated(CacheCounter::CacheID_t cacheID) const
+    { return (cacheID != CacheCounter::NoCache) && (cacheID > fLastCacheID); }
+  
+  /// Returns whether the `cache` was updated since the last `update()` call.
+  bool wasUpdated(CacheCounter const& cache) const
+    { return wasUpdated(cache.cacheID(fCacheTag)); }
+  
+  /// Returns whether the default cache was updated since the last `update()`
+  /// call.
+  bool wasUpdated() const { return wasUpdated(defaultCache()); }
+  
+  /// @}
+  
+  
+  /// @{
+  
+  /// Returns if the cache was outdated, and at the same time updates its ID.
+  bool update(CacheCounter::CacheID_t cacheID)
+    {
+      if (cacheID == CacheCounter::NoCache) return true; // no tracking
+      if (fLastCacheID == cacheID) return false;
+      fLastCacheID = cacheID;
+      return true;
+    }
+  
+  /// Returns if the cache was outdated, and at the same time updates its ID.
+  bool update(CacheCounter const& cache)
+    { return update(cache.cacheID(fCacheTag)); }
+  
+  /// Returns if the default cache was outdated, and at the same time updates
+  /// its ID.
+  bool update() { return update(defaultCache()); }
+  
+  /// @}
+  
+}; // util::CacheGuard
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_UTILITIES_CACHECOUNTER_H

--- a/icaruscode/Utilities/Expected.h
+++ b/icaruscode/Utilities/Expected.h
@@ -1,0 +1,84 @@
+/**
+ * @file   icaruscode/Utilities/Expected.h
+ * @brief  Class providing a value or an error.
+ * @author petrillo@slac,stanford.edu
+ * @date   March 13, 2024
+ * 
+ * This library is header-only.
+ */
+
+#ifndef ICARUSCODE_UTILITIES_EXPECTED_H
+#define ICARUSCODE_UTILITIES_EXPECTED_H
+
+// C/C++ standard libraries
+#include <variant>
+#include <utility> // std::move(), std::forward()
+
+
+// -----------------------------------------------------------------------------
+namespace util { template <typename T, typename E = int> class Expected; }
+
+/**
+ * @brief Class holding a value or an error.
+ * @tparam T type of the value
+ * @tparam E (default: `int`) type of the error
+ * 
+ * This class is loosely based on C++-23 `std::expected`. When C++23 is
+ * available, this class should be removed.
+ * The main difference is the default value of the error type `E`, which is not
+ * present at all in the standard (so the upgrade path would be to define
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * namespace util {
+ *   template <typename T, typename E = int>
+ *   using Expected = std::expected<T, E>;
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+template <typename T, typename E /* = int */>
+class util::Expected {
+  
+  std::variant<T, E> fValue; ///< The stored value or error.
+  
+    public:
+  
+  /// Constructor: starts with a default-constructed error value.
+  constexpr Expected(E e = E{}): fValue{ std::move(e) } {}
+  
+  /// Constructor: starts with a copy of the value `t`.
+  constexpr Expected(T t): fValue{ std::move(t) } {}
+  
+  Expected<T, E>& operator= (E e) { fValue = std::move(e); return *this; }
+  Expected<T, E>& operator= (T t) { fValue = std::move(t); return *this; }
+  
+  /// Constructs the expected _value_ in place.
+  template <typename... Args>
+  T& emplace(Args&&... args)
+    { return fValue.emplace(std::forward<Args>(args)...); }
+  
+  /// Returns whether a value is stored (as opposed to an error).
+  bool has_value() const { return std::holds_alternative<T>(fValue); }
+  
+  /// Returns the error (undefined behaviour when storing a value).
+  E error() const { return std::get<E>(fValue); }
+  
+  /// Returns the value (undefined behaviour when storing an error).
+  T const& value() const { return std::get<T>(fValue); }
+  
+  /// Returns a pointer to the value (`nullptr` when storing an error).
+  T const* valuePtr() const { return has_value()? &value(): nullptr; }
+  
+  /// Implicit conversion to value (undefined behaviour if storing an error).
+  T const& operator*() const { return value(); }
+  
+  /// Implicit conversion to value (undefined behaviour if storing an error).
+  T const* operator-> () const { return valuePtr(); }
+  
+  /// Returns whether a value is stored (as opposed to an error).
+  explicit operator bool() const { return has_value(); }
+  
+}; // util::Expected
+
+
+// -----------------------------------------------------------------------------
+
+#endif // ICARUSCODE_UTILITIES_EXPECTED_H


### PR DESCRIPTION
This pull request includes two parts:
1. an extension of the channel mapping service to provide additional PMT information on PMT pair and adder signals and their path through the hardware; this also includes an utility to extract that mapping information in a format convenient for higher level usage.
2. a trigger decoder able to process and extract all the additional information carried by the adder triggers, including which trigger logic caused the acquisition (majority, adders or both) and the trigger primitive bits that were active at the time of the trigger.

These changes need to be supported by a new channel mapping database with the additional information; with the existing database, the code will still work but won't unpack the trigger primitive bits correctly (close to it, but still no).

This PR depends (and effectively includes) PR #709. The release manager can opt to merge this one directly if it is convenient.

**Dependency on `icarus_data` needs to be bumped to `v09_84_01`**, which @SFBayLaser has tagged and deployed on March 20, 2024.

Once this pull request is merged into a release, ICARUS trigger decoding will be complete.


### Testing

This branch was tested with a data file from run `9435` with the new database version, and on a data file from run `11790` (featuring a mixed majority + adder trigger) with the current database and with the new (not released) one.

### Reviewers

* @jzettle current maintainer of the trigger decoder: please concentrate in particular on the decoder tool
* @SFBayLaser current database release manager (although he'll never admit that)

While this PR is, to my knowledge, non-breaking, it's based on the code breaking #709. Unfortunately that also means that all the code in that PR also appears here, making the review harder.
The new code is expected to correctly process data from the whole ICARUS dataset with no special configuration needs (besides the standard channel mapping service ones).

# Note to the release manager

_*(and to the reviewers if they care)*_

In order to make the review easier, I have rebased this PR on #709, which this one depends on, instead of its real target `develop`.
So please **once this PR is approved, rebase it back to `develop` before merging** (it does make no sense to merge it to `feature/gp_trigDecoderDB` branch, as the PR is configured now).