### PR TITLE
Fix bug in detsim with no YZ-simulation and add new related Stage0/Stage1/CAF fcls

### DIFF
--- a/fcl/detsim/detsim_2d_icarus_refactored.fcl
+++ b/fcl/detsim/detsim_2d_icarus_refactored.fcl
@@ -19,7 +19,7 @@ physics: {
     
     crtdaq:         @local::icarus_crtsim
      opdaq:         @local::icarus_simpmt
-       daq:         @local::icarus_simwire_wirecell_filtersed
+       daq:         @local::icarus_simwire_wirecell_shifted
 
        rns:         { module_type: "RandomNumberSaver" }
   } # producers

--- a/fcl/reco/Stage0/mc/stage0_run2_icarus_noyzsim_mc.fcl
+++ b/fcl/reco/Stage0/mc/stage0_run2_icarus_noyzsim_mc.fcl
@@ -1,0 +1,66 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_mc_defs.fcl"
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: MCstage0
+
+## Add the MC module to the list of producers
+physics.producers: {  @table::icarus_stage0_producers
+                      @table::icarus_stage0_mc_producers
+                   }
+
+## Use the following to run the full defined stage0 set of modules
+physics.path: [   @sequence::icarus_stage0_mc_PMT, 
+                  MCDecodeTPCROI, 
+                  @sequence::icarus_stage0_multiTPC,
+                  simChannelROI,
+                  @sequence::icarus_stage0_mc_crthit,
+                  @sequence::icarus_stage0_mc_crtreco
+              ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamROOT ]
+
+# Drop data products that are no longer needed, but make sure to keep important items!
+# For example, we need to drop the RawDigits from the detector simulation stage but want to keep the SimChannel info from WireCell...
+outputs.rootOutput.outputCommands: ["keep *_*_*_*", 
+                                    "drop *_daq*_*_*", 
+                                    "drop raw::RawDigit*_*_*_*", 
+                                    "drop raw::OpDetWaveform*_opdaq_*_*", 
+                                    "drop *_MCDecodeTPCROI_*_*", 
+                                    "drop *_decon1droi_*_*", 
+                                    "drop recob::Wire*_roifinder*_*_*", 
+                                    "keep *_daq_simpleSC*_*"]
+
+# Set the expected input for ophit
+physics.producers.ophit.InputModule: "shifted"
+
+# Note the default assumption is that our detector simulation input will come from the WireCell 2D drift simulation, a la 'daq'
+# If we are running the 1D drift simulation we need to switch to using:
+# `physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq3:PHYSCRATEDATATPCWW","daq2:PHYSCRATEDATATPCWE","daq1:PHYSCRATEDATATPCEW","daq0:PHYSCRATEDATATPCEE"]`
+#
+physics.producers.MCDecodeTPCROI.FragmentsLabelVec:   ["daq:TPCWW","daq:TPCWE","daq:TPCEW","daq:TPCEE"]
+physics.producers.MCDecodeTPCROI.OutInstanceLabelVec: ["PHYSCRATEDATATPCWW", "PHYSCRATEDATATPCWE", "PHYSCRATEDATATPCEW", "PHYSCRATEDATATPCEE"]
+physics.producers.decon1droi.RawDigitLabelVec:        ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+
+physics.producers.simChannelROI.SimChannelLabelVec:  ["daq:simpleSC"]
+physics.producers.simChannelROI.OutInstanceLabelVec: ["All"]
+
+physics.producers.decon2droiEE.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCEE"
+physics.producers.decon2droiEW.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCEW"
+physics.producers.decon2droiWE.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWE"
+physics.producers.decon2droiWW.wcls_main.params.raw_input_label:  "MCDecodeTPCROI:PHYSCRATEDATATPCWW"
+
+## Need overrides for the purity monitor
+physics.analyzers.purityinfoana0.SelectEvents: [ path ]
+physics.analyzers.purityinfoana1.SelectEvents: [ path ]
+physics.producers.purityana0.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+physics.producers.purityana1.RawModuleLabel:   ["MCDecodeTPCROI:PHYSCRATEDATATPCWW","MCDecodeTPCROI:PHYSCRATEDATATPCWE","MCDecodeTPCROI:PHYSCRATEDATATPCEW","MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+
+# restore legacy G4 labels
+physics.producers.mcophit.SimPhotonsProducer: "shifted"

--- a/fcl/reco/Stage1/mc/stage1_run2_1d_icarus_noyzsim_MC.fcl
+++ b/fcl/reco/Stage1/mc/stage1_run2_1d_icarus_noyzsim_MC.fcl
@@ -8,8 +8,8 @@ physics.reco: [
                 @sequence::icarus_crttrack,
                 @sequence::icarus_crtt0tagging,
                 caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
-                mcassociationsGausCryoE,  mcassociationsGausCryoW
-                # mcreco
+                mcassociationsGausCryoE,  mcassociationsGausCryoW,
+                mcreco
               ]
 
 physics.producers.cluster3DCryoW.Hit3DBuilderAlg.HitFinderTagVec: ["gaushit1dTPCWW", "gaushit1dTPCWE"]

--- a/fcl/reco/Stage1/mc/stage1_run2_1d_icarus_noyzsim_MC.fcl
+++ b/fcl/reco/Stage1/mc/stage1_run2_1d_icarus_noyzsim_MC.fcl
@@ -1,0 +1,22 @@
+#include "stage1_run2_icarus_MC.fcl"
+
+physics.reco: [ 
+                @sequence::icarus_reco_Gauss1D_CryoE ,
+                @sequence::icarus_reco_Gauss1D_CryoW ,
+                @sequence::icarus_reco_fm,
+                @sequence::icarus_tpcpmtbarycentermatch,
+                @sequence::icarus_crttrack,
+                @sequence::icarus_crtt0tagging,
+                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
+                mcassociationsGausCryoE,  mcassociationsGausCryoW
+                # mcreco
+              ]
+
+physics.producers.cluster3DCryoW.Hit3DBuilderAlg.HitFinderTagVec: ["gaushit1dTPCWW", "gaushit1dTPCWE"]
+physics.producers.cluster3DCryoE.Hit3DBuilderAlg.HitFinderTagVec: ["gaushit1dTPCEW", "gaushit1dTPCEE"]
+
+## no yz simulation
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "daq:simpleSC"
+physics.analyzers.caloskimE.SimChannelproducer: "daq:simpleSC"
+physics.analyzers.caloskimW.SimChannelproducer: "daq:simpleSC"
+physics.producers.mcreco.SimChannelLabel: "shifted"

--- a/fcl/reco/Stage1/mc/stage1_run2_icarus_noyzsim_MC.fcl
+++ b/fcl/reco/Stage1/mc/stage1_run2_icarus_noyzsim_MC.fcl
@@ -1,0 +1,123 @@
+#include "mchitmodules.fcl"
+#include "mctrutht0matching.fcl"
+#include "mcreco.fcl"
+#include "backtrackerservice.fcl"
+#include "particleinventoryservice.fcl"
+#include "stage1_icarus_driver_common.fcl"
+
+process_name: MCstage1
+
+# Disabled Space-Charge service for calorimetry
+services.SpaceChargeService: {
+    EnableCalEfieldSCE: false
+    EnableCalSpatialSCE: false
+    EnableCorrSCE: false
+    EnableSimEfieldSCE: false
+    EnableSimSpatialSCE: false
+    InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
+    RepresentationType: "Voxelized_TH3"
+    service_provider: "SpaceChargeServiceICARUS"
+}
+
+services.BackTrackerService:        @local::standard_backtrackerservice
+# In the 2D-detsim, SimChannel objects are made by the WireCell
+# drift simulation (daq), not LArG4 (largeant). Thus, we need
+# to overwrite the truth matching labels in the calibration ntuple maker
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "daq:simpleSC"
+services.ParticleInventoryService:  @local::standard_particleinventoryservice
+
+## Add the MC module to the list of producers
+physics.producers: {
+            @table::icarus_stage1_producers
+
+            #mcophit:                        @local::ICARUSMCOpHit
+            mcopflashTPC0:                  @local::ICARUSMCOpFlashTPC0
+            mcopflashTPC1:                  @local::ICARUSMCOpFlashTPC1
+            mcopflashTPC2:                  @local::ICARUSMCOpFlashTPC2
+            mcopflashTPC3:                  @local::ICARUSMCOpFlashTPC3
+          
+            cheatopflashTPC0:               @local::ICARUSCheatOpFlashTPC0
+            cheatopflashTPC1:               @local::ICARUSCheatOpFlashTPC1
+            cheatopflashTPC2:               @local::ICARUSCheatOpFlashTPC2
+            cheatopflashTPC3:               @local::ICARUSCheatOpFlashTPC3
+
+            ### mc producers
+            mcreco:                         @local::standard_mcreco
+            mchitfinder:                    @local::standard_mchitfinder
+            mcassociationsGausCryoE:        @local::standard_mcparticlehitmatching
+            mcassociationsGausCryoW:        @local::standard_mcparticlehitmatching
+}
+
+physics.reco: [ 
+                @sequence::icarus_reco_Gauss2D_CryoE ,
+                @sequence::icarus_reco_Gauss2D_CryoW ,
+                @sequence::icarus_reco_fm,
+                @sequence::icarus_tpcpmtbarycentermatch,
+                @sequence::icarus_crttrack,
+                @sequence::icarus_crtt0tagging,
+                caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
+                mcassociationsGausCryoE,  mcassociationsGausCryoW
+                # mcreco
+              ]
+
+physics.outana:            [ @sequence::icarus_analysis_modules ]
+physics.trigger_paths:     [ reco ]
+physics.end_paths:         [ outana, stream1 ]
+outputs.out1.fileName:     "%ifb_%tc-%p.root"
+outputs.out1.dataTier:     "reconstructed"
+outputs.out1.outputCommands: [
+  "keep *_*_*_*",
+  "drop *_caloskimCalorimetryCryoE_*_*",
+  "drop *_caloskimCalorimetryCryoW_*_*"
+]
+
+#Redefine TPCPMTBarycenterMatch producers with MC parameters
+physics.producers.tpcpmtbarycentermatchCryoE: @local::mc_tpcpmtbarycentermatchproducer_east
+physics.producers.tpcpmtbarycentermatchCryoW: @local::mc_tpcpmtbarycentermatchproducer_west
+
+# Turn on truth-info for track skimmer 
+physics.analyzers.caloskimE.G4producer: "largeant"
+physics.analyzers.caloskimE.SimChannelproducer: "daq:simpleSC"
+physics.analyzers.caloskimE.RawDigitproducers: ["MCDecodeTPCROI:PHYSCRATEDATATPCEW", "MCDecodeTPCROI:PHYSCRATEDATATPCEE"]
+physics.analyzers.caloskimE.SelectEvents: [reco]
+
+physics.analyzers.caloskimW.G4producer: "largeant"
+physics.analyzers.caloskimW.SimChannelproducer: "daq:simpleSC"
+physics.analyzers.caloskimW.RawDigitproducers: ["MCDecodeTPCROI:PHYSCRATEDATATPCWW", "MCDecodeTPCROI:PHYSCRATEDATATPCWE"]
+physics.analyzers.caloskimW.SelectEvents: [reco]
+
+physics.producers.mcassociationsGausCryoE.HitParticleAssociations.HitModuleLabelVec: ["cluster3DCryoE"]
+physics.producers.mcassociationsGausCryoW.HitParticleAssociations.HitModuleLabelVec: ["cluster3DCryoW"]
+
+# Remove missing products in MC
+physics.analyzers.simpleLightAna.TriggerLabel: ""
+physics.analyzers.simpleLightAna.RWMLabel: ""
+physics.analyzers.simpleLightAna.OpDetWaveformLabels: ["opdaq"]
+
+# Configure mcreco to read SEDLite instead of SED and MCParticleLite in addition to MCParticle
+physics.producers.mcreco.G4ModName: @erase
+physics.producers.mcreco.SimChannelLabel: "shifted"
+physics.producers.mcreco.MCParticleLabel: "largeant"
+physics.producers.mcreco.UseSimEnergyDepositLite: true
+physics.producers.mcreco.UseSimEnergyDeposit: false
+physics.producers.mcreco.IncludeDroppedParticles: true #this is now true with larsoft v09_89 and newer
+physics.producers.mcreco.MCParticleDroppedLabel: "largeant:droppedMCParticles"
+physics.producers.mcreco.MCRecoPart.SavePathPDGList: [13,-13,211,-211,111,311,310,130,321,-321,2212,2112,2224,2214,2114,1114,3122,1000010020,1000010030,1000020030,1000020040]
+physics.producers.mcreco.MCRecoPart.TrackIDOffsets: [0,10000000,20000000] #Account for track ID offsets in labeling primaries
+
+services.message.destinations :
+{
+  STDCOUT:
+  {
+     type:      "cout"      #tells the message service to output this destination to cout
+     threshold: "WARNING"   #tells the message service that this destination applies to WARNING and higher level messages
+     categories:
+     {
+       Cluster3DICARUS:
+       {
+         limit: -1
+         reportEvery: 1
+       }
+     }
+  }
+}

--- a/fcl/reco/Stage1/mc/stage1_run2_icarus_noyzsim_MC.fcl
+++ b/fcl/reco/Stage1/mc/stage1_run2_icarus_noyzsim_MC.fcl
@@ -56,8 +56,8 @@ physics.reco: [
                 @sequence::icarus_crttrack,
                 @sequence::icarus_crtt0tagging,
                 caloskimCalorimetryCryoE, caloskimCalorimetryCryoW,
-                mcassociationsGausCryoE,  mcassociationsGausCryoW
-                # mcreco
+                mcassociationsGausCryoE,  mcassociationsGausCryoW,
+                mcreco
               ]
 
 physics.outana:            [ @sequence::icarus_analysis_modules ]


### PR DESCRIPTION
This PR fixes some labels in the detsim fcl without the YZ-simulation.  The downstream reconstruction chain had to be updated accordingly.  This fix would enable producing testing samples much more quickly, as running the YZ-simulation on the grid got very hard lately. Currently opening this PR with fcls from `v10_06_00_01p01` for discussion: I can provide similar fixes for `develop`, eventually. Thanks!