### PR TITLE
This fixed a CRTPMTMatchingProducer bug.

### DIFF
--- a/icaruscode/CRT/CRTPMTMatchingAna_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingAna_module.cc
@@ -158,9 +158,9 @@ icarus::crt::MatchedCRT CRTHitmatched(
     MatchType = exTop;
   else if (topen == 0 && sideen == 0 && topex == 0 && sideex == 1)
     MatchType = exSide;
-  else if (topen >= 1 && sideen >= 1 && topex == 0 && sideex == 0)
+  else if (topen >= 1 && sideen == 0 && topex == 0 && sideex == 0)
     MatchType = enTop_mult;
-  else if (topen >= 1 && sideen >= 1 && topex == 0 && sideex >= 1)
+  else if (topen >= 1 && sideen == 0 && topex == 0 && sideex >= 1)
     MatchType = enTop_exSide_mult;
   else
     MatchType = others;

--- a/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
@@ -596,7 +596,7 @@ namespace sbn::crt {
         = thisRelGateTime > inBeamMin && thisRelGateTime < inBeamMax;
       
       icarus::crt::CRTMatches const crtMatches = icarus::crt::CRTHitmatched(
-        firstOpHitPeakTime, flash_pos, crtHitList, fTimeOfFlightInterval, isRealData, fGlobalT0Offset, fMatchBottomCRT);
+        tflash, flash_pos, crtHitList, fTimeOfFlightInterval, isRealData, fGlobalT0Offset, fMatchBottomCRT);
       
       std::vector<MatchedCRT> thisFlashCRTmatches;
         std::vector<art::Ptr<sbn::crt::CRTHit>> CRTPtrs; // same order as thisFlashCRTmatches

--- a/icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.cxx
+++ b/icaruscode/CRT/CRTUtils/CRTPMTMatchingUtils.cxx
@@ -109,9 +109,9 @@ icarus::crt::CRTMatches icarus::crt::CRTHitmatched(
   else if (topen == 0 && sideen == 0 && topex == 0 && sideex == 1)
     if(bottomex==0 && bottomen==1) flashType = MatchType::exSide_enBottom;
     else flashType = MatchType::exSide;
-  else if (topen >= 1 && sideen >= 1 && topex == 0 && sideex == 0) // could also add `if (MatchBottomCRT)` here
+  else if (topen >= 1 && sideen == 0 && topex == 0 && sideex == 0) // could also add `if (MatchBottomCRT)` here
     flashType = MatchType::enTop_mult; 
-  else if (topen >= 1 && sideen >= 1 && topex == 0 && sideex >= 1) // and here 
+  else if (topen >= 1 && sideen == 0 && topex == 0 && sideex >= 1) // and here 
     flashType = MatchType::enTop_exSide_mult;
   else
     flashType = MatchType::others;


### PR DESCRIPTION
The flashClassification was based on the first Optical Hit Peak time, but the time differences stored in the data product were evaluated wrt the flash time. Flash time is the correct variable to be used. This fix is already included in develop release.
