### PR TITLE
Add a CRT Hit flag to categorize side CRT Z position reconstruction

### DIFF
--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -229,7 +229,7 @@ namespace crt {
     int       fHitMod;
     int       fNHitFeb;
     float     fHitTotPe;
-
+    double fHitFlag; // CRT Hit flag for side CRT Z reconstruction
     //CRT-PMT Matching vars
     int          fMatchEvent;///< Event number.
     int          fMatchRun;///< Run number.
@@ -404,7 +404,7 @@ namespace crt {
     fHitNtuple->Branch("gate_crt_diff",&m_gate_crt_diff, "gate_crt_diff/l");
     fHitNtuple->Branch("crt_global_trigger",&m_crt_global_trigger,"crt_global_trigger/l");
     fHitNtuple->Branch("crtGT_trig_diff",&m_crtGT_trig_diff,"crtGT_trig_diff/L");
-    
+    fHitNtuple->Branch("hitFlag", &fHitFlag, "hitFlag/D");
     // Define the branches of our CRTPMTMatch ntuple
     fCRTPMTNtuple->Branch("event", &fMatchEvent, "event/I");
     fCRTPMTNtuple->Branch("run", &fMatchRun, "run/I");
@@ -587,7 +587,7 @@ namespace crt {
 	  fZErrHit = hit.z_err;
 	  fT0Hit   = hit.ts0_ns;
 	  fT1Hit   = hit.ts1_ns;
-	   
+	  fHitFlag = 0; //default flag = 0, only fill var. below for side CRT hits
 	  fNHitFeb  = hit.feb_id.size();
 	  fHitTotPe = hit.peshit;
 	  int mactmp = hit.feb_id[0];
@@ -621,6 +621,7 @@ namespace crt {
 		}	
   	     }
 	  } else if (fHitSubSys==1) {
+	    std::cout << "hitFlag = " << hit.ts0_s_corr << "\n";
 	     int arrpos=-1;
 	     std::map<uint8_t, std::vector<std::pair<int,float>>>::const_iterator it;
 	     for (it = hit.pesmap.begin(); it!=hit.pesmap.end();it++){
@@ -636,8 +637,14 @@ namespace crt {
                 }
              }
 	  }
+						      
+	  // Load in CRTHitFlag for side CRT Hits only
+	  // hit.ts0_s_corr was an unused variable in the sbn/common/CRTHit.h, repurposed this var for the hit flag to classify side CRT Z-position reconstruction 
+	  // if hitFlags are filled, hit.ts0_s_corr should be < 7, or else a timestamp is saved in ts0_s_corr
+	  if (hit.ts0_s_corr < 7) fHitFlag = hit.ts0_s_corr; 
+						      
 	  int chantmp = (*ittmp).second[0].first;
-	  
+						      
 	  fHitMod  = fCrtutils->MacToAuxDetID(mactmp, chantmp);
 	  fHitStrip = fCrtutils->ChannelToAuxDetSensitiveID(mactmp, chantmp);
 	  

--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -621,7 +621,6 @@ namespace crt {
 		}	
   	     }
 	  } else if (fHitSubSys==1) {
-	    std::cout << "hitFlag = " << hit.ts0_s_corr << "\n";
 	     int arrpos=-1;
 	     std::map<uint8_t, std::vector<std::pair<int,float>>>::const_iterator it;
 	     for (it = hit.pesmap.begin(); it!=hit.pesmap.end();it++){

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -629,8 +629,29 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   }
 
   if (fVerbose)
-    std ::cout << "line 451: size of febA: \t" << (int)febA.size()
-               << " size of febB: " << (int)febB.size() << '\n';
+    mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
+    << "size of febA: " << (int)febA.size()
+    << ", size of febB: " << (int)febB.size() << '\n';
+  // *** Flag = 6: Check and flag single ended readouts
+  if ((int)febA.size() == 1 and (int)febB.size() == 1 and region!="South" and region!="North"){
+    flag = 6;
+    if(fVerbose) 
+      mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
+	<< "single ended readout for both layers! setting flag == 6 ... \n";
+  }
+  // *** Flag = 1: Check and flag single ended readout on one layer 
+  else if ((int)febA.size() == 1 and region!="South" and region!="North"){
+    if(fVerbose)
+      mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
+	<< "single ended readout for feb A, 1st layer! setting flag == 1 ... \n";
+    flag = 1;
+  }
+  else if ((int)febB.size() == 1 and region!="South" and region!="North"){
+    if(fVerbose)
+      mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
+	<< "single ended readout for feb B, 2nd layer! setting flag == 1 ... \n";
+    flag = 1;
+  }
 
   // loop over FEBs
   for (auto const& data : coinData) {

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -983,8 +983,25 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
             << ", deltat : " << int64_t(t1_1 - t1_2) << '\n';
 
       float zaxixpos = 0.5 * (int64_t(t1_1 - t1_2) / fPropDelay);
-
       posA = adsGeo.GetCenter() + geo::Zaxis() * zaxixpos;
+      if (fVerbose) 
+	mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
+	  << "---\n\tFEB A: (mac_1,mac_2 = " << (int)infn.mac5s << "," 
+	  << (int)informationA[i+1].mac5s<< "), delta_t = t1_1 - t1_2 = " 
+	  << t1_1 << " - " << t1_2 << " = " << int64_t(t1_1 - t1_2) << "\n"
+	  << "\tFEB A z hit pos = .5*(delta_t)/prop + center = .5*(" 
+	  << int64_t(t1_1 - t1_2) << ")/ " << fPropDelay << " + " 
+	  << 1.0*adsGeo.GetCenter().Z() << " = " << posA.Z() << "\n";
+
+      // *** Flag 5: Check and flag if 1st modules delta_t > 50 ns
+      // 50 ns ~= 800 cm (full module length) x 0.062 ns/cm (prop delay)  = 49.5 ns
+      if(std::abs(int64_t(t1_1 - t1_2))>50){
+	flag = 5;
+	if (fVerbose) 
+	  mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
+	    << "*** FEB A delta_t greater than 54! delta_t = " 
+	    << int64_t(t1_1 - t1_2) << ", setting flag == 5 ... \n";
+      }
 
       if (fVerbose)
         mf::LogInfo("CRTHitRecoAlg: ")
@@ -1046,8 +1063,24 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
       // if (foutCSVFile) filecsv << plane << "\t"<<  int64_t(t2_1 - t2_2) <<
       // "\n";
       float zaxixpos = 0.5 * (int64_t(t2_1 - t2_2) / fPropDelay);
-
       posB = adsGeo.GetCenter() + geo::Zaxis() * zaxixpos;
+      if (fVerbose)
+	mf::LogInfo("CRTHitRecoAlg:MakeSideHit") 
+	  << "---\n\tFEB B: (mac_1,mac_2 = " << (int)infn.mac5s << "," 
+	  << (int)informationB[i+1].mac5s << "), delta_t = t2_1 - t2_2 = " 
+	  << t2_1 << " - " << t2_2 << " = " << int64_t(t2_1 - t2_2) << "\n"
+	  << "\tFEB B z hit pos = .5*(delta_t)/prop + center = .5*(" 
+	  << int64_t(t2_1 - t2_2) << ")/ "<< fPropDelay << " + " 
+	  << 1.0*adsGeo.GetCenter().Z() << " = " << posB.Z() << "\n";
+
+      // *** Flag 5: Check and flag if 2nd modules delta_t > 50 ns
+      if(std::abs(int64_t(t2_1 - t2_2))>50){
+	flag = 5;
+	if (fVerbose)
+	  mf::LogInfo("CRTHitRecoAlg:MakeSideHit")
+	    << "*** FEB B delta_t greater than 54! delta_t = "
+	    << int64_t(t2_1 - t2_2) << ", setting flag == 5 ... \n";
+      }
 
       if (fVerbose)
         mf::LogInfo("CRTHitRecoAlg:")

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -1389,7 +1389,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
     std::cout << "flag = " << flag << "\n-------------------------------\n";
   }
   // generate hit
-  CRTHit hit = FillCRTHit(macs, pesmap, petot, thit, flag, thit1, plane, hitpoint[0],
+  CRTHit hit = FillCRTHit(macs, pesmap, petot, flag, thit, thit1, plane, hitpoint[0],
                           hitpointerr[0], hitpoint[1], hitpointerr[1],
                           hitpoint[2], hitpointerr[2], region);
 

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -1300,7 +1300,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
     hitpointerr[1] = adsGeo.HalfWidth1() * 2 / sqrt(12);
     hitpointerr[2] = (zmax - zmin) / sqrt(12);
   }
-  if (flag == 6 and region!="South" && region!="North"){
+  if (flag == 5 and region!="South" && region!="North"){
     if (fVerbose)
       mf::LogInfo("CRTHitRecoAlg:")
 	<< "single ended readout on same end of module! "

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -72,12 +72,6 @@ vector<art::Ptr<CRTData>> CRTHitRecoAlg::PreselectCRTData(
             !crtList[febdat_i]->IsReference_TS0())
           continue;  // filter out low PE and non-T1 and non-T0 ref values
         presel = true;
-        /*if (fVerbose)
-          mf::LogInfo("CRTHitRecoAlg: ")
-              << "\nfebP (mac5, channel, gain, pedestal, adc, pe) = ("
-              << (int)crtList[febdat_i]->fMac5 << ", " << chan << ", "
-              << chg_cal.first << ", " << chg_cal.second << ","
-              << crtList[febdat_i]->fAdc[chan] << "," << pe << ")\n";*/
       }
     } else if (type == 'c') { // 'c' = CERN, Top CRTs
       for (int chan = 0; chan < 32; chan++) {
@@ -597,22 +591,13 @@ sbn::crt::CRTHit CRTHitRecoAlg::MakeSideHit(
   std::vector<int> layID, febA, febB;
 
   uint64_t southt0_v = -999, southt0_h = -999;
-  int layA = fCrtutils.GetMINOSLayerID(adid); // layer ID
   // loop over coinData to group FEBs into inner or outer layers (febA or febB)
   for (auto const& data : coinData) {
-    int modID = (int)fCrtutils.MacToAuxDetID((int)data->fMac5, 0);
-    int lay_X = fCrtutils.GetMINOSLayerID(modID); //layerID of data entry in coinData
     if (adid == (int)fCrtutils.MacToAuxDetID((int)data->fMac5, 0)) {
       febA.push_back(data->fMac5);
-      if (fVerbose)
-	mf::LogInfo("CRTHitRecoAlg: ") 
-	  << "FEB A: mac " << int(data->fMac5) << ", modID " << modID << ", layer " << layA << "\n";
     } 
     else {
       febB.push_back(data->fMac5);
-      if (fVerbose)
-	mf::LogInfo("CRTHitRecoAlg: ") 
-	  << "FEB B: mac " << int(data->fMac5) << ", modID " << modID << ", layer " << lay_X << "\n";
     }
   }
   if (fVerbose)

--- a/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/icaruscode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -90,7 +90,7 @@ class icarus::crt::CRTHitRecoAlg {
   // Function to make filling a CRTHit a bit faster
   CRTHit FillCRTHit(vector<uint8_t> tfeb_id,
                     map<uint8_t, vector<pair<int, float>>> tpesmap,
-                    float peshit, uint64_t time0, Long64_t time1, int plane,
+                    float peshit, double flag, uint64_t time0, Long64_t time1, int plane,
                     double x, double ex, double y, double ey, double z,
                     double ez, string tagger);
 

--- a/icaruscode/CRT/CRTUtils/CRTTrackRecoAlg.cc
+++ b/icaruscode/CRT/CRTUtils/CRTTrackRecoAlg.cc
@@ -249,7 +249,7 @@ sbn::crt::CRTHit CRTTrackRecoAlg::DoAverage(vector<art::Ptr<sbn::crt::CRTHit>> h
   }
 
   // Create a hit
-  sbn::crt::CRTHit crtHit = hitAlg.FillCRTHit(hits[0]->feb_id, hits[0]->pesmap, hits[0]->peshit, 
+  sbn::crt::CRTHit crtHit = hitAlg.FillCRTHit(hits[0]->feb_id, hits[0]->pesmap, hits[0]->peshit, 0, 
                                   (ts0_ns/nhits)*1e-3, (ts1_ns/nhits)*1e-3, hits[0]->plane, xpos/nhits, (xmax-xmin)/2,
                                   ypos/nhits, (ymax-ymin)/2., zpos/nhits, (zmax-zmin)/2., tagger);
 


### PR DESCRIPTION
This PR adds a CRT Hit flag to help identify some cases where the Z-position reconstruction for side CRT hits isnt so good.
The Side CRT Hit are made of coincidences between inner and outer layers, with two layers being readout on opposite ends by two different FEBs (For East and West Side CRT walls only, North and South Side CRT walls use cut modules and readout on a single end).
In some cases, the Side CRT Hit Z position can be reconstructed off the bounds of the module wall due to the FEB readouts on opposite ends being too far apart in time (T0 timestamps on opposite ends of the module are >= 50 ns apart, 50 ns ~ 800 m (full module length) x 0.062 ns/cm (prop delay)). These CRT Hits are flagged with flag = 4. We also see a large collection of CRT Hits with a final Z defaulted to the exact center of the module from single ended readouts on the same end of the module in both layers, which are flaged with flag = 5. I also flag CRT Hits that had timestamps on opposite ends >= 50 ns but are still reconstructed within module bounds with flag = 3.
This PR flags the badly reconstructed side CRT Hits (with flags 4 and 5) so the analyzer can choose whether or not to remove those CRT Hits, which one might want to do if the analysis is CRT position dependent. If wanting to be extra conservative, one might also want to remove CRT Hits with flag = 3. 
