### PR TITLE
Adding CAF Fcl for for Cosmics

### DIFF
--- a/fcl/caf/cafmakerjob_icarus_cosmic_detsim2d.fcl
+++ b/fcl/caf/cafmakerjob_icarus_cosmic_detsim2d.fcl
@@ -1,0 +1,3 @@
+#include "cafmakerjob_icarus_detsim2d.fcl"
+
+physics.producers.cafmaker.SaveGENIEEventRecord: false


### PR DESCRIPTION
Currently, if you try to use CAF Maker on cosmic MC, it breaks because it tries to build the GENIE record. 

The simplest solution is to add a new CAF maker fcl that disables the GENIE Event Record storage. 

This is needed by the CI 