### PR TITLE
Replaced link to DetectorClocksServiceStandard

### DIFF
--- a/icaruscode/Analysis/trigger/CMakeLists.txt
+++ b/icaruscode/Analysis/trigger/CMakeLists.txt
@@ -38,7 +38,7 @@ cet_build_plugin(BeamGateInfoFromTracks  art::module
   lardataobj::Simulation
   lardataobj::AnalysisBase
   lardataobj::RecoBase
-  lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+  lardata::DetectorClocksService
   )
 
 cet_build_plugin(BeamGateInfoFromTracksCRT  art::module
@@ -46,7 +46,7 @@ cet_build_plugin(BeamGateInfoFromTracksCRT  art::module
   lardataobj::Simulation
   lardataobj::AnalysisBase
   lardataobj::RecoBase
-  lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+  lardata::DetectorClocksService
   )
 
 cet_build_plugin(TimeTrackTreeStorage art::module

--- a/icaruscode/CRT/CMakeLists.txt
+++ b/icaruscode/CRT/CMakeLists.txt
@@ -47,7 +47,7 @@ cet_build_plugin( CRTTrueHitProducer art::module
         art::Persistency_Provenance
         canvas::canvas
         cetlib_except::cetlib_except
-        lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+        lardata::DetectorClocksService
         art::Framework_Services_Registry
         messagefacility::MF_MessageLogger
         messagefacility::headers

--- a/icaruscode/CRT/CRTUtils/CMakeLists.txt
+++ b/icaruscode/CRT/CRTUtils/CMakeLists.txt
@@ -37,7 +37,7 @@ art_make_library(LIBRARY_NAME icaruscode_CRTUtils
 	Boost::system
 	sbnobj::ICARUS_CRT
 	sbnobj::Common_CRT
-	lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+	lardata::DetectorClocksService
 	nurandom::RandomUtils_NuRandomService_service
 	)
 

--- a/icaruscode/PMT/CMakeLists.txt
+++ b/icaruscode/PMT/CMakeLists.txt
@@ -117,7 +117,7 @@ cet_build_plugin(CustomPulseFunctionTool art::tool
 cet_build_plugin(PMTconstantPedestalGeneratorTool art::tool
   LIBRARIES
     icaruscode::PMT_Algorithms
-    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardata::DetectorClocksService
     lardataalg::DetectorInfo
     lardataobj::RawData
   )
@@ -125,7 +125,7 @@ cet_build_plugin(PMTconstantPedestalGeneratorTool art::tool
 cet_build_plugin(PMTgausNoiseGeneratorTool art::tool
   LIBRARIES
     icaruscode::PMT_Algorithms
-    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardata::DetectorClocksService
     lardataalg::DetectorInfo
     lardataobj::RawData
   )
@@ -133,7 +133,7 @@ cet_build_plugin(PMTgausNoiseGeneratorTool art::tool
 cet_build_plugin(PMTfastGausNoiseGeneratorTool art::tool
   LIBRARIES
     icaruscode::PMT_Algorithms
-    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardata::DetectorClocksService
     lardataalg::DetectorInfo
     lardataobj::RawData
   )
@@ -141,7 +141,7 @@ cet_build_plugin(PMTfastGausNoiseGeneratorTool art::tool
 cet_build_plugin(PMTnoNoiseGeneratorTool art::tool
   LIBRARIES
     icaruscode::PMT_Algorithms
-    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardata::DetectorClocksService
     lardataalg::DetectorInfo
     lardataobj::RawData
   )
@@ -151,7 +151,7 @@ cet_build_plugin(CopyBeamTimePMTwaveforms art::module
     icaruscode::PMT_Data
     icarusalg::Utilities
     sbnobj::ICARUS_PMT_Data
-    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardata::DetectorClocksService
     lardataalg::DetectorInfo
     lardataobj::RawData
   )
@@ -244,7 +244,7 @@ cet_build_plugin(RequireOnBeamWaveforms art::module
   LIBRARIES
     icaruscode::IcarusObj
     icarusalg::Utilities
-    lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+    lardata::DetectorClocksService
     larcore::Geometry_Geometry_service
     larcore::headers
     lardataalg::DetectorInfo

--- a/icaruscode/PMT/Trigger/CMakeLists.txt
+++ b/icaruscode/PMT/Trigger/CMakeLists.txt
@@ -26,7 +26,7 @@ art_make_library(
 		larcorealg::Geometry
 		lardataobj::RawData
 		lardata::Utilities
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		nusimdata::SimulationBase
 		art_root_io::TFileService_service
 		art_root_io::tfile_support
@@ -61,7 +61,7 @@ set(	MODULE_LIBRARIES
 		sbnobj::ICARUS_PMT_Trigger_Data
 		lardataalg::DetectorInfo
 		lardataobj::RawData
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		messagefacility::MF_MessageLogger
 		fhiclcpp::fhiclcpp
 		larcore::Geometry_Geometry_service
@@ -105,7 +105,7 @@ cet_build_plugin(DiscriminatePMTwaveformsByChannel art::module
   icaruscode::PMT_Algorithms
   lardataobj::RawData
   lardata::Utilities
-  lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+  lardata::DetectorClocksService
   larcore::Geometry_Geometry_service
   art::Framework_Services_Registry
   art::Framework_Principal
@@ -145,7 +145,7 @@ cet_build_plugin(SlidingWindowTrigger art::module
 		larcore::Geometry_Geometry_service
 		larcorealg::Geometry
 		lardata::Utilities
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		lardataobj::RawData
 		art::Framework_Services_Registry
 		art::Framework_Principal
@@ -166,7 +166,7 @@ cet_build_plugin(MajorityTriggerSimulation art::module
 		larcorealg::Geometry
 		lardata::Utilities
 		lardataobj::RawData
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		art_root_io::TFileService_service
 		art_root_io::tfile_support
 		art::Framework_Services_Registry
@@ -183,7 +183,7 @@ cet_build_plugin(SlidingWindowTriggerSimulation art::module
 		larcorealg::Geometry
 		lardataobj::RawData
 		lardata::Utilities
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		art_root_io::TFileService_service
 		art_root_io::tfile_support
 		art::Framework_Services_Registry
@@ -229,7 +229,7 @@ cet_build_plugin(TriggerEfficiencyPlots art::module
 		larcorealg::Geometry
 		lardataobj::RawData
 		lardata::Utilities
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		nusimdata::SimulationBase
 		art_root_io::TFileService_service
 		art_root_io::tfile_support
@@ -254,7 +254,7 @@ cet_build_plugin(MakeTriggerSimulationTree art::module
 		larcore::Geometry_Geometry_service
 		lardataalg::MCDumpers
 		lardata::Utilities
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		larcorealg::Geometry
 		nusimdata::SimulationBase
 		art_root_io::TFileService_service
@@ -302,7 +302,7 @@ foreach(TriggerEfficiencyPlotsModule
 		larcore::Geometry_Geometry_service
 		lardataalg::MCDumpers
 		lardata::Utilities
-		lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+		lardata::DetectorClocksService
 		larcorealg::Geometry
 		lardataobj::RawData
 		nusimdata::SimulationBase

--- a/icaruscode/TPC/SignalProcessing/RecoWire/SimTestPulse/CMakeLists.txt
+++ b/icaruscode/TPC/SignalProcessing/RecoWire/SimTestPulse/CMakeLists.txt
@@ -11,7 +11,7 @@ set(		MODULE_LIBRARIES
 			icaruscode::TPC_SignalProcessing_RecoWire_SimTestPulse
 			icaruscode::TPC_Utilities_SignalShapingICARUSService_service
 			lardata::Utilities
-			lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
+			lardata::DetectorClocksService
 			lardataobj::Simulation
 			larcoreobj::SummaryData
 			larcorealg::Geometry

--- a/icaruscode/TPC/Simulation/Overlay/tools/CMakeLists.txt
+++ b/icaruscode/TPC/Simulation/Overlay/tools/CMakeLists.txt
@@ -33,7 +33,7 @@ set(	TOOL_LIBRARIES
 			CLHEP::Random
 			Eigen3::Eigen
 	)
-cet_build_plugin(Overlay1D art::tool LIBRARIES ${TOOL_LIBRARIES} SOURCE Overlay1D_tool.cc)
+cet_build_plugin(Overlay1D art::tool LIBRARIES ${TOOL_LIBRARIES} REG_SOURCE Overlay1D_tool.cc)
 set_property(SOURCE Overlay1D_tool.cc APPEND PROPERTY COMPILE_DEFINITIONS EIGEN_FFTW_DEFAULT)
 
 install_headers()

--- a/icaruscode/TPC/Tracking/cluster3D/CMakeLists.txt
+++ b/icaruscode/TPC/Tracking/cluster3D/CMakeLists.txt
@@ -57,7 +57,7 @@ set(    MODULE_LIBRARIES
           messagefacility::MF_MessageLogger
        )
 cet_build_plugin(Cluster3DICARUS art::module LIBRARIES ${MODULE_LIBRARIES})
-cet_build_plugin(SnippetHit3DBuilderICARUS art::tool LIBRARIES ${TOOL_LIBRARIES} SOURCE SnippetHit3DBuilderICARUS_tool.cc)
+cet_build_plugin(SnippetHit3DBuilderICARUS art::tool LIBRARIES ${TOOL_LIBRARIES} REG_SOURCE SnippetHit3DBuilderICARUS_tool.cc)
 set_property(SOURCE SnippetHit3DBuilderICARUS_tool.cc APPEND PROPERTY COMPILE_DEFINITIONS EIGEN_FFTW_DEFAULT)
 
 install_headers()


### PR DESCRIPTION
Code should not need to link to service implementations, but only to their interface.
It is _art_ which will dynamically load the appropriate service per the job configuration.
This rule holds for services with multiple implementations (like `DetectorClocksService` and `DetectorPropertiesService`) and not for simple services (like `Geometry` or `WireReadout`).

A flawed seed in a single `CMakeLists.txt` linking directly to `lardata::DetectorInfoServices_DetectorClocksServiceStandard_service` has proliferated throughout `icaruscode`. The correct library to link is instead `lardata::DetectorClocksService` (which is not really a library, but it is what is needed nonetheless). This PR fixes all the faulty links to that service.

There should be no consequences to any level.

Reviewers:
 * @SFBayLaser because when I don't know I bother him

I don't know who else...

