### PR TITLE
Output the correct pedestal to RawDigits

### DIFF
--- a/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
@@ -692,7 +692,7 @@ void DaqDecoderICARUSTPCwROI::processSingleFragment(size_t                      
 
             ConcurrentRawDigitCol::iterator newObjItr = concurrentRawDigitCol.emplace_back(channel,wvfm.size(),wvfm); 
 
-            newObjItr->SetPedestal(localPedestal,localFullRMS);
+            newObjItr->SetPedestal(decoderTool->GetPedestal()[chanIdx]+localPedestal,localFullRMS);
 
             // And, finally, the ROIs 
             const icarus_signal_processing::VectorBool& chanROIs = decoderTool->getROIVals()[chanIdx];

--- a/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
+++ b/icaruscode/Decode/DaqDecoderICARUSTPCwROI_module.cc
@@ -692,7 +692,7 @@ void DaqDecoderICARUSTPCwROI::processSingleFragment(size_t                      
 
             ConcurrentRawDigitCol::iterator newObjItr = concurrentRawDigitCol.emplace_back(channel,wvfm.size(),wvfm); 
 
-            newObjItr->SetPedestal(decoderTool->GetPedestal()[chanIdx]+localPedestal,localFullRMS);
+            newObjItr->SetPedestal(decoderTool->getPedestalVals()[chanIdx]+localPedestal,localFullRMS);
 
             // And, finally, the ROIs 
             const icarus_signal_processing::VectorBool& chanROIs = decoderTool->getROIVals()[chanIdx];

--- a/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
+++ b/icaruscode/Decode/DecoderTools/TPCNoiseFilter1D_tool.cc
@@ -379,7 +379,7 @@ void TPCNoiseFilter1DMC::process_fragment(detinfo::DetectorClocksData const&,
 
         std::copy(dataArray[idx].begin(),dataArray[idx].end(),rawDataVec.begin());
 
-        Eigen::Vector2f meanPos;
+        Eigen::Vector2f meanPos({0.,0.});
         Eigen::Matrix2f eigenVectors {{0.,0.},{0.,0.}};
         Eigen::Vector2f eigenValues {0.,0.};
 
@@ -394,6 +394,9 @@ void TPCNoiseFilter1DMC::process_fragment(detinfo::DetectorClocksData const&,
                                                    fTruncRMSVals[idx],
                                                    fNumTruncBins[idx],
                                                    fRangeBins[idx]);
+
+        // Make sure we correct for low frequency offset if it was run
+        fPedestalVals[idx] += meanPos[1];
 
         if (fRemoveBadRMS && (fFullRMSVals[idx] < 2.5 || fFullRMSVals[idx] > 40.)) std::fill(fSelectVals[idx].begin(),fSelectVals[idx].end(),true);
 


### PR DESCRIPTION
It turns out the pedestal that was output in the RawDigits for noise corrected waveforms was not the full "from raw waveform" pedestal but, rather, the refinement at the end. Fix this and also account for the effective pedestal removal if running the low frequency correction too. 
This results from a request from the folks updating the Online Monitor. 