### PR TITLE
remove largeantmodules fcl

### DIFF
--- a/fcl/gen/genie/prodcorsika_genie_standard_icarus.fcl
+++ b/fcl/gen/genie/prodcorsika_genie_standard_icarus.fcl
@@ -3,7 +3,6 @@
 #include "larproperties.fcl"
 #include "magfield_larsoft.fcl"
 
-#include "largeantmodules.fcl"
 #include "corsika_icarus.fcl"
 #include "mcreco.fcl"
 #include "services_common_icarus.fcl"


### PR DESCRIPTION
This PR fixes `prodcorsika_genie_standard_icarus.fcl` in v10_20_03 by removing the spurious and broken line `#include "largeantmodules.fcl"`