### PR TITLE
sortDataLoggerFiles.py: fixed duplicate file identification

### DIFF
--- a/scripts/sortDataLoggerFiles.py
+++ b/scripts/sortDataLoggerFiles.py
@@ -74,9 +74,8 @@ class DAQIndex:
     except TypeError:
       self.builder = int(builder)
       self.thread = int(thread)
-  def __lt__(self, other):
-    if self.builder != other.builder: return self.builder < other.builder
-    return self.thread < other.thread
+  def key(self): return ( self.builder, self.thread )
+  def __lt__(self, other): return self.key() < other.key()
   def __str__(self): return f"EventBuilder{self.builder}_art{self.thread}"
 # class DAQIndex
 
@@ -357,7 +356,7 @@ def buildFileIndex(
   fileInfo: "list with information from all files",
   ) -> "a dictionary: { key -> list of files }":
   
-  fileKey = lambda info: ( info.run, info.pass_, info.dataLogger, info.stream, info.timestamp )
+  fileKey = lambda info: ( info.run, info.pass_, info.dataLogger.key(), info.stream, info.timestamp )
   index = {}
   for info in fileInfo:
     index.setdefault(fileKey(info), []).append(info)


### PR DESCRIPTION
**TL;DR:** `sortDataLoggerFiles.py` couldn't detect duplicate files any more. This patch fixes it.

A recent DAQ change in the output file name pattern introduced two numbers (an `art` and a `EventBuilder` index) in place of a single one (data logger, `dl`). To support both formats, the number that used to represent the data logger in `sortDataLoggerFiles.py` was replaced by an object that could represent either a data logger or a builder+thread pair.

This quantity (formerly number, now object) was also directly used as a unique key to identify duplicate files. Python then implicitly used the address of an object as component of that key instead of the value of the number (or of the object). Duplicate files would get different objects (with different addresses) with the same value, which would make for different keys. With this fix, the value of the object is explicitly used instead of the address.

Reviewers: @mvicenzi as DAQ convener witnessing the DAQ change.
