### PR TITLE
Add HitWidthClusterMerging algorithms in Pandora steering XML and enabling hit widths

### DIFF
--- a/icaruscode/TPC/Tracking/ICARUSPandora/pandoramodules_icarus.fcl
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/pandoramodules_icarus.fcl
@@ -10,7 +10,7 @@ icarus_basicpandora:
     EnableLineGaps:                              true
     UseGlobalCoordinates:                        true
     UseActiveBoundingBox:                        true
-    UseHitWidths:                                false
+    UseHitWidths:                                true
     ShouldRunAllHitsCosmicReco:                  false
     ShouldRunStitching:                          false
     ShouldRunCosmicHitRemoval:                   false

--- a/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
+++ b/icaruscode/TPC/Tracking/ICARUSPandora/scripts/PandoraSettings_Neutrino_ICARUS.xml
@@ -35,6 +35,7 @@
   <algorithm type = "LArTrackConsolidation">
     <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
   </algorithm>
+  <algorithm type = "LArHitWidthClusterMerging"/>
 
   <algorithm type = "LArClusteringParent">
     <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation"/>
@@ -56,6 +57,7 @@
   <algorithm type = "LArTrackConsolidation">
     <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
   </algorithm>
+  <algorithm type = "LArHitWidthClusterMerging"/>
 
   <algorithm type = "LArClusteringParent">
     <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation"/>
@@ -77,6 +79,7 @@
   <algorithm type = "LArTrackConsolidation">
     <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
   </algorithm>
+  <algorithm type = "LArHitWidthClusterMerging"/>
 
   <!-- VertexAlgorithms -->
   <algorithm type = "LArCutClusterCharacterisation">


### PR DESCRIPTION
# Description

This PR introduces in the Pandora reconstruction chain a couple of algorithms aimed at exploiting the hit width information to improve on the 2D cluster creation. 

In addition to the change in the Pandora steering XML, the flag `UseHitWidths` is switched to `true` in the `pandoramodules_icarus.fcl` configuration.

Requesting review to @rtriozzi and @acampani, please let me know if anyone else should be added as reviewer for this PR.   