### PR TITLE
Fixes from Clang compilation errors

### DIFF
--- a/icaruscode/Decode/ChannelMapping/Legacy/ChannelMapPostGres_tool.cc
+++ b/icaruscode/Decode/ChannelMapping/Legacy/ChannelMapPostGres_tool.cc
@@ -29,7 +29,7 @@
 #include "fhiclcpp/types/TableFragment.h"
 
 
-namespace icarusDB { class ChannelMapPostGresTool; }
+namespace icarusDB { struct ChannelMapPostGresTool; }
 
 /// Toolification of `icarusDB::ChannelMapPostGres`.
 struct icarusDB::ChannelMapPostGresTool: public icarusDB::ChannelMapPostGres {

--- a/icaruscode/Decode/ChannelMapping/Legacy/ChannelMapSQLite_tool.cc
+++ b/icaruscode/Decode/ChannelMapping/Legacy/ChannelMapSQLite_tool.cc
@@ -29,7 +29,7 @@
 #include "fhiclcpp/types/TableFragment.h"
 
 
-namespace icarusDB { class ChannelMapSQLiteTool; }
+namespace icarusDB { struct ChannelMapSQLiteTool; }
 
 /// Toolification of `icarusDB::ChannelMapSQLite`.
 struct icarusDB::ChannelMapSQLiteTool: public icarusDB::ChannelMapSQLite {

--- a/icaruscode/PMT/Algorithms/ParsingToolkit.h
+++ b/icaruscode/PMT/Algorithms/ParsingToolkit.h
@@ -642,6 +642,7 @@ std::string_view icarus::ParsingToolkit::findFirstUnescaped
     std::size_t pos = 0;
     while (pos < sv.length()) {
       pos = sv.find(*iKey, pos);
+      if (pos == std::string_view::npos) break;
       if (!isCharacterEscaped(sv.begin(), sv.begin() + pos)) break;
       ++pos;
     }

--- a/icaruscode/PMT/Calibration/CaloTools/SPEChargeLogisticResponse.h
+++ b/icaruscode/PMT/Calibration/CaloTools/SPEChargeLogisticResponse.h
@@ -1,5 +1,5 @@
 #ifndef __SPEChargeLogisticResponse_H
-#define __SPEChargeLogitsticResponse_H
+#define __SPEChargeLogisticResponse_H
 
 #include "TMath.h"
 

--- a/icaruscode/PMT/OpReco/ICARUSBeamStructureAna_module.cc
+++ b/icaruscode/PMT/OpReco/ICARUSBeamStructureAna_module.cc
@@ -96,7 +96,7 @@ public:
   void clear();
 
   void analyze(art::Event const &e) override;
-  void beginJob();
+  void beginJob() override;
   void beginRun(const art::Run &run) override;
 
 private:

--- a/icaruscode/PMT/OpReco/ICARUSFlashAssAna_module.cc
+++ b/icaruscode/PMT/OpReco/ICARUSFlashAssAna_module.cc
@@ -166,7 +166,6 @@ private:
   std::vector<art::InputTag> fFlashLabels;
   art::InputTag fRWMLabel;
   float fPEOpHitThreshold;
-  bool fDebug;
 
   //----------
   // Output trees

--- a/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.h
+++ b/icaruscode/PMT/Trigger/Algorithms/LVDSbitMaps.h
@@ -142,8 +142,7 @@ struct icarus::trigger::PMTpairBitID: public details::PMTwallBitID<64> {
   using BaseID_t = details::PMTwallBitID<64>;
   
   /// Rebuilds an ID object from its index.
-  static PMTpairBitID fromIndex(Index_t index)
-    { return { BaseID_t::fromIndex(index) }; }
+  static PMTpairBitID fromIndex(Index_t index);
   
 }; // icarus::trigger::PMTpairBitID
 
@@ -156,8 +155,7 @@ struct icarus::trigger::AdderBitID: public details::PMTwallBitID<16> {
   using BaseID_t = details::PMTwallBitID<16>;
   
   /// Rebuilds an ID object from its index.
-  static AdderBitID fromIndex(Index_t index)
-    { return { BaseID_t::fromIndex(index) }; }
+  static AdderBitID fromIndex(Index_t index);
   
 }; // icarus::trigger::AdderBitID
 
@@ -621,6 +619,25 @@ std::ostream& icarus::trigger::details::operator<<
     << '/' << std::setw(2) << std::setfill('0') << bit.statusBit
     << std::setfill(fillch);
   return out;
+}
+
+
+// -----------------------------------------------------------------------------
+// ---  icarus::trigger::PMTpairBitID
+// -----------------------------------------------------------------------------
+inline auto icarus::trigger::PMTpairBitID::fromIndex(Index_t index)
+  -> PMTpairBitID
+{
+  return { BaseID_t::fromIndex(index) };
+}
+
+
+// -----------------------------------------------------------------------------
+// ---  icarus::trigger::AdderBitID
+// -----------------------------------------------------------------------------
+inline auto icarus::trigger::AdderBitID::fromIndex(Index_t index) -> AdderBitID
+{
+  return { BaseID_t::fromIndex(index) };
 }
 
 


### PR DESCRIPTION
Clang 14 (`c14:prof`) complains about a few lines of code.
While the merit of the complains is arguable (not plain wrong, nor right), "fixing" the code is cheap, and needed if we want to compile with Clang.
The fixes are simple and technical.

Reviewers: who is the Collaboration C++ expert?