### PR TITLE
larg4_icarus.fcl update for ML

### DIFF
--- a/fcl/g4/larg4_icarus.fcl
+++ b/fcl/g4/larg4_icarus.fcl
@@ -91,9 +91,9 @@ physics.producers.largeant.StoreDroppedMCParticles: false
 # ------------------------------------------------------------------------------
 # Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
 physics.producers.mcreco.G4ModName: "simdrift"
-physics.producers.mcreco.SimChannelLabel: "simdrift" #"sedlite"
+physics.producers.mcreco.SimChannelLabel: "sedlite"
 physics.producers.mcreco.MCParticleLabel: "largeant"
-physics.producers.mcreco.UseSimEnergyDepositLite: false #true
+physics.producers.mcreco.UseSimEnergyDepositLite: true
 physics.producers.mcreco.UseSimEnergyDeposit: false
 physics.producers.mcreco.IncludeDroppedParticles: true #this is now true with larsoft v09_89 and newer
 physics.producers.mcreco.MCParticleDroppedLabel: "largeant:droppedMCParticles"

--- a/fcl/g4/larg4_icarus.fcl
+++ b/fcl/g4/larg4_icarus.fcl
@@ -95,7 +95,7 @@ physics.producers.mcreco.SimChannelLabel: "simdrift" #"sedlite"
 physics.producers.mcreco.MCParticleLabel: "largeant"
 physics.producers.mcreco.UseSimEnergyDepositLite: false #true
 physics.producers.mcreco.UseSimEnergyDeposit: false
-physics.producers.mcreco.IncludeDroppedParticles: false #this needs to be set to true once the ML chain is ready
+physics.producers.mcreco.IncludeDroppedParticles: true #this is now true with larsoft v09_89 and newer
 physics.producers.mcreco.MCParticleDroppedLabel: "largeant:droppedMCParticles"
 physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
 physics.producers.mcreco.MCRecoPart.TrackIDOffsets: [0,10000000,20000000] #Account for track ID offsets in labeling primaries


### PR DESCRIPTION
larg4_icarus.fcl from previous PR https://github.com/SBNSoftware/icaruscode/pull/731/ seems to have been overwritten by other PRs during the merge for the current release. This is the correct config for ML production.