### PR TITLE
stage0_run2_rawpmt_icarus.fcl: Stage0 configuration preserving PMT waveforms

### DIFF
--- a/fcl/reco/Stage0/Run2/stage0_run2_rawpmt_icarus.fcl
+++ b/fcl/reco/Stage0/Run2/stage0_run2_rawpmt_icarus.fcl
@@ -1,0 +1,26 @@
+# File:    stage0_run2_rawpmt_icarus.fcl
+# Purpose: ICARUS Stage0 data processing with preservation of all PMT waveforms.
+# Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
+# Date:    August 19, 2024
+#
+# This configuration is a spin-off of the standard "Run2" Stage0 configuration.
+# While that configuration creates and saves a copy of the PMT waveforms at
+# beam gate time and then drops the data product of all the waveforms, this one
+# saves all the PMT waveforms and drops the data product with only the ones
+# at beam gate time (`daqPMTonbeam`).
+# 
+# The module `daqPMTonbeam` is still run, because it's much simpler not to
+# touch that part of the configuration, and also because some downstream code
+# might need the side products of that module.
+# 
+# This configuration was tailored on `stage0_run2_icarus.fcl` from
+# icaruscode `v09_90_00`.
+#
+
+#include "stage0_run2_icarus.fcl"
+
+outputs.rootOutput.outputCommands: [
+    @sequence::outputs.rootOutput.outputCommands
+  , "keep raw::OpDetWaveforms_*_*_*"
+  , "drop raw::OpDetWaveforms_daqPMTonbeam_*_*"  # do not keep the duplicate "on beam"
+]


### PR DESCRIPTION
This requests adds `stage0_run2_rawpmt_icarus.fcl`, a Stage0 job configuration which keeps all PMT waveforms.
It is intended for special runs and for reference runs that people can use for detailed studies (for example, request for Run3 runs `11813` and `11816` is ongoing).


## Details

The standard configuration, `run3_stage0_icarus.fcl`, duplicates the PMT waveforms including the trigger time (new data product `daqPMTonbeam`) and then drops the complete PMT data product (`daqPMT`), except for the special PMT waveforms that are stored in their own data products.
The new configuration does not drop, but rather keeps, the `daqPMT` original waveforms.
To reduce the waste, the PMT waveforms from `daqPMTonbeam` are instead dropped (the other data products it produces are instead preserved).
The module producing `daqPMTonbeam` is still kept, with the rationale that it's complicate to safely purge it from the configuration (removing sequence elements in FHiCL is much more prone to errors than adding them), and some downstream modules might still need the additional data products that it produces.


## Impact

This configuration it is not meant for standard production/keep-up.
When chosen, it has shown to yield output files 30% larger than a standard Stage1 _art_/ROOT job.
Note that another configuration is already present in the repository, `stage0_run2_raw_icarus.fcl`, which preserves both PMT and TPC waveforms.


## Review

This configuration is intended to be merged in `develop` and to be available for official production requests.

Reviewers:
* @SFBayLaser , maintainer of the workflow and also of the directory structure in `icaruscode`; in fact, please let me know if you would rather have;
* @amenegol , PMT reconstruction coordinator.