### PR TITLE
Trigger simulation modules now support input tags with process name

### DIFF
--- a/icaruscode/PMT/Trigger/LVDSgates_module.cc
+++ b/icaruscode/PMT/Trigger/LVDSgates_module.cc
@@ -879,7 +879,7 @@ art::InputTag icarus::trigger::LVDSgates::makeTag
     ? art::InputTag{ thresholdStr }
     : defModule.label().empty()
       ? throw (art::Exception(art::errors::Configuration)
-        << "Default module label (`TriggerGatesTag`) specified"
+        << "No default module label (`TriggerGatesTag`) specified"
            ", and it's needed for threshold '" << thresholdStr << "'.\n")
       : art::InputTag{ defModule.label(), thresholdStr, defModule.process() }
     ;

--- a/icaruscode/PMT/Trigger/LVDSgates_module.cc
+++ b/icaruscode/PMT/Trigger/LVDSgates_module.cc
@@ -192,9 +192,9 @@ class icarus::trigger::LVDSgates: public art::EDProducer {
         { ComboMode::OR,      "OR" }
       };
     
-    fhicl::OptionalAtom<std::string> TriggerGatesTag {
+    fhicl::OptionalAtom<art::InputTag> TriggerGatesTag {
       Name("TriggerGatesTag"),
-      Comment("label of trigger gate extraction module (no instance name)")
+      Comment("tag of trigger gate extraction module (no instance name)")
       };
 
     fhicl::Sequence<std::string> Thresholds {
@@ -386,11 +386,11 @@ class icarus::trigger::LVDSgates: public art::EDProducer {
 
   /// Converts a threshold string into an input tag.
   static art::InputTag makeTag
-    (std::string const& thresholdStr, std::string const& defModule);
+    (std::string const& thresholdStr, art::InputTag const& defModule);
 
   /// Converts an input tag into an instance name for the corresponding output.
   static std::string makeOutputInstanceName
-    (art::InputTag const& inputTag, std::string const& defModule);
+    (art::InputTag const& inputTag, art::InputTag const& defModule);
   
 }; // class icarus::trigger::LVDSgates
 
@@ -412,11 +412,11 @@ icarus::trigger::LVDSgates::LVDSgates
   //
   // more complex parameter parsing
   //
-  std::string const discrModuleLabel = config().TriggerGatesTag().value_or("");
+  art::InputTag const discrModuleTag = config().TriggerGatesTag().value_or("");
   for (std::string const& thresholdStr: config().Thresholds()) {
-    art::InputTag const inputTag = makeTag(thresholdStr, discrModuleLabel);
+    art::InputTag const inputTag = makeTag(thresholdStr, discrModuleTag);
     fADCthresholds[thresholdStr]
-      = { inputTag, makeOutputInstanceName(inputTag, discrModuleLabel) };
+      = { inputTag, makeOutputInstanceName(inputTag, discrModuleTag) };
   } // for all thresholds
   
   //
@@ -863,34 +863,38 @@ auto icarus::trigger::LVDSgates::ReadTriggerGates(
 
 //------------------------------------------------------------------------------
 art::InputTag icarus::trigger::LVDSgates::makeTag
-  (std::string const& thresholdStr, std::string const& defModule)
+  (std::string const& thresholdStr, art::InputTag const& defModule)
 {
   auto const isNumber = [pattern=std::regex{ "[+-]?[0-9]+" }]
     (std::string const& s) -> bool
     { return std::regex_match(s, pattern); };
-  return 
+  if (!thresholdStr.empty() && !defModule.instance().empty()) {
+    throw art::Exception(art::errors::Configuration)
+      << "Both the input gate module tag instance name (`TriggerGatesTag`: '"
+      << defModule.encode() << "') and the threshold '" << thresholdStr
+      << "' are set. One of them must be empty.\n";
+  }
+  return
     ((thresholdStr.find(':') != std::string::npos) || !isNumber(thresholdStr))
     ? art::InputTag{ thresholdStr }
-    : defModule.empty()
+    : defModule.label().empty()
       ? throw (art::Exception(art::errors::Configuration)
-        << "No default module label (`TriggerGatesTag`) specified"
-           ", and it's needed for threshold '"
-        << thresholdStr << "'.\n")
-      : art::InputTag{ defModule, thresholdStr }
+        << "Default module label (`TriggerGatesTag`) specified"
+           ", and it's needed for threshold '" << thresholdStr << "'.\n")
+      : art::InputTag{ defModule.label(), thresholdStr, defModule.process() }
     ;
 } // icarus::trigger::LVDSgates::makeTag()
 
 
 //------------------------------------------------------------------------------
 std::string icarus::trigger::LVDSgates::makeOutputInstanceName
-  (art::InputTag const& inputTag, std::string const& defModule)
+  (art::InputTag const& inputTag, art::InputTag const& defModule)
 {
-  return (inputTag.label() == defModule)
+  return (inputTag.label() == defModule.label())
     ? inputTag.instance()
-    : inputTag.instance().empty()
-      ? inputTag.label(): inputTag.label() + inputTag.instance()
+    : inputTag.label() + inputTag.instance()
     ;
-} // icarus::trigger::LVDSgates::makeTag()
+} // icarus::trigger::LVDSgates::makeOutputInstanceName()
 
 
 //------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/MajorityTriggerSimulation_module.cc
+++ b/icaruscode/PMT/Trigger/MajorityTriggerSimulation_module.cc
@@ -359,7 +359,7 @@ class icarus::trigger::MajorityTriggerSimulation
     using Name = fhicl::Name;
     using Comment = fhicl::Comment;
     
-    fhicl::Atom<std::string> TriggerGatesTag {
+    fhicl::Atom<art::InputTag> TriggerGatesTag {
       Name("TriggerGatesTag"),
       Comment("label of the input trigger gate data product (no instance name)")
       };
@@ -597,6 +597,11 @@ class icarus::trigger::MajorityTriggerSimulation
   //@}
   
   
+  /// Returns `defModule` with instance name replaced by `thresholdStr`.
+  static art::InputTag makeTag
+    (art::InputTag const& defModule, std::string const& thresholdStr);
+  
+  
 }; // icarus::trigger::MajorityTriggerSimulation
 
 
@@ -629,10 +634,10 @@ icarus::trigger::MajorityTriggerSimulation::MajorityTriggerSimulation
   //
   // more complex parameter parsing
   //
-  std::string const discrModuleLabel = config().TriggerGatesTag();
+  art::InputTag const& discrModuleTag = config().TriggerGatesTag();
   for (raw::ADC_Count_t threshold: config().Thresholds()) {
     fADCthresholds[icarus::trigger::ADCCounts_t{threshold}]
-      = art::InputTag{ discrModuleLabel, util::to_string(threshold) };
+      = makeTag(discrModuleTag, util::to_string(threshold));
   }
   
   // initialization of a vector of atomic is not as trivial as it sounds...
@@ -941,6 +946,20 @@ icarus::trigger::MajorityTriggerSimulation::triggerInfoToTriggerData
     };
   
 } // icarus::trigger::MajorityTriggerSimulation::triggerInfoToTriggerData()
