### PR TITLE
Fix issue where CRT HitTree in calibration tuples did not store run number [Develop]

### DIFF
--- a/icaruscode/CRT/CRTDataAnalysis_module.cc
+++ b/icaruscode/CRT/CRTDataAnalysis_module.cc
@@ -209,6 +209,8 @@ namespace crt {
     vector<vector<int>> fDetPDG; /// signal inducing particle(s)' PDG code
 
     //CRT hit product vars
+    int      fHitRun;
+    int      fHitSubRun;
     int      fHitEvent;
     float    fXHit; ///< reconstructed X position of CRT hit (cm)
     float    fYHit; ///< reconstructed Y position of CRT hit (cm)
@@ -373,8 +375,8 @@ namespace crt {
     fDAQNtuple->Branch("gate_start_timestamp", &m_gate_start_timestamp, "gate_start_timestamp/l");
 
     // Define the branches of our SimHit n-tuple
-    fHitNtuple->Branch("run",         &fDetRun,      "run/I");
-    fHitNtuple->Branch("subrun",      &fDetSubRun,   "subrun/I");
+    fHitNtuple->Branch("run",         &fHitRun,      "run/I");
+    fHitNtuple->Branch("subrun",      &fHitSubRun,   "subrun/I");
     fHitNtuple->Branch("event",       &fHitEvent,    "event/I");
     fHitNtuple->Branch("nHit",        &fNHit,        "nHit/I");
     fHitNtuple->Branch("x",           &fXHit,        "x/F");
@@ -578,6 +580,8 @@ namespace crt {
       for ( auto const& hit : *crtHitHandle )
         {
 	  fNHit++;
+    fHitRun = fRun;
+    fHitSubRun = fSubRun;
 	  fHitEvent = fEvent;
 	  fXHit    = hit.x_pos;
 	  fYHit    = hit.y_pos;


### PR DESCRIPTION
[Develop Version]
This PR fixes a bug where due to the fact CRTData were dropped from Stage0, running Stage1 did not fill run number and sub run number. This caused the usage of uninitialized variables. This error was spotted thanks to @mt82 who did consistency checks between productions.
On a side note, I cleaned the code from some bad indentation that made the code unreadable.
I also added Trigger Timestamp to the DAQTree, it should have been there since the beginning.