### PR TITLE
Beam time structure simulation using SBN (shared) GENIE configuration for BNB and NuMI

### DIFF
--- a/fcl/gen/genie/genie_icarus_bnb.fcl
+++ b/fcl/gen/genie/genie_icarus_bnb.fcl
@@ -30,8 +30,7 @@
 #
 #
 
-#include "genie.fcl"
-#include "beamspilltimings.fcl"
+#include "genie_beam_settings.fcl"
 
 BEGIN_PROLOG
 
@@ -45,30 +44,44 @@ BEGIN_PROLOG
 ###
 ### icarus_genie_BNB_base
 ###
+#
+# Based on SBN shared BNB configuration, it adds:
+#  * flux
+#  * simulation volume: detector enclosure (includes both cryostats)
+#  * event dump in the log
+#
+#
 icarus_genie_BNB_base: {
+
+  @table::sbn_genie_BNB_base  # from genie_beam_settings.fcl
   
-  @table::standard_genie # from genie.fcl
-  
+  #
+  # flux
+  #
   FluxType:             "simple_flux"
-  GenFlavors:           [12, 14, -12, -14]
-# TopVolume:            "volTPCActive"
-# TopVolume:            "volCryostat"
-  BeamName:             "booster"
-  EventGeneratorList:   "Default"
 # FluxCopyMethod:       "IFDH"
   FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/BNB/standard/v01_00/"
   FluxFiles:            ["converted_beammc_icarus_*.root"]
-  GHepPrintLevel:       13
-  POTPerSpill:          5.0e12
-  EventsPerSpill:       @erase
+
   
-  GlobalTimeOffset:     0.0 # [ns]
-  RandomTimeOffset:     1600.0 # [ns]
+  #
+  # generation volume
+  #
+# TopVolume:            "volTPCActive"
+# TopVolume:            "volCryostat"
+  TopVolume:            "volDetEnclosure"
+
+  #
+  # GENIE event vdump verbosity
+  #
+  GHepPrintLevel:       13
   
 } # icarus_genie_BNB_base
 
 
+#
 # legacy alias
+#
 icarus_genie_simple: @local::icarus_genie_BNB_base
 
 
@@ -76,14 +89,11 @@ icarus_genie_simple: @local::icarus_genie_BNB_base
 ###  icarus_genie_BNB
 ###
 #
-# Adds BnB time structure.
+# Just as the default.
 #
 icarus_genie_BNB: {
   
   @table::icarus_genie_BNB_base
-  
-  SpillTimeConfig: @local::FNAL_BnB_default # from beamspilltimings.fcl
-  RandomTimeOffset: 0.0 # ns; it's ignored anyway when `SpillTimeConfig` is set
   
 } # icarus_genie_BNB
 

--- a/fcl/gen/numi/genie_icarus_numioffaxis.fcl
+++ b/fcl/gen/numi/genie_icarus_numioffaxis.fcl
@@ -31,7 +31,7 @@
 #   updated NuMI POT to 6+6 batches configuration
 #
 
-#include "genie_icarus_bnb.fcl"
+#include "genie_beam_settings.fcl"
 #include "beamspilltimings.fcl"
 
 
