### PR TITLE
Run-time bug fixes for PR#751

### DIFF
--- a/icaruscode/IcarusObj/classes.h
+++ b/icaruscode/IcarusObj/classes.h
@@ -6,6 +6,7 @@
 #include "icaruscode/IcarusObj/CRTTPCMatchingInfo.h"
 #include "icaruscode/IcarusObj/OpDetWaveformMeta.h"
 #include "icaruscode/IcarusObj/PMTWaveformTimeCorrection.h"
+#include "icaruscode/IcarusObj/PMTBeamSignal.h"
 #include "icaruscode/IcarusObj/Hit.h"
 //#include "icaruscode/IcarusObj/CRTPMTMatching.h"
 

--- a/icaruscode/IcarusObj/classes_def.xml
+++ b/icaruscode/IcarusObj/classes_def.xml
@@ -42,6 +42,12 @@
   <class name="art::Wrapper<std::vector<icarus::timing::PMTWaveformTimeCorrection> >"/>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <!-- icarus::timing::PMTBeamSignal -->
+  <class name="art::Wrapper<vector<icarus::timing::PMTBeamSignal> >"/>
+  <class name="icarus::timing::PMTBeamSignal"/>
+  <class name="vector<icarus::timing::PMTBeamSignal>"/>
+
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
   <!-- LArSoft object associations that are missing from LArSoft             -->
   
   <!-- recob::PFParticle - sim::BeamGateInfo associations -->

--- a/icaruscode/PMT/OpReco/ICARUSFlashAssAna_module.cc
+++ b/icaruscode/PMT/OpReco/ICARUSFlashAssAna_module.cc
@@ -107,10 +107,6 @@ public:
         Name("PEOpHitThreshold"),
         Comment("Threshold in PE for an OpHit to be considered in the information calculated for a flash")};
 
-    fhicl::Atom<bool> Debug{
-        Name("Debug"),
-        Comment("Be more verbose"),
-        false};
   };
 
   using Parameters = art::EDAnalyzer::Table<Config>;
@@ -271,7 +267,6 @@ opana::ICARUSFlashAssAna::ICARUSFlashAssAna(Parameters const &config)
       fFlashLabels(config().FlashLabels()),
       fRWMLabel(config().RWMLabel()),
       fPEOpHitThreshold(config().PEOpHitThreshold()),
-      fDebug(config().Debug()),
       fGeom(lar::providerFrom<geo::Geometry>())
 {
 }

--- a/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
@@ -103,7 +103,7 @@ ICARUSParticleAna: {
 ICARUSFlashAssAna: {
     module_type: "ICARUSFlashAssAna"
     TriggerLabel: "daqTrigger"
-    DumpWaveformsInfo: true
+    DumpWaveformsInfo: false
     SaveRawWaveforms: false
     UseSharedBaseline: true
     OpDetWaveformLabels: ["daqPMT"]

--- a/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
+++ b/icaruscode/PMT/OpReco/fcl/icarus_opana_modules.fcl
@@ -112,7 +112,6 @@ ICARUSFlashAssAna: {
     FlashLabels: ["opflashCryoE", "opflashCryoW"]
     RWMLabel: "beamTiming:RWM"
     PEOpHitThreshold: 0
-    Debug: false
 }
 
 ICARUSBeamStructureAna: {


### PR DESCRIPTION
Last minute fixes for runtime bugs coming from new code of #751 .
Thanks to @aheggest for spotting them!

* Added missing dictionary definitions for the new `PMTBeamSignal` structure.
* Disabled waveform ouput tree from `ICARUSFlashAssAna` in stage1 (no optical waveforms available).
* Removed useless debug flag (does nothing, goes nowhere)
