### PR TITLE
Update Pandora track and shower discrimination scheme and training

### DIFF
--- a/fcl/caf/cafmaker_defs.fcl
+++ b/fcl/caf/cafmaker_defs.fcl
@@ -334,6 +334,11 @@ cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]
 cafmaker.SaveGENIEEventRecord: true # save GENIE event record by default. Turn this off for data cafmaker fcl
 cafmaker.TPCPMTBarycenterMatchLabel: "tpcpmtbarycentermatch"
 cafmaker.TrackHitFillRREndCut: 30 # include entire PID region
+cafmaker.PFOCharLabels.EndFractionName: "LArThreeDChargeFeatureTool_ICARUS_EndFraction" # override with some ICARUS-specific tool names
+cafmaker.PFOCharLabels.FractionalSpreadName: "LArThreeDChargeFeatureTool_ICARUS_FractionalSpread"
+cafmaker.PFOCharLabels.HaloTotalRatioName: "LArConeChargeFeatureTool_ICARUS_HaloTotalRatio"
+cafmaker.PFOCharLabels.ConcentrationName: "LArConeChargeFeatureTool_ICARUS_Concentration"
+cafmaker.PFOCharLabels.ConicalnessName: "LArConeChargeFeatureTool_ICARUS_Conicalness"
 
 # Add CAFMaker to the list of producers
 caf_preprocess_producers.cafmaker: @local::cafmaker

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
@@ -331,8 +331,9 @@
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
     <PersistFeatures>true</PersistFeatures>
-    <MvaFileName>PandoraBdt_v09_72_01_ICARUS_pfochar_bnb.xml</MvaFileName>
-    <MvaName>PfoCharBDT</MvaName>
+    <UseICARUSCollectionPlane>true</UseICARUSCollectionPlane>
+    <MvaFileName>PFOCharBDT_v09_84_00_03_20250508_ICARUSCollection.xml</MvaFileName>
+    <MvaName>PFOCharBDT_v09_84_00_03_20250508_ICARUSCollection</MvaName>
     <MvaFileNameNoChargeInfo>PandoraBdt_v09_72_01_ICARUS_pfochar_bnb.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
     <FeatureTools>
@@ -340,8 +341,12 @@
       <tool type = "LArThreeDVertexDistanceFeatureTool"/>
       <tool type = "LArThreeDPCAFeatureTool"/>
       <tool type = "LArThreeDOpeningAngleFeatureTool"/>
-      <tool type = "LArThreeDChargeFeatureTool"/>
-      <tool type = "LArConeChargeFeatureTool"/>
+      <tool type = "LArThreeDChargeFeatureTool">
+        <UseICARUSCollectionPlane>true</UseICARUSCollectionPlane>
+      </tool>
+      <tool type = "LArConeChargeFeatureTool">
+        <UseICARUSCollectionPlane>true</UseICARUSCollectionPlane>
+      </tool>
     </FeatureTools>
     <FeatureToolsNoChargeInfo>
       <tool type = "LArThreeDLinearFitFeatureTool"/>

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
@@ -332,19 +332,19 @@
     <UseThreeDInformation>true</UseThreeDInformation>
     <PersistFeatures>true</PersistFeatures>
     <UseICARUSCollectionPlane>true</UseICARUSCollectionPlane>
-    <MvaFileName>PFOCharBDT_v09_84_00_03_20250508_ICARUSCollection.xml</MvaFileName>
-    <MvaName>PFOCharBDT_v09_84_00_03_20250508_ICARUSCollection</MvaName>
-    <MvaFileNameNoChargeInfo>PandoraBdt_v09_72_01_ICARUS_pfochar_bnb.xml</MvaFileNameNoChargeInfo>
-    <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
+    <MvaFileName>PFOCharBDT_v09_84_00_03_20250718_ICARUSCollection.xml</MvaFileName>
+    <MvaName>PFOCharBDT_v09_84_00_03_20250718_ICARUSCollection</MvaName>
+    <MvaFileNameNoChargeInfo>PFOCharBDT_v09_84_00_03_20250718_NoCharge.xml</MvaFileNameNoChargeInfo>
+    <MvaNameNoChargeInfo>PFOCharBDT_v09_84_00_03_20250718_NoCharge</MvaNameNoChargeInfo>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
       <tool type = "LArThreeDVertexDistanceFeatureTool"/>
       <tool type = "LArThreeDPCAFeatureTool"/>
       <tool type = "LArThreeDOpeningAngleFeatureTool"/>
-      <tool type = "LArThreeDChargeFeatureTool">
+      <tool type = "LArThreeDChargeFeatureTool_ICARUS">
         <UseICARUSCollectionPlane>true</UseICARUSCollectionPlane>
       </tool>
-      <tool type = "LArConeChargeFeatureTool">
+      <tool type = "LArConeChargeFeatureTool_ICARUS">
         <UseICARUSCollectionPlane>true</UseICARUSCollectionPlane>
       </tool>
     </FeatureTools>


### PR DESCRIPTION
This PR changes the Pandora XML (particularly, the `LArBdtPfoCharacterisation` algorithm) to accomodate for changes to the track/shower discrimination scheme, and to introduce the corresponding new BDT training files.

___
### Context

The code change within Pandora consists in choosing the Collection plane to compute calorimetric variables used in the track/shower discrimination BDT, instead of relying on the Induction-1 plane. Due to mapping technicalities, the Pandora `W` view (commonly mapped to Collection in other LArTPCs) is mapped to Induction-1 in ICARUS, whereas the `U` and `V` views are mapped to Induction-2 or Collection, based on the TPC. For more details on the Pandora code change, check the corresponding [PandoraPFA/LArContent PR #246](https://github.com/PandoraPFA/LArContent/pull/246), [SBN DocDB 40882](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40882), and [SBN DocDB 40375](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40357).
The `UseICARUSCollectionPlane` algorithm parameter controls the plane used to determine whether charge information is available or not for the reconstructed particle (Collection if `true`), and as a result which BDT to use.
Two ICARUS-specific tools are defined: `ConeChargeFeatureTool_ICARUS`, and `ThreeDChargeFeatureTool_ICARUS`. The `UseICARUSCollectionPlane` tool parameter controls the plane used for computing charge-based variables (Collection if `true`).
This modification was agreed with Pandora experts.

___
### BDT re-training

Information on the BDT re-training are available on [SBN DocDB 42432](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=42432).
The track/shower BDT was re-trained with BNB MC samples based on `icaruscode` v09_84_00_01, balanced between track and shower particles, and with "good reconstruction" cuts. The accuracy of the classification is shown to improve substantially across all particle types.

___
### Dependency

This PR needs the LArSoft/`larpandoracontent` v04_16_00 release ([LArSoft/larpandoracontent PR #78](https://github.com/LArSoft/larpandoracontent/pull/78)), i.e., `larsoft` v10_08_02.
It also needs the corresponding BDT XMLs added to `icarus_data`: a new `icarus_data` release will be needed to pick up the right XMLs.
After this PR is merged, the CAFMaker needs to be updated to pick up the newly-named tools. A companion PR in `sbncode` was opened ([sbncode PR #546](https://github.com/SBNSoftware/sbncode/pull/546)).

___
### Review

Tagging for review:
- @brucehoward-physics and @cerati as reconstruction experts and shower reconstruction task force conveners;
- @SFBayLaser for assistance with icarus_data and LArSoft releases.

Also tagging @acampani as assignee.

Thanks!