### PR TITLE
TPC YZ correction to use new per-plane database [release/SBN2024A]

### DIFF
--- a/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
+++ b/fcl/configurations/calibration_database_GlobalTags_icarus.fcl
@@ -5,7 +5,7 @@
 BEGIN_PROLOG
 
 ICARUS_Calibration_GlobalTags: {
-  @table::TPC_CalibrationTags_Feb2024
+  @table::TPC_CalibrationTags_Jan2025
   @table::PMT_CalibrationTags_Run3_Dec2023
   @table::CRT_CalibrationTags_Oct2023
 }

--- a/fcl/configurations/calibration_database_TPC_TagSets_icarus.fcl
+++ b/fcl/configurations/calibration_database_TPC_TagSets_icarus.fcl
@@ -26,4 +26,14 @@ TPC_CalibrationTags_Feb2024: {
 
 }
 
+## TPC_CalibrationTags_Feb2024 but updating tpc_yz_correction_data to tpc_yz_correction_allplanes_data
+TPC_CalibrationTags_Jan2025: {
+
+  tpc_channelstatus_data: "v3r2"
+  tpc_elifetime_data: "v2r1"
+  tpc_dqdxcalibration_data: "v2r1"
+  tpc_yz_correction_allplanes_data: "v1r0"
+
+}
+
 END_PROLOG

--- a/icaruscode/TPC/Calorimetry/normtools_icarus.fcl
+++ b/icaruscode/TPC/Calorimetry/normtools_icarus.fcl
@@ -53,8 +53,8 @@ tpcgain_local: {
 
 yznorm_sql: {
   tool_type: NormalizeYZSQL
-  DBFileName: tpc_yz_correction_data
-  DBTag: @local::ICARUS_Calibration_GlobalTags.tpc_yz_correction_data
+  DBFileName: tpc_yz_correction_allplanes_data
+  DBTag: @local::ICARUS_Calibration_GlobalTags.tpc_yz_correction_allplanes_data
   Verbose: false
 }
 


### PR DESCRIPTION
So far, the TPC YZ correction module has been using the scale factor for the Collection plane to all planes. I created a new table, `tpc_yz_correction_allplanes_data`, which has a new column, `plane` and contains scale factor for each plane. This requires a new version in `icarus_data` with this new table added.