### PR TITLE
Get Overlay code to compile

### DIFF
--- a/icaruscode/Overlays/CMakeLists.txt
+++ b/icaruscode/Overlays/CMakeLists.txt
@@ -1,8 +1,8 @@
 find_package(gallery         REQUIRED)
 
-#find_package(larwirecell REQUIRED )
-#find_package(jsoncpp REQUIRED)
-#find_package(spdlog REQUIRED)
+find_package(larwirecell REQUIRED )
+find_package(jsoncpp REQUIRED)
+find_package(spdlog REQUIRED)
 
 include_directories( $ENV{JSONCPP_INC} )
 link_directories( $ENV{JSONCPP_LIB} )
@@ -44,6 +44,7 @@ art_make_library(
 	WireCellPgraph
 	WireCellRoot
 	jsoncpp
+	dl
 )
 
 


### PR DESCRIPTION
Should have been included in https://github.com/SBNSoftware/icaruscode/pull/817. Also can be superseded by https://github.com/SBNSoftware/icaruscode/pull/813.