### PR TITLE
Update FluxSearchPaths to point to the latest NuMI flux production

### DIFF
--- a/fcl/gen/numi/genie_icarus_numioffaxis.fcl
+++ b/fcl/gen/numi/genie_icarus_numioffaxis.fcl
@@ -57,8 +57,8 @@ icarus_genie_NuMI_base: {
   FluxType:             "dk2nu"
   BeamName:             "numi"
   DetectorLocation:     "icarus-numi"
-  FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v02_00/"
-  FluxFiles:            ["g4numiv6_minervame*.root"]
+  FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v03_00/"
+  FluxFiles:            ["g4numi*.root"]
   
   POTPerSpill:          6.0e13 # same as BnB per batch, but 6 batches in spill
   
@@ -92,7 +92,7 @@ icarus_genie_NuMI_rock.DetectorLocation: "icarus-numi-rock"
 
 # RHC Config
 icarus_genie_NuMI_RHC: @local::icarus_genie_NuMI
-icarus_genie_NuMI_RHC.FluxSearchPaths: "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v02_00_RHC/"
+icarus_genie_NuMI_RHC.FluxSearchPaths: "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v03_00_RHC/"
 
 ################################################################################
 


### PR DESCRIPTION
This is a new set of NuMI flux files produced from the `main_modern_g4` branch of G4NuMI. These files include important fixes to the NuMI geometry and physics modeling. Currently, each of the two FHC/RHC directories contain 1000 files x 500k POT, totaling 500M POT. This will be expanded to 2B POT in the near future as soon as the space to accommodate the full production is made available.

This PR resolves the first task outlined in #746.