### PR TITLE
Signal Shape Systematic Fcls

### DIFF
--- a/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_down.fcl
+++ b/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_down.fcl
@@ -3,11 +3,11 @@
 #
 #include "detsim_2d_icarus_refactored.fcl"
 
-#Decrease electronics response width by 10%
-physics.producers.daq.wcls_main.structs.gain0: 18.9468
-physics.producers.daq.wcls_main.structs.gain1: 14.020214
-physics.producers.daq.wcls_main.structs.gain2: 14.4734846667
-physics.producers.daq.wcls_main.structs.shaping0: 1.17
-physics.producers.daq.wcls_main.structs.shaping1: 1.17
-physics.producers.daq.wcls_main.structs.shaping2: 1.17
+#Decrease electronics response width by 30%
+physics.producers.daq.wcls_main.structs.gain0: 24.36017143
+physics.producers.daq.wcls_main.structs.gain1: 18.02598943
+physics.producers.daq.wcls_main.structs.gain2: 18.60876600
+physics.producers.daq.wcls_main.structs.shaping0: 0.91
+physics.producers.daq.wcls_main.structs.shaping1: 0.91
+physics.producers.daq.wcls_main.structs.shaping2: 0.91
 process_name: DetSimSigShapeShrink

--- a/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_down.fcl
+++ b/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_down.fcl
@@ -1,0 +1,13 @@
+#originally developed by G. Putnam, adapt once that PR is in place 
+# Fit field responses, turned up noise on each plane
+#
+#include "detsim_2d_icarus_refactored.fcl"
+
+#Increase electronics response width by 10%
+physics.producers.daq.wcls_main.structs.gain0: 18.9468
+physics.producers.daq.wcls_main.structs.gain1: 14.020214
+physics.producers.daq.wcls_main.structs.gain2: 14.4734846667
+physics.producers.daq.wcls_main.structs.shaping0: 1.17
+physics.producers.daq.wcls_main.structs.shaping1: 1.17
+physics.producers.daq.wcls_main.structs.shaping2: 1.17
+process_name: DetSimSigShapeShrink

--- a/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_down.fcl
+++ b/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_down.fcl
@@ -3,7 +3,7 @@
 #
 #include "detsim_2d_icarus_refactored.fcl"
 
-#Increase electronics response width by 10%
+#Decrease electronics response width by 10%
 physics.producers.daq.wcls_main.structs.gain0: 18.9468
 physics.producers.daq.wcls_main.structs.gain1: 14.020214
 physics.producers.daq.wcls_main.structs.gain2: 14.4734846667

--- a/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_up.fcl
+++ b/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_up.fcl
@@ -3,11 +3,11 @@
 #
 #include "detsim_2d_icarus_refactored.fcl"
 
-#Increase electronics response width by 10%
-physics.producers.daq.wcls_main.structs.gain0: 15.5019272727
-physics.producers.daq.wcls_main.structs.gain1: 11.4710841818
-physics.producers.daq.wcls_main.structs.gain2: 11.841942
-physics.producers.daq.wcls_main.structs.shaping0: 1.43
-physics.producers.daq.wcls_main.structs.shaping1: 1.43
-physics.producers.daq.wcls_main.structs.shaping2: 1.43
+#Increase electronics response width by 30%
+physics.producers.daq.wcls_main.structs.gain0: 13.11701538
+physics.producers.daq.wcls_main.structs.gain1: 9.70630200
+physics.producers.daq.wcls_main.structs.gain2: 10.02010477
+physics.producers.daq.wcls_main.structs.shaping0: 1.69
+physics.producers.daq.wcls_main.structs.shaping1: 1.69
+physics.producers.daq.wcls_main.structs.shaping2: 1.69
 process_name: DetSimSigShapeStretch

--- a/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_up.fcl
+++ b/fcl/syst_variations/detsim_2d_icarus_refactored_variation_signalstretch_up.fcl
@@ -1,0 +1,13 @@
+#originally developed by G. Putnam, adapt once that PR is in place 
+# Fit field responses, turned up noise on each plane
+#
+#include "detsim_2d_icarus_refactored.fcl"
+
+#Increase electronics response width by 10%
+physics.producers.daq.wcls_main.structs.gain0: 15.5019272727
+physics.producers.daq.wcls_main.structs.gain1: 11.4710841818
+physics.producers.daq.wcls_main.structs.gain2: 11.841942
+physics.producers.daq.wcls_main.structs.shaping0: 1.43
+physics.producers.daq.wcls_main.structs.shaping1: 1.43
+physics.producers.daq.wcls_main.structs.shaping2: 1.43
+process_name: DetSimSigShapeStretch


### PR DESCRIPTION
These fcls allow us to stretch or shrink the electronic response shape. 

More details and validation can be found in this DocDB:
https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=39697