### PR TITLE
Fix ctoffset to match RawDigit/Deconvolved collection hit time

### DIFF
--- a/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
+++ b/icaruscode/TPC/ICARUSWireCell/icarus/sp.jsonnet
@@ -24,7 +24,7 @@ function(params, tools, override = {}) {
       dft: wc.tn(tools.dft),
       field_response: wc.tn(tools.field),
       ftoffset: 0.0, // default 0.0
-      ctoffset: 0.5*wc.microsecond, //2.0*wc.microsecond, // default -8.0
+      ctoffset: 1.3*wc.microsecond, //2.0*wc.microsecond, // default -8.0
       per_chan_resp: pc.name,
       fft_flag: 0,  // 1 is faster but higher memory, 0 is slightly slower but lower memory
       elecresponse : wc.tn(tools.elec_resp[2]),


### PR DESCRIPTION
Set ctoffset to match peak time between rawdigit and deconvolved on collection plane in data.

See plot on right. The green line is the collection plane, after ctoffset is set correctly.
![image](https://github.com/user-attachments/assets/e632fc70-fe2b-4309-98c5-46e65a7769f8)
