### PR TITLE
ML refactoring compatible with larsim version for larsoft v09_89

### DIFF
--- a/fcl/g4/larg4_icarus.fcl
+++ b/fcl/g4/larg4_icarus.fcl
@@ -90,7 +90,7 @@ physics.producers.largeant.StoreDroppedMCParticles: false
 
 # ------------------------------------------------------------------------------
 # Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
-physics.producers.mcreco.G4ModName: "largeant" #"simdrift"
+physics.producers.mcreco.G4ModName: "simdrift"
 physics.producers.mcreco.SimChannelLabel: "sedlite"
 physics.producers.mcreco.MCParticleLabel: "largeant"
 physics.producers.mcreco.UseSimEnergyDepositLite: true

--- a/fcl/g4/larg4_icarus.fcl
+++ b/fcl/g4/larg4_icarus.fcl
@@ -90,7 +90,7 @@ physics.producers.largeant.StoreDroppedMCParticles: false
 
 # ------------------------------------------------------------------------------
 # Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
-physics.producers.mcreco.G4ModName: "simdrift"
+physics.producers.mcreco.G4ModName: "largeant" #"simdrift"
 physics.producers.mcreco.SimChannelLabel: "sedlite"
 physics.producers.mcreco.MCParticleLabel: "largeant"
 physics.producers.mcreco.UseSimEnergyDepositLite: true
@@ -98,6 +98,7 @@ physics.producers.mcreco.UseSimEnergyDeposit: false
 physics.producers.mcreco.IncludeDroppedParticles: true
 physics.producers.mcreco.MCParticleDroppedLabel: "largeant:droppedMCParticles"
 physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
+physics.producers.mcreco.MCRecoPart.TrackIDOffsets: [0,10000000,20000000] #Account for track ID offsets in labeling primaries
 
 #info reducer
 physics.producers.sedlite.SimEnergyDepositLabel: "largeant:LArG4DetectorServicevolTPCActive"

--- a/fcl/g4/larg4_icarus_intime.fcl
+++ b/fcl/g4/larg4_icarus_intime.fcl
@@ -75,6 +75,7 @@ physics.producers.sedlite.SimEnergyDepositLabel: "largeant:LArG4DetectorServicev
 
 # mcreco dropped label for intime
 physics.producers.mcreco.MCParticleDroppedLabel: "largeantdropped"
+physics.producers.mcreco.MCRecoPart.TrackIDOffsets: [0,10000000,20000000] #Account for track ID offsets in labeling primaries
 
 # simplemerge for intime
 # simplemerge for ML
@@ -107,7 +108,7 @@ physics.simulate: [ rns
 		  , simplemerge
                   ]
 
-services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]
+services.ParticleListAction.keepGenTrajectories: ["corsika", "GenInTimeSorter"]
 
 # Drop the intime and outtime collections, which have now been
 # been merged into a 'largeant' collection

--- a/fcl/g4/larg4_icarus_intime.fcl
+++ b/fcl/g4/larg4_icarus_intime.fcl
@@ -21,7 +21,7 @@ physics.producers.ionandscintouttime: @local::icarus_ionandscint
 physics.producers.pdfastsimouttime: @local::icarus_pdfastsim_pvs
 physics.producers.simdriftouttime: @local::icarus_simdrift
 physics.producers.genericcrtouttime: @local::icarus_genericCRT
-physics.producers.sedliteouttime: @local::sbn_largeant_info_reducer
+#physics.producers.sedliteouttime: @local::sbn_largeant_info_reducer
 
 # Set the appropriate input labels, to run geant4 only on the outtime cosmics
 physics.producers.simdriftintime.SimulationLabel: "ionandscintintime:priorSCE"
@@ -34,12 +34,14 @@ physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE
 physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime:priorSCE"
 physics.producers.genericcrtouttime.LArG4Label: "larg4outtime"
 #info reducer
-physics.producers.sedliteouttime.SimEnergyDepositLabel: "larg4outtime:LArG4DetectorServicevolTPCActive"
-physics.producers.sedliteouttime.useOrigTrackID: true #needed since origTrackID not filled for sedlite in SBND
+#physics.producers.sedliteouttime.SimEnergyDepositLabel: "larg4outtime:LArG4DetectorServicevolTPCActive"
+#physics.producers.sedliteouttime.useOrigTrackID: true #needed since origTrackID not filled for sedlite in SBND
 
 # Add a process that merges the MCParticles
 physics.producers.largeant: @local::icarus_merge_sim_sources
 physics.producers.largeant.FillMCParticles: true
+physics.producers.largeant.FillSimEnergyDeposits: true
+physics.producers.largeant.EnergyDepositInstanceLabels: @local::largeant_volumes
 physics.producers.largeant.InputSourcesLabels: [ "larg4intime", "larg4outtime"]
 
 # Add a process that merges the SimEnergyDeposits
@@ -64,7 +66,19 @@ physics.producers.pdfastsim.FillSimPhotons: true
 physics.producers.pdfastsim.InputSourcesLabels: [ "pdfastsimintime", "pdfastsimouttime"]
 
 #Add a process that merges the dropped MCParticles
