### PR TITLE
Updates to the Pandora shower-dE/dx reconstruction settings

### DIFF
--- a/fcl/configurations/showerfindermodules_icarus.fcl
+++ b/fcl/configurations/showerfindermodules_icarus.fcl
@@ -39,7 +39,7 @@ icarus_pandorashower_3dTraj.ShowerFinderTools[7].CalorimetryAlg:      @local::ic
 icarus_pandorashower_3dTraj.ShowerFinderTools[7].MinAngleToWire:      0.26
 icarus_pandorashower_3dTraj.ShowerFinderTools[7].ResultsOverrideMode: 1 # override results from showerunidirectiondedx plane-by-plane
 icarus_pandorashower_3dTraj.ShowerFinderTools[7].dEdxTrackLength:     5
-icarus_pandorashower_3dTraj.ShowerFinderTools[7].MinDistCutOff:       2
+icarus_pandorashower_3dTraj.ShowerFinderTools[7].MinDistCutOff:       2 # same as default, used only when CutStartPosition is true
 icarus_pandorashower_3dTraj.ShowerFinderTools[7].CutStartPosition:    true
 
 # An "experimental" configuration. Uses the incremental track hit 

--- a/fcl/configurations/showerfindermodules_icarus.fcl
+++ b/fcl/configurations/showerfindermodules_icarus.fcl
@@ -30,10 +30,17 @@ icarus_pandorashower_3dTraj.ShowerFinderTools: [
   @local::showertrajpointdedx
 ]
 
-icarus_pandorashower_3dTraj.ShowerFinderTools[3].CalorimetryAlg:    @local::icarus_calorimetryalgmc
-icarus_pandorashower_3dTraj.ShowerFinderTools[5].CalorimetryAlg:    @local::icarus_calorimetryalgmc
-icarus_pandorashower_3dTraj.ShowerFinderTools[7].CalorimetryAlg:    @local::icarus_calorimetryalgmc
-icarus_pandorashower_3dTraj.ShowerFinderTools[7].MinAngleToWire:    0.26
+icarus_pandorashower_3dTraj.ShowerFinderTools[3].CalorimetryAlg:      @local::icarus_calorimetryalgmc
+
+icarus_pandorashower_3dTraj.ShowerFinderTools[5].CalorimetryAlg:      @local::icarus_calorimetryalgmc
+icarus_pandorashower_3dTraj.ShowerFinderTools[5].dEdxTrackLength:     5
+
+icarus_pandorashower_3dTraj.ShowerFinderTools[7].CalorimetryAlg:      @local::icarus_calorimetryalgmc
+icarus_pandorashower_3dTraj.ShowerFinderTools[7].MinAngleToWire:      0.26
+icarus_pandorashower_3dTraj.ShowerFinderTools[7].ResultsOverrideMode: 1 # override results from showerunidirectiondedx plane-by-plane
+icarus_pandorashower_3dTraj.ShowerFinderTools[7].dEdxTrackLength:     5
+icarus_pandorashower_3dTraj.ShowerFinderTools[7].MinDistCutOff:       2
+icarus_pandorashower_3dTraj.ShowerFinderTools[7].CutStartPosition:    true
 
 # An "experimental" configuration. Uses the incremental track hit 
 # finder and values for some parameters from the study in SBN-doc-19390


### PR DESCRIPTION
This PR updates the settings of the Pandora Modular Shower Creation shower-dE/dx tools, particularly of

1. `showerunidirectiondedx`: slightly increased the segment length;
2. `showertrajpointdedx`:  slightly increased the segment length, enabled option to skip a couple of wires at the shower start, and introduced plane-by-plane overriding.

Some studies related to such settings can be found in [SBN DocDB 40675](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40675).

This PR depends on `larpandora v10_00_29` (i.e., `larsoft v10_10_04`) for the tool overriding infrastructure ([larpandora PR #32](https://github.com/PandoraPFA/larpandora/pull/32)).

___

### Review

Tagging @cerati and @brucehoward-physics for review, thanks!!