### PR TITLE
Fix ML chain for ICARUS systematics and standard productions

### DIFF
--- a/fcl/g4/larg4_icarus.fcl
+++ b/fcl/g4/larg4_icarus.fcl
@@ -91,11 +91,11 @@ physics.producers.largeant.StoreDroppedMCParticles: false
 # ------------------------------------------------------------------------------
 # Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
 physics.producers.mcreco.G4ModName: "simdrift"
-physics.producers.mcreco.SimChannelLabel: "simdrift" #"sedlite"
+physics.producers.mcreco.SimChannelLabel: "sedlite"
 physics.producers.mcreco.MCParticleLabel: "largeant"
-physics.producers.mcreco.UseSimEnergyDepositLite: false #true
+physics.producers.mcreco.UseSimEnergyDepositLite: true
 physics.producers.mcreco.UseSimEnergyDeposit: false
-physics.producers.mcreco.IncludeDroppedParticles: false #this needs to be set to true once the ML chain is ready
+physics.producers.mcreco.IncludeDroppedParticles: true #this is now true with larsoft v09_89 and newer
 physics.producers.mcreco.MCParticleDroppedLabel: "largeant:droppedMCParticles"
 physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
 physics.producers.mcreco.MCRecoPart.TrackIDOffsets: [0,10000000,20000000] #Account for track ID offsets in labeling primaries

--- a/fcl/syst_variations/refactored_g4_icarus_step1.fcl
+++ b/fcl/syst_variations/refactored_g4_icarus_step1.fcl
@@ -1,4 +1,4 @@
-#include "larg4_icarus_sce.fcl"
+#include "larg4_icarus_cosmics_sce_2d_drift.fcl"
 
 physics.simulate: [ rns
             , loader

--- a/fcl/syst_variations/refactored_g4_icarus_step2.fcl
+++ b/fcl/syst_variations/refactored_g4_icarus_step2.fcl
@@ -7,6 +7,7 @@ physics.simulate: [ rns
 	    , sedlite
             , mcreco
             , genericcrt
+	    , simplemerge
           ]
 
 process_name: G4Step2

--- a/fcl/syst_variations/refactored_g4_icarus_step2_variations.fcl
+++ b/fcl/syst_variations/refactored_g4_icarus_step2_variations.fcl
@@ -7,6 +7,7 @@ physics.simulate: [ rns
 	    , sedlite
             , mcreco
             , genericcrt
+	    , simplemerge
           ]
 
 process_name: G4Step2Var

--- a/fcl/syst_variations/stage0_variation_icarus_savewires.fcl
+++ b/fcl/syst_variations/stage0_variation_icarus_savewires.fcl
@@ -1,3 +1,3 @@
 #include "stage0_variation_icarus_refactored.fcl"
 
-outputs.rootOutput.outputCommands: ["keep *_*_*_*", "drop *_daq*_*_*", "drop *_MCDecodeTPCROI_*_*", "drop *_decon1droi_*_*", "keep *_daq_simpleSC_*"]
+outputs.rootOutput.outputCommands: ["keep *_*_*_*"]


### PR DESCRIPTION
This PR is meant to try to fix the issue seen in v09_89_01 with Supera running when attempting to test things for the variation. Also includes small changes needed for ML running in a couple of the variation fcl. This PR supersedes https://github.com/SBNSoftware/icaruscode/pull/733 and was made in coordination with @yeonjaej ensuring I had included the same changes she did in her PR. Making this against develop as that and the v09_89_01 tag are identical according to github.

Still testing this with the neutrino-only samples to make sure the issue is fixed to the level we can quickly. Also notifying @cerati and @SFBayLaser about this. Will comment results of testing over the rest of the night/tomorrow morning and we can discuss how to patch the release if everything is successful. 

Apparently I cannot request @yeonjaej as a reviewer...?

Relies also on the sbncode PR built against the tag v09_89_01 in sbncode: https://github.com/SBNSoftware/sbncode/pull/460