### PR TITLE
Added trigger logic information to PMT decoder diagnostic ROOT tree

### DIFF
--- a/fcl/reco/Stage0/Run2/partial/decodePMT_icarus_treeonly.fcl
+++ b/fcl/reco/Stage0/Run2/partial/decodePMT_icarus_treeonly.fcl
@@ -1,0 +1,68 @@
+#
+# File:    decodePMT_icarus_treeonly.fcl
+# Purpose: Runs PMT decoding to build a PMT diagnostic tree.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    September 25, 2022
+# 
+# It does not save any waveform.
+# 
+# Input
+# ------
+# 
+# * artDAQ fragments from all 24 PMT readout boards, named
+#   `daq:ContainerCAENV1730` (or any standard ICARUS name)
+# * trigger fragment (autodetected among ICARUS standard names)
+# * DAQ configuration as FHiCL in the art/ROOT input file
+# 
+# This configuration requires a data fragment for each PMT readout board
+# which is mentioned in `physics.producers.daqPMT.DecoderTool.BoardSetup`,
+# which by default is all 24.
+# 
+# 
+# Output
+# -------
+# 
+# In the plain ROOT output file (names `Tree-....root`) a diagnostic tree
+# is stored with one entry per PMT data fragment (see `decodePMT_icarus.fcl`
+# and the decoder module `DaqDecodeICARUSPMT`), as `daqPMT/PMTfragments`.
+#
+# All standard trigger and PMT decoding data products are produced with the
+# standard names (`daqTrigger` and `daqPMT` respectively).
+# The noticeable exception is PMT raw waveforms not the corrections:
+# neither are saved.
+#
+# The log file also dump the trigger information.
+# 
+#
+
+
+# ------------------------------------------------------------------------------
+#include "decodePMT_icarus.fcl"
+
+# add a trigger dumper to the output on console
+physics.analyzers.dumptrigger: {
+  module_type: DumpTrigger
+  TriggerTag: "daqTrigger"
+}
+
+physics.dumpers:  [ dumptrigger ]
+physics.end_paths: [ streams, dumpers ]
+
+outputs.rootoutput.fileProperties: @erase # don't go one output file per input file
+outputs.rootoutput.outputCommands: [
+  @sequence::outputs.rootoutput.outputCommands
+  , "drop raw::OpDetWaveforms_daqPMT_*_DecodePMT"
+]
+
+# disable abundant output on console and the optical waveforms
+physics.producers.daqPMT.SaveCorrectionsFrom: []
+physics.producers.daqPMT.DiagnosticOutput:    false
+physics.producers.daqTrigger.DecoderTool.Decoders[0].ToolConfig.DiagnosticOutput: false
+physics.producers.daqTrigger.DecoderTool.Decoders[1].ToolConfig.DiagnosticOutput: false
+physics.producers.daqTrigger.DecoderTool.Decoders[2].ToolConfig.DiagnosticOutput: false
+
+services.message.destinations.LogDebugFile: @erase
+services.message.destinations.LogSeeds: @erase
+services.TimeTracker: {} # no DB file
+services.MemoryTracker: @erase
+


### PR DESCRIPTION
With the new adder-based trigger, the PMT diagnostic tree should know whether the light collected at beam gate was coming from an adder or a majority trigger.
This commit adds that information to the tree, one piece of information per cryostat, directly from the trigger information.

_Edit_: it also adds a count of triggers from the beginning of the run and the gates from the previous trigger. This tree is being used for trigger studies as well.
_And_ a job configuration to create such trees, for the benefit of grid jobs.

Reviewer: @mvicenzi as PMT decoder insider.