+
+
+//------------------------------------------------------------------------------
+art::InputTag icarus::trigger::MajorityTriggerSimulation::makeTag
+  (art::InputTag const& defModule, std::string const& thresholdStr)
+{
+  if (!thresholdStr.empty() && !defModule.instance().empty()) {
+    throw art::Exception(art::errors::Configuration)
+      << "Module tag instance name (`TriggerGatesTag`: '"
+      << defModule.encode() << "') and the threshold '" << thresholdStr
+      << "' are both set. One of them must be empty.\n";
+  }
+  return { defModule.label(), thresholdStr, defModule.process() };
+} // icarus::trigger::MajorityTriggerSimulation::makeTag()
 
 
 //------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/MajorityTriggerSimulation_module.cc
+++ b/icaruscode/PMT/Trigger/MajorityTriggerSimulation_module.cc
@@ -361,7 +361,7 @@ class icarus::trigger::MajorityTriggerSimulation
     
     fhicl::Atom<art::InputTag> TriggerGatesTag {
       Name("TriggerGatesTag"),
-      Comment("label of the input trigger gate data product (no instance name)")
+      Comment("tag of the input trigger gate data product")
       };
 
     fhicl::Sequence<raw::ADC_Count_t> Thresholds {

--- a/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.cxx
+++ b/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.cxx
@@ -531,9 +531,9 @@ icarus::trigger::TriggerEfficiencyPlotsBase::TriggerEfficiencyPlotsBase
     if (fLogEventDetails.empty()) fLogEventDetails = fLogCategory;
   } // if EventDetailsLogCategory is specified
 
