### PR TITLE
Tuned hit finder parameters

### DIFF
--- a/fcl/reco/Definitions/stage1_icarus_defs.fcl
+++ b/fcl/reco/Definitions/stage1_icarus_defs.fcl
@@ -29,15 +29,15 @@ BEGIN_PROLOG
 icarus_stage1_producers:
 {
   ### TPC hit-finder producers
-  gaushit1dTPCWW:                 @local::gausshit_sbn
-  gaushit1dTPCWE:                 @local::gausshit_sbn
-  gaushit1dTPCEW:                 @local::gausshit_sbn
-  gaushit1dTPCEE:                 @local::gausshit_sbn
+  gaushit1dTPCWW:                 @local::gaus_hitfinder_icarus
+  gaushit1dTPCWE:                 @local::gaus_hitfinder_icarus
+  gaushit1dTPCEW:                 @local::gaus_hitfinder_icarus
+  gaushit1dTPCEE:                 @local::gaus_hitfinder_icarus
 
-  gaushit2dTPCWW:                 @local::gausshit_sbn
-  gaushit2dTPCWE:                 @local::gausshit_sbn
-  gaushit2dTPCEW:                 @local::gausshit_sbn
-  gaushit2dTPCEE:                 @local::gausshit_sbn
+  gaushit2dTPCWW:                 @local::gaus_hitfinder_icarus
+  gaushit2dTPCWE:                 @local::gaus_hitfinder_icarus
+  gaushit2dTPCEW:                 @local::gaus_hitfinder_icarus
+  gaushit2dTPCEE:                 @local::gaus_hitfinder_icarus
 
   ### Cluster3D
   cluster3DCryoW:                 @local::icarus_cluster3d

--- a/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
@@ -1,7 +1,6 @@
 // from larreco/RecoAlg:
 #include "hitalgorithms.fcl"
 #include "HitFinderTools_ICARUS.fcl"
-#include "hitfindermodules.fcl"
 #include "hitfindermodules_sbn.fcl"
 
 BEGIN_PROLOG
@@ -60,7 +59,7 @@ icarus_hitmerger:
 }
 
 # Define icarus version of gaushit finder
-gaus_hitfinder_icarus: @local::gaus_hitfinder
+gaus_hitfinder_icarus: @local::gausshit_sbn
 
 gaus_hitfinder_icarus.CalDataModuleLabel:                                          "decon1droi"
 gaus_hitfinder_icarus.AreaNorms:                                                   [  1.0,  1.0,  1.0 ]

--- a/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
@@ -29,7 +29,7 @@ mixed_hitfinder:
   CalDataModuleLabel: "decon1droi"
 
   ThetaAngle:         0
-  #PeakFitter:           @local::peakfitter_ICARUS
+  # PeakFitter:           @local::peakfitter_ICARUS
   CandidateHits:        @local::candhitfinder_ICARUS
   MaxMultiHit:          3                # maximum hits for multi fit
   Chi2NDF:              10.              # maximum Chisquared / NDF allowed for a hit to be saved (Set very high by default)
