### PR TITLE
Committing CAFmaker changes needed for full electron lifetime variations

### DIFF
--- a/fcl/syst_variations/cafmakerjob_icarus_variation_lifetimehi.fcl
+++ b/fcl/syst_variations/cafmakerjob_icarus_variation_lifetimehi.fcl
@@ -1,0 +1,5 @@
+#include "cafmakerjob_icarus.fcl"
+#include "cafmaker_add_detsim2d_icarus.fcl"
+
+#Average value of e- lifetime in West Cryostat in Run 2 (8.0 ms in West cryostat)
+services.DetectorPropertiesService.Electronlifetime: 8000

--- a/fcl/syst_variations/cafmakerjob_icarus_variation_lifetimelow.fcl
+++ b/fcl/syst_variations/cafmakerjob_icarus_variation_lifetimelow.fcl
@@ -1,0 +1,5 @@
+#include "cafmakerjob_icarus.fcl"
+#include "cafmaker_add_detsim2d_icarus.fcl"
+
+#Average value of e- lifetime in East Cryostat in Run 2 (4.0 ms in East cryostat)
+services.DetectorPropertiesService.Electronlifetime: 4000

--- a/fcl/syst_variations/scrub_stage1_nuonly_variations_icarus.fcl
+++ b/fcl/syst_variations/scrub_stage1_nuonly_variations_icarus.fcl
@@ -1,0 +1,39 @@
+# This fcl purely removes products made in the post-G4step1 processes.
+# This allows for keeping the identical simulated event on the file and running
+# a variation of the downstream detector simulation / reconstruction.
+#
+# Author Jacob Zettlemoyer (jzettle@fnal.gov), originally implemented by H. Lay for SBND
+
+#include "rootoutput_icarus.fcl"
+
+process_name: Scrub
+
+source:
+{
+  module_type:   RootInput
+  inputCommands: [ "keep *_*_*_*",
+  		   "drop *_cosmgen_*_GenBNBbkgr",
+  		   "drop *_*_*_G4Step1",
+  		   "drop *_*_*_G4Step2",
+                   "drop *_*_*_DetSim",
+		   "drop *_*_*_MCstage0",
+                   "drop *_*_*_MCstage1" ]
+}
+
+outputs:
+{
+  out1:
+  {
+    compressionLevel: 1
+    dataTier: "simulated"
+    fileName: "Scrubbed_%tc.root"
+    module_type: "RootOutput"
+    saveMemoryObjectThreshold: 0
+  }
+}
+
+physics:
+{
+  stream1:   [ out1 ]
+  end_paths: [ stream1 ]
+}


### PR DESCRIPTION
This is really a pull request for v09_89_01_01p03 so I think this is the right branch.

This adds the changes in the CAF making to enable to full electron lifetime variation sample. The previous samples did not adjust the lifetime in the reconstruction, only in the simulation which causes an exaggeration of the effect. This PR corrects that and adds the ability to make this adjustment in the reconstruction too.