### PR TITLE
Updating NUMI flux files from v3_00 to v3_01 [release/SBN2024A]

### DIFF
--- a/fcl/gen/numi/genie_icarus_numioffaxis.fcl
+++ b/fcl/gen/numi/genie_icarus_numioffaxis.fcl
@@ -57,7 +57,7 @@ icarus_genie_NuMI_base: {
   FluxType:             "dk2nu"
   BeamName:             "numi"
   DetectorLocation:     "icarus-numi"
-  FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v03_00/"
+  FluxSearchPaths:      "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v03_01/"
   FluxFiles:            ["g4numi*.root"]
   
   POTPerSpill:          6.0e13 # same as BnB per batch, but 6 batches in spill
@@ -92,7 +92,7 @@ icarus_genie_NuMI_rock.DetectorLocation: "icarus-numi-rock"
 
 # RHC Config
 icarus_genie_NuMI_RHC: @local::icarus_genie_NuMI
-icarus_genie_NuMI_RHC.FluxSearchPaths: "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v03_00_RHC/"
+icarus_genie_NuMI_RHC.FluxSearchPaths: "/cvmfs/sbn.osgstorage.org/pnfs/fnal.gov/usr/sbn/persistent/stash/physics/beam/GENIE/NuMI/standard/v03_01_RHC/"
 
 ################################################################################
 


### PR DESCRIPTION
I have updated the search paths for Genie to locate the flux files, from version v03_00 to v03_0, redirecting them to the most recent set.