### PR TITLE
Updated Continuous Integration DetSim configurations to refactored G4

### DIFF
--- a/test/ci/icarus_ci_intimecosmic_detsim_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_intimecosmic_detsim_quick_test_icaruscode.fcl
@@ -1,1 +1,1 @@
-#include "detsim_2d_icarus.fcl"
+#include "standard_mc_all_detsim_icarus.fcl"

--- a/test/ci/icarus_ci_nucosmics_detsim_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_nucosmics_detsim_quick_test_icaruscode.fcl
@@ -1,2 +1,1 @@
-#include "detsim_2d_icarus.fcl"
-
+#include "standard_mc_all_detsim_icarus.fcl"

--- a/test/ci/icarus_ci_single_detsim_quick_test_icaruscode.fcl
+++ b/test/ci/icarus_ci_single_detsim_quick_test_icaruscode.fcl
@@ -1,1 +1,1 @@
-#include "detsim_2d_icarus.fcl"
+#include "standard_mc_all_detsim_icarus.fcl"


### PR DESCRIPTION
Fixes the broken DetSim stage of the C.I. tests.
This change was tested only on the single particle tests; the other two test workflow are (almost) identical though.

This pull request is against `release/SBN2025A` branch and it was developed against `v10_06_00_06p04` tag.
**Release managers: please duplicate, cherry-pick and change target branch as needed.**

Last force-push: I adopted the changes in `develop`. Still reluctant to just cherry-pick the fix in `develop` (308484a6) because of a statement about a discontinued parameter in `MergeSimSources` which [does not seem to have actually been discontinued](https://github.com/LArSoft/larsim/blob/4e1000511eaaad4e3287d44f2786ab7596cbf080/larsim/MergeSimSources/MergeSimSources_module.cc#L88). @vitodb may comment on that.