### PR TITLE
Add CRT-PMT flash classification to TPC-PMT flash-matching producer

### DIFF
--- a/icaruscode/PMT/OpReco/fcl/tpcpmtbarycentermatch_config.fcl
+++ b/icaruscode/PMT/OpReco/fcl/tpcpmtbarycentermatch_config.fcl
@@ -3,14 +3,15 @@ BEGIN_PROLOG
 #Common paramters for the barycenter matching
 tpcpmtbarycentermatch_common_params:
 {
-    OpFlashLabel:     "opflash"
-    PandoraLabel:     "pandoraGaus"
-    CollectionOnly:   true
-    UseTimeRange:     true
-    Verbose:          false
-    FillMatchTree:    false
-    TriggerTolerance: 0.15
-    TimeRangeMargin:  35.
+    OpFlashLabel:         "opflash"
+    PandoraLabel:         "pandoraGaus"
+    CRTPMTMatchingLabel:  "crtpmt"
+    CollectionOnly:       true
+    UseTimeRange:         true
+    Verbose:              false
+    FillMatchTree:        false
+    TriggerTolerance:     0.15
+    TimeRangeMargin:      35.
 }
 
 


### PR DESCRIPTION
This PR (based off of `v10_04_04`) adds the flash classification from the CRT-PMT matching (via the `crtpmt` label) to the best-matched flash in the TPC-PMT barycenter flash-matching producer. This information can be propagated to the CAFs, and enables for using the CRT-PMT matching information at the slice-level in selections. Relevant PRs will follow.

It also adds an option (via `MinimizeZDistance`) to choose the flash that is best-matched to the TPC charge by minimizing only the distance along the longitudinal direction. By default, the code still chooses the best-matched flash by minimizing the longitudinal-vertical distance.

___
### Associated PRs

- https://github.com/SBNSoftware/sbnobj/pull/157
- https://github.com/SBNSoftware/sbnanaobj/pull/179
- https://github.com/SBNSoftware/sbncode/pull/613

___
### Review

Tagging for review @francescopoppi and @PetrilloAtWork as the CRT & light gurus. Thanks!