### PR TITLE
Updates for Doxygen documentation generation

### DIFF
--- a/doc/icaruscode.doxy
+++ b/doc/icaruscode.doxy
@@ -2298,8 +2298,8 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = ROOT.tag=https://root.cern/doc/v618 \
-                         LArSoft.tag=http://nusoft.fnal.gov/larsoft/doxsvn/html
+TAGFILES               = ROOT.tag=https://root.cern/doc/v628 \
+                         LArSoft.tag=https://code-doc.larsoft.org/docs/latest/html
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/doc/scripts/updateLocalDocumentation.sh
+++ b/doc/scripts/updateLocalDocumentation.sh
@@ -122,6 +122,27 @@ function UpdateTag() {
   
   rm "$TempFile"
 
+  while true ; do
+    local FileType="$(file --brief --mime-type "$TagFile")"
+  
+    case "$FileType" in
+      ( 'application/xml' ) break ;; # already ok
+      ( 'application/x-gzip' )
+        echo "Uncompressing tag file '${TagFile}'${Description:+ (${Description})} (${FileType})"
+        if [[ ! "$TagFile" =~ \.gz$ ]]; then
+          local NewName="${TagFile}.gz"
+          mv "$TagFile" "$NewName"
+          TagFile="$NewName"
+        fi
+        gunzip "$TagFile"
+        TagFile="${TagFile%.gz}"
+        ;;
+      ( * )
+        ERROR 1 "Tag file '${TagFile}'${Description:+ (${Description})} of unexpected type ${FileType}."
+        break
+        ;;
+    esac
+  done
 } # UpdateTag()
 
 

--- a/doc/scripts/updateLocalDocumentation.sh
+++ b/doc/scripts/updateLocalDocumentation.sh
@@ -166,7 +166,7 @@ function UpdateLArSoftTag() {
 #   local LArSoftVersion="$(UPSversion 'larsoft')"
 
   # Only one documented version: hope you like it
-  UpdateTag 'LArSoft.tag' 'http://nusoft.fnal.gov/larsoft/doxsvn/html/doxytags-larsoft.xml' "LArSoft"
+  UpdateTag 'LArSoft.tag' 'https://code-doc.larsoft.org/docs/latest/html/doxytags-larsoft.xml' "LArSoft"
 
 } # UpdateLArSoftTag()
 

--- a/doc/scripts/utilities.sh
+++ b/doc/scripts/utilities.sh
@@ -112,8 +112,8 @@ function isExperiment() {
     ExperimentHostNames[$Name]="${Name,,}"
     ExperimentDirectories[$Name]="${Name,,}"
   done
-  ExperimentHostNames['MicroBooNE']='uboone'
-  ExperimentDirectories['MicroBooNE']='uboone'
+  ExperimentHostNames[MicroBooNE]='uboone'
+  ExperimentDirectories[MicroBooNE]='uboone'
 
   local -a Experiments
   local ExperimentCandidate ExperimentHostName


### PR DESCRIPTION
* LArSoft has moved to a different server, and since we somehow link to their "tag file", we need an update 
* ROOT tag file is now compressed (Gzip), but (my) Doxygen does not support that: the documentation update script now decompresses tag files
* bug fix (it seems Alma Linux 9 Bash is more picky than Scientific Linux 7)
