### PR TITLE
fix a few issues with g4 fcl files

### DIFF
--- a/fcl/g4/intime_g4_icarus.fcl
+++ b/fcl/g4/intime_g4_icarus.fcl
@@ -37,6 +37,8 @@ services:
   @table::icarus_g4_services
   scheduler:    { defaultExceptions: false }    # Make all uncaught exceptions fatal.
 }
+services.Geometry.GDML: "icarus_complete_20220518_overburden.gdml"
+services.Geometry.ROOT: "icarus_complete_20220518_overburden.gdml"
 
 #source is now a root file
 source:

--- a/fcl/g4/larg4_icarus.fcl
+++ b/fcl/g4/larg4_icarus.fcl
@@ -91,11 +91,11 @@ physics.producers.largeant.StoreDroppedMCParticles: false
 # ------------------------------------------------------------------------------
 # Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
 physics.producers.mcreco.G4ModName: "simdrift"
-physics.producers.mcreco.SimChannelLabel: "sedlite"
+physics.producers.mcreco.SimChannelLabel: "simdrift" #"sedlite"
 physics.producers.mcreco.MCParticleLabel: "largeant"
-physics.producers.mcreco.UseSimEnergyDepositLite: true
+physics.producers.mcreco.UseSimEnergyDepositLite: false #true
 physics.producers.mcreco.UseSimEnergyDeposit: false
-physics.producers.mcreco.IncludeDroppedParticles: true
+physics.producers.mcreco.IncludeDroppedParticles: false #this needs to be set to true once the ML chain is ready
 physics.producers.mcreco.MCParticleDroppedLabel: "largeant:droppedMCParticles"
 physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
 

--- a/fcl/g4/larg4_icarus_intime.fcl
+++ b/fcl/g4/larg4_icarus_intime.fcl
@@ -95,7 +95,7 @@ services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]
 
 # Drop the intime and outtime collections, which have now been
 # been merged into a 'largeant' collection
-outputs.out1.outputCommands: [ "keep *_*_*_*"
+outputs.rootoutput.outputCommands: [ "keep *_*_*_*"
                              # Drop G4
                              , "drop *_larg4intime_*_*"
                              , "drop *_larg4outtime_*_*"


### PR DESCRIPTION
This PR fixes a few issues with G4 fcl that were not detected in time for v09_88_00_02.

1. Usage of legacy G4 was not fixed in intime_g4_icarus.fcl
2. Revert some mcreco changes that are not ready yet (may be changed back with next larsim and after tests from ML group)
3. Wrong output module used in larg4_icarus_intime.fcl