### PR TITLE
Removal of the requirement of a certain number of opHit to be above a given threshold - Develop

### DIFF
--- a/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
@@ -581,14 +581,14 @@ namespace sbn::crt {
           << ") cm [" << hits.size() << " op.hits] -> first time: "
           << firstOpHitPeakTime << " us, centroid: " << flash_pos << " cm";
       }
-      
+      /*
       if (nPMTsTriggering < fnOpHitToTrigger) {
         mf::LogTrace("CRTPMTMatchingProducer")
           << "  => skipped (only " << nPMTsTriggering << " < " << fnOpHitToTrigger
           << " hits above threshold)";
         continue;
       }
-      
+      */
       double const thisRelGateTime = triggerGateDiff + tflash * 1e3; // ns
       bool const thisInTime_gate
         = thisRelGateTime > BeamGateMin && thisRelGateTime < BeamGateMax;


### PR DESCRIPTION
As discussed here: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=39068
There was one more issue which needed to be addressed in the CRTPMT matching data product.
The requirement of a specific number of opHits to be above threshold does have some reasoning behind and it is a good way to reject fake flashes, but this is a decision that the analyzers should do, not the data product.
I just comment this part because for our current production we can survive with skipping this requirement.
I probably will follow with opening an issue about the addition of the number of op hit above threshold in the data product (sbnobj) and in the Standard Record (sbnanaobj). At that point I will address this once again in the CRTPMTMatching Producer.