-physics.producers.sedlite: @local::icarus_merge_intime_dropped_mcparts
+physics.producers.largeantdropped: @local::icarus_merge_intime_dropped_mcparts
+physics.producers.largeantdropped.InputSourcesLabels: [ "larg4intime:droppedMCParticles", "larg4outtime:droppedMCParticles"]
+
+#Add a process for sedlite generation
+physics.producers.sedlite: @local::sbn_largeant_info_reducer 
+physics.producers.sedlite.SimEnergyDepositLabel: "largeant:LArG4DetectorServicevolTPCActive"
+
+# mcreco dropped label for intime
+physics.producers.mcreco.MCParticleDroppedLabel: "largeantdropped"
+
+# simplemerge for intime
+# simplemerge for ML
+physics.producers.simplemerge.InputSourcesLabels: ["largeant", "largeantdropped"]
 
 # Add all these new modules to the simulate path
 physics.simulate: [ rns
@@ -79,16 +93,18 @@ physics.simulate: [ rns
                   , pdfastsimouttime
                   , simdriftouttime
                   , genericcrtouttime
-                  , sedliteouttime
+                  #, sedliteouttime
                   ### Merge the intime and outtime paths
                   , largeant
+		  , largeantdropped
                   , ionization
                   , simdrift
                   , pdfastsim
                   , genericcrt
                   ### Do truth-level reconstruction
+		  , sedlite
                   , mcreco
-                  , sedlite 
+		  , simplemerge
                   ]
 
 services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]
@@ -110,5 +126,8 @@ outputs.out1.outputCommands: [ "keep *_*_*_*"
                              , "drop *_simdriftouttime_*_*"
                              # Drop LArG4 AuxDetHits, now replaced by AuxDetSimChannels
                              , "drop sim::AuxDetHits_*_*_*"
+			     # Drop sedlite
+			     , "drop *_sedliteintime_*_*"
+			     , "drop *_sedliteouttime_*_*"
                              ]
 

--- a/fcl/g4/mergesimsources_icarus.fcl
+++ b/fcl/g4/mergesimsources_icarus.fcl
@@ -19,7 +19,7 @@ icarus_merge_sim_sources : {
 largeant_volumes: [ "LArG4DetectorServicevolTPCPlaneV"
                   , "LArG4DetectorServicevolTPC0"
                   , "LArG4DetectorServicevolTPCPlaneU"
-                  , "LArG4DetectorServicevolOpDetSensitive" #is this needed?
+                  #, "LArG4DetectorServicevolOpDetSensitive" #is this needed?
                   , "LArG4DetectorServicevolTPCPlaneY"
                   , "LArG4DetectorServicevolTPCActive"
                   ]

--- a/fcl/g4/simplemerge_icarus.fcl
+++ b/fcl/g4/simplemerge_icarus.fcl
@@ -3,7 +3,8 @@ BEGIN_PROLOG
 simplemerge : {
   module_type: "SimpleMerge"
   InputSourcesLabels: ["largeant", "largeant:droppedMCParticles"]
-  ResetMotherIDs: [ 0 ]
+  ResetMotherIDs : [10000000,20000000]  
+  #ResetMotherIDs: [ 0 ]
 }
 
 END_PROLOG

--- a/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
+++ b/fcl/gen/corsika/prodcorsika_proton_intime_filter_bnb.fcl
@@ -72,7 +72,7 @@ physics.producers.sedliteintime.useOrigTrackID: true #needed
 physics.filters.timefilter.SimPhotonsLiteCollectionLabel: "pdfastsimintime"
 
 
-services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]
+services.ParticleListAction.keepGenTrajectories: ["corsika", "GenInTimeSorter:intime", "GenInTimeSorter:outtime"]
 services.LArG4Parameters.UseLitePhotons: true
 
 outputs.out1.SelectEvents: [ "simulate" ]

--- a/fcl/reco/Definitions/stage1_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage1_icarus_defs.fcl
@@ -88,7 +88,7 @@ icarus_stage1_analyzers:
   superaMC:        @local::icarus_supera_MC_PMT_CRT
   superaNu:        @local::icarus_supera_generator_PMT_CRT
   superaMPVMPR:	   @local::icarus_supera_MC_MPVMPR_cryoE_PMT_CRT
-
+  superaCosmic:    @local::icarus_supera_cosmgen_all_cryo_PMT_CRT
   CRTDataAnalysis: 
    {
      module_type:   "CRTDataAnalysis"
@@ -161,7 +161,8 @@ icarus_analysis_superaNu:          [ superaNu
 
 icarus_analysis_superaMPVMPR:      [ superaMPVMPR
                                    ]
-
+icarus_analysis_superaCosmic:      [ superaCosmic
+				   ]
 icarus_analysis_larcv_modules:     [  @sequence::icarus_analysis_modules
                                      ,@sequence::icarus_analysis_supera 
                                    ]

--- a/fcl/reco/Stage1/Run2/stage1_run2_1d_larcv_icarus_Cosmic.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_1d_larcv_icarus_Cosmic.fcl
@@ -1,0 +1,6 @@
+# This runs larcv as part of stage 1 processing for MC (MPVMPR)
+
+#include "stage1_run2_1d_icarus_MC.fcl"
+
+physics.outana:    [  @sequence::icarus_analysis_modules, @sequence::icarus_analysis_superaCosmic ]
+physics.end_paths: [ outana, stream1 ]

--- a/fcl/reco/Stage1/Run2/stage1_run2_larcv_icarus_Cosmic.fcl
+++ b/fcl/reco/Stage1/Run2/stage1_run2_larcv_icarus_Cosmic.fcl
@@ -1,0 +1,6 @@
+# This runs larcv as part of stage 1 processing for MC (MPVMPR)
+
+#include "stage1_run2_icarus_MC.fcl"
+
+physics.outana:    [  @sequence::icarus_analysis_modules, @sequence::icarus_analysis_superaCosmic ]
+physics.end_paths: [ outana, stream1 ]


### PR DESCRIPTION
- stage1_run2_larcv_icarus_Cosmic.fcl, stage1_run2_1d_larcv_icarus_Cosmic.fcl, added for intime cosmic larcv generation. 
- larg4_icarus.fcl / larg4_icarus_intime.fcl updated
- mergesimsources_icarus.fcl / simplemerge_icarus.fcl  trackId offset added