### PR TITLE
Adding fcls for YZ systematic production

### DIFF
--- a/fcl/syst_variations/cafmakerjob_icarus_detsim2d_nosimchan.fcl
+++ b/fcl/syst_variations/cafmakerjob_icarus_detsim2d_nosimchan.fcl
@@ -1,0 +1,6 @@
+#include "cafmakerjob_icarus.fcl"
+#include "cafmaker_add_detsim2d_icarus.fcl"
+
+physics.producers.mcreco.SimChannelLabel: "simdrift"
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"
+physics.producers.cafmaker.SimChannelLabel: "simdrift" 

--- a/fcl/syst_variations/detsim_2d_icarus_refactored_yzsim_nomerge.fcl
+++ b/fcl/syst_variations/detsim_2d_icarus_refactored_yzsim_nomerge.fcl
@@ -1,0 +1,49 @@
+#include "services_icarus_simulation.fcl"
+#include "larg4_services_icarus.fcl"  
+#include "detsimmodules_wirecell_ICARUS_YZsim.fcl"
+#include "opdetsim_pmt_icarus.fcl"
+#include "crtsimmodules_icarus.fcl"
+#include "trigger_emulation_icarus.fcl"
+#include "rootoutput_icarus.fcl"
+
+process_name: DetSimYZ
+
+services: {
+    @table::icarus_detsim_services
+    @table::icarus_g4_services
+    @table::icarus_larg4_services
+  #FileCatalogMetadata:  @local::art_file_catalog_mc
+} # services
+
+physics: {
+
+  producers: {
+    crtdaq:         @local::icarus_crtsim
+     opdaq:         @local::icarus_simpmt
+       daq:         @local::icarus_simwire_wirecell
+
+       rns:         { module_type: "RandomNumberSaver" }
+  } # producers
+
+  simulate: [ rns, opdaq, daq, crtdaq ]
+
+  # define the output stream, there could be more than one if using filters
+  stream:  [ rootoutput ]
+
+} # physics
+
+outputs: {
+  rootoutput: {
+    @table::icarus_rootoutput
+    outputCommands: [
+      "keep *"
+#     , "drop *_ionization_*_*"
+#     , "drop *_pmtlvdsgatesinit_*_*"
+#     , "drop *_pmtfixedthrinit_*_*"
+#     , "drop *_pmttriggerwindowsinit_*_*"
+#     , "drop *_triggersimgatesinit_*_*"
+      ]
+  }
+}
+
+physics.producers.daq.wcls_main.configs: ["pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet"]

