### PR TITLE
Update enable_spacecharge_icarus.fcl

### DIFF
--- a/fcl/g4/modifiers/enable_spacecharge_icarus.fcl
+++ b/fcl/g4/modifiers/enable_spacecharge_icarus.fcl
@@ -4,7 +4,7 @@
 
 services.SpaceChargeService.EnableSimSpatialSCE: true
 services.SpaceChargeService.EnableSimEfieldSCE: true
-services.SpaceChargeService.is2DdriftSimHack: false
+services.SpaceChargeService.is2DdriftSimHack: true
 
 services.SpaceChargeService.RepresentationType: "Voxelized_TH3"
 


### PR DESCRIPTION
We don't use 1D drift sim. Use correct space charge G4 sim for 2D case by default.