### PR TITLE
Disable UseTimeRange in TPC-PMT matching 

### DIFF
--- a/icaruscode/PMT/OpReco/fcl/tpcpmtbarycentermatch_config.fcl
+++ b/icaruscode/PMT/OpReco/fcl/tpcpmtbarycentermatch_config.fcl
@@ -6,7 +6,7 @@ tpcpmtbarycentermatch_common_params:
     OpFlashLabel:     "opflash"
     PandoraLabel:     "pandoraGaus"
     CollectionOnly:   true
-    UseTimeRange:     true
+    UseTimeRange:     false
     Verbose:          false
     FillMatchTree:    false
     TriggerTolerance: 0.15


### PR DESCRIPTION
This PR simply disables the `UseTimeRange` option in the TPC-PMT barycenter-based matching.

The `UseTimeRange` option uses a slice's extent along the drift direction to constrain the time range for matching optical flashes, reducing the amount of candidate flashes. This time range is especially tight when the slice crosses the cathode.

While this is straightforward for tracks, it is definitely not for showers, or more generally for slices involving showery particles and deposits crossing the cathode. The code has no way of knowing the nature of the particle crossing the cathode, so the safest bet here is to just disable this option. 

I have debugged and discussed this with @cerati and @PetrilloAtWork, and I'm adding them as reviewers. Thanks!