### PR TITLE
fhicl file to run purity monitor for keep up processing

### DIFF
--- a/fcl/reco/Stage0/data/stage0_purity_only_icarus.fcl
+++ b/fcl/reco/Stage0/data/stage0_purity_only_icarus.fcl
@@ -1,0 +1,43 @@
+###
+## This fhicl file is used to run "stage0" processing specifically for the case where all
+## TPC data is included in an artdaq data product from a single instance
+##
+#include "stage0_icarus_driver_common.fcl"
+
+process_name: stage0
+
+## Define the path we'll execute
+physics.path:     [ daqTPCROI,@sequence::icarus_purity_monitor ]
+
+## boiler plate...
+physics.outana:        [ purityinfoana0, purityinfoana1 ]
+physics.trigger_paths: [ path ]
+physics.end_paths:     [ outana, streamROOT ]
+
+# Drop the artdaq format files on output, 
+# Drop all output from the TPC decoder stage
+# Drop all output from the 1D deconvolution stage
+# Drop the recob::Wire output from the roifinder (but keep the ChannelROIs)
+# Drop the reconstructed optical hits before the timing correction
+# Drop the PMT waveforms (will keep the ones from daqPMTonbeam)
+# Keep the Trigger fragment
+outputs.rootOutput.outputCommands: [
+    "keep *_*_*_*", 
+    "drop artdaq::Fragments_*_*_ICARUSReprocessRaw",
+    "drop *_*_*_DAQ*",
+    "drop *_ophituncorrected_*_*",
+    "drop *_daqPMT_*_*",
+    "drop *_daqPMTonbeam_*_*",
+    "drop *_daqTPCROI_*_*", 
+    "drop *_decon2droiEE_*_*",
+    "drop *_decon2droiEW_*_*",
+    "drop *_decon2droiWE_*_*",
+    "drop *_decon2droiWW_*_*",
+    "drop *_decon1droi_*_*", 
+    "drop recob::Wire*_roifinder_*_*",
+    "keep *_daq_ICARUSTriggerV*_*"]
+
+## Modify the event selection for the purity analyzers
+physics.analyzers.purityinfoana0.SelectEvents:    [ path ]
+physics.analyzers.purityinfoana1.SelectEvents:    [ path ]
+


### PR DESCRIPTION
We would like to pull back the keep up processing to only run the code necessary to maintain the argon purity measurement. This fhicl file, produced and tested by Christan Farnese will do that job. 