### PR TITLE
Use QGSP_BERT_HP physics list

### DIFF
--- a/fcl/g4/larg4_services_icarus.fcl
+++ b/fcl/g4/larg4_services_icarus.fcl
@@ -8,7 +8,7 @@ BEGIN_PROLOG
 #
 icarus_physics_list_fastoptical:
 {
-  PhysicsListName: "SBN_QGSP_BERT_NNC"
+  PhysicsListName: "QGSP_BERT_HP"
   DumpList: true
   enableNeutronLimit: false
   NeutronTimeLimit: 0.0


### PR DESCRIPTION
With this PR we switch to using the QGSP_BERT_HP Geant4 physics list. This is analogous to the sbndcode PR https://github.com/SBNSoftware/sbndcode/pull/468 and is the ICARUS-specific implementation of the goal mentioned in sbncode PR https://github.com/SBNSoftware/sbncode/pull/462 by @marcodeltutto. 

More details in sbncode issue https://github.com/SBNSoftware/sbncode/issues/453

Comparison of performances is below (10 events generated with prodcorsika_bnb_genie_protononly_icarus.fcl followed by larg4_icarus_cosmics_sce_2d_drift.fcl).

Original (SBN_QGSP_BERT_NNC):

```
                           Hadronic Processes for neutron

  Process: hadElastic
        Model:             hElasticCHIPS: 0 eV  ---> 100 TeV
     Cr_sctns:        G4NeutronElasticXS: 0 eV  ---> 100 TeV

  Process: neutronInelastic
        Model:                      QGSP: 12 GeV ---> 100 TeV
        Model:                      FTFP: 3 GeV ---> 25 GeV
        Model:            BertiniCascade: 0 eV  ---> 6 GeV
     Cr_sctns:      G4NeutronInelasticXS: 0 eV  ---> 100 TeV

  Process: nCapture
        Model:               nRadCapture: 0 eV  ---> 100 TeV
     Cr_sctns:        G4NeutronCaptureXS: 0 eV  ---> 100 TeV

TrigReport ---------- Event summary -------------
TrigReport Events total = 10 passed = 10 failed = 0

TrigReport ---------- Modules in End-path ----------
TrigReport        Run    Success      Error Name
TrigReport         10         10          0 rootoutput

TimeReport ---------- Time summary [sec] -------
TimeReport CPU = 448.800813 Real = 503.898121

MemReport  ---------- Memory summary [base-10 MB] ------
MemReport  VmPeak = 5905.76 VmHWM = 4908.11
```

New (QGSP_BERT_HP ):

```
Process: hadElastic
        Model:             hElasticCHIPS: 19.5 MeV ---> 100 TeV
        Model:          NeutronHPElastic: 0 eV  ---> 20 MeV
     Cr_sctns:        NeutronHPElasticXS: 0 eV  ---> 20 MeV
     Cr_sctns:        G4NeutronElasticXS: 0 eV  ---> 100 TeV

  Process: neutronInelastic
        Model:                      QGSP: 12 GeV ---> 100 TeV
        Model:                      FTFP: 3 GeV ---> 25 GeV
        Model:            BertiniCascade: 19.9 MeV ---> 6 GeV
        Model:        NeutronHPInelastic: 0 eV  ---> 20 MeV
     Cr_sctns:      NeutronHPInelasticXS: 0 eV  ---> 20 MeV
     Cr_sctns:  BarashenkovGlauberGribov: 0 eV  ---> 100 TeV

  Process: nCapture
        Model:          NeutronHPCapture: 0 eV  ---> 20 MeV
        Model:               nRadCapture: 19.9 MeV ---> 100 TeV
     Cr_sctns:        NeutronHPCaptureXS: 0 eV  ---> 20 MeV
     Cr_sctns:        G4NeutronCaptureXS: 0 eV  ---> 100 TeV

  Process: nFission
        Model:          NeutronHPFission: 0 eV  ---> 20 MeV
        Model:                G4LFission: 19.9 MeV ---> 100 TeV
     Cr_sctns:        NeutronHPFissionXS: 0 eV  ---> 20 MeV
     Cr_sctns:          GheishaFissionXS: 0 eV  ---> 100 TeV

TrigReport ---------- Event summary -------------
TrigReport Events total = 10 passed = 10 failed = 0

TrigReport ---------- Modules in End-path ----------
TrigReport        Run    Success      Error Name
TrigReport         10         10          0 rootoutput

TimeReport ---------- Time summary [sec] -------
TimeReport CPU = 556.819878 Real = 783.395946

MemReport  ---------- Memory summary [base-10 MB] ------
MemReport  VmPeak = 6711.65 VmHWM = 5710.61
```
