### PR TITLE
Two updates: bug fix for keep up processing, adjust interplane time offsets and decon timing for truth matching

### DIFF
--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus.fcl
@@ -11,7 +11,7 @@ process_name: stage0
 physics.path:         [ @sequence::icarus_stage0_2d_data ]
 
 ## boiler plate...
-physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.outana:        [ ]
 physics.trigger_paths: [ path ]
 physics.end_paths:     [ outana, streamROOT ]
 
@@ -31,10 +31,6 @@ outputs.rootOutput.outputCommands:         ["keep *_*_*_*",
                                             "drop recob::Wire*_roifinder*_*_*",
                                             "keep *_daq_ICARUSTriggerV*_*"
                                            ]
-
-## Modify the event selection for the purity analyzers
-physics.analyzers.purityinfoana0.SelectEvents:    [ path ]
-physics.analyzers.purityinfoana1.SelectEvents:    [ path ]
 
 # Add below as per Gray Putnam (should we move to jsonnet files?)
 physics.producers.decon2droiEE.wcls_main.structs.gain0: 17.05212 

--- a/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_keepup.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_wc_icarus_keepup.fcl
@@ -13,5 +13,3 @@ physics.end_paths:     [ outana, streamROOT ]
 ## Need overrides for the purity monitor
 physics.analyzers.purityinfoana0.SelectEvents: [ path ]
 physics.analyzers.purityinfoana1.SelectEvents: [ path ]
-physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
-physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]

--- a/icaruscode/Analysis/tools/analysis_tools_icarus.fcl
+++ b/icaruscode/Analysis/tools/analysis_tools_icarus.fcl
@@ -20,6 +20,7 @@ TrackHitEfficiencyAnalysisTool:
   SimChannelLabel:         "largeant"
   LocalDirName:            "EfficHists"
   OffsetVec:               [0,0,0]
+  THitOffsetVec:           [0,0,0]
   SigmaVec:                [1.,1.,1.]
   MinAllowedChannelStatus: 1
 }

--- a/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
+++ b/icaruscode/TPC/ICARUSWireCell/detsimmodules_wirecell_ICARUS.fcl
@@ -68,8 +68,8 @@ icarus_simwire_wirecell:
 
             # Time offsets for truth matching
             time_offset_u: 0.0 # us
-            time_offset_v: 0.5 # us
-            time_offset_y: 1.0 # us
+            time_offset_v: 0.0 # us
+            time_offset_y: 0.0 # us
            
         }
     }

--- a/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
@@ -24,7 +24,7 @@ function(params, tools, override = {}) {
       dft: wc.tn(tools.dft),
       field_response: wc.tn(tools.field),
       ftoffset: 0.0, // default 0.0
-      ctoffset: 2.0*wc.microsecond, // default -8.0
+      ctoffset: 0.5*wc.microsecond, //2.0*wc.microsecond, // default -8.0
       per_chan_resp: pc.name,
       fft_flag: 0,  // 1 is faster but higher memory, 0 is slightly slower but lower memory
       elecresponse : wc.tn(tools.elec_resp[2]),


### PR DESCRIPTION
1) A bug was reported in the keepup processing fhicl file that caused a loss of purity monitor output. This was because the input RawDigit data product names were wrong, set back to default.
1) Adjusted the interplane time offsets and the overall deconvolution offset (in the finall inverse FFT) to get simulation and reconstruction times to match for truth matching. 