@@ -72,21 +72,21 @@ gaus_hitfinder_icarus.LongMaxHits:                                              
 gaus_hitfinder_icarus.LongPulseWidth:                                              [17, 13, 12]
 
 # Keeping these here even though not used in case we want to know working values for testing
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0:                        @local::candhitfinder_morphological
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.Plane:                  0
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.MinDeltaTicks:          4
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.MinDeltaPeaks:          2.5
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.DilationThreshold:      8
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1:                        @local::candhitfinder_morphological
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.Plane:                  1
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.MinDeltaTicks:          4
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.MinDeltaPeaks:          2.5
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.DilationThreshold:      8
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2:                        @local::candhitfinder_morphological
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.Plane:                  2
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.MinDeltaTicks:          4
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.MinDeltaPeaks:          2.5
-#gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.DilationThreshold:      8
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0:                        @local::candhitfinder_morphological
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.Plane:                  0
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.MinDeltaTicks:          4
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.MinDeltaPeaks:          2.5
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.DilationThreshold:      8
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1:                        @local::candhitfinder_morphological
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.Plane:                  1
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.MinDeltaTicks:          4
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.MinDeltaPeaks:          2.5
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.DilationThreshold:      8
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2:                        @local::candhitfinder_morphological
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.Plane:                  2
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.MinDeltaTicks:          4
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.MinDeltaPeaks:          2.5
+# gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.DilationThreshold:      8
 
 # These are default settings for production running
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0:                        @local::candhitfinder_standard      # Sets hit finding for plane 0
@@ -101,24 +101,6 @@ gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2:                     
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.Plane:                  2
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:           6.16
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.NextADCThreshold:       -0.23
-
-# Now set parameters for the GaussHitFinderSBN
-# Note these are "default" for ICARUS and will move to a fcl file in icaruscode
-# We do not modify the SBN version here (happening upstream) 
-# Downstram FHiCL only use gaus_hitfinder_icarus for the correct ICARUS version
-
-# gausshit_sbn.PeakFitter.MinWidth:                                                 1
-# gausshit_sbn.PeakFitter.FloatBaseline:                                            false
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0:                                @local::candhitfinder_standard
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0.Plane:                          0
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:                   9.
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1:                                @local::candhitfinder_standard
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1.Plane:                          1
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:                   9.5
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2:                                @local::candhitfinder_standard
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2.Plane:                          2
-# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:                   9.
-# gausshit_sbn.LongMaxHits:          [ 1,  1,  1]      # disable pulse trains
 
 icarus_hitconverter:
 {

--- a/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
@@ -64,14 +64,13 @@ gaus_hitfinder_icarus: @local::gaus_hitfinder
 
 gaus_hitfinder_icarus.CalDataModuleLabel:                                          "decon1droi"
 gaus_hitfinder_icarus.AreaNorms:                                                   [  1.0,  1.0,  1.0 ]
-gaus_hitfinder_icarus.MaxMultiHit:                                                 5
-gaus_hitfinder_icarus.TryNplus1Fits:                                               false
-gaus_hitfinder_icarus.Chi2NDF:                                                     500.
+gaus_hitfinder_icarus.MaxMultiHit:                                                 [10, 10, 6]
+gaus_hitfinder_icarus.Chi2NDF:                                                     [1967, 1200, 1350]
 gaus_hitfinder_icarus.PeakFitter.MinWidth:                                         1
 gaus_hitfinder_icarus.PeakFitter.FloatBaseline:                                    false
 gaus_hitfinder_icarus.PeakFitter.tool_type:                                        "PeakFitterMrqdt"
-gaus_hitfinder_icarus.LongMaxHits:                                                 [1, 1, 1]
-gaus_hitfinder_icarus.LongPulseWidth:                                              [10, 10, 10]
+gaus_hitfinder_icarus.LongMaxHits:                                                 [5, 6, 5]
+gaus_hitfinder_icarus.LongPulseWidth:                                              [17, 13, 12]
 
 # Keeping these here even though not used in case we want to know working values for testing
 #gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0:                        @local::candhitfinder_morphological
@@ -93,28 +92,34 @@ gaus_hitfinder_icarus.LongPulseWidth:                                           
 # These are default settings for production running
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0:                        @local::candhitfinder_standard      # Sets hit finding for plane 0
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.Plane:                  0
-gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:           9.
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:           6.63
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane0.NextADCThreshold:       -0.03
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1:                        @local::candhitfinder_standard      # Sets hit finding for plane 1
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.Plane:                  1
-gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:           9.5
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:           5.74
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane1.NextADCThreshold:       -0.05
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2:                        @local::candhitfinder_standard      # Sets hit finding for plane 2
 gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.Plane:                  2
-gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:           9.
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:           6.16
+gaus_hitfinder_icarus.HitFinderToolVec.CandidateHitsPlane2.NextADCThreshold:       -0.23
 
 # Now set parameters for the GaussHitFinderSBN
 # Note these are "default" for ICARUS and will move to a fcl file in icaruscode
-gausshit_sbn.PeakFitter.MinWidth:                                                 1
-gausshit_sbn.PeakFitter.FloatBaseline:                                            false
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0:                                @local::candhitfinder_standard
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0.Plane:                          0
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:                   9.
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1:                                @local::candhitfinder_standard
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1.Plane:                          1
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:                   9.5
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2:                                @local::candhitfinder_standard
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2.Plane:                          2
-gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:                   9.
-gausshit_sbn.LongMaxHits:          [ 1,  1,  1]      # disable pulse trains
+# We do not modify the SBN version here (happening upstream) 
+# Downstram FHiCL only use gaus_hitfinder_icarus for the correct ICARUS version
+
+# gausshit_sbn.PeakFitter.MinWidth:                                                 1
+# gausshit_sbn.PeakFitter.FloatBaseline:                                            false
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0:                                @local::candhitfinder_standard
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0.Plane:                          0
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold:                   9.
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1:                                @local::candhitfinder_standard
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1.Plane:                          1
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold:                   9.5
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2:                                @local::candhitfinder_standard
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2.Plane:                          2
+# gausshit_sbn.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold:                   9.
+# gausshit_sbn.LongMaxHits:          [ 1,  1,  1]      # disable pulse trains
 
 icarus_hitconverter:
 {

--- a/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
+++ b/icaruscode/TPC/SignalProcessing/HitFinder/hitfindermodules_icarus.fcl
@@ -68,7 +68,7 @@ gaus_hitfinder_icarus.Chi2NDF:                                                  
 gaus_hitfinder_icarus.PeakFitter.MinWidth:                                         1
 gaus_hitfinder_icarus.PeakFitter.FloatBaseline:                                    false
 gaus_hitfinder_icarus.PeakFitter.tool_type:                                        "PeakFitterMrqdt"
-gaus_hitfinder_icarus.LongMaxHits:                                                 [5, 6, 5]
+gaus_hitfinder_icarus.LongMaxHits:                                                 [1, 1, 1]
 gaus_hitfinder_icarus.LongPulseWidth:                                              [17, 13, 12]
 
 # Keeping these here even though not used in case we want to know working values for testing


### PR DESCRIPTION
This PR introduces the updated hit finder parameters values obtained after the latest tuning. 

Details can be found in the latest presentation given at the sim/reco ICARUS WG meeting, found on [docdb-48139](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=48139). 

# Description
This refactor the dependencies of the hit finder module across the FHiCL in stage1, removing the _outdated_ sbn default and introducing the ICARUS-tailored version. 

In `hitfindermodules_icarus.fcl` the updated parameter values are set, and the `NextADCThreshold` parameter value is introduced for the candidate hit finder module. 

# Depends on
This PR has been done as part of an infrastructure-wide attempt of freezing the code up to a certain version. The following is a list of (both closed/merged and open) PR that have been included as part of the validation studies. 

- https://github.com/SBNSoftware/sbncode/pull/659
- https://github.com/SBNSoftware/sbncode/pull/626
- https://github.com/SBNSoftware/icaruscode/pull/892
- https://github.com/LArSoft/larreco/pull/92

Additionally, it requires the following to be merged to address some issues that we've been seeing on shower like topologies
- https://github.com/SBNSoftware/icaruscode/pull/855 (this is dependent on https://github.com/PandoraPFA/larpandora/pull/32, thus requiring a newer version of the `PandoraPFA/larpandora` dependency)


This will also require `develop` to be on the same page as `release/SBN2025A` since this was cut starting from there.

Asking @acampani, @cerati and @SFBayLaser for a review. 