### PR TITLE
Set SaveGENIEEventRecord as true be default cafmaker fcl

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -330,6 +330,7 @@ cafmaker.TriggerLabel: "emuTrigger"
 cafmaker.FlashTrigLabel: "" # unavailable
 cafmaker.SimChannelLabel: "largeant"
 cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]
+cafmaker.SaveGENIEEventRecord: true # save GENIE event record by default. Turn this off for data cafmaker fcl
 cafmaker.TPCPMTBarycenterMatchLabel: "tpcpmtbarycentermatch"
 cafmaker.TrackHitFillRREndCut: 30 # include entire PID region
 

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -30,5 +30,6 @@ physics.producers.cafmaker.G4Label: ""
 physics.producers.cafmaker.GenLabel: ""
 physics.producers.cafmaker.SimChannelLabel: ""
 physics.producers.cafmaker.SystWeightLabels: []
+physics.producers.cafmaker.SaveGENIEEventRecord: false
 
 physics.producers.cafmaker.TriggerLabel: "daqTrigger" # the general configuration, for MC, has a different one (see also https://github.com/SBNSoftware/icaruscode/issues/556)


### PR DESCRIPTION
From https://github.com/SBNSoftware/sbncode/pull/459, which is merged to develop, I added a feature to save GENIE event record to the CAFMaker output. Here I set the default value of a boolean, `SaveGENIEEventRecord`, to `true`; this is crucial to constantly adopt new cross-section systematics without re-running CAFMaker job. More importantly, we now stopped updating [LarSoft/nusystematics](https://github.com/larsoft/nusystematics) but moved to [NuSystematics/nusystematics](https://github.com/NuSystematics/nusystematics), and there are some missing dials that we cannot currently evaluate from `lar` based jobs. We can add those once we have GENIE record saved together with StandarRecord.