### PR TITLE
Updating fhicls for 2023A NuMI reproecssing

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -314,6 +314,7 @@ cafmaker.TriggerLabel: "emuTrigger"
 cafmaker.FlashTrigLabel: "" # unavailable
 cafmaker.SimChannelLabel: "largeant"
 cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]
+cafmaker.SaveGENIEEventRecord: true # save GENIE event record by default. Turn this off for data cafmaker fcl
 cafmaker.TPCPMTBarycenterMatchLabel: "tpcpmtbarycentermatch"
 cafmaker.TrackHitFillRREndCut: 30 # include entire PID region
 

--- a/fcl/caf/cafmakerjob_icarus_data.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data.fcl
@@ -30,6 +30,7 @@ physics.producers.cafmaker.G4Label: ""
 physics.producers.cafmaker.GenLabel: ""
 physics.producers.cafmaker.SimChannelLabel: ""
 physics.producers.cafmaker.SystWeightLabels: []
+physics.producers.cafmaker.SaveGENIEEventRecord: false
 
 # use different angular resolution for MCS in data
 physics.producers.pandoraTrackMCSCryoE: @local::mcs_icarus_data

--- a/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
@@ -51,7 +51,7 @@ physics.end_paths:         [ outana, stream1 ]
 source.inputCommands: [
   "keep *_*_*_*",
   "drop *_*_*_stage1",
-  "keep *_crthit_*_stage1" # Run1 input stage 1files have crthit objects produced during the stage1 step, so we should not drop them here
+  "keep *_crthit_*_stage1" # Run1 input stage1 files have crthit objects produced during the stage1 step, so we should not drop them here
 ]
 
 physics.analyzers.caloskimE.SelectEvents: [ runprod ]

--- a/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
@@ -35,9 +35,10 @@ physics.analyzers: {
 physics.runprod: [
   @sequence::icarus_filter_cluster3D,
   @sequence::icarus_pandora_Gauss,
-  # @sequence::icarus_reco_fm,
-  # @sequence::icarus_crttrack,
-  # @sequence::icarus_crtt0match,
+  @sequence::icarus_reco_fm,
+  @sequence::icarus_tpcpmtbarycentermatch,
+  @sequence::icarus_crttrack,
+  @sequence::icarus_crtt0match,
   caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
   
   @sequence::physics.runprod
@@ -50,7 +51,8 @@ physics.end_paths:         [ outana, stream1 ]
 
 source.inputCommands: [
   "keep *_*_*_*",
-  "drop *_*_*_stage1"
+  "drop *_*_*_stage1",
+  "keep *_crthit_*_stage1" # Run1 input files has crthit objects produced during stage1, and we need to save ethem
 ]
 
 physics.analyzers.caloskimE.SelectEvents: [ runprod ]

--- a/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
@@ -52,7 +52,7 @@ physics.end_paths:         [ outana, stream1 ]
 source.inputCommands: [
   "keep *_*_*_*",
   "drop *_*_*_stage1",
-  "keep *_crthit_*_stage1" # Run1 input files has crthit objects produced during stage1, and we need to save ethem
+  "keep *_crthit_*_stage1" # Run1 input stage 1files have crthit objects produced during the stage1 step, so we should not drop them here
 ]
 
 physics.analyzers.caloskimE.SelectEvents: [ runprod ]

--- a/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
+++ b/fcl/caf/cafmakerjob_icarus_data_rereco_numi.fcl
@@ -3,7 +3,6 @@
 #   gputnam_DMCP2023F_F-Run1-OnBeam_flatcafs, gputnam_DMCP2023F_F2-Run2-OffBeam_flatcafs,
 #   gputnam_DMCP2023F_F4-Run2-OnBeam_flatcafs, gputnam_DMCP2023F_F-Run1-OffBeam_flatcafs
 # - Redo stage1 and then run cafmaker in a single job
-# - Skipping flash matching and crt related modules
 
 #include "stage1_icarus_defs.fcl"
 #include "cafmakerjob_icarus_data.fcl"

--- a/fcl/caf/cafmakerjob_rereco_numi_icarus_systtools_and_fluxwgt.fcl
+++ b/fcl/caf/cafmakerjob_rereco_numi_icarus_systtools_and_fluxwgt.fcl
@@ -36,9 +36,10 @@ physics.runprod: [
   rns, 
   @sequence::icarus_filter_cluster3D,
   @sequence::icarus_pandora_Gauss,
-  # @sequence::icarus_reco_fm,
-  # @sequence::icarus_crttrack,
-  # @sequence::icarus_crtt0match,
+  @sequence::icarus_reco_fm,
+  @sequence::icarus_tpcpmtbarycentermatch,
+  @sequence::icarus_crttrack,
+  @sequence::icarus_crtt0match,
   caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
   systtools, fluxweight,
   

--- a/fcl/caf/cafmakerjob_rereco_numi_icarus_systtools_and_fluxwgt_ReprocRelease.fcl
+++ b/fcl/caf/cafmakerjob_rereco_numi_icarus_systtools_and_fluxwgt_ReprocRelease.fcl
@@ -34,9 +34,10 @@ physics.runprod: [
   rns, 
   @sequence::icarus_filter_cluster3D,
   @sequence::icarus_pandora_Gauss,
-  # @sequence::icarus_reco_fm,
-  # @sequence::icarus_crttrack,
-  # @sequence::icarus_crtt0match,
+  @sequence::icarus_reco_fm,
+  @sequence::icarus_tpcpmtbarycentermatch,
+  @sequence::icarus_crttrack,
+  @sequence::icarus_crtt0match,
   caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
   systtools, fluxweight,
   

--- a/fcl/caf/cafmakerjob_rereco_numi_icarus_systtools_and_fluxwgt_ReprocRelease_stage1.fcl
+++ b/fcl/caf/cafmakerjob_rereco_numi_icarus_systtools_and_fluxwgt_ReprocRelease_stage1.fcl
@@ -40,9 +40,10 @@ physics.runprod: [
   rns, 
   @sequence::icarus_filter_cluster3D,
   @sequence::icarus_pandora_Gauss,
-  # @sequence::icarus_reco_fm,
-  # @sequence::icarus_crttrack,
-  # @sequence::icarus_crtt0match,
+  @sequence::icarus_reco_fm,
+  @sequence::icarus_tpcpmtbarycentermatch,
+  @sequence::icarus_crttrack,
+  @sequence::icarus_crtt0match,
   caloskimCalorimetryCryoE, caloskimCalorimetryCryoW
 ]
 

--- a/icaruscode/CRT/crtpmtmatchingproducer_icarus_numi_Run1_ReprocRelease.fcl
+++ b/icaruscode/CRT/crtpmtmatchingproducer_icarus_numi_Run1_ReprocRelease.fcl
@@ -1,0 +1,2 @@
+#include "crtpmtmatchingproducer_icarus.fcl"
+services.Geometry: @local::icarus_geometry_services_no_overburden_legacy_icarus_v3.Geometry


### PR DESCRIPTION
There was a request to adding CRT-PMT matching, FlashMatching, and barycenter FlashMatching back to our reprocessing, for the inclusive muon analysis. This PR includes necessary fhicl updates for that. For our Run1 data inputfiles (stage1), they have crthit objects produced during the `stage1`, so we should not drop them; so made an update in  `source.inputCommands`. It was `MCstage0` stage for the MC, so it's fine.
Also cherry-picked https://github.com/SBNSoftware/icaruscode/pull/739; this is to save GENIE EventRecord as a default MC cafmaker.