### PR TITLE
Fix wrong comment in PMTsimulationAlg

### DIFF
--- a/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
+++ b/icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
@@ -124,7 +124,7 @@ icarus::opdet::PMTsimulationAlg::PMTsimulationAlg
     mf::LogWarning("PMTsimulationAlg")
       << "WARNING: Quantum efficiency set in the configuration (QE="
         << fParams.QEbase << ") seems to be too large!"
-      "\nThe photon visibility library is assumed to already include a"
+      "\nAccording to the job configuration, the input already includes a"
         " quantum efficiency of " << fParams.larProp->ScintPreScale() <<
         " (`ScintPreScale` setting of `LArProperties` service)"
         " and here we are requesting a higher one."


### PR DESCRIPTION
I just got fed up of reading that wrong information, probably because it was me to write it.

So the photon library does not include any quantum efficiency; the quantum efficiency is applied before writing the scintillation photons (`sim::SimPhotons[Lite]`) in `G4` stage.

Reviewer is who picks the shortest straw... @amenegol.