### PR TITLE
Fix sim label for PDFastSim

### DIFF
--- a/fcl/g4/PDFastSim_icarus.fcl
+++ b/fcl/g4/PDFastSim_icarus.fcl
@@ -157,7 +157,7 @@ icarus_vis_timing_parameterization:
 # standard configuration
 icarus_pdfastsim_pvs:                     @local::standard_pdfastsim_pvs
 
-icarus_pdfastsim_pvs.SimulationLabel:     "ionization"
+icarus_pdfastsim_pvs.SimulationLabel:     "ionization:priorSCE"
 icarus_pdfastsim_pvs.IncludePropTime: true
 icarus_pdfastsim_pvs.ScintTimeTool.SlowDecayTime: 1300.0
 


### PR DESCRIPTION
SimPhotons should be generated from pre-SCE energy deposits.
It looks like this has not been the case ever since we switched to the refactored G4 steps.

I'm deeply confused by our fhicl structure.
Please advise if you think this should be overriden somewhere else.