### PR TITLE
Remove unsupported parameter SkipTrackIDOffsets

### DIFF
--- a/fcl/g4/mergesimsources_icarus.fcl
+++ b/fcl/g4/mergesimsources_icarus.fcl
@@ -52,6 +52,7 @@ icarus_merge_intime_dropped_mcparts:
 {
     @table::icarus_merge_sim_sources
     module_type: "MergeSimSourcesSBN"
+    SkipTrackIDOffsets: @erase
     InputSourcesLabels: ["larg4intime:droppedMCParticles","larg4outtime:droppedMCParticles"]
     FillMCParticles: true
     FillMCParticlesLite: false


### PR DESCRIPTION
The parameter `SkipTrackIDOffsets` is supported by `MergeSimSources` but not by `MergeSimSourcesSBN`.

:warning: This is a GitHub-written commit: **completely untested** :warning:

The C.I. tests should validate the change.

Historical note
----------------

From my investigation, many years ago Laura Domine needed a customisation of `MergeSimSources` for ICARUS Machine Learning simulation path, and [frustrated by the impossibility to make a derived class](https://github.com/SBNSoftware/sbncode/commits/09ec97086c60ffcb9d9606eb55eb917fcf2db44c) she copied the module altogether (`MergeSimSourcesSBN`). The special ICARUS configuration that comes with it (`largeantdropped`) was derived from the one used for the "standard" workflow.
Fast forward one year, [a new desired feature is added](https://github.com/LArSoft/larsim/pull/151) in the original LArSim version, and [ICARUS updates the standard configuration](https://github.com/SBNSoftware/icaruscode/commit/bb6e659f84cb6c90c70ab038a2aaffb8514c9e30) and  the ML one (`largeantdropped`) silently inherits the change (the dates are confusing... ICARUS configuration change seems to predate by a lot the change in LArSoft...). So: the code has diverged, the configuration has not, `MergeSimSourcesSBN` can't handle the new parameter and it has it known. Why we notice now is probably a story of mixed branches, partial patches and the wish to go fast and furious.

This patch
-----------

I am just removing the unsupported parameter from `largeantdropped` configuration, leaving it in the `icarus_merge_sim_sources` ("standard") one. The two configurations are still related.

