### PR TITLE
In WireCell Sim the One Is Already Counted

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet
@@ -438,7 +438,7 @@ local deposetfilteryz = [ g.pnode({
 		  zoffset: 900*wc.cm,
 		  nbinsy: 31,
 		  nbinsz: 180,
-		  resp: std.mod(r,15)+1,	
+		  resp: std.mod(r,15),	
                   anode: wc.tn(tools.anodes[std.floor(r/45)]),
 		  plane: std.mod(std.floor(r/15),3)	
             	  }

--- a/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-shifted-refactored.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-shifted-refactored.jsonnet
@@ -438,7 +438,7 @@ local deposetfilteryz = [ g.pnode({
 		  zoffset: 900*wc.cm,
 		  nbinsy: 31,
 		  nbinsz: 180,
-		  resp: std.mod(r,15)+1,	
+		  resp: std.mod(r,15),	
                   anode: wc.tn(tools.anodes[std.floor(r/45)]),
 		  plane: std.mod(std.floor(r/15),3)	
             	  }


### PR DESCRIPTION
https://github.com/WireCell/wire-cell-toolkit/blob/ffd31bade2b8c3d1dbb1ccd78dab1637ffb50845/gen/src/DepoSetFilterYZ.cxx#L122

Joseph didn't Trust Past Joseph, but Future Joseph realized Past Joseph was correct. 

I added one in the jsonnet config and it was double counting shifting the maps over by one and making tracks in the highest dQdx region drop out