### PR TITLE
This PR reverts the requirement of opFlash with op hits following trigger like requirements.

### DIFF
--- a/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
+++ b/icaruscode/CRT/CRTPMTMatchingProducer_module.cc
@@ -582,14 +582,14 @@ namespace sbn::crt {
           << firstOpHitPeakTime << " us, centroid: " << flash_pos << " cm";
       }
       
-      /*
+      /// Francesco: this was reintroduced as requested for the production release
       if (nPMTsTriggering < fnOpHitToTrigger) {
         mf::LogTrace("CRTPMTMatchingProducer")
           << "  => skipped (only " << nPMTsTriggering << " < " << fnOpHitToTrigger
           << " hits above threshold)";
         continue;
       }
-      */
+      
       
       double const thisRelGateTime = triggerGateDiff + tflash * 1e3; // ns
       bool const thisInTime_gate


### PR DESCRIPTION
This was introduced in icaruscode v09_89_01_02 and in develop.
It should remain in develop, the reason for return to the old version is that it could change selection w.r.t. CV evaluated on icaruscode v09_89_01_01p03.