-  std::string const discrModuleLabel = config.TriggerGatesTag();
+  art::InputTag const& discrModuleTag = config.TriggerGatesTag();
   for (std::string const& threshold: config.Thresholds())
-    fADCthresholds[threshold] = art::InputTag{ discrModuleLabel, threshold };
+    fADCthresholds[threshold] = makeInputTag(discrModuleTag, threshold);
   
 
   if (config.EventTreeName.hasValue()) {
@@ -1495,6 +1495,20 @@ icarus::trigger::TriggerEfficiencyPlotsBase::makeEdepTag(
   }
   
 } // icarus::trigger::MakeTriggerSimulationTree::makeEdepTag()
+
+
+//------------------------------------------------------------------------------
+art::InputTag icarus::trigger::TriggerEfficiencyPlotsBase::makeInputTag
+  (art::InputTag const& defModule, std::string const& thresholdStr)
+{
+  if (!thresholdStr.empty() && !defModule.instance().empty()) {
+    throw art::Exception(art::errors::Configuration)
+      << "Module tag instance name (`TriggerGatesTag`: '"
+      << defModule.encode() << "') and the threshold '" << thresholdStr
+      << "' are both set. One of them must be empty.\n";
+  }
+  return { defModule.label(), thresholdStr, defModule.process() };
+} // icarus::trigger::TriggerEfficiencyPlotsBase::makeInputTag()
 
 
 //------------------------------------------------------------------------------

--- a/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.h
+++ b/icaruscode/PMT/Trigger/TriggerEfficiencyPlotsBase.h
@@ -222,7 +222,7 @@ class icarus::trigger::details::TriggerPassCounters {
   
   /// Registers a new pattern in the index and returns its index (unchecked).
   std::size_t registerPattern(std::string const& name);
-  
+
 }; // icarus::trigger::details::TriggerPassCounters
 
 
@@ -1010,9 +1010,9 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
       Comment("label of energy deposition summary data product")
       };
 
-    fhicl::Atom<std::string> TriggerGatesTag {
+    fhicl::Atom<art::InputTag> TriggerGatesTag {
       Name("TriggerGatesTag"),
-      Comment("label of the input trigger gate data product (no instance name)")
+      Comment("tag of the input trigger gate data product (no instance name)")
       };
 
     fhicl::Sequence<std::string> Thresholds {
@@ -1564,6 +1564,10 @@ class icarus::trigger::TriggerEfficiencyPlotsBase {
     fhicl::Sequence<art::InputTag> const& EnergyDepositTags,
     fhicl::OptionalAtom<art::InputTag> const& EnergyDepositSummaryTag
     );
+  
+  /// Returns `defModule` with instance name replaced by `thresholdStr`.
+  static art::InputTag makeInputTag
+    (art::InputTag const& defModule, std::string const& thresholdStr);
   
 }; // icarus::trigger::TriggerEfficiencyPlotsBase
 


### PR DESCRIPTION
These modules are special in that they compose the list of input tags from a base tag and an instance name from a list. The simplistic tag creation logic did not account for base input tags with process names.

Now the base tag can be specified as a full input tag and an exception is raised if there is a conflict between the input tag instance and the instance in the list (if both are not empty — I expect the instance name of the input tag to be always empty; otherwise, a new protocol needs to be developed). Both module label and process name are correctly propagated.

The fix has been applied to all modules known to suffer from the issue; several of them are not commonly used, and a couple are actually deprecated and should be removed.

This pull request is against the main code branch (`develop`).

Reviewers:
* @mvicenzi who reported the issue and needed a fix
* @rtriozzi as a person informed on trigger simulation