--- a/fcl/syst_variations/stage0_run2_icarus_mc_refactored_nosimchan.fcl
+++ b/fcl/syst_variations/stage0_run2_icarus_mc_refactored_nosimchan.fcl
@@ -1,0 +1,55 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_mc_defs.fcl"
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: MCstage0NoSimChan
+
+## Add the MC module to the list of producers
+physics.producers: {  @table::icarus_stage0_producers
+                      @table::icarus_stage0_mc_producers
+                   }
+
+## Use the following to run the full defined stage0 set of modules
+physics.path: [   @sequence::icarus_stage0_mc_PMT,
+                  MCDecodeTPCROI,
+                  @sequence::icarus_stage0_multiTPC,
+                  @sequence::icarus_stage0_mc_crt
+              ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamROOT ]
+
+# Drop data products that are no longer needed, but make sure to keep important items!
+# For example, we need to drop the RawDigits from the detector simulation stage but want to keep the SimChannel info from WireCell...
+outputs.rootOutput.outputCommands: ["keep *_*_*_*", "drop *_daq*_*_*", "drop *_MCDecodeTPCROI_*_*", "drop *_decon1droi_*_*", "drop recob::Wire*_roifinder_*_*", "keep *_daq_simpleSC_*"]
+
+# Set the expected input for ophit
+physics.producers.ophit.InputModule: "opdaq"
+
+# Note the default assumption is that our detector simulation input will come from the WireCell 2D drift simulation, a la 'daq'
+# If we are running the 1D drift simulation we need to switch to using:
+# `physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq3:PHYSCRATEDATATPCWW","daq2:PHYSCRATEDATATPCWE","daq1:PHYSCRATEDATATPCEW","daq0:PHYSCRATEDATATPCEE"]`
+#
+physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq:TPCWW","daq:TPCWE","daq:TPCEW","daq:TPCEE"]
+physics.producers.MCDecodeTPCROI.OutInstanceLabelVec: ["PHYSCRATEDATATPCWW", "PHYSCRATEDATATPCWE", "PHYSCRATEDATATPCEW", "PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:        ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+
+physics.producers.simChannelROI.SimChannelLabelVec:  ["daq:simpleSC"]
+physics.producers.simChannelROI.OutInstanceLabelVec: ["All"]
+
+physics.producers.decon2droiEE.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCEE"
+physics.producers.decon2droiEW.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCEW"
+physics.producers.decon2droiWE.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWE"
+physics.producers.decon2droiWW.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWW"
+
+## Need overrides for the purity monitor
+physics.analyzers.purityinfoana0.SelectEvents: [ path ]
+physics.analyzers.purityinfoana1.SelectEvents: [ path ]
+physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+

--- a/fcl/syst_variations/stage1_variation_icarus_larcv_nosimchan.fcl
+++ b/fcl/syst_variations/stage1_variation_icarus_larcv_nosimchan.fcl
@@ -1,0 +1,8 @@
+#include "stage1_run2_1d_larcv_icarus_MC.fcl"
+
+process_name: MCstage1Var
+
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"
+physics.analyzers.caloskimE.SimChannelproducer: "simdrift"
+physics.analyzers.caloskimW.SimChannelproducer: "simdrift"
+physics.analyzers.superaMC.supera_params: "supera_icarus_MC_all_cryo_PMT_CRT_nosimchan.fcl"

--- a/fcl/syst_variations/supera_icarus_MC_all_cryo_PMT_CRT_nosimchan.fcl
+++ b/fcl/syst_variations/supera_icarus_MC_all_cryo_PMT_CRT_nosimchan.fcl
@@ -1,0 +1,198 @@
+ProcessDriver: {
+
+  Verbosity:    2
+  EnableFilter: true
+  RandomAccess: false
+  ProcessType:  ["SuperaMCTruth","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePoint","SuperaSpacePoint","Tensor3DFromCluster3D","CombineTensor3D","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3D","RescaleChargeTensor3D","SuperaOptical","SuperaCRT"]
+  ProcessName:  ["MultiPartVrtx","SuperaBBoxInteraction","SuperaMCParticleCluster","SuperaSimEnergyDeposit","SuperaSpacePointCryoE","SuperaSpacePointCryoW","Tensor3DFromCluster3D","CombineTensor3DGhost","ThresholdTensor3D","CombineTensor3D","ParticleCorrector","EmptyTensorFilter","RescaleChargeTensor3DCryoE","RescaleChargeTensor3DCryoW","SuperaOptical","SuperaCRT"]
+
+  IOManager: {
+    Verbosity:   2
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: []
+    StoreOnlyName: []
+  }
+
+  ProcessList: {
+    SuperaCRT: {
+      CRTHitProducers: ["crthit"]
+      CRTHitOutputs: ["crthit"]
+    }
+
+		SuperaOptical: {
+		  OpFlashProducers: ["opflashCryoE","opflashCryoW"]
+			OpFlashOutputs: ["cryoE","cryoW"]
+		}
+
+    EmptyTensorFilter: {
+      Tensor3DProducerList: ["pcluster_semantics_ghost"]
+      MinVoxel3DCountList:  [1]
+    }
+
+    RescaleChargeTensor3DCryoE: {
+      HitKeyProducerList:    ["reco_cryoE_hit_key0","reco_cryoE_hit_key1","reco_cryoE_hit_key2"]
+      HitChargeProducerList: ["reco_cryoE_hit_charge0","reco_cryoE_hit_charge1","reco_cryoE_hit_charge2"]
+      OutputProducer:        "reco_cryoE_rescaled"
+      ReferenceProducer:     "pcluster"
+    }
+
+    RescaleChargeTensor3DCryoW: {
+      HitKeyProducerList:    ["reco_cryoW_hit_key0","reco_cryoW_hit_key1","reco_cryoW_hit_key2"]
+      HitChargeProducerList: ["reco_cryoW_hit_charge0","reco_cryoW_hit_charge1","reco_cryoW_hit_charge2"]
+      OutputProducer:        "reco_cryoW_rescaled"
+      ReferenceProducer:     "pcluster"
+    }
+
+    ThresholdTensor3D: { # fill with ghost value (5)
+      TargetProducer: "pcluster_semantics_ghost"
+      OutputProducer: "pcluster_semantics_ghost"
+      PaintValue: 5
+    }
+
+    CombineTensor3DGhost: { # Combine voxels of cryoE and cryoW
+      OutputProducer: "pcluster_semantics_ghost"
+      Tensor3DProducers: ["reco_cryoE","reco_cryoW"]
+      PoolType: 0
+    }
+
+    CombineTensor3D: {
+      Tensor3DProducers: ["pcluster_semantics_ghost","pcluster_semantics"]
+      OutputProducer:    "pcluster_semantics_ghost"
+      PoolType: 0
+    }
+
+    SuperaMCParticleCluster: {
+      OutputLabel: "pcluster"
+      LArMCParticleProducer: "simplemerge"
+      LArMCShowerProducer: "mcreco"
+      LArMCTrackProducer:  "mcreco"
+      #LArMCMiniPartProducer: #"largeant"
+      DeltaSize: 10
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+      Meta3DFromCluster3D: "mcst"
+      Meta2DFromTensor2D:  ""
+      Verbosity: 2
+      UseSimEnergyDeposit: false #true
+      UseSimEnergyDepositLite: false #true
+      UseSimEnergyDepositPoints: false #true
+      UseOrigTrackID: true
+      CryostatList: [0,0,0,0,1,1,1,1]
+      TPCList: [0,1,2,3,0,1,2,3]
+      PlaneList: []
+      #SemanticPriority: [2,1,0,3,4] # 0-4 for shower track michel delta LE-scattering
+      SemanticPriority: [1,2,0,3,4] # 0-4 for shower track michel delta LE-scattering
+      CheckParticleValidity: false #set false, but this needs to be checked later
+
+      SuperaTrue2RecoVoxel3D: {
+        DebugMode: false
+        Verbosity: 2
+        Meta3DFromCluster3D: "pcluster"
+        #LArSimChProducer: "largeant"
+	LArSimChProducer: "simdrift"
+        LArSpacePointProducers: ["cluster3DCryoE","cluster3DCryoW"]
+        TwofoldMatching: true
+        UseTruePosition: true
+        HitThresholdNe: 100
+        HitWindowTicks: 15 #5
+        HitPeakFinding: false
+        PostAveraging: true
+        PostAveragingThreshold_cm: 0.425
+        DumpToCSV: false
+        RecoChargeRange: [-1000,50000]
+				VoxelDistanceThreshold: 3.
+        UseOrigTrackID: true
+      }
+    }
+
+    MultiPartVrtx: {
+      Verbosity: 2
+      #LArMCTruthProducer: "generator"
+      MCTruthProducers: ["generator","cosmgen"]
+      OutParticleLabel: "mpv"
+      Origin: 0
+    }
+
+    SuperaBBoxInteraction: {
+      Verbosity: 2
+      LArMCTruthProducer: "generator"
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+			UseSEDLite: true
+      Origin: 0
+      Cluster3DLabels: ["mcst","pcluster","sed","masked_true2reco"]
+      Tensor3DLabels:  ["reco_cryoE","reco_cryoW","pcluster_index","masked_true"]
+      #BBoxSize: [230.4,230.4,230.4]
+      BBoxSize: [1843.2,1843.2,1843.2] # Covers the whole detector with the smallest possible cube -> yields 6144 = 1024*6 px
+      #BBoxBottom: [-460.8,-230.4,-921.6]
+      #BBoxSize: [1789.902,1789.902,1789.902]
+      #BBoxBottom: [-358.49,-181.86,-894.951] # geometry from icarus_complete_20210527_no_overburden.gdml
+      #BBoxBottom: [-412.788,-181.86,-894.951] # geometry from icarus_complete_20210527_no_overburden.gdml taking readout window into account
+			# 358.49+340*1.6/10 = 412.89
+      BBoxBottom: [-412.89,-181.86,-894.951] # geometry from icarus_complete_20210527_no_overburden.gdml taking readout window into account
+      UseFixedBBox: true
+      VoxelSize: [0.3,0.3,0.3]
+      CryostatList: [0,0,0,0,1,1,1,1]
+      TPCList: [0,1,2,3,0,1,2,3]
+    }
+
+    SuperaSimEnergyDeposit: {
+      Verbosity: 2
+      #LArSimEnergyDepositProducer: "largeant TPCActive"
+      LArSimEnergyDepositLiteProducer: "sedlite"
+      LArMCShowerProducer: "mcreco"
+			UseSEDLite: true
+      ParticleProducer: "pcluster"
+      OutCluster3DLabel: "sed"
+      StoreLength: false
+      StoreCharge: false
+      StorePhoton: false
+      StoreDiffTime: false
+      StoreAbsTime: true
+      StoreDEDX: false
+      TPCList: [0,1,2,3,0,1,2,3]
+      CryostatList: [0,0,0,0,1,1,1,1]
+    }
+
+    ParticleCorrector: {
+      Verbosity: 2
+      Cluster3DProducer: "pcluster_highE"
+      ParticleProducer:  "pcluster"
+      OutputProducer:    "corrected"
+      VoxelMinValue:     -1000
+   }
+
+
+    Tensor3DFromCluster3D: {
+      Verbosity: 2
+      Cluster3DProducerList: ["pcluster","sed"]
+      OutputProducerList:    ["pcluster","sed"]
+      PITypeList:  [1,1]
+      FixedPIList: [0.,0.]
+    }
+
+    SuperaSpacePointCryoE: {
+      Verbosity: 2
+      SpacePointProducers: ["cluster3DCryoE"]
+      OutputLabel:        "reco_cryoE"
+      DropOutput: ["hit_amp","hit_time","hit_rms","hit_mult","nhits","occupancy"]
+      StoreWireInfo: true
+      RecoChargeRange: [-1000, 50000]
+    }
+
+    SuperaSpacePointCryoW: {
+      Verbosity: 2
+      SpacePointProducers: ["cluster3DCryoW"]
+      OutputLabel:        "reco_cryoW"
+      DropOutput: ["hit_amp","hit_time","hit_rms","hit_mult","nhits","occupancy"]
+      StoreWireInfo: true
+      RecoChargeRange: [-1000, 50000]
+    }
+
+  }
+}
+


### PR DESCRIPTION
This adds the fcls needed for the YZ Production (since it does not currently support SimChannel). 

This is the workflow needed for the YZ Production:
```
detsim_2d_icarus_refactored_yzsim_nomerge.fcl
stage0_run2_icarus_mc_refactored_nosimchan.fcl 
stage1_variation_icarus_larcv_nosimchan.fcl 
cafmakerjob_icarus_detsim2d_nosimchan.fcl 
```