### PR TITLE
Temporarily disabling DNN ROI to enable CI tests in short term

### DIFF
--- a/fcl/reco/Stage0/data/stage0_run2_wcdnn_icarus.fcl
+++ b/fcl/reco/Stage0/data/stage0_run2_wcdnn_icarus.fcl
@@ -1,3 +1,3 @@
 #include "stage0_run2_wc_icarus.fcl"
 
-#include "enable_dnn_sp.fcl"
+#####include "enable_dnn_sp.fcl"

--- a/fcl/reco/Stage0/mc/stage0_run2_wcdnn_icarus_mc.fcl
+++ b/fcl/reco/Stage0/mc/stage0_run2_wcdnn_icarus_mc.fcl
@@ -1,3 +1,3 @@
 #include "stage0_run2_wc_yz_icarus_mc.fcl"
 
-#include "enable_dnn_sp.fcl"
+#####include "enable_dnn_sp.fcl"


### PR DESCRIPTION
This PR is meant to temporarily disable the DNN ROI finding in both data and MC. At issue is that the latest versions of the Wirecell toolkit, including the version that gives us the updated yz simulation, are crashing in the DNN ROI finding and this is preventing us from debugging the rest of the CI test system. We don't know when we will see an updated wirecell toolkit so hopefully "unsticking" the problem with this temporary update. 