### PR TITLE
Update EMB calibration to published values

### DIFF
--- a/icaruscode/TPC/Calorimetry/calorimetryICARUS.fcl
+++ b/icaruscode/TPC/Calorimetry/calorimetryICARUS.fcl
@@ -13,9 +13,10 @@ icarus_calorimetryalgmc.CalAreaConstants: [0.01343, 0.01338, 0.01219]
 
 icarus_calorimetryalgdata.CalAreaConstants: @local::icarus_data_calconst
 icarus_calorimetryalgdata.CaloDoLifeTimeCorrection: false # handled by NormTools
-icarus_calorimetryalgdata.ModBoxA: 0.903
+# EMB alpha and B90 values from: https://arxiv.org/pdf/2407.12969
+icarus_calorimetryalgdata.ModBoxA: 0.904
 icarus_calorimetryalgdata.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/180)**2 + TMath::Cos(x*TMath::Pi()/180)**2/[1]**2)"
-icarus_calorimetryalgdata.ModBoxBParam: [0.205, 1.25]
+icarus_calorimetryalgdata.ModBoxBParam: [0.204, 1.25]
 
 standard_gnocchicaloicarus:
 {

--- a/icaruscode/TPC/Calorimetry/normtools_icarus.fcl
+++ b/icaruscode/TPC/Calorimetry/normtools_icarus.fcl
@@ -61,8 +61,8 @@ yznorm_sql: {
 #icarus_calonormtools: [@local::driftnorm, @local::yznorm, @local::tpcgain]
  icarus_calonormtools: [@local::driftnorm_sql, @local::yznorm_sql, @local::tpcgain_sql]
 
-# Gain with angular dep. recombination
+# Gain with angular dep. recombination. Measurement from: https://arxiv.org/pdf/2407.12969
 # Assume equal on planes -- this is __wrong__ -- will need to be fixed when they are calibrated
-icarus_data_calconst: [0.013351, 0.013351, 0.013351]
+icarus_data_calconst: [0.0133333, 0.0133333, 0.0133333]
 
 END_PROLOG


### PR DESCRIPTION
The values shifted slightly in preparation for publication. Now they are official: https://arxiv.org/abs/2407.12969