### PR TITLE
Update PostGres DB new column names

### DIFF
--- a/icaruscode/Decode/ChannelMapping/ChannelMapPostGres.cxx
+++ b/icaruscode/Decode/ChannelMapping/ChannelMapPostGres.cxx
@@ -421,8 +421,8 @@ int icarusDB::ChannelMapPostGres::BuildPMTFragmentToDigitizerChannelMap
      AdderConnectorColumn
   ]= details::WDAPositionFinder{ getTuple(dataset, 0) }(
     "light_fiber_label"s,   "digitizer_ch_number"s, "channel_id"s,
-    "fragment_id"s,         "digitizer_label"s,     "FPGA_connector_DIO"s,
-    "adder_connector_DIO"s
+    "fragment_id"s,         "digitizer_label"s,     "fpga_connector_dio"s,
+    "adder_connector_dio"s
     );
   
   // Ok, now we can start extracting the information


### PR DESCRIPTION
This is a follow up from #720. The hardware PostGres DB was updated in RITM2043469, and new data has been added to the existing tables. Due to some internal constraints, column names are required to be lowercase so I'm updating the hardcoded names in `ChannelMapPostGres.cxx` to match them.

This was tested with `ChannelMapDumper`, and confirmed to be working.