@@ -49,7 +49,7 @@ BEGIN_PROLOG
 ###
 icarus_genie_NuMI_base: {
   
-  @table::icarus_genie_BNB_base # from genie_icarus_bnb.fcl
+  @table::sbn_genie_NuMI_base  # from genie_beam_settings.fcl
   
   #
   # flux
@@ -60,10 +60,18 @@ icarus_genie_NuMI_base: {
   FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v03_00/"
   FluxFiles:            ["g4numi*.root"]
   
-  POTPerSpill:          6.0e13 # same as BnB per batch, but 6 batches in spill
-  
-  RandomTimeOffset:     9600.0 # same batch as BnB, but 6 batches in spill [ns]
+  #
+  # generation volume
+  #
+# TopVolume:            "volTPCActive"
+# TopVolume:            "volCryostat"
+  TopVolume:            "volDetEnclosure"
 
+  #
+  # GENIE event vdump verbosity
+  #
+  GHepPrintLevel:       13
+  
 } # icarus_genie_NuMI_base
 
 
@@ -75,14 +83,11 @@ icarus_genienumi_simple: @local::icarus_genie_NuMI_base
 ### icarus_genie_NuMI
 ###
 #
-# Adds NuMI beam time structure.
+# Just as the default.
 #
 icarus_genie_NuMI: {
   
   @table::icarus_genie_NuMI_base
-  
-  SpillTimeConfig: @local::FNAL_NuMI_default # from beamspilltimings.fcl
-  RandomTimeOffset: 0.0 # ns; it's ignored anyway when `SpillTimeConfig` is set
   
 } # icarus_genie_NuMI
 

--- a/icaruscode/Generators/beamspilltimings.fcl
+++ b/icaruscode/Generators/beamspilltimings.fcl
@@ -2,8 +2,8 @@
 # File:    beamspilltimings.fcl
 # Purpose: Configuration of FNAL beam time structure for GENIEHelper.
 # Author:  Gianluca Petrillo (petrillo@slac.stanford.edu)
-# Date:    August 19, 2019
-# Version: 1.0
+# Date:    December 4, 2024
+# Version: 2.0
 #
 # Configurations are provided to drive GENIEGen/GENIEHelper to produce a
 # neutrino interactions with time distribution reflecting the beam time
@@ -23,66 +23,29 @@
 # -----------------
 # 
 # Assuming there is a configuration `generator` for `GENIEGen`, FHiCL
-# configuration can be amended by appending to it:
+# configuration for a NuMI generation can be amended by appending to it:
 #     
-#     physics.producers.generator.SpillTimeConfig: @local::FNAL_BnB_default
+#     physics.producers.generator.SpillTimeConfig: @local::FNAL_NuMI_default
 #     
-# 
 # 
 # Provided configurations
 # ------------------------
 # 
 # * `FNAL_BnB_default`: settings from `evgb::EvtTimeFNALBeam` itself
+#     (suggested to use SBN configuration directly)
 # * `FNAL_NuMI_default`: settings from `evgb::EvtTimeFNALBeam` itself
 # 
-# 
-# Explanation of the configuration parameters
-# --------------------------------------------
-# 
-# This documentation reflects the configuration string of
-# `evgb::EvtTimeFNALBeam` class in `nugen` `v1_00_01` (`nutools` `v3_02_00`).
-# It is parsed by `evgb::EvtTimeFNALBeam::Config()` (the first word,
-# representing the name of the algorithm, is stripped by the caller,
-# `evgb::GENIEHelper`).
-# The configuration string is, well, a single string, sequence of
-# case-insensitive words separated by blanks (space, tabulation or new line).
-# Parameters are parsed in sequence and the latter overrides the previous.
-# Parameters may appear in any order, except for the algorithm name which must
-# be the first.
-# 
-# * `evgb::EvtTimeFNALBeam`: the algorithm name; `evgb::EvtTimeFNALBeam`
-#     describes a beam spill structured in a contiguous sequence of "batches",
-#     each one with a substructure of "buckets". Some batches can be "disabled",
-#     and some of the buckets at the end of each batch may be empty.
-#     Each bucket has a Gaussian time distribution. See the content of
-#     `nugen/EventGeneratorBase/GENIE/EvtTime*.h` for other possible algorithms.
-# * `intentsity <INT 1> <INT 2> ...  <INT M>` describes the relative intensity
-#     of the batches in the spill, and at the same time it defines the number
-#     _M_ of batches in the spill. A standard setting is to have all the batches
-#     (6 for NuMI, just 1 for BnB) set to `1.0`; `GENIEHelper` will take care of
-#     normalizing the numbers to a sum of 1.
-# * `sigma` or `FWHM` [ns]: the RMS or full width at half maximum peak of the
-#     time structure of a single bucket. The time distribution is always
-#     Gaussian (if specified as FWHM, it is converted to RMS for a Gaussian
-#     distribution).
-# * `dtbucket` [ns]: the time between the peak of two consecutive buckets.
-#     The default value (18.83 ns) assumes an extraction rate of 53.103 MHz.
-# * `nperbatch`, `nfilled`: the number of buckets in each spill, and the number
-#     of those which have actual protons in them. The default values include
-#     84 buckets, of which 81 are filled and the remaining 3, always at the end
-#     of the spill ("notch") are empty.
-# * `global` [ns]: offset of the start of the spill (i.e. the time of the peak
-#     of the first bucket of the first batch) with respect to the start
-#     of the generator time scale (see `detinfo::DetectorClocks`).
-# * `Booster`, `NuMI`: presets including all the above in hard-coded fashion;
-#     avoid using these to have better control and awareness of the settings.
 # 
 # Changes
 # --------
 # 
 # 20190819 (petrillo@slac.stanford.edu) [v1.0]
 #   explicitly pick settings hard-coded in `evgb::EvtTimeFNALBeam`
+# 20241204 (petrillo@slac.stanford.edu) [v2.0]
+#   delegate to SBN configuration (genie_beam_settings.fcl)
 #
+
+#include "genie_beam_settings.fcl"
 
 BEGIN_PROLOG
 
@@ -95,8 +58,9 @@ BEGIN_PROLOG
 # According to the comments in the code, "2.0 - 2.5 ns width for Booster is
 # reasonable", and "it is expected that the Booster width >> NuMI width due to
 # higher electric fields / deeper buckets".
+# It was used by ICARUS before merging parameters with SBN.
 #
-FNAL_BnB_default: "evgb::EvtTimeFNALBeam
+FNAL_BnB_legacy: "evgb::EvtTimeFNALBeam
 intensity  1.0
 sigma      2.00
 dtbucket   18.8313277969
@@ -104,6 +68,12 @@ nperbatch  84
 nfilled    81
 global     0.0
 "
+
+#
+# the default time structure is now taken from SBN;
+# configurations should refer to that one (`beam_structure_BNB`) directly.
+#
+FNAL_BnB_default: @local::beam_structure_BNB.SpillTimeConfig  # from `genie_beam_settings.fcl`
 
 
 ################################################################################
@@ -114,8 +84,9 @@ global     0.0
 # `evgb::EvtTimeFNALBeam` on `nugen` `v1_00_01` for NuMI.
 # According to the comments in the code, "0.75 ns sigma for NuMI comes from
 # MINOS Time-of-Flight paper though it could be currently ~ 1ns".
+# The inter-bunch time has been confirmed by ICARUS (SBN DocDB 34988).
 #
-FNAL_NuMI_default: "evgb::EvtTimeFNALBeam
+FNAL_NuMI_legacy: "evgb::EvtTimeFNALBeam
 intensity  1.0 1.0 1.0 1.0 1.0 1.0
 sigma      0.75
 dtbucket   18.8313277969
@@ -123,6 +94,13 @@ nperbatch  84
 nfilled    81
 global     0.0
 "
+
+#
+# the default time structure is now taken from SBN;
+# configurations should refer to that one (`beam_structure_NuMI`) directly.
+#
+FNAL_NuMI_default: @local::beam_structure_NuMI.SpillTimeConfig  # from `genie_beam_settings.fcl`
+
 
 ################################################################################
 


### PR DESCRIPTION
This is a revamp of the GENIE generation configuration jobs with BNB and NuMI beams:
 * it now relies to a shared SBN configuration (meaning that the new shared configuration is kept in `sbncode` and it is available to SBND too — it's up to them to use it or not);
 * **it enables the beam timing structure simulation**.

Some checks on the beam timing can be found in [SBN DocDB 39065](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=39065).

Reviewers:
 * @leoaliaga, generator expert
 * @betan009, NuMI analyses coordinator
 * @woodtp, expert on NuMI and its flux simulation

Dependent on SBNSoftware/sbncode#492.